### PR TITLE
refactor: Rename loan_club → current_club on TrackedPlayer

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -135,7 +135,7 @@ API-Football                    Database                      Frontend
 | Admin team sync | All players at one academy | `POST /admin/teams/{id}/sync-all-fixtures` |
 | Batch sync | All tracked players | `POST /admin/sync-all-player-fixtures` |
 
-The batch sync groups players by their current team to minimize API calls — `O(teams × fixtures)` not `O(players × fixtures)`. For sold/released players with no team on record, it discovers their current team via the `/players` endpoint and backfills `TrackedPlayer.loan_club_api_id`.
+The batch sync groups players by their current team to minimize API calls — `O(teams × fixtures)` not `O(players × fixtures)`. For sold/released players with no team on record, it discovers their current team via the `/players` endpoint and backfills `TrackedPlayer.current_club_api_id`.
 
 ### Club-First Default (National Team Filtering)
 
@@ -144,7 +144,7 @@ API-Football's `/players` endpoint returns statistics for **all teams** a player
 This ensures:
 - **Default view** (header stats, Performance Analysis charts) shows club data
 - **International data** is preserved in the journey timeline and accessible by clicking the national team node
-- `TrackedPlayer.loan_club_api_id` is always a club, never a national team
+- `TrackedPlayer.current_club_api_id` is always a club, never a national team
 
 The position fallback chain also prioritizes club data: `Player.position` → `TrackedPlayer.position` → most recent `FixturePlayerStats.position` (from club matches). The frontend uses the backend profile position as the initial value, overridden by stats-inferred position if match data exists.
 
@@ -181,7 +181,7 @@ Team (academy club)
   │
   ├── TrackedPlayer (one row per player per academy)
   │     ├── status: academy | on_loan | first_team | sold | released
-  │     ├── loan_club_api_id (current club if on_loan or sold)
+  │     ├── current_club_api_id (current club if on_loan or sold)
   │     ├── sale_fee (transfer fee if sold)
   │     ├── position (Goalkeeper, Defender, Midfielder, Attacker)
   │     └── journey_id → PlayerJourney

--- a/academy-watch-backend/migrations/versions/z8_rename_loan_club_to_current_club.py
+++ b/academy-watch-backend/migrations/versions/z8_rename_loan_club_to_current_club.py
@@ -1,0 +1,29 @@
+"""rename loan_club columns to current_club on tracked_players
+
+Revision ID: z8_rename
+Revises: z7_fees
+Create Date: 2026-03-17
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'z8_rename'
+down_revision = 'z7_fees'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('tracked_players', 'loan_club_api_id',
+                    new_column_name='current_club_api_id')
+    op.alter_column('tracked_players', 'loan_club_name',
+                    new_column_name='current_club_name')
+
+
+def downgrade():
+    op.alter_column('tracked_players', 'current_club_api_id',
+                    new_column_name='loan_club_api_id')
+    op.alter_column('tracked_players', 'current_club_name',
+                    new_column_name='loan_club_name')

--- a/academy-watch-backend/scripts/full_rebuild.py
+++ b/academy-watch-backend/scripts/full_rebuild.py
@@ -385,7 +385,7 @@ def stage_4_tracked_players(team_ids, seasons, dry_run):
                 position = pi.get('position') or ''
                 age = pi.get('age')
 
-                status, loan_club_api_id, loan_club_name = derive_player_status(
+                status, current_club_api_id, current_club_name = derive_player_status(
                     current_club_api_id=journey.current_club_api_id if journey else None,
                     current_club_name=journey.current_club_name if journey else None,
                     current_level=journey.current_level if journey else None,
@@ -408,8 +408,8 @@ def stage_4_tracked_players(team_ids, seasons, dry_run):
                     team_id=team.id,
                     status=status,
                     current_level=current_level,
-                    loan_club_api_id=loan_club_api_id,
-                    loan_club_name=loan_club_name,
+                    current_club_api_id=current_club_api_id,
+                    current_club_name=current_club_name,
                     data_source='api-football',
                     data_depth='full_stats',
                     journey_id=journey.id if journey else None,
@@ -490,7 +490,7 @@ def stage_6_refresh_statuses(team_ids, dry_run):
             continue
 
         journey = tp.journey
-        status, loan_club_api_id, loan_club_name = derive_player_status(
+        status, current_club_api_id, current_club_name = derive_player_status(
             current_club_api_id=journey.current_club_api_id if journey else None,
             current_club_name=journey.current_club_name if journey else None,
             current_level=journey.current_level if journey else None,
@@ -500,14 +500,14 @@ def stage_6_refresh_statuses(team_ids, dry_run):
 
         changed = (
             tp.status != status or
-            tp.loan_club_api_id != loan_club_api_id or
-            tp.loan_club_name != loan_club_name
+            tp.current_club_api_id != current_club_api_id or
+            tp.current_club_name != current_club_name
         )
 
         if changed and not dry_run:
             tp.status = status
-            tp.loan_club_api_id = loan_club_api_id
-            tp.loan_club_name = loan_club_name
+            tp.current_club_api_id = current_club_api_id
+            tp.current_club_name = current_club_name
             updated += 1
         elif changed:
             updated += 1

--- a/academy-watch-backend/src/admin/sandbox_tasks.py
+++ b/academy-watch-backend/src/admin/sandbox_tasks.py
@@ -543,7 +543,7 @@ def _diff_loan_rows(
                 pass
 
             if apply_changes and classification.get('valid') and team is not None:
-                loan_club_name = classification.get('loan_club') or loan_team_name
+                current_club_name = classification.get('loan_club') or loan_team_name
                 parent_name = classification.get('parent_club') or parent_club or team.name
                 resolved_player = classification.get('player_name') or player_name
                 season_start = classification.get('season_start_year') or season_value
@@ -551,26 +551,26 @@ def _diff_loan_rows(
                     "[sandbox-diff] applying change create supplemental for player=%s parent=%s loan=%s season=%s source=%s",
                     resolved_player,
                     parent_name,
-                    loan_club_name,
+                    current_club_name,
                     season_start,
                     data_source,
                 )
 
                 loan_team = (
                     context.db_session.query(Team)
-                    .filter(func.lower(Team.name) == loan_club_name.lower())
+                    .filter(func.lower(Team.name) == current_club_name.lower())
                     .first()
                 )
                 # Canonicalize loan club name when we can resolve a Team row
                 if loan_team:
-                    loan_club_name = loan_team.name
+                    current_club_name = loan_team.name
 
                 existing_sup = (
                     context.db_session.query(SupplementalLoan)
                     .filter(
                         SupplementalLoan.parent_team_id == team.id,
                         func.lower(SupplementalLoan.player_name) == resolved_player.lower(),
-                        func.lower(SupplementalLoan.loan_team_name) == loan_club_name.lower(),
+                        func.lower(SupplementalLoan.loan_team_name) == current_club_name.lower(),
                         SupplementalLoan.season_year == season_start,
                     )
                     .first()
@@ -595,7 +595,7 @@ def _diff_loan_rows(
                         parent_team_id=team.id,
                         parent_team_name=parent_name,
                         loan_team_id=loan_team.id if loan_team else None,
-                        loan_team_name=loan_club_name,
+                        loan_team_name=current_club_name,
                         season_year=season_start,
                         api_player_id=resolved_api_player_id,
                         data_source=data_source,
@@ -608,14 +608,14 @@ def _diff_loan_rows(
                         "[sandbox-diff] created SupplementalLoan player=%s parent_id=%s loan_team=%s season=%s",
                         resolved_player,
                         team.id,
-                        loan_club_name,
+                        current_club_name,
                         season_start,
                     )
                 else:
                     logger.info(
                         "[sandbox-diff] supplemental already exists for player=%s loan_team=%s season=%s; skipping",
                         resolved_player,
-                        loan_club_name,
+                        current_club_name,
                         season_start,
                     )
 

--- a/academy-watch-backend/src/agents/weekly_newsletter_agent.py
+++ b/academy-watch-backend/src/agents/weekly_newsletter_agent.py
@@ -1778,9 +1778,9 @@ def fetch_pipeline_report_tool(parent_team_db_id: int, season_start_year: int, s
         }
 
         if tp.status == 'on_loan':
-            player_dict['loan_team_name'] = tp.loan_club_name
-            player_dict['loan_team_api_id'] = tp.loan_club_api_id
-            player_dict['loan_team'] = tp.loan_club_name
+            player_dict['loan_team_name'] = tp.current_club_name
+            player_dict['loan_team_api_id'] = tp.current_club_api_id
+            player_dict['loan_team'] = tp.current_club_name
             # Delegate to existing loan stats pipeline via AcademyPlayer bridge
             if tp.loaned_player_id:
                 lp = AcademyPlayer.query.get(tp.loaned_player_id)
@@ -1790,8 +1790,8 @@ def fetch_pipeline_report_tool(parent_team_db_id: int, season_start_year: int, s
             # Get weekly stats from FixturePlayerStats
             _enrich_on_loan_stats(player_dict, tp, start, end, season_start_year)
             # Fallback: derive loan league from Team record if not set from match data
-            if not player_dict.get('loan_league_name') and tp.loan_club_api_id:
-                loan_team_row = Team.query.filter_by(team_id=tp.loan_club_api_id).first()
+            if not player_dict.get('loan_league_name') and tp.current_club_api_id:
+                loan_team_row = Team.query.filter_by(team_id=tp.current_club_api_id).first()
                 if loan_team_row and loan_team_row.league:
                     player_dict['loan_league_name'] = loan_team_row.league.name
             groups['on_loan'].append(player_dict)
@@ -1849,7 +1849,7 @@ def _enrich_on_loan_stats(player_dict: dict, tp: "TrackedPlayer", start: date, e
             totals['reds'] += row.reds or 0
             totals['saves'] += getattr(row, 'saves', 0) or 0
             if fixture:
-                is_home = fixture.home_team_api_id == tp.loan_club_api_id
+                is_home = fixture.home_team_api_id == tp.current_club_api_id
                 opp_api_id = fixture.away_team_api_id if is_home else fixture.home_team_api_id
                 # Resolve team name from Team table (Fixture model has no name columns)
                 opp_team_row = Team.query.filter_by(team_id=opp_api_id).first()

--- a/academy-watch-backend/src/models/tracked_player.py
+++ b/academy-watch-backend/src/models/tracked_player.py
@@ -31,9 +31,9 @@ class TrackedPlayer(db.Model):
     current_level = db.Column(db.String(20))
     #   'U18' | 'U21' | 'U23' | 'Reserve' | 'Senior'
 
-    # If on loan, where (also used for sold players' current club)
-    loan_club_api_id = db.Column(db.Integer)
-    loan_club_name = db.Column(db.String(200))
+    # Current club (loan club if on_loan, buying club if sold, new club if released)
+    current_club_api_id = db.Column(db.Integer)
+    current_club_name = db.Column(db.String(200))
 
     # Transfer fee when sold (raw string from API-Football, e.g. "€50M", "Free")
     sale_fee = db.Column(db.String(100))
@@ -86,8 +86,8 @@ class TrackedPlayer(db.Model):
             'team_api_id': self.team.team_id if self.team else None,
             'status': self.status,
             'current_level': self.current_level,
-            'loan_club_api_id': self.loan_club_api_id,
-            'loan_club_name': self.loan_club_name,
+            'current_club_api_id': self.current_club_api_id,
+            'current_club_name': self.current_club_name,
             'sale_fee': self.sale_fee,
             'data_source': self.data_source,
             'data_depth': self.data_depth,
@@ -114,8 +114,8 @@ class TrackedPlayer(db.Model):
             'primary_team_id': self.team_id,
             'primary_team_name': self.team.name if self.team else None,
             'primary_team_api_id': self.team.team_id if self.team else None,
-            'loan_team_name': self.loan_club_name,
-            'loan_team_api_id': self.loan_club_api_id,
+            'loan_team_name': self.current_club_name,
+            'loan_team_api_id': self.current_club_api_id,
             'loan_team_logo': None,  # Caller can enrich
             'is_active': self.is_active,
             'status': self.status,

--- a/academy-watch-backend/src/routes/api.py
+++ b/academy-watch-backend/src/routes/api.py
@@ -1721,8 +1721,8 @@ def get_public_player_stats(player_id: int):
                     }
         
         # TrackedPlayer fallback: inject loan club if no AcademyPlayer provided teams
-        if not loan_teams_info and tracked_player_for_stats and tracked_player_for_stats.loan_club_api_id:
-            loan_team_record = Team.query.filter_by(team_id=tracked_player_for_stats.loan_club_api_id).first()
+        if not loan_teams_info and tracked_player_for_stats and tracked_player_for_stats.current_club_api_id:
+            loan_team_record = Team.query.filter_by(team_id=tracked_player_for_stats.current_club_api_id).first()
             if loan_team_record:
                 loan_teams_info[loan_team_record.team_id] = {
                     'name': loan_team_record.name,
@@ -1785,8 +1785,8 @@ def get_public_player_stats(player_id: int):
                     if best_team_id and best_team_info:
                         loan_teams_info[best_team_id] = best_team_info
                         # Backfill TrackedPlayer for future lookups
-                        tracked_player_for_stats.loan_club_api_id = best_team_id
-                        tracked_player_for_stats.loan_club_name = best_team_info['name']
+                        tracked_player_for_stats.current_club_api_id = best_team_id
+                        tracked_player_for_stats.current_club_name = best_team_info['name']
                         db.session.commit()
             except Exception as e:
                 logger.warning(f"Failed to discover teams for player {player_id}: {e}")
@@ -2103,7 +2103,7 @@ def public_player_search():
                 'photo_url': row.photo_url,
                 'position': row.position,
                 'team_name': row.team.name if row.team else None,
-                'loan_club_name': row.loan_club_name,
+                'current_club_name': row.current_club_name,
             })
             if len(results) >= 8:
                 break
@@ -2242,9 +2242,9 @@ def get_public_player_profile(player_id: int):
                     result['parent_team_id'] = tracked.team.team_id
                     result['primary_team_db_id'] = tracked.team_id
                 # Loan team from tracked player (if on_loan)
-                if not result['loan_team_name'] and tracked.loan_club_api_id:
-                    result['loan_team_name'] = tracked.loan_club_name
-                    loan_team_record = Team.query.filter_by(team_id=tracked.loan_club_api_id).first()
+                if not result['loan_team_name'] and tracked.current_club_api_id:
+                    result['loan_team_name'] = tracked.current_club_name
+                    loan_team_record = Team.query.filter_by(team_id=tracked.current_club_api_id).first()
                     if loan_team_record:
                         result['loan_team_logo'] = loan_team_record.logo
                         result['loan_team_id'] = loan_team_record.team_id
@@ -2338,11 +2338,11 @@ def get_public_player_profile(player_id: int):
             })
         
         # If loan_history is empty and TrackedPlayer is on_loan, synthesize an entry
-        if not loan_history and tracked and tracked.status == 'on_loan' and tracked.loan_club_api_id:
-            loan_team_record = Team.query.filter_by(team_id=tracked.loan_club_api_id).first()
+        if not loan_history and tracked and tracked.status == 'on_loan' and tracked.current_club_api_id:
+            loan_team_record = Team.query.filter_by(team_id=tracked.current_club_api_id).first()
             loan_history.append({
-                'loan_team_name': tracked.loan_club_name or (loan_team_record.name if loan_team_record else None),
-                'loan_team_id': tracked.loan_club_api_id,
+                'loan_team_name': tracked.current_club_name or (loan_team_record.name if loan_team_record else None),
+                'loan_team_id': tracked.current_club_api_id,
                 'loan_team_db_id': loan_team_record.id if loan_team_record else None,
                 'loan_team_logo': loan_team_record.logo if loan_team_record else None,
                 'parent_team_name': tracked.team.name if tracked.team else None,
@@ -2425,8 +2425,8 @@ def get_public_player_season_stats(player_id: int):
                     if linked_loan:
                         all_loans = [linked_loan]
                 # If on loan with a club but no AcademyPlayer, inject the loan club
-                elif tracked_for_season.loan_club_api_id:
-                    loan_team_record = Team.query.filter_by(team_id=tracked_for_season.loan_club_api_id).first()
+                elif tracked_for_season.current_club_api_id:
+                    loan_team_record = Team.query.filter_by(team_id=tracked_for_season.current_club_api_id).first()
                     if loan_team_record:
                         # Create a minimal object-like dict for downstream processing
                         # We'll handle this in the loan_teams_info block below
@@ -2447,7 +2447,7 @@ def get_public_player_season_stats(player_id: int):
                 return jsonify(result)
             # For on_loan tracked players with a loan club but no AcademyPlayer row,
             # proceed with loan_teams_info injection below
-            if not (tracked_for_season and tracked_for_season.loan_club_api_id):
+            if not (tracked_for_season and tracked_for_season.current_club_api_id):
                 return jsonify(result)
 
         # 📊 CHECK FOR LIMITED COVERAGE (e.g., National League)
@@ -2503,8 +2503,8 @@ def get_public_player_season_stats(player_id: int):
                     loan_team_api_ids.append(loan_team.team_id)
         
         # TrackedPlayer fallback: inject loan club if no AcademyPlayer provided teams
-        if not loan_teams_info and tracked_for_season and tracked_for_season.loan_club_api_id:
-            loan_team_record = Team.query.filter_by(team_id=tracked_for_season.loan_club_api_id).first()
+        if not loan_teams_info and tracked_for_season and tracked_for_season.current_club_api_id:
+            loan_team_record = Team.query.filter_by(team_id=tracked_for_season.current_club_api_id).first()
             if loan_team_record:
                 loan_teams_info.append({
                     'api_id': loan_team_record.team_id,
@@ -9031,9 +9031,9 @@ def admin_sync_player_fixtures(player_id: int):
         
         if tp:
             player_name = tp.player_name
-            if tp.status == 'on_loan' and tp.loan_club_api_id:
-                team_api_id = tp.loan_club_api_id
-                team_name = tp.loan_club_name or f'Team {tp.loan_club_api_id}'
+            if tp.status == 'on_loan' and tp.current_club_api_id:
+                team_api_id = tp.current_club_api_id
+                team_name = tp.current_club_name or f'Team {tp.current_club_api_id}'
             elif tp.status == 'first_team':
                 parent_team = Team.query.get(tp.team_id)
                 if parent_team:
@@ -9336,8 +9336,8 @@ def _run_batch_fixture_sync(data: dict, job_id: str = None) -> dict:
 
     tracked_api_ids = set()
     for tp in tracked:
-        if tp.status == 'on_loan' and tp.loan_club_api_id:
-            team_players[tp.loan_club_api_id].append((tp.player_api_id, tp.player_name))
+        if tp.status == 'on_loan' and tp.current_club_api_id:
+            team_players[tp.current_club_api_id].append((tp.player_api_id, tp.player_name))
             tracked_api_ids.add(tp.player_api_id)
         elif tp.status in ('first_team', 'academy') and tp.team_id:
             parent_team = Team.query.get(tp.team_id)
@@ -9361,8 +9361,8 @@ def _run_batch_fixture_sync(data: dict, job_id: str = None) -> dict:
         if tp.player_api_id in tracked_api_ids:
             continue
         # If we already have a team from a prior backfill, use it
-        if tp.loan_club_api_id:
-            team_players[tp.loan_club_api_id].append((tp.player_api_id, tp.player_name))
+        if tp.current_club_api_id:
+            team_players[tp.current_club_api_id].append((tp.player_api_id, tp.player_name))
             tracked_api_ids.add(tp.player_api_id)
             continue
         # Discover team from API-Football /players endpoint
@@ -9400,8 +9400,8 @@ def _run_batch_fixture_sync(data: dict, job_id: str = None) -> dict:
                     tracked_api_ids.add(tp.player_api_id)
                     # Backfill team on TrackedPlayer
                     if not dry_run:
-                        tp.loan_club_api_id = team_api_id
-                        tp.loan_club_name = best_team_block.get('name')
+                        tp.current_club_api_id = team_api_id
+                        tp.current_club_name = best_team_block.get('name')
                         # Also backfill position if missing
                         if not tp.position:
                             games = best_stat.get('games', {}) or {}
@@ -9777,10 +9777,10 @@ def _run_team_fixtures_sync(team_id: int, data: dict, job_id: str = None) -> dic
         # Build a unified list of (player_api_id, player_name, team_api_id, team_name)
         players_to_sync = []
         for tp in tracked_players:
-            if tp.status == 'on_loan' and tp.loan_club_api_id:
+            if tp.status == 'on_loan' and tp.current_club_api_id:
                 players_to_sync.append((
                     tp.player_api_id, tp.player_name,
-                    tp.loan_club_api_id, tp.loan_club_name or f'Team {tp.loan_club_api_id}',
+                    tp.current_club_api_id, tp.current_club_name or f'Team {tp.current_club_api_id}',
                 ))
             elif tp.status in ('first_team', 'academy'):
                 players_to_sync.append((
@@ -13961,12 +13961,12 @@ def get_player_journey_map(player_id: int):
                     'source': 'tracked-player',
                 }
                 # Add loan club stop if on loan
-                if tracked.loan_club_api_id:
-                    loan_team = Team.query.filter_by(team_id=tracked.loan_club_api_id).first()
+                if tracked.current_club_api_id:
+                    loan_team = Team.query.filter_by(team_id=tracked.current_club_api_id).first()
                     if loan_team:
                         map_data['stops'].append({
-                            'club_id': tracked.loan_club_api_id,
-                            'club_name': tracked.loan_club_name or loan_team.name,
+                            'club_id': tracked.current_club_api_id,
+                            'club_name': tracked.current_club_name or loan_team.name,
                             'club_logo': loan_team.logo,
                             'years': str(datetime.now().year),
                             'levels': ['First Team'],
@@ -14481,8 +14481,8 @@ def admin_test_classify():
                 'parent_api_id': pid,
                 'parent_club_name': parent_name,
                 'status': status,
-                'loan_club_api_id': loan_id,
-                'loan_club_name': loan_name,
+                'current_club_api_id': loan_id,
+                'current_club_name': loan_name,
                 'reasoning': reasoning,
             })
 
@@ -15045,8 +15045,8 @@ def admin_create_tracked_player():
             position=data.get('position'),
             nationality=data.get('nationality'),
             age=data.get('age'),
-            loan_club_api_id=data.get('loan_club_api_id'),
-            loan_club_name=data.get('loan_club_name'),
+            current_club_api_id=data.get('current_club_api_id'),
+            current_club_name=data.get('current_club_name'),
             data_source=data.get('data_source', 'manual'),
             notes=data.get('notes'),
         )
@@ -15069,7 +15069,7 @@ def admin_update_tracked_player(player_id):
             return jsonify({'error': 'Player not found'}), 404
 
         data = request.get_json(force=True)
-        allowed = ['status', 'current_level', 'loan_club_api_id', 'loan_club_name',
+        allowed = ['status', 'current_level', 'current_club_api_id', 'current_club_name',
                     'notes', 'position', 'is_active', 'photo_url', 'team_id',
                     'pinned_parent']
         for field in allowed:
@@ -15288,10 +15288,10 @@ def _seed_single_team(team, max_age=30, sync_journeys=True, years=4, season=None
                     api_client=_api,
                     latest_season=_get_latest_season(journey.id, parent_api_id=parent_api_id, parent_club_name=team.name) if journey else None,
                 )
-                if existing.status != new_status or existing.loan_club_api_id != new_loan_id:
+                if existing.status != new_status or existing.current_club_api_id != new_loan_id:
                     existing.status = new_status
-                    existing.loan_club_api_id = new_loan_id
-                    existing.loan_club_name = new_loan_name
+                    existing.current_club_api_id = new_loan_id
+                    existing.current_club_name = new_loan_name
                 skipped += 1
                 continue
 
@@ -15312,7 +15312,7 @@ def _seed_single_team(team, max_age=30, sync_journeys=True, years=4, season=None
                 position = (stats_list[0].get('games') or {}).get('position') or ''
             age = pi.get('age')
 
-            status, loan_club_api_id, loan_club_name = classify_tracked_player(
+            status, current_club_api_id, current_club_name = classify_tracked_player(
                 current_club_api_id=journey.current_club_api_id if journey else None,
                 current_club_name=journey.current_club_name if journey else None,
                 current_level=journey.current_level if journey else None,
@@ -15338,8 +15338,8 @@ def _seed_single_team(team, max_age=30, sync_journeys=True, years=4, season=None
                 team_id=team_id,
                 status=status,
                 current_level=current_level,
-                loan_club_api_id=loan_club_api_id,
-                loan_club_name=loan_club_name,
+                current_club_api_id=current_club_api_id,
+                current_club_name=current_club_name,
                 data_source='api-football',
                 data_depth='full_stats',
                 journey_id=journey.id if journey else None,
@@ -15866,7 +15866,7 @@ def get_team_players(team_identifier):
         from src.models.weekly import FixturePlayerStats
         from sqlalchemy import func as sa_func
 
-        player_api_ids_on_loan = [tp.player_api_id for tp in players if tp.loan_club_api_id]
+        player_api_ids_on_loan = [tp.player_api_id for tp in players if tp.current_club_api_id]
         player_stats_map = {}
         if player_api_ids_on_loan:
             stats_rows = db.session.query(
@@ -15938,10 +15938,10 @@ def get_team_players(team_identifier):
                 }
 
         # Batch-fetch loan team logos (1 query)
-        loan_club_api_ids = list({tp.loan_club_api_id for tp in players if tp.loan_club_api_id})
+        current_club_api_ids = list({tp.current_club_api_id for tp in players if tp.current_club_api_id})
         loan_team_logos = {}
-        if loan_club_api_ids:
-            loan_teams = Team.query.filter(Team.team_id.in_(loan_club_api_ids)).all()
+        if current_club_api_ids:
+            loan_teams = Team.query.filter(Team.team_id.in_(current_club_api_ids)).all()
             loan_team_logos = {lt.team_id: lt.logo for lt in loan_teams}
 
         # Build results with batch-enriched data
@@ -15984,8 +15984,8 @@ def get_team_players(team_identifier):
                     d['position'] = POSITION_MAP.get(fps_pos, fps_pos)
 
             # Fill in loan team logo
-            if tp.loan_club_api_id:
-                logo = loan_team_logos.get(tp.loan_club_api_id)
+            if tp.current_club_api_id:
+                logo = loan_team_logos.get(tp.current_club_api_id)
                 if logo:
                     d['loan_team_logo'] = logo
 

--- a/academy-watch-backend/src/routes/teams.py
+++ b/academy-watch-backend/src/routes/teams.py
@@ -877,7 +877,7 @@ def get_academy_network(team_identifier):
                 'player_name': tp.player_name,
                 'player_photo': tp.photo_url,
                 'status': tp.status,
-                'current_club_name': tp.loan_club_name,
+                'current_club_name': tp.current_club_name,
                 'total_appearances': 0,
                 'parent_club_appearances': 0,
                 'destinations': [],

--- a/academy-watch-backend/src/services/gol_dataframes.py
+++ b/academy-watch-backend/src/services/gol_dataframes.py
@@ -55,7 +55,7 @@ class DataFrameCache:
                     tp.position, tp.nationality,
                     tp.team_id AS parent_team_id,
                     t.name AS parent_club,
-                    tp.loan_club_name,
+                    tp.current_club_name,
                     tp.current_level, tp.is_active
                 FROM tracked_players tp
                 LEFT JOIN teams t ON tp.team_id = t.id
@@ -77,7 +77,7 @@ class DataFrameCache:
                     tp.player_api_id, tp.player_name, tp.position,
                     tp.nationality, tp.age, tp.team_id,
                     tp.status, tp.current_level,
-                    tp.loan_club_name, tp.data_source, tp.is_active
+                    tp.current_club_name, tp.data_source, tp.is_active
                 FROM tracked_players tp
                 WHERE tp.is_active = true
             """)

--- a/academy-watch-backend/src/services/gol_player_lookup.py
+++ b/academy-watch-backend/src/services/gol_player_lookup.py
@@ -351,7 +351,7 @@ class GolPlayerLookup:
         current_club_name = journey.current_club_name if journey else None
         current_level = journey.current_level if journey else None
 
-        status, loan_club_api_id, loan_club_name = classify_tracked_player(
+        status, current_club_api_id, current_club_name = classify_tracked_player(
             current_club_api_id=current_club_id,
             current_club_name=current_club_name,
             current_level=current_level,
@@ -390,8 +390,8 @@ class GolPlayerLookup:
             existing.age = age if age is not None else existing.age
             existing.status = status
             existing.current_level = current_level or existing.current_level
-            existing.loan_club_api_id = loan_club_api_id
-            existing.loan_club_name = loan_club_name
+            existing.current_club_api_id = current_club_api_id
+            existing.current_club_name = current_club_name
             existing.journey_id = journey.id if journey else existing.journey_id
             existing.data_source = 'api-football'
             existing.data_depth = 'full_stats'
@@ -410,8 +410,8 @@ class GolPlayerLookup:
             team_id=team.id,
             status=status,
             current_level=current_level,
-            loan_club_api_id=loan_club_api_id,
-            loan_club_name=loan_club_name,
+            current_club_api_id=current_club_api_id,
+            current_club_name=current_club_name,
             data_source='api-football',
             data_depth='full_stats',
             journey_id=journey.id if journey else None,

--- a/academy-watch-backend/src/services/gol_sandbox.py
+++ b/academy-watch-backend/src/services/gol_sandbox.py
@@ -118,7 +118,7 @@ def _build_helpers(dataframes: dict) -> dict:
         tracked = dataframes.get('tracked', pd.DataFrame())
         teams = dataframes.get('teams', pd.DataFrame())
         if tracked.empty or teams.empty:
-            return pd.DataFrame(columns=['player_name', 'team', 'status', 'position', 'loan_club_name', 'age'])
+            return pd.DataFrame(columns=['player_name', 'team', 'status', 'position', 'current_club_name', 'age'])
 
         active = tracked[tracked['status'].isin(['academy', 'on_loan', 'first_team'])]
         merged = active.merge(teams[['id', 'name']], left_on='team_id', right_on='id', how='inner')
@@ -126,7 +126,7 @@ def _build_helpers(dataframes: dict) -> dict:
             merged = merged[merged['name'].str.contains(team_name, case=False, na=False)]
         else:
             merged = merged[merged['name'].isin(BIG_6)]
-        return (merged[['player_name', 'name', 'status', 'position', 'loan_club_name', 'age']]
+        return (merged[['player_name', 'name', 'status', 'position', 'current_club_name', 'age']]
                 .rename(columns={'name': 'team'})
                 .sort_values(['team', 'status', 'player_name'])
                 .reset_index(drop=True))
@@ -170,7 +170,7 @@ def _build_helpers(dataframes: dict) -> dict:
         if merged.empty:
             return pd.DataFrame(columns=['player_name', 'parent_club', 'loan_club', 'goals', 'assists', 'minutes', 'avg_rating'])
 
-        agg = merged.groupby(['player_api_id', 'player_name', 'parent_club', 'loan_club_name']).agg(
+        agg = merged.groupby(['player_api_id', 'player_name', 'parent_club', 'current_club_name']).agg(
             goals=('goals', 'sum'),
             assists=('assists', 'sum'),
             minutes=('minutes', 'sum'),
@@ -179,7 +179,7 @@ def _build_helpers(dataframes: dict) -> dict:
         agg['avg_rating'] = agg['avg_rating'].round(2)
         agg = agg.sort_values(['goals', 'assists'], ascending=[False, False]).head(limit)
         return agg.rename(columns={
-            'loan_club_name': 'loan_club'
+            'current_club_name': 'loan_club'
         })[['player_name', 'parent_club', 'loan_club', 'goals', 'assists', 'minutes', 'avg_rating']].reset_index(drop=True)
 
     def player_career(player_name):

--- a/academy-watch-backend/src/services/gol_service.py
+++ b/academy-watch-backend/src/services/gol_service.py
@@ -40,7 +40,7 @@ format for the data. `pd` (pandas) and `np` (numpy) are pre-loaded. NEVER use \
 ### `loan_players` (players currently on loan — roster ONLY, NO stats)
 Columns: player_api_id (int, API-Football ID), player_name (str), age (int), \
 position (str), nationality (str), parent_team_id (int, FK to teams.id), \
-parent_club (str, parent/academy club name), loan_club_name (str, where on loan), \
+parent_club (str, parent/academy club name), current_club_name (str, where on loan), \
 current_level (str), is_active (bool)
 **This table has NO stats columns.** For goals, assists, appearances, minutes, \
 use `fixture_stats` (per-match) or `journey_entries` (season aggregates).
@@ -54,7 +54,7 @@ country (str), league_name (str or null), is_tracked (bool), season (int)
 Columns: player_api_id (int), player_name (str), position (str: Goalkeeper/Defender/Midfielder/Attacker), \
 nationality (str), age (int), team_id (int, FK to teams.id), \
 status (str: academy/on_loan/first_team/released/sold), \
-current_level (str), loan_club_name (str or null), data_source (str), is_active (bool)
+current_level (str), current_club_name (str or null), data_source (str), is_active (bool)
 
 ### `journeys` (career summaries)
 Columns: player_api_id (int), player_name (str), nationality (str), \
@@ -135,7 +135,7 @@ aggregates. Standard pattern for loan player stats:
   ```
   fs = fixture_stats[fixture_stats['season'] == fixture_stats['season'].max()]
   agg = fs.groupby('player_api_id')[['goals','assists','minutes']].sum().reset_index()
-  result = loan_players[['player_api_id','player_name','loan_club_name']].merge(agg, on='player_api_id', how='inner')
+  result = loan_players[['player_api_id','player_name','current_club_name']].merge(agg, on='player_api_id', how='inner')
   ```
 - **Season filtering:** When aggregating `fixture_stats`, always filter by season \
 first: `fixture_stats[fixture_stats['season'] == fixture_stats['season'].max()]`. This avoids \
@@ -560,7 +560,7 @@ class GolService:
         ).order_by(func.random()).limit(2).all()
 
         for p in recent_players:
-            suggestions.append(f"How is {p.player_name} doing at {p.loan_club_name}?")
+            suggestions.append(f"How is {p.player_name} doing at {p.current_club_name}?")
 
         suggestions.extend([
             "Which Big 6 academy is producing the most first-team players?",

--- a/academy-watch-backend/src/services/journey_sync.py
+++ b/academy-watch-backend/src/services/journey_sync.py
@@ -1001,7 +1001,7 @@ class JourneySyncService:
                 team_id=team.id,
             ).first()
 
-            status, loan_club_api_id, loan_club_name = classify_tracked_player(
+            status, current_club_api_id, current_club_name = classify_tracked_player(
                 current_club_api_id=journey.current_club_api_id,
                 current_club_name=journey.current_club_name,
                 current_level=journey.current_level,
@@ -1023,8 +1023,8 @@ class JourneySyncService:
                     data_source='journey-sync',
                     data_depth='full_stats',
                     status=status,
-                    loan_club_api_id=loan_club_api_id,
-                    loan_club_name=loan_club_name,
+                    current_club_api_id=current_club_api_id,
+                    current_club_name=current_club_name,
                 )
                 db.session.add(tp)
             else:
@@ -1038,8 +1038,8 @@ class JourneySyncService:
                     )
                     continue
                 existing.status = status
-                existing.loan_club_api_id = loan_club_api_id
-                existing.loan_club_name = loan_club_name
+                existing.current_club_api_id = current_club_api_id
+                existing.current_club_name = current_club_name
 
     @staticmethod
     def _get_latest_departure_type(transfers, parent_api_id):

--- a/academy-watch-backend/src/services/transfer_heal_service.py
+++ b/academy-watch-backend/src/services/transfer_heal_service.py
@@ -4,7 +4,7 @@ Detects loan club changes for tracked players by re-querying API-Football,
 updates statuses, and optionally cascades fixture syncs for affected players.
 
 Uses TrackedPlayer as the primary model — fixture syncs are cascaded
-per-player via _sync_player_club_fixtures using TrackedPlayer.loan_club_api_id
+per-player via _sync_player_club_fixtures using TrackedPlayer.current_club_api_id
 directly, without depending on AcademyPlayer rows.
 """
 
@@ -69,7 +69,7 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False,
 
     # Batch pre-fetch squads for loan + parent clubs
     squad_members_by_club = {}
-    loan_club_ids = {tp.loan_club_api_id for tp in players if tp.loan_club_api_id}
+    loan_club_ids = {tp.current_club_api_id for tp in players if tp.current_club_api_id}
     parent_club_ids = set()
     _team_cache = {}
     for tp in players:
@@ -149,16 +149,16 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False,
             continue
 
         changed = False
-        old_loan_id = tp.loan_club_api_id
+        old_loan_id = tp.current_club_api_id
 
         if tp.status != new_status:
             tp.status = new_status
             changed = True
-        if tp.loan_club_api_id != new_loan_id:
-            tp.loan_club_api_id = new_loan_id
+        if tp.current_club_api_id != new_loan_id:
+            tp.current_club_api_id = new_loan_id
             changed = True
-        if tp.loan_club_name != new_loan_name:
-            tp.loan_club_name = new_loan_name
+        if tp.current_club_name != new_loan_name:
+            tp.current_club_name = new_loan_name
             changed = True
         if journey.current_level and tp.current_level != journey.current_level:
             tp.current_level = journey.current_level
@@ -172,8 +172,8 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False,
                     'player_api_id': tp.player_api_id,
                     'player_name': tp.player_name,
                     'team_id': tp.team_id,
-                    'old_loan_club_api_id': old_loan_id,
-                    'new_loan_club_api_id': new_loan_id,
+                    'old_current_club_api_id': old_loan_id,
+                    'new_current_club_api_id': new_loan_id,
                     'new_loan_club': new_loan_name,
                 })
 
@@ -193,7 +193,7 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False,
             try:
                 synced = _sync_player_club_fixtures(
                     player_id=pc['player_api_id'],
-                    loan_team_api_id=pc['new_loan_club_api_id'],
+                    loan_team_api_id=pc['new_current_club_api_id'],
                     season=season,
                     player_name=pc.get('player_name'),
                 )
@@ -202,12 +202,12 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False,
                     'transfer-heal: synced %d fixtures for player %d (%s) '
                     'at new club %s (api_id=%d)',
                     synced, pc['player_api_id'], pc.get('player_name'),
-                    pc['new_loan_club'], pc['new_loan_club_api_id'],
+                    pc['new_loan_club'], pc['new_current_club_api_id'],
                 )
             except Exception as exc:
                 logger.error(
                     'transfer-heal: fixture sync failed for player %d at club %d: %s',
-                    pc['player_api_id'], pc['new_loan_club_api_id'], exc,
+                    pc['player_api_id'], pc['new_current_club_api_id'], exc,
                 )
 
     return {

--- a/academy-watch-backend/src/utils/academy_classifier.py
+++ b/academy-watch-backend/src/utils/academy_classifier.py
@@ -141,7 +141,7 @@ def derive_player_status(
     parent_api_id: int,
     parent_club_name: str,
 ) -> Tuple[str, Optional[int], Optional[str]]:
-    """Derive (status, loan_club_api_id, loan_club_name) for a player
+    """Derive (status, current_club_api_id, current_club_name) for a player
     relative to their parent / academy club.
 
     Rules (in order):
@@ -151,7 +151,7 @@ def derive_player_status(
     4. Different club → on_loan
 
     Returns:
-        (status, loan_club_api_id, loan_club_name)
+        (status, current_club_api_id, current_club_name)
         where status is one of 'academy', 'first_team', 'on_loan'
     """
     # No current club info → assume still at academy
@@ -188,7 +188,7 @@ def derive_player_status_with_reasoning(
     """Like derive_player_status but also returns step-by-step reasoning.
 
     Returns:
-        (status, loan_club_api_id, loan_club_name, reasoning)
+        (status, current_club_api_id, current_club_name, reasoning)
         where reasoning is a list of dicts with rule/check/result/detail.
     """
     reasoning: List[Dict] = []
@@ -432,8 +432,8 @@ def classify_tracked_player(
             inactivity check.
 
     Returns:
-        ``(status, loan_club_api_id, loan_club_name)`` or
-        ``(status, loan_club_api_id, loan_club_name, reasoning)``
+        ``(status, current_club_api_id, current_club_name)`` or
+        ``(status, current_club_api_id, current_club_name, reasoning)``
         when *with_reasoning* is True.
     """
     if config is None:

--- a/academy-watch-backend/src/utils/rebuild_runner.py
+++ b/academy-watch-backend/src/utils/rebuild_runner.py
@@ -348,7 +348,7 @@ def _run_full_rebuild(job_id, config):
                     position = pi.get('position') or ''
                     age = pi.get('age')
 
-                    status, loan_club_api_id, loan_club_name = classify_tracked_player(
+                    status, current_club_api_id, current_club_name = classify_tracked_player(
                         current_club_api_id=journey.current_club_api_id if journey else None,
                         current_club_name=journey.current_club_name if journey else None,
                         current_level=journey.current_level if journey else None,
@@ -372,8 +372,8 @@ def _run_full_rebuild(job_id, config):
                         team_id=team.id,
                         status=status,
                         current_level=current_level,
-                        loan_club_api_id=loan_club_api_id,
-                        loan_club_name=loan_club_name,
+                        current_club_api_id=current_club_api_id,
+                        current_club_name=current_club_name,
                         data_source='api-football',
                         data_depth='full_stats',
                         journey_id=journey.id if journey else None,
@@ -420,7 +420,7 @@ def _run_full_rebuild(job_id, config):
 
         # Build squad membership map for squad cross-reference
         squad_members_by_club = {}
-        _loan_ids = {tp.loan_club_api_id for tp in tracked if tp.loan_club_api_id}
+        _loan_ids = {tp.current_club_api_id for tp in tracked if tp.current_club_api_id}
         _parent_ids = {tp.team.team_id for tp in tracked if tp.team}
         for _cid in (_loan_ids | _parent_ids):
             try:
@@ -449,10 +449,10 @@ def _run_full_rebuild(job_id, config):
                 latest_season=_get_latest_season(journey.id, parent_api_id=tp.team.team_id, parent_club_name=tp.team.name) if journey else None,
                 squad_members_by_club=squad_members_by_club,
             )
-            if tp.status != status or tp.loan_club_api_id != loan_api_id:
+            if tp.status != status or tp.current_club_api_id != loan_api_id:
                 tp.status = status
-                tp.loan_club_api_id = loan_api_id
-                tp.loan_club_name = loan_name
+                tp.current_club_api_id = loan_api_id
+                tp.current_club_name = loan_name
                 updated += 1
             status_counts[status] = status_counts.get(status, 0) + 1
         if updated:

--- a/academy-watch-frontend/src/pages/admin/AdminPlayers.jsx
+++ b/academy-watch-frontend/src/pages/admin/AdminPlayers.jsx
@@ -90,8 +90,8 @@ function AllPlayersTab({ teams, setMessage }) {
         setEditForm({
             status: player.status || 'academy',
             current_level: player.current_level || '',
-            loan_club_api_id: player.loan_club_api_id || '',
-            loan_club_name: player.loan_club_name || '',
+            current_club_api_id: player.current_club_api_id || '',
+            current_club_name: player.current_club_name || '',
             notes: player.notes || '',
             position: player.position || '',
         })
@@ -276,8 +276,8 @@ function AllPlayersTab({ teams, setMessage }) {
                                             <div>
                                                 <Label className="text-xs">Loan Club Name</Label>
                                                 <Input
-                                                    value={editForm.loan_club_name}
-                                                    onChange={(e) => setEditForm({ ...editForm, loan_club_name: e.target.value })}
+                                                    value={editForm.current_club_name}
+                                                    onChange={(e) => setEditForm({ ...editForm, current_club_name: e.target.value })}
                                                     placeholder="e.g. Sheffield Wednesday"
                                                 />
                                             </div>
@@ -285,8 +285,8 @@ function AllPlayersTab({ teams, setMessage }) {
                                                 <Label className="text-xs">Loan Club API ID</Label>
                                                 <Input
                                                     type="number"
-                                                    value={editForm.loan_club_api_id}
-                                                    onChange={(e) => setEditForm({ ...editForm, loan_club_api_id: e.target.value })}
+                                                    value={editForm.current_club_api_id}
+                                                    onChange={(e) => setEditForm({ ...editForm, current_club_api_id: e.target.value })}
                                                     placeholder="Optional"
                                                 />
                                             </div>
@@ -327,7 +327,7 @@ function AllPlayersTab({ teams, setMessage }) {
                                                 <span>{p.team_name || '—'}</span>
                                                 {p.position && <span>{p.position}</span>}
                                                 {p.current_level && <span>{p.current_level}</span>}
-                                                {p.loan_club_name && <span>@ {p.loan_club_name}</span>}
+                                                {p.current_club_name && <span>@ {p.current_club_name}</span>}
                                             </div>
                                         </div>
                                     </div>
@@ -620,7 +620,7 @@ function ManualAddForm({ teams, setMessage }) {
         team_id: '',
         status: 'academy',
         current_level: '',
-        loan_club_name: '',
+        current_club_name: '',
         notes: '',
     })
 
@@ -645,12 +645,12 @@ function ManualAddForm({ teams, setMessage }) {
             if (form.nationality) payload.nationality = form.nationality
             if (form.age) payload.age = parseInt(form.age)
             if (form.current_level) payload.current_level = form.current_level
-            if (form.loan_club_name) payload.loan_club_name = form.loan_club_name
+            if (form.current_club_name) payload.current_club_name = form.current_club_name
             if (form.notes) payload.notes = form.notes
 
             await APIService.adminTrackedPlayerCreate(payload)
             setMessage({ type: 'success', text: `Added ${form.player_name}` })
-            setForm({ player_name: '', position: '', nationality: '', age: '', team_id: '', status: 'academy', current_level: '', loan_club_name: '', notes: '' })
+            setForm({ player_name: '', position: '', nationality: '', age: '', team_id: '', status: 'academy', current_level: '', current_club_name: '', notes: '' })
         } catch (error) {
             setMessage({ type: 'error', text: `Create failed: ${error?.body?.error || error.message}` })
         }
@@ -698,7 +698,7 @@ function ManualAddForm({ teams, setMessage }) {
                 {form.status === 'on_loan' && (
                     <div className="md:col-span-2">
                         <Label>Loan Club Name</Label>
-                        <Input value={form.loan_club_name} onChange={(e) => setForm({ ...form, loan_club_name: e.target.value })} placeholder="e.g. Sheffield Wednesday" />
+                        <Input value={form.current_club_name} onChange={(e) => setForm({ ...form, current_club_name: e.target.value })} placeholder="e.g. Sheffield Wednesday" />
                     </div>
                 )}
                 <div className="md:col-span-2">

--- a/academy-watch-frontend/src/pages/admin/AdminSandbox.jsx
+++ b/academy-watch-frontend/src/pages/admin/AdminSandbox.jsx
@@ -95,7 +95,7 @@ export function AdminSandbox() {
             id: tp.player_api_id,
             name: tp.player_name,
             photo: tp.photo_url,
-            team: tp.loan_club_name || (tp.team?.name),
+            team: tp.current_club_name || (tp.team?.name),
         })
         setSearchQuery(tp.player_name || '')
         setResult(null)
@@ -365,9 +365,9 @@ export function AdminSandbox() {
                                             Classification: {cls.parent_club_name}
                                         </CardTitle>
                                         <StatusBadge status={cls.status} />
-                                        {cls.loan_club_name && (
+                                        {cls.current_club_name && (
                                             <span className="text-sm text-muted-foreground">
-                                                at {cls.loan_club_name}
+                                                at {cls.current_club_name}
                                             </span>
                                         )}
                                     </div>


### PR DESCRIPTION
## Summary
- Renamed `loan_club_api_id` / `loan_club_name` → `current_club_api_id` / `current_club_name` on `TrackedPlayer`
- The old name was semantically wrong for sold/released players — "loan club" ≠ "club they were sold to"
- `current_club` accurately describes the field for all statuses: loan club (on_loan), buying club (sold), new club (released)
- 18 files updated across model, routes, services, utils, agents, frontend, and docs
- DB migration renames the columns (already applied to production)

## Test plan
- [ ] Verify Garnacho page shows Chelsea stats
- [ ] Verify admin Players & Loans Manager form still works
- [ ] `pnpm build` passes (verified)
- [ ] All Python files pass syntax check (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)