### PR TITLE
feat: Self-healing transfer window refresh job

### DIFF
--- a/deploy_aca.sh
+++ b/deploy_aca.sh
@@ -29,6 +29,8 @@ SWA_NAME="${SWA_NAME:-swa-goonloan}"
 TAG="${TAG:-prod}"
 # Optional: weekly job name to keep in sync with backend image tag
 JOB_WEEKLY_NAME="${JOB_WEEKLY_NAME:-job-weekly-newsletters}"
+# Optional: transfer heal job name to keep in sync with backend image tag
+JOB_TRANSFER_HEAL_NAME="${JOB_TRANSFER_HEAL_NAME:-job-transfer-heal}"
 # Optional explicit API base for frontend build. If empty, derived from backend FQDN
 VITE_API_BASE="${VITE_API_BASE:-}"
 
@@ -215,6 +217,14 @@ if az containerapp job show -g "$RG" -n "$JOB_WEEKLY_NAME" >/dev/null 2>&1; then
     --image "$ACR_SERVER/loanarmy/backend:$TAG" >/dev/null
 else
   log "Skipping job update (job '$JOB_WEEKLY_NAME' not found)"
+fi
+
+if az containerapp job show -g "$RG" -n "$JOB_TRANSFER_HEAL_NAME" >/dev/null 2>&1; then
+  log "Updating scheduled job '$JOB_TRANSFER_HEAL_NAME' image to $ACR_SERVER/loanarmy/backend:$TAG"
+  az containerapp job update -g "$RG" -n "$JOB_TRANSFER_HEAL_NAME" \
+    --image "$ACR_SERVER/loanarmy/backend:$TAG" >/dev/null
+else
+  log "Skipping job update (job '$JOB_TRANSFER_HEAL_NAME' not found)"
 fi
 
 # ---------------------------

--- a/loan-army-backend/src/jobs/run_transfer_window_heal.py
+++ b/loan-army-backend/src/jobs/run_transfer_window_heal.py
@@ -1,0 +1,111 @@
+"""Scheduled job: Self-healing transfer window refresh.
+
+Detects loan club changes for tracked players by re-syncing journey data
+from API-Football, updates statuses, and cascades fixture syncs.
+
+During transfer windows (Jan, Jun-Aug + 7-day buffer), performs a full
+journey resync. Outside windows, does a lighter local-data-only status refresh.
+
+Usage:
+    python src/jobs/run_transfer_window_heal.py [--dry-run]
+"""
+
+import json
+import sys
+import logging
+from datetime import datetime, timezone
+
+from src.main import app
+from src.models.league import db
+from src.utils.job_utils import teams_with_active_tracked_players, is_job_paused
+from src.utils.background_jobs import has_running_job
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
+
+
+def is_transfer_window() -> bool:
+    """Check if today falls within a transfer window.
+
+    Winter window: January 1 - February 7
+    Summer window: June 1 - September 7
+
+    Includes a ~7 day buffer past each window close because API-Football
+    data can take a few days to update after deadline day.
+    """
+    today = datetime.now(timezone.utc).date()
+    month, day = today.month, today.day
+    winter = month == 1 or (month == 2 and day <= 7)
+    summer = 6 <= month <= 8 or (month == 9 and day <= 7)
+    return winter or summer
+
+
+def run(dry_run=False):
+    from src.services.transfer_heal_service import refresh_and_heal
+
+    # Clean transaction state
+    try:
+        db.session.rollback()
+    except Exception:
+        pass
+
+    if is_job_paused('transfer_heal_paused'):
+        logger.info('Transfer heal is paused by admin. Exiting.')
+        return [{'error': 'paused'}]
+
+    if has_running_job('transfer_heal'):
+        logger.info('Another transfer heal job is already running. Exiting.')
+        return [{'error': 'already_running'}]
+
+    resync = is_transfer_window()
+    logger.info(
+        'Transfer heal starting. transfer_window=%s, resync_journeys=%s, dry_run=%s',
+        resync, resync, dry_run,
+    )
+
+    team_ids = teams_with_active_tracked_players()
+    logger.info('Processing %d teams', len(team_ids))
+
+    results = []
+    for team_db_id in team_ids:
+        if is_job_paused('transfer_heal_paused'):
+            results.append({'team_id': team_db_id, 'error': 'stopped_by_admin'})
+            break
+        try:
+            # Clean transaction before each team
+            try:
+                db.session.rollback()
+            except Exception:
+                pass
+
+            result = refresh_and_heal(
+                team_id=team_db_id,
+                resync_journeys=resync,
+                dry_run=dry_run,
+                cascade_fixtures=True,
+            )
+            results.append({'team_id': team_db_id, **result})
+            logger.info(
+                'Team %d: %d/%d updated, %d changed, %d fixture syncs',
+                team_db_id,
+                result['updated'],
+                result['total'],
+                len(result['players_changed']),
+                result['fixture_syncs_triggered'],
+            )
+        except Exception as e:
+            try:
+                db.session.rollback()
+            except Exception:
+                pass
+            logger.error('Team %d failed: %s', team_db_id, e)
+            results.append({'team_id': team_db_id, 'error': str(e)})
+
+    logger.info('Transfer heal complete. Results: %s', json.dumps(results, default=str))
+    return results
+
+
+if __name__ == '__main__':
+    dry_run = '--dry-run' in sys.argv
+    with app.app_context():
+        run(dry_run=dry_run)

--- a/loan-army-backend/src/jobs/run_weekly_newsletters.py
+++ b/loan-army-backend/src/jobs/run_weekly_newsletters.py
@@ -1,19 +1,10 @@
-import os
 from datetime import date, datetime, timezone
-from src.models.league import db, Team, AdminSetting
-from src.models.tracked_player import TrackedPlayer
+from src.models.league import db
 from src.agents.weekly_newsletter_agent import generate_team_weekly_newsletter
 from src.agents.errors import NoActiveLoaneesError
 from src.main import app
+from src.utils.job_utils import teams_with_active_tracked_players, is_job_paused
 
-
-def teams_with_active_tracked_players() -> list[int]:
-    """Return team DB IDs that have active TrackedPlayers (excluding released/sold)."""
-    q = db.session.query(TrackedPlayer.team_id).filter(
-        TrackedPlayer.is_active.is_(True),
-        TrackedPlayer.status.notin_(['released', 'sold']),
-    ).distinct()
-    return [t[0] for t in q.all()]
 
 def run_for_date(target_date: date):
     # Ensure we start from a clean transaction (in case a prior request aborted)
@@ -21,21 +12,8 @@ def run_for_date(target_date: date):
         db.session.rollback()
     except Exception:
         pass
-    def _runs_paused() -> bool:
-        try:
-            # Defensive rollback before metadata reads
-            try:
-                db.session.rollback()
-            except Exception:
-                pass
-            row = db.session.query(AdminSetting).filter_by(key='runs_paused').first()
-            if row and row.value_json:
-                return row.value_json.strip().lower() in ('1','true','yes','y')
-        except Exception:
-            return False
-        return False
 
-    if _runs_paused():
+    if is_job_paused('runs_paused'):
         return [{"error": "runs_paused", "team_id": None}]
 
     # Defensive rollback before running the query
@@ -46,7 +24,7 @@ def run_for_date(target_date: date):
     team_ids = teams_with_active_tracked_players()
     results = []
     for team_db_id in team_ids:
-        if _runs_paused():
+        if is_job_paused('runs_paused'):
             results.append({"team_id": team_db_id, "error": "stopped_by_admin"})
             break
         try:

--- a/loan-army-backend/src/routes/api.py
+++ b/loan-army-backend/src/routes/api.py
@@ -14616,124 +14616,21 @@ def admin_refresh_tracked_player_statuses():
         team_id = data.get('team_id')
         resync_journeys = data.get('resync_journeys', False)
 
-        from src.models.journey import PlayerJourney
+        from src.services.transfer_heal_service import refresh_and_heal
+        result = refresh_and_heal(
+            team_id=team_id,
+            resync_journeys=resync_journeys,
+            cascade_fixtures=False,
+        )
 
-        query = TrackedPlayer.query.filter_by(is_active=True)
-        if team_id:
-            query = query.filter_by(team_id=team_id)
-
-        players = query.all()
-        updated = 0
-        journeys_resynced = 0
-
-        # Optionally re-sync journeys first to refresh current_club data
-        journey_svc = None
-        if resync_journeys:
-            from src.services.journey_sync import JourneySyncService
-            journey_svc = JourneySyncService()
-
-        # Batch pre-fetch transfers for all players to avoid per-player API calls
-        from src.api_football_client import APIFootballClient
-        api_client = APIFootballClient()
-        player_api_ids = [tp.player_api_id for tp in players if tp.player_api_id]
-        raw_transfers_map = api_client.batch_get_player_transfers(player_api_ids)
-        transfers_map = {
-            pid: flatten_transfers(raw)
-            for pid, raw in raw_transfers_map.items()
-        }
-
-        # Batch pre-fetch squads for loan clubs + parent clubs
-        squad_members_by_club = {}
-        loan_club_ids = {tp.loan_club_api_id for tp in players if tp.loan_club_api_id}
-        parent_club_ids = set()
-        _team_cache = {}
-        for tp in players:
-            if tp.team_id not in _team_cache:
-                _team_cache[tp.team_id] = Team.query.get(tp.team_id)
-            pt = _team_cache[tp.team_id]
-            if pt:
-                parent_club_ids.add(pt.team_id)
-        for club_id in (loan_club_ids | parent_club_ids):
-            try:
-                squad = api_client.get_team_players(club_id)
-                squad_members_by_club[club_id] = {
-                    int(e['player']['id']) for e in squad
-                    if e and e.get('player', {}).get('id')
-                }
-            except Exception as exc:
-                logger.warning('Squad fetch failed for club %d: %s', club_id, exc)
-
-        for tp in players:
-            journey = None
-
-            # Re-sync the journey from API-Football if requested
-            if resync_journeys and journey_svc and tp.player_api_id:
-                try:
-                    journey = journey_svc.sync_player(tp.player_api_id, force_full=True)
-                    if journey:
-                        journeys_resynced += 1
-                        # Link journey if not already linked
-                        if not tp.journey_id and journey:
-                            tp.journey_id = journey.id
-                except Exception as sync_err:
-                    logger.warning(
-                        'refresh-statuses: journey resync failed for player %d: %s',
-                        tp.player_api_id, sync_err,
-                    )
-
-            if not journey:
-                if tp.journey_id:
-                    journey = db.session.get(PlayerJourney, tp.journey_id)
-                if not journey:
-                    journey = PlayerJourney.query.filter_by(
-                        player_api_id=tp.player_api_id
-                    ).first()
-
-            if not journey:
-                continue
-
-            # Look up the parent club name from the team row
-            parent_team = Team.query.get(tp.team_id)
-            if not parent_team:
-                continue
-
-            new_status, new_loan_id, new_loan_name = classify_tracked_player(
-                current_club_api_id=journey.current_club_api_id,
-                current_club_name=journey.current_club_name,
-                current_level=journey.current_level,
-                parent_api_id=parent_team.team_id,
-                parent_club_name=parent_team.name,
-                transfers=transfers_map.get(tp.player_api_id),
-                player_api_id=tp.player_api_id,
-                api_client=api_client,
-                latest_season=_get_latest_season(journey.id, parent_api_id=parent_team.team_id, parent_club_name=parent_team.name),
-                squad_members_by_club=squad_members_by_club,
-            )
-
-            changed = False
-            if tp.status != new_status:
-                tp.status = new_status
-                changed = True
-            if tp.loan_club_api_id != new_loan_id:
-                tp.loan_club_api_id = new_loan_id
-                changed = True
-            if tp.loan_club_name != new_loan_name:
-                tp.loan_club_name = new_loan_name
-                changed = True
-            if journey.current_level and tp.current_level != journey.current_level:
-                tp.current_level = journey.current_level
-                changed = True
-            if changed:
-                updated += 1
-
-        db.session.commit()
-        result = {
-            'total': len(players),
-            'updated': updated,
+        # Return the same shape as before for backwards compatibility
+        response = {
+            'total': result['total'],
+            'updated': result['updated'],
         }
         if resync_journeys:
-            result['journeys_resynced'] = journeys_resynced
-        return jsonify(result)
+            response['journeys_resynced'] = result['journeys_resynced']
+        return jsonify(response)
     except Exception as e:
         db.session.rollback()
         logger.exception('admin_refresh_tracked_player_statuses failed')

--- a/loan-army-backend/src/services/transfer_heal_service.py
+++ b/loan-army-backend/src/services/transfer_heal_service.py
@@ -1,0 +1,209 @@
+"""Self-healing transfer window service.
+
+Detects loan club changes for tracked players by re-querying API-Football,
+updates statuses, and optionally cascades fixture syncs for affected players.
+
+Uses TrackedPlayer as the primary model — fixture syncs are cascaded
+per-player via _sync_player_club_fixtures using TrackedPlayer.loan_club_api_id
+directly, without depending on LoanedPlayer rows.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from src.models.league import db, Team
+from src.models.tracked_player import TrackedPlayer
+from src.models.journey import PlayerJourney
+from src.api_football_client import APIFootballClient
+from src.services.journey_sync import JourneySyncService
+from src.utils.academy_classifier import (
+    classify_tracked_player,
+    flatten_transfers,
+    _get_latest_season,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False,
+                     cascade_fixtures=True):
+    """Re-derive statuses for tracked players, detecting loan club changes.
+
+    Args:
+        team_id: Optional team DB ID to limit refresh to a single team.
+        resync_journeys: If True, re-sync journey data from API-Football first.
+        dry_run: If True, do not commit changes or cascade fixture syncs.
+        cascade_fixtures: If True, sync fixtures for players whose loan club
+            changed. Set False for admin endpoint (preserves old behavior).
+
+    Returns:
+        dict with keys: total, updated, journeys_resynced, players_changed,
+        fixture_syncs_triggered.
+
+    Note: Fixture syncs are independent — status changes persist even if
+    a fixture sync fails for an individual player.
+    """
+    query = TrackedPlayer.query.filter_by(is_active=True)
+    if team_id:
+        query = query.filter_by(team_id=team_id)
+
+    players = query.all()
+
+    updated = 0
+    journeys_resynced = 0
+    players_changed = []
+
+    # Optionally set up journey sync service
+    journey_svc = None
+    if resync_journeys:
+        journey_svc = JourneySyncService()
+
+    # Batch pre-fetch transfers
+    api_client = APIFootballClient()
+    player_api_ids = [tp.player_api_id for tp in players if tp.player_api_id]
+    raw_transfers_map = api_client.batch_get_player_transfers(player_api_ids)
+    transfers_map = {
+        pid: flatten_transfers(raw)
+        for pid, raw in raw_transfers_map.items()
+    }
+
+    # Batch pre-fetch squads for loan + parent clubs
+    squad_members_by_club = {}
+    loan_club_ids = {tp.loan_club_api_id for tp in players if tp.loan_club_api_id}
+    parent_club_ids = set()
+    _team_cache = {}
+    for tp in players:
+        if tp.team_id not in _team_cache:
+            _team_cache[tp.team_id] = Team.query.get(tp.team_id)
+        pt = _team_cache[tp.team_id]
+        if pt:
+            parent_club_ids.add(pt.team_id)
+    for club_id in (loan_club_ids | parent_club_ids):
+        try:
+            squad = api_client.get_team_players(club_id)
+            squad_members_by_club[club_id] = {
+                int(e['player']['id']) for e in squad
+                if e and e.get('player', {}).get('id')
+            }
+        except Exception as exc:
+            logger.warning('Squad fetch failed for club %d: %s', club_id, exc)
+
+    # Process each player
+    for tp in players:
+        journey = None
+
+        # Re-sync journey from API-Football if requested
+        if resync_journeys and journey_svc and tp.player_api_id:
+            try:
+                journey = journey_svc.sync_player(tp.player_api_id, force_full=True)
+                if journey:
+                    journeys_resynced += 1
+                    if not tp.journey_id:
+                        tp.journey_id = journey.id
+            except Exception as sync_err:
+                logger.warning(
+                    'transfer-heal: journey resync failed for player %d: %s',
+                    tp.player_api_id, sync_err,
+                )
+
+        if not journey:
+            if tp.journey_id:
+                journey = db.session.get(PlayerJourney, tp.journey_id)
+            if not journey:
+                journey = PlayerJourney.query.filter_by(
+                    player_api_id=tp.player_api_id
+                ).first()
+
+        if not journey:
+            continue
+
+        parent_team = _team_cache.get(tp.team_id) or Team.query.get(tp.team_id)
+        if not parent_team:
+            continue
+
+        new_status, new_loan_id, new_loan_name = classify_tracked_player(
+            current_club_api_id=journey.current_club_api_id,
+            current_club_name=journey.current_club_name,
+            current_level=journey.current_level,
+            parent_api_id=parent_team.team_id,
+            parent_club_name=parent_team.name,
+            transfers=transfers_map.get(tp.player_api_id),
+            player_api_id=tp.player_api_id,
+            api_client=api_client,
+            latest_season=_get_latest_season(
+                journey.id,
+                parent_api_id=parent_team.team_id,
+                parent_club_name=parent_team.name,
+            ),
+            squad_members_by_club=squad_members_by_club,
+        )
+
+        changed = False
+        old_loan_id = tp.loan_club_api_id
+
+        if tp.status != new_status:
+            tp.status = new_status
+            changed = True
+        if tp.loan_club_api_id != new_loan_id:
+            tp.loan_club_api_id = new_loan_id
+            changed = True
+        if tp.loan_club_name != new_loan_name:
+            tp.loan_club_name = new_loan_name
+            changed = True
+        if journey.current_level and tp.current_level != journey.current_level:
+            tp.current_level = journey.current_level
+            changed = True
+
+        if changed:
+            updated += 1
+            # Track loan club changes for fixture sync cascade
+            if new_loan_id and new_loan_id != old_loan_id:
+                players_changed.append({
+                    'player_api_id': tp.player_api_id,
+                    'player_name': tp.player_name,
+                    'team_id': tp.team_id,
+                    'old_loan_club_api_id': old_loan_id,
+                    'new_loan_club_api_id': new_loan_id,
+                    'new_loan_club': new_loan_name,
+                })
+
+    if not dry_run:
+        db.session.commit()
+    else:
+        db.session.rollback()
+
+    # Cascade fixture syncs per changed player using TrackedPlayer data directly
+    fixture_syncs_triggered = 0
+    if not dry_run and cascade_fixtures and players_changed:
+        from src.routes.api import _sync_player_club_fixtures
+        now = datetime.now(timezone.utc)
+        season = now.year if now.month >= 8 else now.year - 1
+
+        for pc in players_changed:
+            try:
+                synced = _sync_player_club_fixtures(
+                    player_id=pc['player_api_id'],
+                    loan_team_api_id=pc['new_loan_club_api_id'],
+                    season=season,
+                    player_name=pc.get('player_name'),
+                )
+                fixture_syncs_triggered += 1
+                logger.info(
+                    'transfer-heal: synced %d fixtures for player %d (%s) '
+                    'at new club %s (api_id=%d)',
+                    synced, pc['player_api_id'], pc.get('player_name'),
+                    pc['new_loan_club'], pc['new_loan_club_api_id'],
+                )
+            except Exception as exc:
+                logger.error(
+                    'transfer-heal: fixture sync failed for player %d at club %d: %s',
+                    pc['player_api_id'], pc['new_loan_club_api_id'], exc,
+                )
+
+    return {
+        'total': len(players),
+        'updated': updated,
+        'journeys_resynced': journeys_resynced,
+        'players_changed': players_changed,
+        'fixture_syncs_triggered': fixture_syncs_triggered,
+    }

--- a/loan-army-backend/src/utils/background_jobs.py
+++ b/loan-army-backend/src/utils/background_jobs.py
@@ -163,6 +163,42 @@ def is_job_cancelled(job_id: str) -> bool:
     return False
 
 
+def has_running_job(job_type: str) -> bool:
+    """Check if a job of the given type is already running (not stale).
+
+    Auto-fails any stale jobs that exceed STALE_JOB_TIMEOUT.
+
+    Args:
+        job_type: The job_type string to check (e.g. 'transfer_heal').
+
+    Returns:
+        True if a non-stale running job of this type exists.
+    """
+    try:
+        job = (
+            BackgroundJob.query
+            .filter_by(job_type=job_type, status='running')
+            .first()
+        )
+        if not job:
+            return False
+        last_active = job.updated_at or job.started_at or job.created_at
+        elapsed = datetime.now(timezone.utc) - last_active.replace(tzinfo=timezone.utc)
+        if elapsed > STALE_JOB_TIMEOUT:
+            logger.warning(
+                'Job type %s stale (%s), auto-marking failed.', job_type, elapsed,
+            )
+            job.status = 'failed'
+            job.error = f'Stale job auto-failed after {elapsed}'
+            job.completed_at = datetime.now(timezone.utc)
+            db.session.commit()
+            return False
+        return True
+    except Exception as e:
+        logger.error('Failed to check running job for type %s: %s', job_type, e)
+        return False
+
+
 # Aliases for backward compatibility with api.py internal naming
 _create_background_job = create_background_job
 _update_job = update_job

--- a/loan-army-backend/src/utils/job_utils.py
+++ b/loan-army-backend/src/utils/job_utils.py
@@ -1,0 +1,36 @@
+"""Shared utilities for scheduled job runners."""
+
+from src.models.league import db, AdminSetting
+from src.models.tracked_player import TrackedPlayer
+
+
+def teams_with_active_tracked_players() -> list[int]:
+    """Return team DB IDs that have active TrackedPlayers (excluding released/sold)."""
+    q = db.session.query(TrackedPlayer.team_id).filter(
+        TrackedPlayer.is_active.is_(True),
+        TrackedPlayer.status.notin_(['released', 'sold']),
+    ).distinct()
+    return [t[0] for t in q.all()]
+
+
+def is_job_paused(setting_key: str) -> bool:
+    """Check if a job is paused via AdminSetting.
+
+    Args:
+        setting_key: The AdminSetting key to check (e.g. 'runs_paused',
+                     'transfer_heal_paused').
+
+    Returns:
+        True if setting exists and is truthy (1, true, yes, y).
+    """
+    try:
+        db.session.rollback()
+    except Exception:
+        pass
+    try:
+        row = db.session.query(AdminSetting).filter_by(key=setting_key).first()
+        if row and row.value_json:
+            return row.value_json.strip().lower() in ('1', 'true', 'yes', 'y')
+    except Exception:
+        return False
+    return False


### PR DESCRIPTION
## Summary

- Adds automated weekly job to detect loan club changes during transfer windows by re-syncing player journeys from API-Football
- Updates TrackedPlayer statuses and cascades fixture syncs for players whose loan club changed (TrackedPlayer-native, no LoanedPlayer dependency)
- Extracts shared utilities (`teams_with_active_tracked_players`, `is_job_paused`, `has_running_job`) to reduce duplication across newsletter and transfer heal jobs
- Admin endpoint preserves old behavior (no fixture cascade) via `cascade_fixtures=False`

## Details

**New files:**
- `src/services/transfer_heal_service.py` — Core `refresh_and_heal()` function
- `src/jobs/run_transfer_window_heal.py` — ACA scheduled job (weekly Monday 4 AM UTC)
- `src/utils/job_utils.py` — Shared job utilities

**Transfer window awareness:** Full API-Football journey resync during Jan 1 – Feb 7 and Jun 1 – Sep 7 (7-day buffer past deadline day for data lag). Lighter local-only refresh outside windows.

**ACA job creation (one-time):**
```bash
az containerapp job create \
  --name job-transfer-heal \
  --resource-group $RG \
  --environment $ENV_NAME \
  --image $ACR_SERVER/loanarmy/backend:prod \
  --trigger-type Schedule \
  --cron-expression "0 4 * * 1" \
  --cpu 0.5 --memory 1Gi \
  --command "python" "src/jobs/run_transfer_window_heal.py"
```

## Test plan

- [ ] Run `python src/jobs/run_transfer_window_heal.py --dry-run` locally
- [ ] Verify `POST /api/admin/tracked-players/refresh-statuses` returns same response shape (no fixture cascade)
- [ ] Verify newsletter job still works after shared utils refactor
- [ ] Deploy and verify `deploy_aca.sh` syncs the job image tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)