### PR TITLE
feat: Add sync-fixtures CLI command and Azure job

### DIFF
--- a/academy-watch-backend/src/main.py
+++ b/academy-watch-backend/src/main.py
@@ -313,6 +313,16 @@ def seed_teams_cmd():
     print("Seed complete.", flush=True)
 
 
+@app.cli.command("sync-fixtures")
+def sync_fixtures_cmd():
+    """Sync match fixtures and player stats for all active tracked players."""
+    from src.routes.api import _run_batch_fixture_sync
+
+    print("Starting batch fixture sync ...", flush=True)
+    result = _run_batch_fixture_sync({})
+    print(f"Done — {result}", flush=True)
+
+
 if __name__ == "__main__":
     # Only run when you execute `python src/main.py`,
     # NOT when Flask CLI imports the app.

--- a/deploy_aca.sh
+++ b/deploy_aca.sh
@@ -31,6 +31,8 @@ TAG="${TAG:-prod}"
 JOB_WEEKLY_NAME="${JOB_WEEKLY_NAME:-job-weekly-newsletters}"
 # Optional: transfer heal job name to keep in sync with backend image tag
 JOB_TRANSFER_HEAL_NAME="${JOB_TRANSFER_HEAL_NAME:-job-transfer-heal}"
+# Optional: fixture sync job name to keep in sync with backend image tag
+JOB_SYNC_FIXTURES_NAME="${JOB_SYNC_FIXTURES_NAME:-job-sync-fixtures}"
 # Optional explicit API base for frontend build. If empty, derived from backend FQDN
 VITE_API_BASE="${VITE_API_BASE:-}"
 
@@ -225,6 +227,14 @@ if az containerapp job show -g "$RG" -n "$JOB_TRANSFER_HEAL_NAME" >/dev/null 2>&
     --image "$ACR_SERVER/loanarmy/backend:$TAG" >/dev/null
 else
   log "Skipping job update (job '$JOB_TRANSFER_HEAL_NAME' not found)"
+fi
+
+if az containerapp job show -g "$RG" -n "$JOB_SYNC_FIXTURES_NAME" >/dev/null 2>&1; then
+  log "Updating scheduled job '$JOB_SYNC_FIXTURES_NAME' image to $ACR_SERVER/loanarmy/backend:$TAG"
+  az containerapp job update -g "$RG" -n "$JOB_SYNC_FIXTURES_NAME" \
+    --image "$ACR_SERVER/loanarmy/backend:$TAG" >/dev/null
+else
+  log "Skipping job update (job '$JOB_SYNC_FIXTURES_NAME' not found)"
 fi
 
 # ---------------------------


### PR DESCRIPTION
## Summary
- Adds `flask sync-fixtures` CLI command that calls `_run_batch_fixture_sync()` to populate FixturePlayerStats
- Adds `job-sync-fixtures` image sync to `deploy_aca.sh` so deploys keep the job up to date
- Azure Container Apps Job already created and waiting for this image update

## Test plan
- [x] CLI command mirrors existing `seed-teams` pattern
- [ ] Deploy updates job image; re-run job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)