### PR TITLE
fix: Academy classification misclassifying youth players

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -226,6 +226,25 @@ Team (club — one row per API-Football team_id)
                     └── shots, passes, tackles, duels, dribbles, cards
 ```
 
+### Academy Classification Pipeline
+
+Determines which team's academy a player belongs to. Core logic in `services/journey_sync.py`.
+
+**Entry classification** (`_classify_level`): Each career entry gets a `level` (U15-U23, Reserve, First Team, International, International Youth) and `entry_type`:
+- `academy` — genuine youth entry, no prior senior experience
+- `development` — youth entry at a club where player already had first-team appearances (promoted player getting youth minutes)
+- `integration` — youth entry at a club the player was transferred to with prior senior experience elsewhere (bought player being integrated)
+- `first_team`, `loan`, `international` — non-youth types
+
+**Reclassification** (`_apply_development_classification`): Three passes refine `academy` entries:
+1. **Journey-based**: first-team at same club → `development`; first-team at different club → `integration` (with age/experience gate: ≤18 years old and ≤15 apps at other club are skipped as normal academy transfers)
+2. **Transfer-based**: permanent transfer TO this club → `integration`
+3. **Age-based**: first youth appearance at age 21+ → `integration`
+
+**Academy ID computation** (`_compute_academy_club_ids`): Collects youth entries with `entry_type` in (`academy`, `development`), strips youth suffix from club names, resolves to parent club API IDs, removes permanent transfer destinations. Result stored as `PlayerJourney.academy_club_ids` JSON array.
+
+**TrackedPlayer creation**: For each academy club ID, creates a `TrackedPlayer` row linking the player to that academy team.
+
 ## Deployment Topology
 
 ```
@@ -258,6 +277,7 @@ Supabase                         │ stripe-*           │
 Scheduled Jobs (Azure Container Apps Jobs):
   - job-weekly-newsletters: Weekly newsletter generation
   - job-transfer-heal: Transfer data reconciliation
+  - job-sync-fixtures: Batch fixture + player stats sync
 ```
 
 ### CI/CD

--- a/academy-watch-backend/src/main.py
+++ b/academy-watch-backend/src/main.py
@@ -313,6 +313,70 @@ def seed_teams_cmd():
     print("Seed complete.", flush=True)
 
 
+@app.cli.command("reclass-journeys")
+def reclass_journeys_cmd():
+    """Re-run academy classification on all existing journeys.
+
+    Reprocesses entry_type classification and recomputes academy_club_ids
+    using the latest rules, without re-fetching career data from API-Football.
+    Transfer records are fetched (cached) for accurate permanent-transfer gating.
+    """
+    from src.models.journey import PlayerJourney, PlayerJourneyEntry
+    from src.services.journey_sync import JourneySyncService
+
+    svc = JourneySyncService()
+    journeys = PlayerJourney.query.all()
+    total = len(journeys)
+    print(f"Reclassifying {total} journeys ...", flush=True)
+
+    changed = 0
+    errors = 0
+    for i, journey in enumerate(journeys):
+        if (i + 1) % 100 == 0:
+            print(f"  [{i+1}/{total}] ...", flush=True)
+        try:
+            entries = PlayerJourneyEntry.query.filter_by(journey_id=journey.id).all()
+            if not entries:
+                continue
+
+            old_ids = sorted(journey.academy_club_ids or [])
+
+            # Reset youth entries to 'academy' so classification starts fresh
+            for e in entries:
+                if e.is_youth and not e.is_international and e.entry_type in ('academy', 'development', 'integration'):
+                    e.entry_type = 'academy'
+
+            # Fetch transfers (hits DB cache first, then API if needed)
+            transfers = svc._get_player_transfers(journey.player_api_id)
+
+            # Re-run classification passes
+            svc._apply_development_classification(entries, transfers=transfers, birth_date=journey.birth_date)
+
+            # Re-run level classification for entries that may have wrong level (U17 fix)
+            for e in entries:
+                new_level = svc._classify_level(e.club_name, e.league_name or '')
+                if new_level != e.level:
+                    e.level = new_level
+                    e.is_youth = new_level in ('U15', 'U16', 'U17', 'U18', 'U19', 'U21', 'U23', 'Reserve', 'International Youth')
+                    e.entry_type = svc._classify_entry_type(new_level, e.league_name or '')
+
+            # Recompute academy_club_ids and update TrackedPlayer rows
+            svc._compute_academy_club_ids(journey, entries, transfers=transfers)
+
+            new_ids = sorted(journey.academy_club_ids or [])
+            if old_ids != new_ids:
+                changed += 1
+
+            db.session.flush()
+        except Exception as e:
+            errors += 1
+            print(f"  FAILED journey {journey.id} (player {journey.player_api_id}): {e}", flush=True)
+            db.session.rollback()
+
+    db.session.commit()
+    print(f"Done — {changed} journeys changed, {errors} errors out of {total} total.", flush=True)
+
+
 @app.cli.command("sync-fixtures")
 def sync_fixtures_cmd():
     """Sync match fixtures and player stats for all active tracked players."""

--- a/academy-watch-backend/src/models/journey.py
+++ b/academy-watch-backend/src/models/journey.py
@@ -425,4 +425,4 @@ LEVEL_PRIORITY = {
 }
 
 # Youth levels for classification
-YOUTH_LEVELS = {'U18', 'U19', 'U21', 'U23', 'Reserve', 'International Youth'}
+YOUTH_LEVELS = {'U15', 'U16', 'U17', 'U18', 'U19', 'U21', 'U23', 'Reserve', 'International Youth'}

--- a/academy-watch-backend/src/services/journey_sync.py
+++ b/academy-watch-backend/src/services/journey_sync.py
@@ -37,6 +37,9 @@ class JourneySyncService:
 
     # Patterns to detect youth/academy levels
     LEVEL_PATTERNS = {
+        'U15': ['u15', 'under 15', 'under-15'],
+        'U16': ['u16', 'under 16', 'under-16'],
+        'U17': ['u17', 'under 17', 'under-17'],
         'U18': ['u18', 'under 18', 'under-18', 'youth cup'],
         'U19': ['u19', 'under 19', 'under-19', 'youth league'],
         'U21': ['u21', 'under 21', 'under-21'],
@@ -592,12 +595,17 @@ class JourneySyncService:
         """
         # Build lookup: parent_base_name -> earliest first-team season
         first_team_debut_by_club = {}
+        # Also track total first-team appearances per club for age/experience gate
+        first_team_apps_by_club = {}
         for entry in entries:
             if entry.level == 'First Team' and not entry.is_international:
                 base_name = self._strip_youth_suffix(entry.club_name)
                 existing = first_team_debut_by_club.get(base_name)
                 if existing is None or entry.season < existing:
                     first_team_debut_by_club[base_name] = entry.season
+                first_team_apps_by_club[base_name] = (
+                    first_team_apps_by_club.get(base_name, 0) + (entry.appearances or 0)
+                )
 
         # Build set of clubs the player was permanently transferred TO.
         # A permanent transfer TO a club means the player is NOT an academy
@@ -654,9 +662,18 @@ class JourneySyncService:
                     continue
 
                 # Integration: first-team at a DIFFERENT club before or during
-                # this youth season (player was bought with senior experience)
+                # this youth season (player was bought with senior experience).
+                # Gate: a young player (≤18) with few apps (≤15) at a small club
+                # before joining a big academy is a normal academy transfer, not
+                # an integration (e.g., Hansen-Aarøen: 7 apps at Tromso age 16,
+                # then 4 years in ManU youth).
                 for club_name, debut in first_team_debut_by_club.items():
                     if club_name != parent_name and debut <= entry.season:
+                        if birth_year is not None:
+                            age_at_other_debut = debut - birth_year
+                            other_apps = first_team_apps_by_club.get(club_name, 0)
+                            if age_at_other_debut <= 18 and other_apps <= 15:
+                                continue
                         entry.entry_type = 'integration'
                         logger.debug(
                             f"Reclassified {entry.club_name} season {entry.season} as "

--- a/academy-watch-backend/src/utils/academy_classifier.py
+++ b/academy-watch-backend/src/utils/academy_classifier.py
@@ -74,6 +74,8 @@ INTERNATIONAL_PATTERNS = [
     'world cup', 'euro', 'copa america', 'african cup', 'asian cup',
     'gold cup', 'nations league', 'friendlies', 'qualification',
     'u20 world', 'u17 world', 'olympic', 'toulon', 'maurice revello',
+    'caf', 'concacaf', 'conmebol', 'afc',
+    'cup of nations',
 ]
 
 # ── levels that count as "international" ───────────────────────────────


### PR DESCRIPTION
## Summary
- **Integration rule too aggressive**: Players like Hansen-Aarøen (74 ManU youth apps) were classified under Werder Bremen because a few teenage first-team apps at Tromso triggered the integration rule for all subsequent youth entries. Added age (≤18) + experience (≤15 apps) gate to skip integration for normal academy transfers.
- **U17 national teams as "First Team"**: ~1,000 entries (Germany U17, Spain U17, etc.) misclassified because `LEVEL_PATTERNS` lacked U15-U17 and `INTERNATIONAL_PATTERNS` missed confederation names (CAF, CONCACAF, etc.)
- **`flask reclass-journeys` CLI command**: Reprocesses all existing journeys with fixed rules without re-fetching from API
- **ARCHITECTURE.md**: Documents academy classification pipeline and adds `job-sync-fixtures`

## Test plan
- [x] `_classify_level('Germany U17', 'CAF Cup of Nations - U17')` → `U17` (was `First Team`)
- [x] Hansen-Aarøen gate: age 16, 7 apps → skips integration (ManU academy)
- [x] Diallo gate: age 16, 34 apps → still integration (correct)
- [x] No false positives in `INTERNATIONAL_PATTERNS` — all `afc`/`caf` league names are legitimately international
- [ ] Deploy, run `reclass-journeys` job, verify Hansen-Aarøen → ManU

🤖 Generated with [Claude Code](https://claude.com/claude-code)