### PR TITLE
fix: Scope repair queries to active tracked players & deduplicate

### DIFF
--- a/loan-army-backend/src/routes/api.py
+++ b/loan-army-backend/src/routes/api.py
@@ -13668,21 +13668,29 @@ def admin_repair_journeys():
         service = JourneySyncService()
         player_ids_to_sync = []
 
+        # error category — only journeys linked to active tracked players
         if category in ('error', 'all'):
-            error_journeys = db.session.query(PlayerJourney.player_api_id).filter(
-                PlayerJourney.sync_error.isnot(None)
-            ).limit(limit).all()
+            error_journeys = db.session.query(PlayerJourney.player_api_id).join(
+                TrackedPlayer, TrackedPlayer.journey_id == PlayerJourney.id
+            ).filter(
+                TrackedPlayer.is_active == True,
+                PlayerJourney.sync_error.isnot(None),
+            ).distinct().limit(limit).all()
             player_ids_to_sync.extend([j[0] for j in error_journeys])
 
+        # empty category — same scoping
         if category in ('empty', 'all') and len(player_ids_to_sync) < limit:
             journeys_with_entries = db.session.query(
                 PlayerJourneyEntry.journey_id
             ).distinct().subquery()
-            empty_journeys = db.session.query(PlayerJourney.player_api_id).filter(
+            empty_journeys = db.session.query(PlayerJourney.player_api_id).join(
+                TrackedPlayer, TrackedPlayer.journey_id == PlayerJourney.id
+            ).filter(
+                TrackedPlayer.is_active == True,
                 ~PlayerJourney.id.in_(
                     db.session.query(journeys_with_entries.c.journey_id)
-                )
-            ).limit(limit - len(player_ids_to_sync)).all()
+                ),
+            ).distinct().limit(limit - len(player_ids_to_sync)).all()
             player_ids_to_sync.extend([j[0] for j in empty_journeys])
 
         if category in ('unlinked', 'all') and len(player_ids_to_sync) < limit:
@@ -15388,7 +15396,15 @@ def admin_sync_tracked_player_journeys():
             )
         ).all()
 
+        # Deduplicate by player_api_id to avoid redundant API calls
+        seen_pids = set()
+        unique_broken = []
         for tp in broken_linked:
+            if tp.player_api_id not in seen_pids:
+                seen_pids.add(tp.player_api_id)
+                unique_broken.append(tp)
+
+        for tp in unique_broken:
             try:
                 journey = service.sync_player(tp.player_api_id, force_full=True)
                 if journey:
@@ -15405,7 +15421,7 @@ def admin_sync_tracked_player_journeys():
         db.session.commit()
         return jsonify({
             'total_unlinked': len(unlinked),
-            'total_broken': len(broken_linked),
+            'total_broken': len(unique_broken),
             'linked': linked,
             'synced': synced,
             'repaired': repaired,


### PR DESCRIPTION
## Summary
- **Repair endpoint** (`admin_repair_journeys`): `error` and `empty` category queries now join through `TrackedPlayer` and filter on `is_active == True`, so API quota is only spent on journeys tied to active tracked players
- **Sync endpoint** (`admin_sync_tracked_player_journeys`): Pass 3 deduplicates `broken_linked` rows by `player_api_id` before the sync loop, eliminating redundant `sync_player(force_full=True)` calls when a player is tracked under multiple parent clubs

## Test plan
- [ ] Verify `POST /admin/journey/repair` with `category=error` only returns players with active TrackedPlayer rows
- [ ] Verify `POST /admin/journey/repair` with `category=empty` scopes to active tracked players
- [ ] Verify Pass 3 of `admin_sync_tracked_player_journeys` does not call `sync_player` multiple times for the same `player_api_id`
- [ ] Confirm `total_broken` in response reflects deduplicated count

🤖 Generated with [Claude Code](https://claude.com/claude-code)