### PR TITLE
fix: Prevent auto-seed regressions in bulk tracking and seed-all

### DIFF
--- a/loan-army-backend/src/routes/api.py
+++ b/loan-army-backend/src/routes/api.py
@@ -10066,18 +10066,48 @@ def admin_bulk_update_team_tracking():
                 return jsonify({'error': 'team_ids or all=true required'}), 400
             teams = Team.query.filter(Team.id.in_(team_ids)).all()
         
+        # Capture previous tracking state before updating
+        was_tracked = {t.id: t.is_tracked for t in teams}
+
         updated_count = 0
         for team in teams:
             if team.id not in exclude_ids:
                 team.is_tracked = is_tracked
                 updated_count += 1
-        
+
         db.session.commit()
-        return jsonify({
+
+        # Auto-seed newly tracked teams in a single background process
+        seed_info = None
+        if is_tracked:
+            newly_tracked = [t for t in teams
+                             if t.id not in exclude_ids and not was_tracked.get(t.id, False)]
+            if newly_tracked:
+                import multiprocessing
+                job_id = _create_background_job('seed_bulk_tracked')
+                team_db_ids = [t.id for t in newly_tracked]
+                p = multiprocessing.Process(
+                    target=_run_seed_teams_process,
+                    args=(job_id, team_db_ids),
+                    daemon=False,
+                )
+                p.start()
+                multiprocessing.process._children.discard(p)
+                seed_info = {
+                    'job_id': job_id,
+                    'teams_to_seed': len(newly_tracked),
+                    'team_names': [t.name for t in newly_tracked],
+                }
+
+        response = {
             'message': f'Updated {updated_count} teams',
             'is_tracked': is_tracked,
-            'updated_count': updated_count
-        })
+            'updated_count': updated_count,
+        }
+        if seed_info:
+            response['seed_job'] = seed_info
+            response['message'] += f' (seeding {seed_info["teams_to_seed"]} newly tracked teams)'
+        return jsonify(response)
     except Exception as e:
         logger.exception('admin_bulk_update_team_tracking failed')
         db.session.rollback()
@@ -14405,6 +14435,90 @@ def _run_seed_team_process(job_id, team_id, max_age=30, sync_journeys=True, year
                        completed_at=datetime.now(timezone.utc).isoformat())
 
 
+def _run_seed_teams_process(job_id, team_db_ids, max_age=30, sync_journeys=True, years=4):
+    """Background worker: seed a specific list of teams (cohort discovery + TrackedPlayers).
+
+    Unlike _run_seed_all_tracked_process, this processes ALL specified teams
+    regardless of existing TrackedPlayer rows — suitable for bulk-tracking
+    where re-enabled teams need cohort refresh.
+    """
+    import signal
+    import sys
+    logging.basicConfig(
+        stream=sys.stderr, level=logging.INFO,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', force=True,
+    )
+    from src.main import app
+
+    def _sigterm_handler(signum, frame):
+        try:
+            with app.app_context():
+                from src.utils.background_jobs import update_job as _upd
+                _upd(job_id, status='failed',
+                     error='Process terminated (SIGTERM)',
+                     completed_at=datetime.now(timezone.utc).isoformat())
+        except Exception:
+            pass
+        sys.exit(1)
+
+    signal.signal(signal.SIGTERM, _sigterm_handler)
+
+    with app.app_context():
+        from src.utils.background_jobs import update_job, is_job_cancelled
+        try:
+            target_teams = Team.query.filter(Team.id.in_(team_db_ids)).all()
+            if not target_teams:
+                update_job(job_id, status='completed', progress=0, total=0,
+                           results={'teams': {}, 'errors': []},
+                           completed_at=datetime.now(timezone.utc).isoformat())
+                return
+
+            update_job(job_id, status='running', progress=0, total=len(target_teams))
+
+            # Phase 1: Cohort discovery for all target teams
+            try:
+                from src.services.big6_seeding_service import run_big6_seed
+                now = datetime.now()
+                current_season = now.year if now.month >= 8 else now.year - 1
+                team_api_ids = [t.team_id for t in target_teams]
+                update_job(job_id, current_player='Discovering cohorts...')
+                run_big6_seed(job_id, seasons=[current_season], team_ids=team_api_ids)
+            except Exception as cohort_err:
+                logger.warning('Bulk cohort discovery failed (continuing with squad seed): %s',
+                               cohort_err)
+
+            # Phase 2: TrackedPlayer seeding per team
+            results = {'teams': {}, 'errors': []}
+            for i, team in enumerate(target_teams):
+                if is_job_cancelled(job_id):
+                    update_job(job_id, status='cancelled',
+                               error=f'Cancelled after {i}/{len(target_teams)} teams',
+                               results=results,
+                               completed_at=datetime.now(timezone.utc).isoformat())
+                    return
+                update_job(job_id, progress=i, total=len(target_teams),
+                           current_player=f'Seeding {team.name}...')
+                try:
+                    team_result = _seed_single_team(team, max_age=max_age,
+                                                     sync_journeys=sync_journeys, years=years)
+                    results['teams'][team.name] = {
+                        'created': team_result.get('created', 0),
+                        'skipped': team_result.get('skipped', 0),
+                        'candidates': team_result.get('candidates_found', 0),
+                    }
+                except Exception as team_err:
+                    logger.warning('seed_teams: failed for %s: %s', team.name, team_err)
+                    results['errors'].append(f'{team.name}: {team_err}')
+            update_job(job_id, status='completed', progress=len(target_teams),
+                       total=len(target_teams), results=results,
+                       completed_at=datetime.now(timezone.utc).isoformat())
+        except Exception as e:
+            logger.exception('Background seed-teams failed')
+            db.session.rollback()
+            update_job(job_id, status='failed', error=str(e),
+                       completed_at=datetime.now(timezone.utc).isoformat())
+
+
 def _run_seed_all_tracked_process(job_id, max_age=30, sync_journeys=True, years=4):
     """Background worker: seed all tracked teams that have no TrackedPlayers."""
     import signal
@@ -14434,7 +14548,28 @@ def _run_seed_all_tracked_process(job_id, max_age=30, sync_journeys=True, years=
             teams = Team.query.filter_by(is_tracked=True, is_active=True).all()
             empty_teams = [t for t in teams
                            if TrackedPlayer.query.filter_by(team_id=t.id, is_active=True).count() == 0]
+
+            if not empty_teams:
+                update_job(job_id, status='completed', progress=0, total=0,
+                           results={'teams': {}, 'errors': []},
+                           completed_at=datetime.now(timezone.utc).isoformat())
+                return
+
             update_job(job_id, status='running', progress=0, total=len(empty_teams))
+
+            # Phase 1: Cohort discovery for all empty teams
+            try:
+                from src.services.big6_seeding_service import run_big6_seed
+                now = datetime.now()
+                current_season = now.year if now.month >= 8 else now.year - 1
+                team_api_ids = [t.team_id for t in empty_teams]
+                update_job(job_id, current_player='Discovering cohorts for all teams...')
+                run_big6_seed(job_id, seasons=[current_season], team_ids=team_api_ids)
+            except Exception as cohort_err:
+                logger.warning('Bulk cohort discovery failed (continuing with squad seed): %s',
+                               cohort_err)
+
+            # Phase 2: TrackedPlayer seeding per team
             results = {'teams': {}, 'errors': []}
             for i, team in enumerate(empty_teams):
                 if is_job_cancelled(job_id):

--- a/loan-army-frontend/src/lib/api.js
+++ b/loan-army-frontend/src/lib/api.js
@@ -1610,6 +1610,13 @@ export class APIService {
         }, { admin: true })
     }
 
+    static async adminSeedAllTrackedPlayers(data = {}) {
+        return this.request('/admin/tracked-players/seed-all-tracked', {
+            method: 'POST',
+            body: JSON.stringify(data),
+        }, { admin: true })
+    }
+
     static async adminSeedBig6(data = {}) {
         return this.request('/admin/cohorts/seed-big6', {
             method: 'POST',

--- a/loan-army-frontend/src/pages/admin/AdminTeams.jsx
+++ b/loan-army-frontend/src/pages/admin/AdminTeams.jsx
@@ -31,7 +31,8 @@ import {
   Wand2,
   LayoutGrid,
   MoreVertical,
-  ChevronsUpDown
+  ChevronsUpDown,
+  Sprout
 } from 'lucide-react'
 import {
   DropdownMenu,
@@ -81,6 +82,9 @@ export function AdminTeams() {
   const [bulkFixDryRun, setBulkFixDryRun] = useState(true)
   const [propagating, setPropagating] = useState(false)
   const [propagateDryRun, setPropagateDryRun] = useState(true)
+
+  // Seed all tracked state
+  const [seedingAll, setSeedingAll] = useState(false)
 
   // Sync fixtures state
   const [syncingTeamId, setSyncingTeamId] = useState(null)
@@ -266,6 +270,26 @@ export function AdminTeams() {
       }
       return next
     })
+  }
+
+  const handleSeedUnseeded = async () => {
+    setSeedingAll(true)
+    setMessage(null)
+    try {
+      const res = await APIService.adminSeedAllTrackedPlayers()
+      if (res.empty_teams === 0) {
+        setMessage({ type: 'info', text: 'All tracked teams already have players seeded.' })
+      } else {
+        setMessage({
+          type: 'success',
+          text: `Seeding started for ${res.teams_to_seed} team(s). Job ID: ${res.job_id}`,
+        })
+      }
+    } catch (err) {
+      setMessage({ type: 'error', text: `Seed failed: ${err.message}` })
+    } finally {
+      setSeedingAll(false)
+    }
   }
 
   const selectAllTracked = () => {
@@ -715,6 +739,14 @@ export function AdminTeams() {
               </CardDescription>
               <CardAction>
                 <div className="flex items-center gap-1">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleSeedUnseeded} disabled={seedingAll} aria-label="Seed unseeded teams">
+                        {seedingAll ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sprout className="h-4 w-4" />}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Seed Unseeded Teams</TooltipContent>
+                  </Tooltip>
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <Button variant="ghost" size="icon" className="h-8 w-8" onClick={selectAllTracked} aria-label="Select all">


### PR DESCRIPTION
## Summary
- **Re-enabled teams skipped**: Bulk-tracking was using `_run_seed_all_tracked_process` which filters to only teams with zero TrackedPlayers. Re-enabling tracking for teams that still had rows would silently skip cohort discovery and player refresh. Added a dedicated `_run_seed_teams_process` that processes all specified teams regardless of existing rows.
- **Empty list → Big 6 fallback**: `_run_seed_all_tracked_process` passed `team_ids=[]` to `run_big6_seed` when no empty teams remained (e.g. filled by a concurrent job). `run_big6_seed` treats falsy `team_ids` as "use Big 6 defaults", unexpectedly seeding unrelated clubs. Added early-return guard.
- **Re-applied frontend changes**: Seed Unseeded button and `adminSeedAllTrackedPlayers` API method that were lost on merge.

## Test plan
- [ ] Bulk-track a team that was previously tracked and still has TrackedPlayer rows — verify cohort discovery + seed runs (not skipped)
- [ ] Run seed-all-tracked when all tracked teams already have players — verify job completes immediately with `progress=0`
- [ ] Verify "Seed Unseeded Teams" button appears in admin/teams

🤖 Generated with [Claude Code](https://claude.com/claude-code)