### PR TITLE
fix: Pass season arg to rebuild runner's team sync

### DIFF
--- a/academy-watch-backend/src/utils/rebuild_runner.py
+++ b/academy-watch-backend/src/utils/rebuild_runner.py
@@ -124,7 +124,7 @@ def _run_full_rebuild(job_id, config):
                 if not league or Team.query.filter_by(league_id=league.id, is_active=True).count() == 0:
                     update_job(job_id, current_player='Syncing European league teams...')
                     from src.routes.teams import _lazy_sync_european_teams
-                    _lazy_sync_european_teams()
+                    _lazy_sync_european_teams(seasons[0] if seasons else None)
                     break
 
         # ── Stage 1: Clean slate ──


### PR DESCRIPTION
## Summary
- `_lazy_sync_european_teams()` requires a `season` parameter but `rebuild_runner.py` called it without one
- Full rebuilds with `league_ids` config crashed at the pre-check stage
- Now passes the first season from the config

🤖 Generated with [Claude Code](https://claude.com/claude-code)