### PR TITLE
fix: academy classification accuracy — pinned_parent, transfer gate, player_name bug

### DIFF
--- a/academy-watch-backend/src/routes/api.py
+++ b/academy-watch-backend/src/routes/api.py
@@ -9458,7 +9458,6 @@ def _run_team_fixtures_sync(team_id: int, data: dict, job_id: str = None) -> dic
                                 fps = FixturePlayerStats(
                                     fixture_id=existing_fixture.id,
                                     player_api_id=p_api_id,
-                                    player_name=p_name,
                                     team_api_id=p_team_api_id,
                                     minutes=minutes,
                                     position=games.get('position'),

--- a/academy-watch-backend/src/services/journey_sync.py
+++ b/academy-watch-backend/src/services/journey_sync.py
@@ -937,6 +937,29 @@ class JourneySyncService:
                 f"{journey.player_api_id}: {set(unresolved)}"
             )
 
+        # ── Transfer gate: remove clubs the player was permanently transferred TO ──
+        # Defense-in-depth — _apply_development_classification should have already
+        # reclassified entries as 'integration', but if it missed a case this catches it.
+        if transfers and academy_ids:
+            permanent_dest_ids = set()
+            for t in transfers:
+                transfer_type = (t.get('type') or '').strip().lower()
+                if not transfer_type or is_new_loan_transfer(transfer_type):
+                    continue
+                if transfer_type in LOAN_RETURN_TYPES:
+                    continue
+                dest_id = t.get('teams', {}).get('in', {}).get('id')
+                if dest_id:
+                    permanent_dest_ids.add(dest_id)
+
+            removed = academy_ids & permanent_dest_ids
+            if removed:
+                logger.info(
+                    f"Transfer gate: removing {removed} from academy_club_ids "
+                    f"for player {journey.player_api_id} (permanent transfer destinations)"
+                )
+                academy_ids -= permanent_dest_ids
+
         journey.academy_club_ids = sorted(academy_ids)
 
         # Auto-upsert TrackedPlayer rows for each academy connection
@@ -952,12 +975,15 @@ class JourneySyncService:
         from src.utils.academy_classifier import classify_tracked_player, _get_latest_season
 
         # Deactivate journey-sync rows whose academy connection no longer holds
+        # Skip pinned rows — manual corrections must persist.
         stale_rows = TrackedPlayer.query.filter_by(
             player_api_id=journey.player_api_id,
             data_source='journey-sync',
             is_active=True,
         ).all()
         for tp in stale_rows:
+            if tp.pinned_parent:
+                continue
             if tp.team and tp.team.team_id not in academy_ids:
                 tp.is_active = False
 
@@ -1002,8 +1028,15 @@ class JourneySyncService:
                 )
                 db.session.add(tp)
             else:
-                # Update status and journey link if stale
+                # Always keep journey link fresh
                 existing.journey_id = journey.id
+                # Skip status/loan updates for pinned players — manual corrections persist
+                if existing.pinned_parent:
+                    logger.debug(
+                        f"Skipping status update for pinned player "
+                        f"{journey.player_api_id} at team {team.name}"
+                    )
+                    continue
                 existing.status = status
                 existing.loan_club_api_id = loan_club_api_id
                 existing.loan_club_name = loan_club_name

--- a/academy-watch-backend/src/services/transfer_heal_service.py
+++ b/academy-watch-backend/src/services/transfer_heal_service.py
@@ -138,6 +138,16 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False,
             squad_members_by_club=squad_members_by_club,
         )
 
+        # Pinned players: skip all automated field changes.
+        # Journey data was already resynced above, but status/loan/level
+        # fields are frozen until explicitly unpinned.
+        if tp.pinned_parent:
+            logger.info(
+                'transfer-heal: skipping status update for pinned player %d (%s)',
+                tp.player_api_id, tp.player_name,
+            )
+            continue
+
         changed = False
         old_loan_id = tp.loan_club_api_id
 


### PR DESCRIPTION
## Summary
- **Remove `player_name` kwarg bug** — `_run_team_fixtures_sync` passed `player_name` to `FixturePlayerStats()` but the model has no such column, causing fixture sync inserts to fail
- **Enforce `pinned_parent`** — Manual corrections now persist through `refresh_and_heal()` and `_upsert_tracked_players()`. Pinned players skip all automated status/loan field changes (fully frozen). Journey data still syncs.
- **Add transfer gate in `_compute_academy_club_ids`** — Players permanently transferred TO a club are excluded from that club's academy connections, preventing false positives (e.g. Malacia at Man United) and duplicate TrackedPlayer records

## Test plan
- [ ] Verify `FixturePlayerStats` inserts succeed in `sync-all-fixtures` endpoint
- [ ] Pin a test player, run `refresh-statuses` — confirm status unchanged
- [ ] Run journey sync for a known false positive (Malacia) — confirm not classified as academy
- [ ] Verify no regression in newsletter generation sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)