### PR TITLE
fix: Filter teams by TrackedPlayer to hide empty teams

### DIFF
--- a/loan-army-backend/src/routes/teams.py
+++ b/loan-army-backend/src/routes/teams.py
@@ -141,9 +141,9 @@ def get_teams():
         # Handle has_loans filter
         has_loans = request.args.get('has_loans', '').lower() == 'true'
         if has_loans:
-            logger.info("Filtering for teams with active loans")
-            query = query.join(LoanedPlayer, Team.id == LoanedPlayer.primary_team_id)\
-                        .filter(LoanedPlayer.is_active == True)\
+            logger.info("Filtering for teams with active tracked players")
+            query = query.join(TrackedPlayer, Team.id == TrackedPlayer.team_id)\
+                        .filter(TrackedPlayer.is_active.is_(True))\
                         .distinct()
 
         # Handle search filter (for global search)


### PR DESCRIPTION
## Summary
- Teams without academy players were appearing on pages like "Build Your Dream XI" because the `has_loans` filter in `/teams` joined on the legacy `LoanedPlayer` table, while the player endpoint (`/teams/<id>/players`) serves from `TrackedPlayer`
- Switched the `has_loans` join from `LoanedPlayer` to `TrackedPlayer` so only teams with active tracked players appear in team selectors

## Test plan
- [ ] Hit `GET /api/teams?european_only=true&has_loans=true` and verify all returned teams have `tracked_player_count > 0`
- [ ] Open Dream XI page and confirm no empty teams appear in the selector
- [ ] Select a team and verify players load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)