### PR TITLE
feat: Add Squad Origins page for Champions League academy breakdown

### DIFF
--- a/loan-army-backend/src/main.py
+++ b/loan-army-backend/src/main.py
@@ -21,6 +21,7 @@ from src.routes.cohort import cohort_bp
 from src.routes.gol import gol_bp
 from src.routes.formation import formation_bp
 from src.routes.teams import teams_bp
+from src.routes.feeder import feeder_bp
 import logging
 from sqlalchemy.engine.url import make_url, URL
 from flask_migrate import Migrate
@@ -95,6 +96,7 @@ app.register_blueprint(cohort_bp, url_prefix='/api')
 app.register_blueprint(gol_bp, url_prefix='/api')
 app.register_blueprint(formation_bp, url_prefix='/api')
 app.register_blueprint(teams_bp, url_prefix='/api')
+app.register_blueprint(feeder_bp, url_prefix='/api')
 
 csp = {
     'default-src': ["'self'"],

--- a/loan-army-backend/src/routes/feeder.py
+++ b/loan-army-backend/src/routes/feeder.py
@@ -1,0 +1,58 @@
+"""Feeder blueprint for squad origins endpoints.
+
+Public read-only endpoints that show which academies feed a club's squad.
+"""
+
+import logging
+from flask import Blueprint, jsonify, request
+
+logger = logging.getLogger(__name__)
+
+feeder_bp = Blueprint('feeder', __name__)
+
+
+def _get_feeder_service():
+    """Lazy-load FeederService to avoid circular imports."""
+    from src.services.feeder_service import FeederService
+    return FeederService()
+
+
+@feeder_bp.route('/feeder/competitions', methods=['GET'])
+def get_competitions():
+    """Return supported competitions for browsing."""
+    service = _get_feeder_service()
+    return jsonify({'competitions': service.get_competitions()})
+
+
+@feeder_bp.route('/feeder/competitions/<int:league_api_id>/teams', methods=['GET'])
+def get_competition_teams(league_api_id):
+    """Return teams in a competition for a given season."""
+    season = request.args.get('season', type=int)
+    if not season:
+        return jsonify({'error': 'season parameter is required'}), 400
+
+    service = _get_feeder_service()
+    try:
+        teams = service.get_competition_teams(league_api_id, season)
+        return jsonify({'teams': teams, 'season': season, 'league_api_id': league_api_id})
+    except Exception as e:
+        logger.error(f"Failed to fetch competition teams: {e}", exc_info=True)
+        return jsonify({'error': 'Failed to fetch teams'}), 500
+
+
+@feeder_bp.route('/feeder/teams/<int:team_api_id>/origins', methods=['GET'])
+def get_squad_origins(team_api_id):
+    """Return academy breakdown for a team's squad."""
+    league = request.args.get('league', type=int)
+    season = request.args.get('season', type=int)
+
+    if not league or not season:
+        return jsonify({'error': 'league and season parameters are required'}), 400
+
+    service = _get_feeder_service()
+    try:
+        result = service.get_squad_origins(team_api_id, league, season)
+        return jsonify(result)
+    except Exception as e:
+        logger.error(f"Failed to fetch squad origins for team {team_api_id}: {e}", exc_info=True)
+        return jsonify({'error': 'Failed to fetch squad origins'}), 500

--- a/loan-army-backend/src/services/feeder_service.py
+++ b/loan-army-backend/src/services/feeder_service.py
@@ -1,0 +1,237 @@
+"""
+Feeder Service
+
+Provides the "squad origins" view — given a team in a competition (e.g. Champions League),
+shows which academies produced the players in that squad.
+"""
+
+import logging
+from collections import defaultdict
+from typing import Optional, Dict, Any, List
+
+from src.models.league import db, TeamProfile
+from src.models.journey import PlayerJourney
+from src.api_football_client import APIFootballClient
+from src.services.journey_sync import JourneySyncService
+
+logger = logging.getLogger(__name__)
+
+# Competitions available for browsing
+SUPPORTED_COMPETITIONS = [
+    {
+        'league_api_id': 2,
+        'name': 'Champions League',
+        'logo': 'https://media.api-sports.io/football/leagues/2.png',
+        'type': 'cup',
+    },
+]
+
+
+class FeederService:
+    """Service for discovering which academies feed a club's squad."""
+
+    def __init__(self, api_client: Optional[APIFootballClient] = None):
+        self.api = api_client or APIFootballClient()
+        self.journey_sync = JourneySyncService(api_client=self.api)
+
+    def get_competitions(self) -> List[Dict[str, Any]]:
+        return SUPPORTED_COMPETITIONS
+
+    def get_competition_teams(self, league_api_id: int, season: int) -> List[Dict[str, Any]]:
+        """Fetch all teams in a competition for a given season."""
+        response = self.api._make_request('teams', {
+            'league': league_api_id,
+            'season': season,
+        })
+
+        teams = []
+        for item in response.get('response', []):
+            team = item.get('team', {})
+            venue = item.get('venue', {})
+            teams.append({
+                'team_api_id': team.get('id'),
+                'name': team.get('name'),
+                'logo': team.get('logo'),
+                'country': team.get('country'),
+                'venue': venue.get('name'),
+                'city': venue.get('city'),
+            })
+
+        teams.sort(key=lambda t: (t.get('name') or ''))
+        return teams
+
+    def get_squad_origins(
+        self,
+        team_api_id: int,
+        league_api_id: int,
+        season: int,
+        auto_sync: bool = True,
+    ) -> Dict[str, Any]:
+        """
+        Get the academy breakdown for a team's squad in a competition/season.
+
+        Returns players grouped by their academy origin club.
+        If auto_sync is True, syncs journeys for players without journey data.
+        """
+        # Fetch squad from API-Football (paginated)
+        squad_players = self._fetch_squad(team_api_id, league_api_id, season)
+
+        if not squad_players:
+            return {
+                'team': {'api_id': team_api_id},
+                'squad_size': 0,
+                'academy_breakdown': [],
+                'unknown_origin': [],
+                'homegrown_count': 0,
+                'homegrown_pct': 0,
+            }
+
+        player_api_ids = [p['player_api_id'] for p in squad_players]
+
+        # Look up existing journeys
+        journeys_by_player = {}
+        existing_journeys = PlayerJourney.query.filter(
+            PlayerJourney.player_api_id.in_(player_api_ids)
+        ).all()
+        for j in existing_journeys:
+            journeys_by_player[j.player_api_id] = j
+
+        # Auto-sync missing journeys
+        missing_ids = [pid for pid in player_api_ids if pid not in journeys_by_player]
+        if auto_sync and missing_ids:
+            logger.info(f"Auto-syncing {len(missing_ids)} missing journeys for team {team_api_id}")
+            for pid in missing_ids:
+                try:
+                    journey = self.journey_sync.sync_player(pid)
+                    if journey:
+                        journeys_by_player[pid] = journey
+                except Exception as e:
+                    logger.warning(f"Failed to sync journey for player {pid}: {e}")
+
+        # Group players by academy origin
+        academy_groups = defaultdict(list)
+        unknown_origin = []
+
+        for player in squad_players:
+            pid = player['player_api_id']
+            journey = journeys_by_player.get(pid)
+
+            if journey and journey.origin_club_api_id:
+                origin_key = journey.origin_club_api_id
+                academy_groups[origin_key].append({
+                    **player,
+                    'academy_club_id': journey.origin_club_api_id,
+                    'academy_club_name': journey.origin_club_name,
+                    'academy_club_ids': journey.academy_club_ids or [],
+                })
+            else:
+                unknown_origin.append(player)
+
+        # Build breakdown with academy logos
+        breakdown = []
+        for academy_id, players in academy_groups.items():
+            academy_name = players[0]['academy_club_name']
+            academy_logo = self._get_team_logo(academy_id)
+
+            breakdown.append({
+                'academy': {
+                    'api_id': academy_id,
+                    'name': academy_name,
+                    'logo': academy_logo,
+                },
+                'players': sorted(players, key=lambda p: p.get('player_name', '')),
+                'count': len(players),
+                'is_homegrown': academy_id == team_api_id,
+            })
+
+        breakdown.sort(key=lambda g: (-g['count'], g['academy']['name']))
+
+        homegrown = next((g for g in breakdown if g['is_homegrown']), None)
+        homegrown_count = homegrown['count'] if homegrown else 0
+        total = len(squad_players)
+
+        # Get team info from first player's data
+        team_info = {
+            'api_id': team_api_id,
+            'name': squad_players[0].get('team_name') if squad_players else None,
+            'logo': squad_players[0].get('team_logo') if squad_players else None,
+        }
+
+        return {
+            'team': team_info,
+            'squad_size': total,
+            'academy_breakdown': breakdown,
+            'unknown_origin': unknown_origin,
+            'homegrown_count': homegrown_count,
+            'homegrown_pct': round(homegrown_count / total * 100) if total > 0 else 0,
+            'resolved_count': total - len(unknown_origin),
+        }
+
+    def _fetch_squad(self, team_api_id: int, league_api_id: int, season: int) -> List[Dict[str, Any]]:
+        """Fetch all squad players for a team in a league/season from API-Football."""
+        players = []
+        page = 1
+        total_pages = 1
+
+        while page <= total_pages:
+            response = self.api._make_request('players', {
+                'team': team_api_id,
+                'league': league_api_id,
+                'season': season,
+                'page': page,
+            })
+
+            paging = response.get('paging', {})
+            total_pages = paging.get('total', 1)
+
+            for player_data in response.get('response', []):
+                player = player_data.get('player', {})
+                stats_list = player_data.get('statistics', [])
+
+                player_api_id = player.get('id')
+                if not player_api_id:
+                    continue
+
+                # Extract stats from first statistics entry
+                appearances = 0
+                goals = 0
+                assists = 0
+                position = None
+                team_name = None
+                team_logo = None
+                if stats_list:
+                    stat = stats_list[0]
+                    games = stat.get('games', {})
+                    goals_data = stat.get('goals', {})
+                    appearances = games.get('appearences') or games.get('appearances') or 0
+                    goals = goals_data.get('total') or 0
+                    assists = goals_data.get('assists') or 0
+                    position = games.get('position')
+                    team_info = stat.get('team', {})
+                    team_name = team_info.get('name')
+                    team_logo = team_info.get('logo')
+
+                players.append({
+                    'player_api_id': player_api_id,
+                    'player_name': player.get('name'),
+                    'photo': player.get('photo'),
+                    'age': player.get('age'),
+                    'nationality': player.get('nationality'),
+                    'position': position,
+                    'appearances': appearances,
+                    'goals': goals,
+                    'assists': assists,
+                    'team_name': team_name,
+                    'team_logo': team_logo,
+                })
+
+            page += 1
+
+        return players
+
+    def _get_team_logo(self, team_api_id: int) -> Optional[str]:
+        """Get team logo from TeamProfile cache."""
+        profile = TeamProfile.query.filter_by(team_id=team_api_id).first()
+        if profile:
+            return profile.logo_url
+        return f"https://media.api-sports.io/football/teams/{team_api_id}.png"

--- a/loan-army-frontend/src/App.jsx
+++ b/loan-army-frontend/src/App.jsx
@@ -97,6 +97,7 @@ import { AdminTools } from '@/pages/admin/AdminTools'
 import { AdminSandbox } from '@/pages/admin/AdminSandbox'
 import { AdminFormation } from '@/pages/admin/AdminFormation'
 import { PublicFormationBuilder } from '@/pages/PublicFormationBuilder'
+import { SquadOrigins } from '@/pages/SquadOrigins'
 import { CohortBrowser } from '@/pages/CohortBrowser'
 import { CohortDetail } from '@/pages/CohortDetail'
 import { CohortAnalytics } from '@/pages/CohortAnalytics'
@@ -7148,6 +7149,7 @@ function Navigation() {
       { path: '/teams', label: 'Teams', icon: Users },
       { path: '/dream-team', label: 'Dream XI', icon: Trophy },
       { path: '/newsletters', label: 'Newsletters', icon: FileText },
+      { path: '/squad-origins', label: 'Squad Origins', icon: Globe },
       { path: '/journalists', label: 'Journalists', icon: UserPlus },
     ]
     if (isJournalist) {
@@ -10838,6 +10840,7 @@ function AppRoutes() {
       <Route path="/verify" element={<VerifyPage />} />
       <Route path="/claim-account" element={<ClaimAccount />} />
       <Route path="/submit-take" element={<SubmitTake />} />
+      <Route path="/squad-origins" element={<SquadOrigins />} />
       <Route path="/academy" element={<CohortBrowser />} />
       <Route path="/academy/cohorts/:cohortId" element={<CohortDetail />} />
       <Route path="/academy/analytics" element={<CohortAnalytics />} />

--- a/loan-army-frontend/src/lib/api.js
+++ b/loan-army-frontend/src/lib/api.js
@@ -1583,6 +1583,18 @@ export class APIService {
         return this.request(`/cohorts/${cohortId}${query ? '?' + query : ''}`)
     }
 
+    static async getFeederCompetitions() {
+        return this.request('/feeder/competitions')
+    }
+
+    static async getFeederTeams(leagueApiId, season) {
+        return this.request(`/feeder/competitions/${leagueApiId}/teams?season=${season}`)
+    }
+
+    static async getSquadOrigins(teamApiId, { league, season }) {
+        return this.request(`/feeder/teams/${teamApiId}/origins?league=${league}&season=${season}`)
+    }
+
     static async getCohortTeams() {
         return this.request('/cohorts/teams')
     }

--- a/loan-army-frontend/src/pages/SquadOrigins.jsx
+++ b/loan-army-frontend/src/pages/SquadOrigins.jsx
@@ -1,0 +1,372 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Link } from 'react-router-dom'
+import { APIService } from '@/lib/api'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
+import { Button } from '@/components/ui/button'
+import { Loader2, ArrowLeft, ChevronDown, ChevronRight } from 'lucide-react'
+
+const CURRENT_SEASON = new Date().getFullYear() - (new Date().getMonth() < 7 ? 1 : 0)
+const SEASONS = Array.from({ length: 4 }, (_, i) => CURRENT_SEASON - i)
+
+export function SquadOrigins() {
+    const [season, setSeason] = useState(CURRENT_SEASON)
+    const [teams, setTeams] = useState([])
+    const [teamsLoading, setTeamsLoading] = useState(true)
+    const [selectedTeam, setSelectedTeam] = useState(null)
+    const [origins, setOrigins] = useState(null)
+    const [originsLoading, setOriginsLoading] = useState(false)
+    const [expandedAcademy, setExpandedAcademy] = useState(null)
+
+    const CL_LEAGUE_ID = 2
+
+    const loadTeams = useCallback(async (s) => {
+        setTeamsLoading(true)
+        setSelectedTeam(null)
+        setOrigins(null)
+        try {
+            const data = await APIService.getFeederTeams(CL_LEAGUE_ID, s)
+            setTeams(data?.teams || [])
+        } catch (err) {
+            console.error('Failed to load competition teams', err)
+            setTeams([])
+        } finally {
+            setTeamsLoading(false)
+        }
+    }, [])
+
+    useEffect(() => {
+        loadTeams(season)
+    }, [season, loadTeams])
+
+    const handleTeamSelect = useCallback(async (team) => {
+        setSelectedTeam(team)
+        setOriginsLoading(true)
+        setExpandedAcademy(null)
+        try {
+            const data = await APIService.getSquadOrigins(team.team_api_id, {
+                league: CL_LEAGUE_ID,
+                season,
+            })
+            setOrigins(data)
+        } catch (err) {
+            console.error('Failed to load squad origins', err)
+            setOrigins(null)
+        } finally {
+            setOriginsLoading(false)
+        }
+    }, [season])
+
+    const handleBack = () => {
+        setSelectedTeam(null)
+        setOrigins(null)
+    }
+
+    const formatSeason = (s) => `${s}/${(s + 1).toString().slice(-2)}`
+
+    return (
+        <div className="min-h-screen bg-gradient-to-b from-secondary to-background">
+            <div className="max-w-6xl mx-auto px-4 py-8">
+                {/* Header */}
+                <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-8">
+                    <div>
+                        <h1 className="text-3xl font-bold tracking-tight text-foreground">
+                            Squad Origins
+                        </h1>
+                        <p className="text-muted-foreground mt-1">
+                            Discover which academies produced the players in Champions League squads
+                        </p>
+                    </div>
+                    <Select value={String(season)} onValueChange={(v) => setSeason(Number(v))}>
+                        <SelectTrigger className="w-[140px]">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {SEASONS.map((s) => (
+                                <SelectItem key={s} value={String(s)}>
+                                    {formatSeason(s)}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+
+                {/* Team grid or origins detail */}
+                {selectedTeam ? (
+                    <OriginsDetail
+                        team={selectedTeam}
+                        origins={origins}
+                        loading={originsLoading}
+                        season={season}
+                        formatSeason={formatSeason}
+                        onBack={handleBack}
+                        expandedAcademy={expandedAcademy}
+                        setExpandedAcademy={setExpandedAcademy}
+                    />
+                ) : (
+                    <TeamGrid
+                        teams={teams}
+                        loading={teamsLoading}
+                        onSelect={handleTeamSelect}
+                        season={season}
+                        formatSeason={formatSeason}
+                    />
+                )}
+            </div>
+        </div>
+    )
+}
+
+function TeamGrid({ teams, loading, onSelect, season, formatSeason }) {
+    if (loading) {
+        return (
+            <div className="flex items-center justify-center py-16">
+                <Loader2 className="h-8 w-8 animate-spin text-primary" />
+            </div>
+        )
+    }
+
+    if (teams.length === 0) {
+        return (
+            <Card>
+                <CardContent className="py-12 text-center text-muted-foreground">
+                    No teams found for this season.
+                </CardContent>
+            </Card>
+        )
+    }
+
+    return (
+        <div>
+            <h2 className="text-lg font-semibold text-foreground/80 mb-4">
+                Champions League {formatSeason(season)} — {teams.length} teams
+            </h2>
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+                {teams.map((team) => (
+                    <Card
+                        key={team.team_api_id}
+                        className="cursor-pointer transition-all hover:shadow-md hover:border-primary/20"
+                        onClick={() => onSelect(team)}
+                    >
+                        <CardContent className="flex flex-col items-center gap-2 p-4 text-center">
+                            <img
+                                src={team.logo}
+                                alt={team.name}
+                                className="w-12 h-12 object-contain"
+                            />
+                            <span className="font-medium text-sm text-foreground truncate w-full">
+                                {team.name}
+                            </span>
+                            <span className="text-xs text-muted-foreground">{team.country}</span>
+                        </CardContent>
+                    </Card>
+                ))}
+            </div>
+        </div>
+    )
+}
+
+function OriginsDetail({ team, origins, loading, season, formatSeason, onBack, expandedAcademy, setExpandedAcademy }) {
+    if (loading) {
+        return (
+            <div className="space-y-4">
+                <Button variant="ghost" size="sm" onClick={onBack} className="mb-2">
+                    <ArrowLeft className="h-4 w-4 mr-1" /> Back to teams
+                </Button>
+                <div className="flex flex-col items-center justify-center py-16 gap-3">
+                    <Loader2 className="h-8 w-8 animate-spin text-primary" />
+                    <p className="text-sm text-muted-foreground">
+                        Resolving academy origins — this may take a moment for first-time lookups...
+                    </p>
+                </div>
+            </div>
+        )
+    }
+
+    if (!origins || origins.squad_size === 0) {
+        return (
+            <div>
+                <Button variant="ghost" size="sm" onClick={onBack} className="mb-4">
+                    <ArrowLeft className="h-4 w-4 mr-1" /> Back to teams
+                </Button>
+                <Card>
+                    <CardContent className="py-12 text-center text-muted-foreground">
+                        No squad data found for this team.
+                    </CardContent>
+                </Card>
+            </div>
+        )
+    }
+
+    const { academy_breakdown, unknown_origin, squad_size, homegrown_count, homegrown_pct } = origins
+
+    return (
+        <div className="space-y-6">
+            {/* Header */}
+            <div className="flex items-center gap-4">
+                <Button variant="ghost" size="sm" onClick={onBack}>
+                    <ArrowLeft className="h-4 w-4 mr-1" /> Back
+                </Button>
+            </div>
+
+            <div className="flex items-center gap-4">
+                <img
+                    src={team.logo}
+                    alt={team.name}
+                    className="w-16 h-16 object-contain"
+                />
+                <div>
+                    <h2 className="text-2xl font-bold text-foreground">{team.name}</h2>
+                    <p className="text-muted-foreground">
+                        Champions League {formatSeason(season)}
+                    </p>
+                </div>
+            </div>
+
+            {/* Summary stats */}
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                <Card>
+                    <CardContent className="p-4 text-center">
+                        <div className="text-2xl font-bold text-foreground">{squad_size}</div>
+                        <div className="text-xs text-muted-foreground">Squad Players</div>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardContent className="p-4 text-center">
+                        <div className="text-2xl font-bold text-primary">{homegrown_count}</div>
+                        <div className="text-xs text-muted-foreground">Homegrown</div>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardContent className="p-4 text-center">
+                        <div className="text-2xl font-bold text-foreground">{homegrown_pct}%</div>
+                        <div className="text-xs text-muted-foreground">Homegrown Rate</div>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardContent className="p-4 text-center">
+                        <div className="text-2xl font-bold text-foreground">{academy_breakdown.length}</div>
+                        <div className="text-xs text-muted-foreground">Feeder Academies</div>
+                    </CardContent>
+                </Card>
+            </div>
+
+            {/* Academy breakdown */}
+            <div className="space-y-2">
+                <h3 className="text-lg font-semibold text-foreground/80">Academy Breakdown</h3>
+                {academy_breakdown.map((group) => {
+                    const isExpanded = expandedAcademy === group.academy.api_id
+                    return (
+                        <Card key={group.academy.api_id} className="overflow-hidden">
+                            <div
+                                className="flex items-center gap-3 p-4 cursor-pointer hover:bg-secondary/50 transition-colors"
+                                onClick={() => setExpandedAcademy(isExpanded ? null : group.academy.api_id)}
+                            >
+                                <img
+                                    src={group.academy.logo}
+                                    alt={group.academy.name}
+                                    className="w-8 h-8 object-contain flex-shrink-0"
+                                />
+                                <div className="flex-1 min-w-0">
+                                    <span className="font-medium text-foreground">
+                                        {group.academy.name}
+                                    </span>
+                                    {group.is_homegrown && (
+                                        <Badge className="ml-2 bg-primary/10 text-primary border-primary/20 text-xs">
+                                            Homegrown
+                                        </Badge>
+                                    )}
+                                </div>
+                                <Badge variant="outline" className="flex-shrink-0">
+                                    {group.count} {group.count === 1 ? 'player' : 'players'}
+                                </Badge>
+                                {isExpanded ? (
+                                    <ChevronDown className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                                ) : (
+                                    <ChevronRight className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                                )}
+                            </div>
+                            {isExpanded && (
+                                <div className="border-t bg-secondary/20 px-4 py-2">
+                                    <div className="space-y-2">
+                                        {group.players.map((player) => (
+                                            <Link
+                                                key={player.player_api_id}
+                                                to={`/players/${player.player_api_id}`}
+                                                className="flex items-center gap-3 py-2 px-2 rounded-md hover:bg-secondary transition-colors no-underline"
+                                            >
+                                                <Avatar className="h-8 w-8">
+                                                    <AvatarImage src={player.photo} alt={player.player_name} />
+                                                    <AvatarFallback className="text-xs">
+                                                        {(player.player_name || '').split(' ').map(n => n[0]).join('').slice(0, 2)}
+                                                    </AvatarFallback>
+                                                </Avatar>
+                                                <div className="flex-1 min-w-0">
+                                                    <div className="text-sm font-medium text-foreground">
+                                                        {player.player_name}
+                                                    </div>
+                                                    <div className="text-xs text-muted-foreground">
+                                                        {player.position} — {player.nationality}
+                                                    </div>
+                                                </div>
+                                                <div className="text-xs text-muted-foreground text-right">
+                                                    {player.appearances > 0 && (
+                                                        <span>{player.appearances} apps</span>
+                                                    )}
+                                                    {player.goals > 0 && (
+                                                        <span className="ml-2">{player.goals}G</span>
+                                                    )}
+                                                    {player.assists > 0 && (
+                                                        <span className="ml-1">{player.assists}A</span>
+                                                    )}
+                                                </div>
+                                            </Link>
+                                        ))}
+                                    </div>
+                                </div>
+                            )}
+                        </Card>
+                    )
+                })}
+            </div>
+
+            {/* Unknown origins */}
+            {unknown_origin.length > 0 && (
+                <div className="space-y-2">
+                    <h3 className="text-lg font-semibold text-foreground/80">
+                        Unknown Origin
+                        <Badge variant="outline" className="ml-2">{unknown_origin.length}</Badge>
+                    </h3>
+                    <Card>
+                        <CardContent className="p-4">
+                            <div className="space-y-2">
+                                {unknown_origin.map((player) => (
+                                    <Link
+                                        key={player.player_api_id}
+                                        to={`/players/${player.player_api_id}`}
+                                        className="flex items-center gap-3 py-2 px-2 rounded-md hover:bg-secondary transition-colors no-underline"
+                                    >
+                                        <Avatar className="h-8 w-8">
+                                            <AvatarImage src={player.photo} alt={player.player_name} />
+                                            <AvatarFallback className="text-xs">
+                                                {(player.player_name || '').split(' ').map(n => n[0]).join('').slice(0, 2)}
+                                            </AvatarFallback>
+                                        </Avatar>
+                                        <span className="text-sm font-medium text-foreground">
+                                            {player.player_name}
+                                        </span>
+                                        <span className="text-xs text-muted-foreground">
+                                            {player.position}
+                                        </span>
+                                    </Link>
+                                ))}
+                            </div>
+                        </CardContent>
+                    </Card>
+                </div>
+            )}
+        </div>
+    )
+}


### PR DESCRIPTION
## Summary
- New **Squad Origins** page (`/squad-origins`) that shows which academies produced the players in Champions League squads
- Browse CL teams by season, click a team to see academy breakdown with homegrown rate
- Auto-syncs player journey data on first view using existing `JourneySyncService`
- No new database models — leverages existing `PlayerJourney` with `origin_club_api_id` and `academy_club_ids`

## Test plan
- [ ] Navigate to `/squad-origins` — verify CL teams load for current season
- [ ] Change season selector — verify teams update
- [ ] Click a team — verify academy breakdown loads with player groupings
- [ ] Click a player — verify navigation to `/players/:id` works
- [ ] Hit `GET /api/feeder/competitions` — verify returns Champions League entry
- [ ] Hit `GET /api/feeder/competitions/2/teams?season=2025` — verify returns CL teams

🤖 Generated with [Claude Code](https://claude.com/claude-code)