### PR TITLE
fix: Remove guardrails-ai conflict and skip inactive teams in bulk-seed

### DIFF
--- a/loan-army-backend/requirements.txt
+++ b/loan-army-backend/requirements.txt
@@ -20,7 +20,6 @@ Flask-SQLAlchemy==3.1.1
 flask-talisman==1.1.0
 fonttools==4.61.1
 greenlet==3.2.3
-guardrails-ai>=0.5.0
 griffe==1.10.0
 groq==0.32.0
 gunicorn==22.0.0

--- a/loan-army-backend/src/routes/api.py
+++ b/loan-army-backend/src/routes/api.py
@@ -10081,7 +10081,9 @@ def admin_bulk_update_team_tracking():
         seed_info = None
         if is_tracked:
             newly_tracked = [t for t in teams
-                             if t.id not in exclude_ids and not was_tracked.get(t.id, False)]
+                             if t.id not in exclude_ids
+                             and t.is_active
+                             and not was_tracked.get(t.id, False)]
             if newly_tracked:
                 import multiprocessing
                 job_id = _create_background_job('seed_bulk_tracked')

--- a/loan-army-backend/src/services/gol_service.py
+++ b/loan-army-backend/src/services/gol_service.py
@@ -16,7 +16,6 @@ from sqlalchemy import func
 from src.models.league import db
 from src.models.tracked_player import TrackedPlayer
 from src.services.gol_dataframes import DataFrameCache
-from src.services.gol_guardrails import validate_input, validate_output
 from src.services.gol_sandbox import execute_analysis
 
 logger = logging.getLogger(__name__)
@@ -359,13 +358,6 @@ class GolService:
             Dict events: {event: str, data: dict}
         """
         try:
-            # --- Input Guard: block jailbreaks and off-topic abuse ---
-            is_safe, rejection = validate_input(message)
-            if not is_safe:
-                yield {"event": "token", "data": {"content": rejection}}
-                yield {"event": "done", "data": {}}
-                return
-
             messages = [{"role": "system", "content": SYSTEM_PROMPT}]
 
             # Add history (cap at 20 messages = 10 turns)
@@ -478,11 +470,6 @@ class GolService:
                 return
 
             if finish_reason == "stop":
-                # --- Output Guard: sanitize toxic content / PII ---
-                if content_buffer:
-                    cleaned = validate_output(content_buffer)
-                    if cleaned != content_buffer:
-                        yield {"event": "replace", "data": {"content": cleaned}}
                 yield {"event": "done", "data": {}}
                 return
 


### PR DESCRIPTION
## Summary
- **Remove `guardrails-ai`** from `requirements.txt` — it conflicts with `openai-agents` over `griffe` version bounds, blocking all deployments since PR #5
- **Strip guardrails call sites** from `gol_service.py` (input/output guard blocks and import). The `gol_guardrails.py` module stays as dead code for future re-enablement.
- **Filter inactive teams** in `admin_bulk_update_team_tracking` — add `t.is_active` check to `newly_tracked` so archived teams are not auto-seeded

## Test plan
- [ ] Verify deployment succeeds on GitHub Actions (guardrails-ai conflict resolved)
- [ ] Bulk-track with `all=true` and confirm only active teams are seeded
- [ ] GOL chat still works without guardrails (input/output pass through directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)