### PR TITLE
feat: Auto-seed academy data for tracked teams

### DIFF
--- a/loan-army-backend/requirements.txt
+++ b/loan-army-backend/requirements.txt
@@ -20,6 +20,7 @@ Flask-SQLAlchemy==3.1.1
 flask-talisman==1.1.0
 fonttools==4.61.1
 greenlet==3.2.3
+guardrails-ai>=0.5.0
 griffe==1.10.0
 groq==0.32.0
 gunicorn==22.0.0

--- a/loan-army-backend/scripts/full_rebuild.py
+++ b/loan-army-backend/scripts/full_rebuild.py
@@ -104,7 +104,13 @@ def stage_0_preflight(team_ids, seasons, dry_run):
         print('  [SKIP] Could not check API usage (table may not exist)')
 
     # Print plan
-    team_names = [BIG_6.get(t, str(t)) for t in team_ids]
+    team_names = []
+    for t in team_ids:
+        name = BIG_6.get(t)
+        if not name:
+            team_row = Team.query.filter_by(team_id=t).order_by(Team.season.desc()).first()
+            name = team_row.name if team_row else str(t)
+        team_names.append(name)
     combos = len(team_ids) * 6 * len(seasons)  # 6 youth leagues
     print(f'\n  Teams: {", ".join(team_names)}')
     print(f'  Seasons: {seasons}')
@@ -248,7 +254,10 @@ def stage_4_tracked_players(team_ids, seasons, dry_run):
     current_season = max(seasons)
 
     for api_team_id in team_ids:
-        team_name = BIG_6.get(api_team_id, str(api_team_id))
+        team_name = BIG_6.get(api_team_id)
+        if not team_name:
+            _team_row = Team.query.filter_by(team_id=api_team_id).order_by(Team.season.desc()).first()
+            team_name = _team_row.name if _team_row else str(api_team_id)
         print(f'\n  Processing {team_name} (api_id={api_team_id})...')
 
         # Find the Team row (most recent season)
@@ -586,6 +595,10 @@ def main():
                         help='Comma-separated API team IDs (default: all Big 6)')
     parser.add_argument('--seasons', type=str, default=None,
                         help='Comma-separated seasons (default: 2020,2021,2022,2023,2024)')
+    parser.add_argument('--league', type=int, default=None,
+                        help='API league ID to auto-discover teams (e.g. 39 for Premier League)')
+    parser.add_argument('--exclude-teams', type=str, default=None,
+                        help='Comma-separated API team IDs to exclude (use with --league)')
     parser.add_argument('--skip-clean', action='store_true',
                         help='Skip stage 1 (keep existing data)')
     parser.add_argument('--skip-cohorts', action='store_true',
@@ -597,19 +610,42 @@ def main():
 
     args = parser.parse_args()
 
+    # Parse seasons (needed before --league resolution)
+    if args.seasons:
+        seasons = [int(s.strip()) for s in args.seasons.split(',')]
+    else:
+        seasons = DEFAULT_SEASONS
+
+    # Parse exclude set
+    exclude_ids = set()
+    if args.exclude_teams:
+        exclude_ids = {int(t.strip()) for t in args.exclude_teams.split(',')}
+
     # Parse team IDs
     if args.teams:
         team_ids = [int(t.strip()) for t in args.teams.split(',')]
     else:
         team_ids = list(BIG_6.keys())
 
-    # Parse seasons
-    if args.seasons:
-        seasons = [int(s.strip()) for s in args.seasons.split(',')]
-    else:
-        seasons = DEFAULT_SEASONS
-
     with app.app_context():
+        # --league: auto-discover teams from DB for the given league
+        if args.league:
+            from src.models.league import League
+            season_for_lookup = max(seasons)
+            league_row = League.query.filter_by(league_id=args.league).first()
+            if not league_row:
+                print(f'\n  [FAIL] League {args.league} not found in DB. Run sync-teams first.')
+                sys.exit(1)
+            league_teams = Team.query.filter_by(
+                league_id=league_row.id, season=season_for_lookup
+            ).all()
+            if not league_teams:
+                print(f'\n  [FAIL] No teams found for league {args.league} season {season_for_lookup}.')
+                print(f'  Run: POST /api/sync-teams/{season_for_lookup}')
+                sys.exit(1)
+            team_ids = [t.team_id for t in league_teams if t.team_id not in exclude_ids]
+            print(f'\n  Discovered {len(team_ids)} teams from league {league_row.name} '
+                  f'(season {season_for_lookup}, excluded {len(exclude_ids)})')
         print('\n' + '='*60)
         print('  FULL ACADEMY REBUILD')
         print('='*60)

--- a/loan-army-backend/src/routes/api.py
+++ b/loan-army-backend/src/routes/api.py
@@ -10066,18 +10066,35 @@ def admin_bulk_update_team_tracking():
                 return jsonify({'error': 'team_ids or all=true required'}), 400
             teams = Team.query.filter(Team.id.in_(team_ids)).all()
         
+        # Capture previous tracking state before updating
+        was_tracked = {t.id: t.is_tracked for t in teams}
+
         updated_count = 0
         for team in teams:
             if team.id not in exclude_ids:
                 team.is_tracked = is_tracked
                 updated_count += 1
-        
+
         db.session.commit()
-        return jsonify({
+
+        # Auto-seed newly tracked teams in background
+        seed_job_ids = []
+        if is_tracked:
+            newly_tracked = [t for t in teams
+                             if t.id not in exclude_ids and not was_tracked.get(t.id, False)]
+            for team in newly_tracked:
+                job_id = _start_background_seed(team.id)
+                seed_job_ids.append({'team': team.name, 'job_id': job_id})
+
+        response = {
             'message': f'Updated {updated_count} teams',
             'is_tracked': is_tracked,
-            'updated_count': updated_count
-        })
+            'updated_count': updated_count,
+        }
+        if seed_job_ids:
+            response['seed_jobs'] = seed_job_ids
+            response['message'] += f' (seeding {len(seed_job_ids)} newly tracked teams)'
+        return jsonify(response)
     except Exception as e:
         logger.exception('admin_bulk_update_team_tracking failed')
         db.session.rollback()
@@ -14392,7 +14409,20 @@ def _run_seed_team_process(job_id, team_id, max_age=30, sync_journeys=True, year
                            completed_at=datetime.now(timezone.utc).isoformat())
                 return
             update_job(job_id, status='running', progress=0, total=1,
-                       current_player=f'Seeding {team.name}...')
+                       current_player=f'Discovering cohorts for {team.name}...')
+
+            # Phase 1: Cohort discovery (youth league data)
+            try:
+                from src.services.big6_seeding_service import run_big6_seed
+                now = datetime.now()
+                current_season = now.year if now.month >= 8 else now.year - 1
+                run_big6_seed(job_id, seasons=[current_season], team_ids=[team.team_id])
+            except Exception as cohort_err:
+                logger.warning('Cohort discovery for %s failed (continuing with squad seed): %s',
+                               team.name, cohort_err)
+
+            # Phase 2: TrackedPlayer seeding from cohorts + squads
+            update_job(job_id, current_player=f'Seeding {team.name}...')
             result = _seed_single_team(team, max_age=max_age,
                                        sync_journeys=sync_journeys, years=years)
             update_job(job_id, status='completed', progress=1, total=1,
@@ -14435,6 +14465,20 @@ def _run_seed_all_tracked_process(job_id, max_age=30, sync_journeys=True, years=
             empty_teams = [t for t in teams
                            if TrackedPlayer.query.filter_by(team_id=t.id, is_active=True).count() == 0]
             update_job(job_id, status='running', progress=0, total=len(empty_teams))
+
+            # Phase 1: Cohort discovery for all empty teams
+            try:
+                from src.services.big6_seeding_service import run_big6_seed
+                now = datetime.now()
+                current_season = now.year if now.month >= 8 else now.year - 1
+                team_api_ids = [t.team_id for t in empty_teams]
+                update_job(job_id, current_player='Discovering cohorts for all teams...')
+                run_big6_seed(job_id, seasons=[current_season], team_ids=team_api_ids)
+            except Exception as cohort_err:
+                logger.warning('Bulk cohort discovery failed (continuing with squad seed): %s',
+                               cohort_err)
+
+            # Phase 2: TrackedPlayer seeding per team
             results = {'teams': {}, 'errors': []}
             for i, team in enumerate(empty_teams):
                 if is_job_cancelled(job_id):

--- a/loan-army-backend/src/routes/teams.py
+++ b/loan-army-backend/src/routes/teams.py
@@ -141,9 +141,9 @@ def get_teams():
         # Handle has_loans filter
         has_loans = request.args.get('has_loans', '').lower() == 'true'
         if has_loans:
-            logger.info("Filtering for teams with active loans")
-            query = query.join(LoanedPlayer, Team.id == LoanedPlayer.primary_team_id)\
-                        .filter(LoanedPlayer.is_active == True)\
+            logger.info("Filtering for teams with active tracked players")
+            query = query.join(TrackedPlayer, Team.id == TrackedPlayer.team_id)\
+                        .filter(TrackedPlayer.is_active.is_(True))\
                         .distinct()
 
         # Handle search filter (for global search)

--- a/loan-army-backend/src/services/gol_guardrails.py
+++ b/loan-army-backend/src/services/gol_guardrails.py
@@ -1,0 +1,140 @@
+"""Guardrails AI integration for GOL chatbot safety.
+
+Provides input validation (prompt injection, topic restriction) and
+output validation (toxicity, PII redaction) using guardrails-ai validators.
+
+Install validators:
+    guardrails hub install hub://guardrails/detect_jailbreak
+    guardrails hub install hub://guardrails/toxic_language
+    guardrails hub install hub://guardrails/detect_pii
+    guardrails hub install hub://guardrails/profanity_free
+    guardrails hub install hub://guardrails/restrict_to_topic
+"""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_ENABLED = None
+_input_guard = None
+_output_guard = None
+
+REJECTION_MESSAGE = (
+    "I can only help with football and academy-related questions. "
+    "Try asking about players, loans, academies, or match stats!"
+)
+
+
+def _is_enabled() -> bool:
+    """Check if guardrails is enabled and available."""
+    global _ENABLED
+    if _ENABLED is not None:
+        return _ENABLED
+
+    if not os.getenv('GUARDRAILS_ENABLED', '').lower() in ('1', 'true', 'yes'):
+        logger.info("Guardrails disabled (set GUARDRAILS_ENABLED=true to enable)")
+        _ENABLED = False
+        return False
+
+    try:
+        import guardrails  # noqa: F401
+        _ENABLED = True
+        logger.info("Guardrails AI enabled")
+    except ImportError:
+        logger.warning("guardrails-ai not installed — guardrails disabled")
+        _ENABLED = False
+
+    return _ENABLED
+
+
+def _get_input_guard():
+    """Lazy-init the input guard (validates user messages)."""
+    global _input_guard
+    if _input_guard is not None:
+        return _input_guard
+
+    from guardrails import Guard
+    from guardrails.hub import DetectJailbreak, RestrictToTopic
+
+    _input_guard = Guard(name="gol_input").use_many(
+        DetectJailbreak(on_fail="exception"),
+        RestrictToTopic(
+            valid_topics=[
+                "football", "soccer", "players", "academies",
+                "loans", "transfers", "premier league", "statistics",
+                "teams", "managers", "coaches", "matches", "fixtures",
+                "goals", "assists", "ratings", "performance",
+                "career", "youth development", "scouting",
+            ],
+            disable_llm=True,
+            on_fail="exception",
+        ),
+    )
+    return _input_guard
+
+
+def _get_output_guard():
+    """Lazy-init the output guard (validates LLM responses)."""
+    global _output_guard
+    if _output_guard is not None:
+        return _output_guard
+
+    from guardrails import Guard
+    from guardrails.hub import ToxicLanguage, ProfanityFree, DetectPII
+
+    _output_guard = Guard(name="gol_output").use_many(
+        ToxicLanguage(threshold=0.7, on_fail="fix"),
+        ProfanityFree(on_fail="fix"),
+        DetectPII(
+            pii_entities=["EMAIL_ADDRESS", "PHONE_NUMBER", "CREDIT_CARD"],
+            on_fail="fix",
+        ),
+    )
+    return _output_guard
+
+
+def validate_input(message: str) -> tuple[bool, str | None]:
+    """Validate user input before sending to LLM.
+
+    Returns:
+        (is_safe, rejection_reason) — if is_safe is False, rejection_reason
+        contains a user-friendly message to return instead of calling the LLM.
+    """
+    if not _is_enabled():
+        return True, None
+
+    try:
+        guard = _get_input_guard()
+        result = guard.parse(message)
+        if result.validation_passed:
+            return True, None
+        logger.info(f"Input guard rejected message: {message[:80]}")
+        return False, REJECTION_MESSAGE
+    except Exception as e:
+        logger.warning(f"Input guard triggered: {e}")
+        return False, REJECTION_MESSAGE
+
+
+def validate_output(text: str) -> str:
+    """Validate and sanitize LLM output.
+
+    Returns the cleaned text. If the guard can't run or errors,
+    returns the original text (fail-open for output).
+    """
+    if not _is_enabled():
+        return text
+
+    if not text or not text.strip():
+        return text
+
+    try:
+        guard = _get_output_guard()
+        result = guard.parse(text)
+        cleaned = result.validated_output
+        if cleaned and cleaned != text:
+            logger.info("Output guard modified LLM response")
+        return cleaned or text
+    except Exception as e:
+        logger.warning(f"Output guard error (fail-open): {e}")
+        return text

--- a/loan-army-backend/src/services/gol_service.py
+++ b/loan-army-backend/src/services/gol_service.py
@@ -16,6 +16,7 @@ from sqlalchemy import func
 from src.models.league import db
 from src.models.tracked_player import TrackedPlayer
 from src.services.gol_dataframes import DataFrameCache
+from src.services.gol_guardrails import validate_input, validate_output
 from src.services.gol_sandbox import execute_analysis
 
 logger = logging.getLogger(__name__)
@@ -358,6 +359,13 @@ class GolService:
             Dict events: {event: str, data: dict}
         """
         try:
+            # --- Input Guard: block jailbreaks and off-topic abuse ---
+            is_safe, rejection = validate_input(message)
+            if not is_safe:
+                yield {"event": "token", "data": {"content": rejection}}
+                yield {"event": "done", "data": {}}
+                return
+
             messages = [{"role": "system", "content": SYSTEM_PROMPT}]
 
             # Add history (cap at 20 messages = 10 turns)
@@ -470,6 +478,11 @@ class GolService:
                 return
 
             if finish_reason == "stop":
+                # --- Output Guard: sanitize toxic content / PII ---
+                if content_buffer:
+                    cleaned = validate_output(content_buffer)
+                    if cleaned != content_buffer:
+                        yield {"event": "replace", "data": {"content": cleaned}}
                 yield {"event": "done", "data": {}}
                 return
 

--- a/loan-army-frontend/src/hooks/useGolChat.js
+++ b/loan-army-frontend/src/hooks/useGolChat.js
@@ -59,6 +59,15 @@ export function useGolChat() {
                   updated[updated.length - 1] = last
                   return updated
                 })
+              } else if (eventType === 'replace') {
+                // Output guard corrected the response — swap content
+                setMessages(prev => {
+                  const updated = [...prev]
+                  const last = { ...updated[updated.length - 1] }
+                  last.content = data.content || ''
+                  updated[updated.length - 1] = last
+                  return updated
+                })
               } else if (eventType === 'data_card') {
                 setMessages(prev => {
                   const updated = [...prev]

--- a/loan-army-frontend/src/lib/api.js
+++ b/loan-army-frontend/src/lib/api.js
@@ -1610,6 +1610,13 @@ export class APIService {
         }, { admin: true })
     }
 
+    static async adminSeedAllTrackedPlayers(data = {}) {
+        return this.request('/admin/tracked-players/seed-all-tracked', {
+            method: 'POST',
+            body: JSON.stringify(data),
+        }, { admin: true })
+    }
+
     static async adminSeedBig6(data = {}) {
         return this.request('/admin/cohorts/seed-big6', {
             method: 'POST',

--- a/loan-army-frontend/src/pages/admin/AdminTeams.jsx
+++ b/loan-army-frontend/src/pages/admin/AdminTeams.jsx
@@ -31,7 +31,8 @@ import {
   Wand2,
   LayoutGrid,
   MoreVertical,
-  ChevronsUpDown
+  ChevronsUpDown,
+  Sprout
 } from 'lucide-react'
 import {
   DropdownMenu,
@@ -81,6 +82,9 @@ export function AdminTeams() {
   const [bulkFixDryRun, setBulkFixDryRun] = useState(true)
   const [propagating, setPropagating] = useState(false)
   const [propagateDryRun, setPropagateDryRun] = useState(true)
+
+  // Seed all tracked state
+  const [seedingAll, setSeedingAll] = useState(false)
 
   // Sync fixtures state
   const [syncingTeamId, setSyncingTeamId] = useState(null)
@@ -266,6 +270,26 @@ export function AdminTeams() {
       }
       return next
     })
+  }
+
+  const handleSeedUnseeded = async () => {
+    setSeedingAll(true)
+    setMessage(null)
+    try {
+      const res = await APIService.adminSeedAllTrackedPlayers()
+      if (res.empty_teams === 0) {
+        setMessage({ type: 'info', text: 'All tracked teams already have players seeded.' })
+      } else {
+        setMessage({
+          type: 'success',
+          text: `Seeding started for ${res.teams_to_seed} team(s). Job ID: ${res.job_id}`,
+        })
+      }
+    } catch (err) {
+      setMessage({ type: 'error', text: `Seed failed: ${err.message}` })
+    } finally {
+      setSeedingAll(false)
+    }
   }
 
   const selectAllTracked = () => {
@@ -715,6 +739,14 @@ export function AdminTeams() {
               </CardDescription>
               <CardAction>
                 <div className="flex items-center gap-1">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleSeedUnseeded} disabled={seedingAll} aria-label="Seed unseeded teams">
+                        {seedingAll ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sprout className="h-4 w-4" />}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Seed Unseeded Teams</TooltipContent>
+                  </Tooltip>
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <Button variant="ghost" size="icon" className="h-8 w-8" onClick={selectAllTracked} aria-label="Select all">


### PR DESCRIPTION
## Summary
- **Auto-seed on bulk tracking**: When teams are bulk-marked as tracked, background seed jobs now launch automatically for newly tracked teams
- **Comprehensive seeding with cohort discovery**: All seed processes now run `run_big6_seed` (youth league cohort discovery) before TrackedPlayer seeding, giving every team — not just Big 6 — full youth league coverage
- **UI fallback button**: Added "Seed Unseeded Teams" (sprout icon) to the Tracked Teams card in AdminTeams for manually triggering seeding of any teams that were missed

## Test plan
- [ ] Verify "Seed Unseeded Teams" button appears in admin/teams Tracked Teams card header
- [ ] Click the button — confirm it shows success message with job ID and team count (or "already seeded" message)
- [ ] Bulk-track a previously untracked team — verify background seed job starts (check response includes `seed_jobs`)
- [ ] Verify cohort discovery errors are non-fatal (seed continues with squad-based data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)