### PR TITLE
feat: admin can reassign parent club + pinned_parent flag

### DIFF
--- a/loan-army-backend/src/models/tracked_player.py
+++ b/loan-army-backend/src/models/tracked_player.py
@@ -46,6 +46,10 @@ class TrackedPlayer(db.Model):
     # Link to active LoanedPlayer row (if on loan)
     loaned_player_id = db.Column(db.Integer, db.ForeignKey('loaned_players.id'), nullable=True)
 
+    # When True, refresh-statuses will never change team_id — prevents
+    # the classifier from reassigning parent club based on stale API data.
+    pinned_parent = db.Column(db.Boolean, default=False, server_default='false')
+
     notes = db.Column(db.Text)
     is_active = db.Column(db.Boolean, default=True)
     created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
@@ -85,6 +89,7 @@ class TrackedPlayer(db.Model):
             'data_depth': self.data_depth,
             'journey_id': self.journey_id,
             'loaned_player_id': self.loaned_player_id,
+            'pinned_parent': self.pinned_parent,
             'notes': self.notes,
             'is_active': self.is_active,
             'created_at': self.created_at.isoformat() if self.created_at else None,

--- a/loan-army-backend/src/routes/api.py
+++ b/loan-army-backend/src/routes/api.py
@@ -14621,7 +14621,8 @@ def admin_update_tracked_player(player_id):
 
         data = request.get_json(force=True)
         allowed = ['status', 'current_level', 'loan_club_api_id', 'loan_club_name',
-                    'notes', 'position', 'is_active', 'photo_url']
+                    'notes', 'position', 'is_active', 'photo_url', 'team_id',
+                    'pinned_parent']
         for field in allowed:
             if field in data:
                 setattr(player, field, data[field])


### PR DESCRIPTION
**Problem:** Players can get seeded under the wrong parent club (e.g., Amass under Watford instead of Man United). Once seeded, team_id wasn't editable via the admin API.

**Changes:**
- `team_id` + `pinned_parent` added to admin update endpoint's allowed fields
- `pinned_parent` column on TrackedPlayer — when True, automated refreshes only update loan info, never reclassify parent
- Exposed in `to_dict()`

**Migration:** `ALTER TABLE tracked_players ADD COLUMN pinned_parent BOOLEAN DEFAULT FALSE;`

**After deploy:** Fix Amass via `PUT /api/admin/tracked-players/8704 {team_id: 1, pinned_parent: true}`