### PR TITLE
fix: Correct academy player classification

### DIFF
--- a/loan-army-backend/src/routes/api.py
+++ b/loan-army-backend/src/routes/api.py
@@ -13839,6 +13839,381 @@ def admin_test_classify():
         return jsonify(_safe_error_payload(e, 'Classification failed')), 500
 
 
+@api_bp.route('/admin/players/explain-academy', methods=['POST'])
+@require_api_key
+def admin_explain_academy():
+    """Explain why a player is (or isn't) classified as an academy product.
+
+    Shows the full evidence chain: youth entries, entry_type classification
+    reasoning, name resolution, academy_club_ids, and TrackedPlayer rows.
+
+    Body: { player_api_id: int, team_api_id?: int, force_sync?: bool }
+    """
+    data = request.get_json() or {}
+    player_api_id = data.get('player_api_id')
+    if not player_api_id:
+        return jsonify({'error': 'player_api_id is required'}), 400
+    try:
+        player_api_id = int(player_api_id)
+    except (ValueError, TypeError):
+        return jsonify({'error': 'player_api_id must be an integer'}), 400
+
+    team_api_id = data.get('team_api_id')
+    if team_api_id:
+        team_api_id = int(team_api_id)
+    force_sync = data.get('force_sync', False)
+
+    try:
+        from src.models.journey import PlayerJourney, PlayerJourneyEntry
+        from src.services.journey_sync import JourneySyncService
+        from src.api_football_client import APIFootballClient, is_new_loan_transfer, LOAN_RETURN_TYPES
+        from src.utils.academy_classifier import strip_youth_suffix
+
+        api = APIFootballClient()
+        service = JourneySyncService(api)
+
+        journey = PlayerJourney.query.filter_by(player_api_id=player_api_id).first()
+        if not journey or force_sync:
+            journey = service.sync_player(player_api_id, force_full=force_sync)
+        if not journey:
+            return jsonify({'error': f'No journey data for player {player_api_id}'}), 404
+
+        entries = PlayerJourneyEntry.query.filter_by(
+            journey_id=journey.id
+        ).order_by(PlayerJourneyEntry.season, PlayerJourneyEntry.sort_priority).all()
+
+        # Replay _apply_development_classification reasoning
+        first_team_debut_by_club = {}
+        for e in entries:
+            if e.level == 'First Team' and not e.is_international:
+                base = strip_youth_suffix(e.club_name)
+                if base not in first_team_debut_by_club or e.season < first_team_debut_by_club[base]:
+                    first_team_debut_by_club[base] = e.season
+
+        # Detect permanent transfer destinations
+        raw_transfers = api.get_player_transfers(player_api_id)
+        transfers = flatten_transfers(raw_transfers)
+        permanent_dest_ids = set()
+        permanent_dest_info = []
+        for t in (transfers or []):
+            ttype = (t.get('type') or '').strip().lower()
+            if not ttype or is_new_loan_transfer(ttype) or ttype in LOAN_RETURN_TYPES:
+                continue
+            teams = t.get('teams', {})
+            dest = teams.get('in', {})
+            dest_id = dest.get('id')
+            if dest_id:
+                permanent_dest_ids.add(dest_id)
+                permanent_dest_info.append({
+                    'date': t.get('date'),
+                    'type': t.get('type'),
+                    'from': teams.get('out', {}).get('name'),
+                    'to': dest.get('name'),
+                    'to_id': dest_id,
+                })
+
+        # Parse birth year
+        birth_year = None
+        if journey.birth_date:
+            try:
+                birth_year = int(str(journey.birth_date)[:4])
+            except (ValueError, TypeError):
+                pass
+
+        # Track earliest youth season per club
+        earliest_youth = {}
+        for e in entries:
+            if e.is_youth and not e.is_international:
+                base = strip_youth_suffix(e.club_name)
+                if base not in earliest_youth or e.season < earliest_youth[base]:
+                    earliest_youth[base] = e.season
+
+        # Build detailed entry analysis
+        entry_analysis = []
+        for e in entries:
+            analysis = {
+                'season': e.season,
+                'club_name': e.club_name,
+                'club_api_id': e.club_api_id,
+                'league_name': e.league_name,
+                'league_country': getattr(e, 'league_country', None),
+                'level': e.level,
+                'entry_type': e.entry_type,
+                'is_youth': e.is_youth,
+                'is_international': e.is_international,
+                'appearances': e.appearances,
+            }
+            if e.is_youth and not e.is_international:
+                base = strip_youth_suffix(e.club_name)
+                reasons = []
+                if e.entry_type == 'integration':
+                    for club, debut in first_team_debut_by_club.items():
+                        if club != base and debut <= e.season:
+                            reasons.append(f'first-team at {club} in season {debut}')
+                            break
+                    if e.club_api_id in permanent_dest_ids:
+                        reasons.append('permanent transfer destination')
+                    if birth_year:
+                        first_s = earliest_youth.get(base)
+                        if first_s and (first_s - birth_year) >= 21:
+                            reasons.append(f'age {first_s - birth_year} at first youth appearance')
+                    if not reasons:
+                        reasons.append('classified by journey sync')
+                elif e.entry_type == 'development':
+                    same_debut = first_team_debut_by_club.get(base)
+                    if same_debut is not None:
+                        reasons.append(f'first-team debut at same club in season {same_debut}')
+                elif e.entry_type == 'academy':
+                    reasons.append('genuine academy entry')
+                analysis['classification_reasons'] = reasons
+                analysis['included_in_academy_computation'] = (
+                    e.entry_type in ('academy', 'development')
+                )
+            entry_analysis.append(analysis)
+
+        # Academy club IDs computation trace
+        academy_entries = [
+            e for e in entries
+            if e.is_youth and not e.is_international
+            and e.entry_type in ('academy', 'development')
+        ]
+        club_apps = {}
+        for e in academy_entries:
+            base = strip_youth_suffix(e.club_name)
+            club_apps[base] = club_apps.get(base, 0) + (e.appearances or 0)
+
+        academy_computation = []
+        senior_name_to_id = {}
+        for e in entries:
+            if not e.is_youth and not e.is_international:
+                senior_name_to_id[e.club_name] = e.club_api_id
+
+        for base_name, apps in club_apps.items():
+            passed = apps >= 3
+            entry_country = None
+            for e in academy_entries:
+                if strip_youth_suffix(e.club_name) == base_name and getattr(e, 'league_country', None):
+                    entry_country = e.league_country
+                    break
+            comp = {
+                'base_name': base_name,
+                'total_youth_appearances': apps,
+                'passed_min_threshold': passed,
+                'league_country': entry_country,
+            }
+            if passed:
+                if base_name in senior_name_to_id:
+                    comp['resolution_method'] = 'senior_entry_match'
+                    comp['resolved_api_id'] = senior_name_to_id[base_name]
+                else:
+                    profile = TeamProfile.query.filter(TeamProfile.name == base_name).first()
+                    if profile:
+                        comp['resolution_method'] = 'team_profile_exact'
+                        comp['resolved_api_id'] = profile.team_id
+                    else:
+                        team_match = Team.query.filter(Team.name == base_name).first()
+                        if team_match:
+                            comp['resolution_method'] = 'team_table_exact'
+                            comp['resolved_api_id'] = team_match.team_id
+                        else:
+                            comp['resolution_method'] = 'substring_fallback_or_unresolved'
+                            comp['resolved_api_id'] = None
+            academy_computation.append(comp)
+
+        # Team-specific result
+        team_result = None
+        if team_api_id:
+            is_in = team_api_id in (journey.academy_club_ids or [])
+            team_result = {'team_api_id': team_api_id, 'is_academy_for_team': is_in}
+            if not is_in:
+                reasons = []
+                has_youth = any(
+                    e.is_youth and not e.is_international and e.club_api_id == team_api_id
+                    for e in entries
+                )
+                if not has_youth:
+                    reasons.append('No youth entries found for this team')
+                else:
+                    excluded = [
+                        e for e in entries
+                        if e.is_youth and not e.is_international
+                        and e.club_api_id == team_api_id
+                        and e.entry_type == 'integration'
+                    ]
+                    if excluded:
+                        reasons.append(f'{len(excluded)} youth entries classified as integration')
+                    below = [
+                        e for e in entries
+                        if e.is_youth and not e.is_international
+                        and e.club_api_id == team_api_id
+                        and e.entry_type in ('academy', 'development')
+                    ]
+                    if below:
+                        total = sum(e.appearances or 0 for e in below)
+                        if total < 3:
+                            reasons.append(f'Only {total} youth appearances (minimum 3 required)')
+                team_result['exclusion_reasons'] = reasons
+
+        # Existing TrackedPlayer rows
+        existing = TrackedPlayer.query.filter_by(player_api_id=player_api_id).all()
+        tracked_info = [{
+            'team_name': tp.team.name if tp.team else None,
+            'team_api_id': tp.team.team_id if tp.team else None,
+            'status': tp.status,
+            'is_active': tp.is_active,
+            'data_source': tp.data_source,
+        } for tp in existing]
+
+        return jsonify({
+            'player': {
+                'api_id': player_api_id,
+                'name': journey.player_name,
+                'birth_date': journey.birth_date,
+                'birth_year': birth_year,
+                'nationality': journey.nationality,
+            },
+            'academy_club_ids': journey.academy_club_ids or [],
+            'team_result': team_result,
+            'first_team_history': first_team_debut_by_club,
+            'permanent_transfers_in': permanent_dest_info,
+            'entries': entry_analysis,
+            'academy_computation': academy_computation,
+            'existing_tracked_players': tracked_info,
+        })
+    except Exception as e:
+        logger.exception('admin_explain_academy failed')
+        return jsonify(_safe_error_payload(e, 'Explain academy failed')), 500
+
+
+@api_bp.route('/admin/tracked-players/recompute-academy-ids', methods=['POST'])
+@require_api_key
+def admin_recompute_academy_ids():
+    """Batch recompute academy_club_ids for all journeys using updated logic.
+
+    Replays _compute_academy_club_ids() with current classification rules.
+    Players whose academy_club_ids shrinks will have orphaned TrackedPlayer
+    rows deactivated.
+
+    Body (optional): { dry_run?: bool (default true) }
+    """
+    data = request.get_json(force=True) if request.data else {}
+    dry_run = data.get('dry_run', True)
+
+    try:
+        from src.models.journey import PlayerJourney, PlayerJourneyEntry
+        from src.services.journey_sync import JourneySyncService
+        from src.utils.academy_classifier import strip_youth_suffix
+
+        service = JourneySyncService()
+
+        journeys = PlayerJourney.query.filter(
+            PlayerJourney.academy_club_ids.isnot(None),
+            db.func.jsonb_array_length(PlayerJourney.academy_club_ids) > 0,
+        ).all()
+
+        changes = []
+        unchanged = 0
+        total = len(journeys)
+
+        for journey in journeys:
+            old_ids = set(journey.academy_club_ids or [])
+
+            entries = PlayerJourneyEntry.query.filter_by(
+                journey_id=journey.id
+            ).order_by(PlayerJourneyEntry.season).all()
+
+            if not entries:
+                continue
+
+            # Fetch transfers for enhanced integration detection
+            transfers = []
+            try:
+                from src.api_football_client import APIFootballClient
+                api_client = APIFootballClient()
+                raw = api_client.get_player_transfers(journey.player_api_id)
+                transfers = flatten_transfers(raw)
+            except Exception:
+                pass
+
+            # Re-run development classification on entries
+            service._apply_development_classification(
+                entries, transfers=transfers,
+                birth_date=journey.birth_date,
+            )
+
+            # Re-run academy computation
+            if not dry_run:
+                service._compute_academy_club_ids(journey, entries, transfers=transfers)
+                new_ids = set(journey.academy_club_ids or [])
+            else:
+                # Simulate without writing
+                youth_entries = [
+                    e for e in entries
+                    if e.is_youth and not e.is_international
+                    and e.entry_type in ('academy', 'development')
+                ]
+                club_apps = {}
+                for e in youth_entries:
+                    base = strip_youth_suffix(e.club_name)
+                    club_apps[base] = club_apps.get(base, 0) + (e.appearances or 0)
+
+                new_ids = set()
+                senior_map = {}
+                for e in entries:
+                    if not e.is_youth and not e.is_international:
+                        senior_map[e.club_name] = e.club_api_id
+                for base, apps in club_apps.items():
+                    if apps >= 3 and base in senior_map:
+                        new_ids.add(senior_map[base])
+
+            removed = old_ids - new_ids
+            added = new_ids - old_ids
+
+            if removed or added:
+                changes.append({
+                    'player_api_id': journey.player_api_id,
+                    'player_name': journey.player_name,
+                    'old_academy_ids': sorted(old_ids),
+                    'new_academy_ids': sorted(new_ids),
+                    'removed': sorted(removed),
+                    'added': sorted(added),
+                })
+            else:
+                unchanged += 1
+
+        if not dry_run:
+            deactivated = 0
+            for change in changes:
+                for removed_id in change['removed']:
+                    team_rec = Team.query.filter_by(team_id=removed_id).first()
+                    if team_rec:
+                        tp = TrackedPlayer.query.filter_by(
+                            player_api_id=change['player_api_id'],
+                            team_id=team_rec.id,
+                            is_active=True,
+                        ).first()
+                        if tp:
+                            tp.is_active = False
+                            deactivated += 1
+            db.session.commit()
+        else:
+            deactivated = sum(len(c['removed']) for c in changes)
+
+        return jsonify({
+            'dry_run': dry_run,
+            'total_journeys': total,
+            'unchanged': unchanged,
+            'changed': len(changes),
+            'would_deactivate' if dry_run else 'deactivated': deactivated,
+            'changes': changes[:100],
+            'truncated': len(changes) > 100,
+        })
+    except Exception as e:
+        logger.exception('admin_recompute_academy_ids failed')
+        db.session.rollback()
+        return jsonify(_safe_error_payload(e, 'Recompute failed')), 500
+
+
 @api_bp.route('/admin/api-football/status', methods=['GET'])
 @require_api_key
 def admin_api_football_status():

--- a/loan-army-backend/src/routes/api.py
+++ b/loan-army-backend/src/routes/api.py
@@ -14115,6 +14115,13 @@ def admin_recompute_academy_ids():
         unchanged = 0
         total = len(journeys)
 
+        # Use a savepoint so dry-run can roll back all mutations
+        # (_apply_development_classification mutates entry_type,
+        # _compute_academy_club_ids writes academy_club_ids and
+        # calls _upsert_tracked_players).
+        if dry_run:
+            savepoint = db.session.begin_nested()
+
         for journey in journeys:
             old_ids = set(journey.academy_club_ids or [])
 
@@ -14141,30 +14148,11 @@ def admin_recompute_academy_ids():
                 birth_date=journey.birth_date,
             )
 
-            # Re-run academy computation
-            if not dry_run:
-                service._compute_academy_club_ids(journey, entries, transfers=transfers)
-                new_ids = set(journey.academy_club_ids or [])
-            else:
-                # Simulate without writing
-                youth_entries = [
-                    e for e in entries
-                    if e.is_youth and not e.is_international
-                    and e.entry_type in ('academy', 'development')
-                ]
-                club_apps = {}
-                for e in youth_entries:
-                    base = strip_youth_suffix(e.club_name)
-                    club_apps[base] = club_apps.get(base, 0) + (e.appearances or 0)
-
-                new_ids = set()
-                senior_map = {}
-                for e in entries:
-                    if not e.is_youth and not e.is_international:
-                        senior_map[e.club_name] = e.club_api_id
-                for base, apps in club_apps.items():
-                    if apps >= 3 and base in senior_map:
-                        new_ids.add(senior_map[base])
+            # Re-run academy computation using the real method to ensure
+            # dry-run and live results match (including all name-resolution
+            # fallbacks: TeamProfile, Team table, substring matching).
+            service._compute_academy_club_ids(journey, entries, transfers=transfers)
+            new_ids = set(journey.academy_club_ids or [])
 
             removed = old_ids - new_ids
             added = new_ids - old_ids
@@ -14181,22 +14169,13 @@ def admin_recompute_academy_ids():
             else:
                 unchanged += 1
 
-        if not dry_run:
-            deactivated = 0
-            for change in changes:
-                for removed_id in change['removed']:
-                    team_rec = Team.query.filter_by(team_id=removed_id).first()
-                    if team_rec:
-                        tp = TrackedPlayer.query.filter_by(
-                            player_api_id=change['player_api_id'],
-                            team_id=team_rec.id,
-                            is_active=True,
-                        ).first()
-                        if tp:
-                            tp.is_active = False
-                            deactivated += 1
-            db.session.commit()
+        if dry_run:
+            # Roll back all mutations — entry_type changes, academy_club_ids,
+            # and any TrackedPlayer deactivations from _upsert_tracked_players
+            savepoint.rollback()
+            deactivated = sum(len(c['removed']) for c in changes)
         else:
+            db.session.commit()
             deactivated = sum(len(c['removed']) for c in changes)
 
         return jsonify({

--- a/loan-army-backend/src/services/journey_sync.py
+++ b/loan-army-backend/src/services/journey_sync.py
@@ -801,6 +801,8 @@ class JourneySyncService:
         ]
         if not youth_entries:
             journey.academy_club_ids = []
+            # Deactivate any stale tracked-player rows from prior runs
+            self._upsert_tracked_players(journey, set(), transfers=transfers)
             return
 
         # ── Minimum youth appearances threshold ──
@@ -818,6 +820,8 @@ class JourneySyncService:
         ]
         if not youth_entries:
             journey.academy_club_ids = []
+            # Deactivate any stale tracked-player rows from prior runs
+            self._upsert_tracked_players(journey, set(), transfers=transfers)
             return
 
         # Build lookup: base_name -> api_id from non-youth, non-international entries

--- a/loan-army-backend/src/services/journey_sync.py
+++ b/loan-army-backend/src/services/journey_sync.py
@@ -40,7 +40,8 @@ class JourneySyncService:
         'U18': ['u18', 'under 18', 'under-18', 'youth cup'],
         'U19': ['u19', 'under 19', 'under-19', 'youth league'],
         'U21': ['u21', 'under 21', 'under-21'],
-        'U23': ['u23', 'under 23', 'under-23', 'premier league 2', 'pl2', 'development'],
+        'U23': ['u23', 'under 23', 'under-23', 'premier league 2', 'pl2',
+                'development squad', 'development league', 'efl development'],
         'Reserve': ['reserve', 'b team', ' ii', ' b ', 'second team'],
     }
     
@@ -160,9 +161,12 @@ class JourneySyncService:
             # don't already have one (ensures current-club tiebreaker works)
             self._apply_permanent_transfer_dates(all_entries, transfers)
 
-            # Reclassify youth entries as 'development' where the player
-            # already had first-team appearances at the same parent club
-            self._apply_development_classification(all_entries)
+            # Reclassify youth entries as 'development' or 'integration'
+            # based on first-team history, transfer records, and age
+            self._apply_development_classification(
+                all_entries, transfers=transfers,
+                birth_date=(player_info or {}).get('birth', {}).get('date'),
+            )
 
             # Update player info
             if player_info:
@@ -569,7 +573,8 @@ class JourneySyncService:
                     f"season {entry.season} (from permanent transfer)"
                 )
 
-    def _apply_development_classification(self, entries: list):
+    def _apply_development_classification(self, entries: list, transfers=None,
+                                          birth_date=None):
         """
         Reclassify youth 'academy' entries based on the player's career context.
 
@@ -582,6 +587,11 @@ class JourneySyncService:
         - 'integration': player had first-team apps at a DIFFERENT club
           before this youth entry — bought player being integrated
           (e.g. Diallo playing Man Utd U23 after Atalanta first team).
+
+        Enhanced detection uses three signals:
+        1. Journey entries (original): first-team at another club in data
+        2. Transfer records: permanent transfer TO this club = not academy
+        3. Age at entry: first appearance at club aged 21+ = not academy
         """
         # Build lookup: parent_base_name -> earliest first-team season
         first_team_debut_by_club = {}
@@ -592,35 +602,104 @@ class JourneySyncService:
                 if existing is None or entry.season < existing:
                     first_team_debut_by_club[base_name] = entry.season
 
-        if not first_team_debut_by_club:
-            return
+        # Build set of clubs the player was permanently transferred TO.
+        # A permanent transfer TO a club means the player is NOT an academy
+        # product of that club — academy products don't need to be transferred in.
+        permanent_transfer_dest_ids = set()
+        if transfers:
+            for transfer in transfers:
+                transfer_type = (transfer.get('type') or '').strip().lower()
+                # Skip loans — loan moves don't disqualify academy status
+                if not transfer_type or is_new_loan_transfer(transfer_type):
+                    continue
+                if transfer_type in LOAN_RETURN_TYPES:
+                    continue
+                # This is a permanent transfer (bought, free agent, swap, etc.)
+                teams = transfer.get('teams', {})
+                dest = teams.get('in', {})
+                dest_id = dest.get('id')
+                if dest_id:
+                    permanent_transfer_dest_ids.add(dest_id)
 
+        # Parse birth year for age-at-entry validation
+        birth_year = None
+        if birth_date:
+            try:
+                birth_year = int(str(birth_date)[:4])
+            except (ValueError, TypeError):
+                pass
+
+        # Track earliest season per club for age-based checks
+        earliest_season_at_club = {}
         for entry in entries:
-            if entry.entry_type != 'academy' or entry.is_international:
-                continue
+            if entry.is_youth and not entry.is_international:
+                base = self._strip_youth_suffix(entry.club_name)
+                existing = earliest_season_at_club.get(base)
+                if existing is None or entry.season < existing:
+                    earliest_season_at_club[base] = entry.season
 
-            parent_name = self._strip_youth_suffix(entry.club_name)
-            same_club_debut = first_team_debut_by_club.get(parent_name)
+        # Pass 1: journey-entry-based classification (original logic)
+        if first_team_debut_by_club:
+            for entry in entries:
+                if entry.entry_type != 'academy' or entry.is_international:
+                    continue
 
-            # Development: same parent club had first-team in a prior season
-            if same_club_debut is not None and entry.season > same_club_debut:
-                entry.entry_type = 'development'
-                logger.debug(
-                    f"Reclassified {entry.club_name} season {entry.season} as "
-                    f"development (first-team debut at {parent_name} in {same_club_debut})"
-                )
-                continue
+                parent_name = self._strip_youth_suffix(entry.club_name)
+                same_club_debut = first_team_debut_by_club.get(parent_name)
 
-            # Integration: first-team at a DIFFERENT club before or during
-            # this youth season (player was bought with senior experience)
-            for club_name, debut in first_team_debut_by_club.items():
-                if club_name != parent_name and debut <= entry.season:
+                # Development: same parent club had first-team in a prior season
+                if same_club_debut is not None and entry.season > same_club_debut:
+                    entry.entry_type = 'development'
+                    logger.debug(
+                        f"Reclassified {entry.club_name} season {entry.season} as "
+                        f"development (first-team debut at {parent_name} in {same_club_debut})"
+                    )
+                    continue
+
+                # Integration: first-team at a DIFFERENT club before or during
+                # this youth season (player was bought with senior experience)
+                for club_name, debut in first_team_debut_by_club.items():
+                    if club_name != parent_name and debut <= entry.season:
+                        entry.entry_type = 'integration'
+                        logger.debug(
+                            f"Reclassified {entry.club_name} season {entry.season} as "
+                            f"integration (first-team at {club_name} in {debut})"
+                        )
+                        break
+
+        # Pass 2: transfer-based integration detection
+        # If a player was permanently transferred TO a club, any youth entries
+        # at that club are integration, not academy.
+        if permanent_transfer_dest_ids:
+            for entry in entries:
+                if entry.entry_type != 'academy' or entry.is_international:
+                    continue
+                if entry.club_api_id in permanent_transfer_dest_ids:
                     entry.entry_type = 'integration'
                     logger.debug(
                         f"Reclassified {entry.club_name} season {entry.season} as "
-                        f"integration (first-team at {club_name} in {debut})"
+                        f"integration (permanent transfer destination)"
                     )
-                    break
+
+        # Pass 3: age-at-entry validation
+        # If a player's FIRST appearance at a club's youth system was at age 21+,
+        # they are not an academy product — they were bought as a senior player.
+        # Players who joined younger and continue playing U23 at 21-22 are fine.
+        if birth_year:
+            for entry in entries:
+                if entry.entry_type != 'academy' or entry.is_international:
+                    continue
+                parent_name = self._strip_youth_suffix(entry.club_name)
+                first_season = earliest_season_at_club.get(parent_name)
+                if first_season is not None:
+                    age_at_first = first_season - birth_year
+                    if age_at_first >= 21:
+                        entry.entry_type = 'integration'
+                        logger.debug(
+                            f"Reclassified {entry.club_name} season {entry.season} as "
+                            f"integration (age {age_at_first} at first youth appearance, "
+                            f"season {first_season})"
+                        )
 
     def _update_journey_aggregates(self, journey: PlayerJourney, transfers=None):
         """Update aggregate stats on the journey record"""
@@ -718,7 +797,24 @@ class JourneySyncService:
         youth_entries = [
             e for e in entries
             if e.is_youth and not e.is_international
-            and e.entry_type in ('academy', 'development', 'integration')
+            and e.entry_type in ('academy', 'development')
+        ]
+        if not youth_entries:
+            journey.academy_club_ids = []
+            return
+
+        # ── Minimum youth appearances threshold ──
+        # Clubs below threshold are excluded to filter noise / data errors.
+        MIN_ACADEMY_APPEARANCES = 3
+        club_youth_apps = {}
+        for e in youth_entries:
+            base = self._strip_youth_suffix(e.club_name)
+            club_youth_apps[base] = club_youth_apps.get(base, 0) + (e.appearances or 0)
+
+        youth_entries = [
+            e for e in youth_entries
+            if club_youth_apps.get(self._strip_youth_suffix(e.club_name), 0)
+            >= MIN_ACADEMY_APPEARANCES
         ]
         if not youth_entries:
             journey.academy_club_ids = []
@@ -730,18 +826,26 @@ class JourneySyncService:
             if not e.is_youth and not e.is_international:
                 senior_name_to_id[e.club_name] = e.club_api_id
 
+        # Collect league_country per base_name for country-aware fallback matching
+        club_country = {}
+        for e in youth_entries:
+            base = self._strip_youth_suffix(e.club_name)
+            if e.league_country and base not in club_country:
+                club_country[base] = e.league_country
+
         academy_ids = set()
         unresolved = []
 
         for entry in youth_entries:
             base_name = self._strip_youth_suffix(entry.club_name)
+            entry_country = club_country.get(base_name)
 
             # Try matching a senior entry first
             if base_name in senior_name_to_id:
                 academy_ids.add(senior_name_to_id[base_name])
                 continue
 
-            # Fallback 1: query TeamProfile
+            # Fallback 1: query TeamProfile (exact name)
             profile = TeamProfile.query.filter(
                 TeamProfile.name == base_name
             ).first()
@@ -749,7 +853,7 @@ class JourneySyncService:
                 academy_ids.add(profile.team_id)
                 continue
 
-            # Fallback 2: query Team table (broader coverage)
+            # Fallback 2: query Team table (exact name, broader coverage)
             team = Team.query.filter(Team.name == base_name).first()
             if team:
                 academy_ids.add(team.team_id)
@@ -757,19 +861,31 @@ class JourneySyncService:
 
             # Fallback 3: TeamProfile name is a substring of base_name
             # Handles "Tottenham Hotspur" containing "Tottenham", etc.
-            profile = TeamProfile.query.filter(
+            # Country filter prevents cross-contamination between similarly
+            # named clubs in different countries.
+            fb3_query = TeamProfile.query.filter(
                 db.func.strpos(base_name, TeamProfile.name) > 0,
-                db.func.length(TeamProfile.name) >= 4,
-            ).order_by(db.func.length(TeamProfile.name).desc()).first()
+                db.func.length(TeamProfile.name) >= 5,
+            )
+            if entry_country:
+                fb3_query = fb3_query.filter(TeamProfile.country == entry_country)
+            profile = fb3_query.order_by(
+                db.func.length(TeamProfile.name).desc()
+            ).first()
             if profile:
                 academy_ids.add(profile.team_id)
                 continue
 
             # Fallback 4: Team name is a substring of base_name
-            team = Team.query.filter(
+            fb4_query = Team.query.filter(
                 db.func.strpos(base_name, Team.name) > 0,
-                db.func.length(Team.name) >= 4,
-            ).order_by(db.func.length(Team.name).desc()).first()
+                db.func.length(Team.name) >= 5,
+            )
+            if entry_country:
+                fb4_query = fb4_query.filter(Team.country == entry_country)
+            team = fb4_query.order_by(
+                db.func.length(Team.name).desc()
+            ).first()
             if team:
                 academy_ids.add(team.team_id)
                 continue


### PR DESCRIPTION
## Summary

- **Root cause fix:** Exclude `integration` entry types from `_compute_academy_club_ids()` — the system already classified entries as integration but then ignored that label
- **Enhanced integration detection:** Use transfer records (permanent transfers TO a club = not academy) and age-at-entry validation (21+ at first youth appearance = not academy)
- **Hardened name resolution:** Added country validation to substring fallbacks in academy ID resolution to prevent cross-contamination (e.g. "Real Madrid" matching "Real Sociedad"), increased min name length from 4 to 5
- **Tightened level patterns:** Replaced bare `development` keyword in U23 patterns with specific variants (`development squad`, `development league`, `efl development`)
- **Added minimum appearances threshold:** Clubs with fewer than 3 total youth appearances are excluded from academy classification
- **Stale row cleanup:** Early-return paths in `_compute_academy_club_ids` now deactivate orphaned `TrackedPlayer` rows instead of leaving them active
- **Diagnostic endpoint:** `POST /api/admin/players/explain-academy` — shows full evidence chain for any player's academy classification
- **Batch re-sync endpoint:** `POST /api/admin/tracked-players/recompute-academy-ids` — replays updated logic across all journeys (dry-run uses DB savepoint + real resolution logic for accurate previews)

## Test plan

- [ ] Call explain-academy with Rudiger's API ID + Chelsea (49) — confirm Chelsea is NOT in academy_club_ids
- [ ] Call explain-academy with Rashford's API ID + Man Utd (33) — confirm he IS correctly classified
- [ ] Run recompute-academy-ids in dry_run mode to audit impact across all players
- [ ] Spot check 5+ teams with explain-academy to verify accuracy
- [ ] Run full deployment and verify no regressions in tracked player counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)