### PR TITLE
fix: Consolidate team name resolution to single source of truth

### DIFF
--- a/academy-watch-backend/src/agents/weekly_agent.py
+++ b/academy-watch-backend/src/agents/weekly_agent.py
@@ -1603,6 +1603,12 @@ def _persist_team_profile(payload: dict | None) -> TeamProfile | None:
     return None
 
 
+def _resolve_team_name_central(team_api_id: int) -> str:
+    """Resolve team name via centralized resolver (Team → TeamProfile → API)."""
+    from src.utils.team_resolver import resolve_team_name
+    return resolve_team_name(team_api_id)
+
+
 def _team_logo_for_team(team_api_id: Any, *, fallback_name: str | None = None) -> str | None:
     if team_api_id is None:
         return None
@@ -1636,7 +1642,7 @@ def _team_logo_for_team(team_api_id: Any, *, fallback_name: str | None = None) -
                 try:
                     record = profile_model(
                         team_id=key,
-                        name=team_row.name or fallback_name or f"Team {key}",
+                        name=team_row.name or fallback_name or _resolve_team_name_central(key),
                         code=team_row.code,
                         country=team_row.country,
                         founded=team_row.founded,

--- a/academy-watch-backend/src/agents/weekly_newsletter_agent.py
+++ b/academy-watch-backend/src/agents/weekly_newsletter_agent.py
@@ -1924,12 +1924,13 @@ def _enrich_on_loan_stats(player_dict: dict, tp: "TrackedPlayer", start: date, e
             if fixture:
                 is_home = fixture.home_team_api_id == tp.current_club_api_id
                 opp_api_id = fixture.away_team_api_id if is_home else fixture.home_team_api_id
-                # Resolve team name from Team table (Fixture model has no name columns)
-                opp_team_row = Team.query.filter_by(team_id=opp_api_id).first()
-                opp_name = opp_team_row.name if opp_team_row else str(opp_api_id)
+                # Resolve opponent name + logo via centralized resolver (Team → TeamProfile → API)
+                from src.utils.team_resolver import resolve_team_name_and_logo
+                opp_name, opp_logo = resolve_team_name_and_logo(opp_api_id, season)
                 matches.append({
                     'opponent': opp_name,
                     'opponent_id': opp_api_id,
+                    'opponent_logo': opp_logo,
                     'competition': getattr(fixture, 'competition_name', None),
                     'date': fixture.date_utc.isoformat() if fixture.date_utc else None,
                     'home': is_home,
@@ -2034,11 +2035,12 @@ def _enrich_first_team_stats(player_dict: dict, tp: "TrackedPlayer", team: "Team
             if fixture:
                 is_home = fixture.home_team_api_id == team.team_id
                 opp_api_id = fixture.away_team_api_id if is_home else fixture.home_team_api_id
-                opp_team_row = Team.query.filter_by(team_id=opp_api_id).first()
-                opp_name = opp_team_row.name if opp_team_row else str(opp_api_id)
+                from src.utils.team_resolver import resolve_team_name_and_logo
+                opp_name, opp_logo = resolve_team_name_and_logo(opp_api_id, season)
                 matches.append({
                     'opponent': opp_name,
                     'opponent_id': opp_api_id,
+                    'opponent_logo': opp_logo,
                     'competition': getattr(fixture, 'competition_name', None),
                     'date': fixture.date_utc.isoformat() if fixture.date_utc else None,
                     'home': is_home,
@@ -2120,9 +2122,21 @@ def _enrich_academy_stats(player_dict: dict, tp: "TrackedPlayer", season: int) -
                     totals['reds'] += row.reds or 0
                     totals['saves'] += getattr(row, 'saves', 0) or 0
                     if fixture:
+                        # Resolve opponent for academy matches (youth team fixtures)
+                        acad_team_id = tp.current_club_api_id or (team.team_id if hasattr(tp, 'team') and tp.team else None)
+                        is_home = fixture.home_team_api_id == acad_team_id if acad_team_id else True
+                        opp_api_id = (fixture.away_team_api_id if is_home else fixture.home_team_api_id) if acad_team_id else None
+                        opp_name, opp_logo = None, None
+                        if opp_api_id:
+                            from src.utils.team_resolver import resolve_team_name_and_logo
+                            opp_name, opp_logo = resolve_team_name_and_logo(opp_api_id, season)
                         matches.append({
+                            'opponent': opp_name,
+                            'opponent_id': opp_api_id,
+                            'opponent_logo': opp_logo,
                             'competition': getattr(fixture, 'competition_name', None),
                             'date': fixture.date_utc.isoformat() if fixture.date_utc else None,
+                            'home': is_home,
                             'played': (row.minutes or 0) > 0,
                             'role': getattr(row, 'role', None),
                             'player': {

--- a/academy-watch-backend/src/jobs/run_data_integrity_fix.py
+++ b/academy-watch-backend/src/jobs/run_data_integrity_fix.py
@@ -86,7 +86,8 @@ def phase_1_backfill_team_profiles(dry_run=False):
             if not t.get('id'):
                 continue
 
-            name = t.get('name', f'Team {t["id"]}')
+            from src.utils.team_resolver import resolve_team_name
+            name = t.get('name') or resolve_team_name(t['id'])
             slug = generate_unique_team_slug(name, t.get('country'), t['id'], existing_slugs)
             existing_slugs.add(slug)
 

--- a/academy-watch-backend/src/routes/api.py
+++ b/academy-watch-backend/src/routes/api.py
@@ -1658,9 +1658,13 @@ def get_public_player_stats(player_id: int):
             for (tid,) in existing_team_ids:
                 if tid not in loan_teams_info:
                     team_rec = Team.query.filter_by(team_id=tid).first()
+                    if team_rec and team_rec.name:
+                        t_name, t_logo = team_rec.name, team_rec.logo
+                    else:
+                        t_name, t_logo = resolve_team_name_and_logo(tid)
                     loan_teams_info[tid] = {
-                        'name': team_rec.name if team_rec else f'Team {tid}',
-                        'logo': team_rec.logo if team_rec else None,
+                        'name': t_name,
+                        'logo': t_logo,
                         'window_type': 'Summer',
                         'is_active': False,
                     }
@@ -8541,57 +8545,12 @@ def _run_reconcile_ids_logic(data: dict, job_id: str = None) -> dict:
         raise
 
 
-# --- Admin: Missing names helpers ---
-def _is_placeholder_name(name: str | None) -> bool:
-    if not name:
-        return True
-    s = str(name).strip()
-    if not s:
-        return True
-    low = s.lower()
-    return low.startswith('player ') or low.startswith('unknown')
-
-
-def _is_placeholder_team_name(name: str | None) -> bool:
-    if not name:
-        return True
-    s = str(name).strip()
-    if not s:
-        return True
-    return s.lower().startswith('team ')
-
-
-def _update_team_name_if_missing(team_row, *, season: int, dry_run: bool = False) -> dict:
-    """Update a Team row's name when it is a placeholder.
-
-    Returns a dict with status and optional new_name/error for logging/testing.
-    """
-    if not team_row:
-        return {'status': 'no_team_row'}
-
-    current_name = getattr(team_row, 'name', None)
-    api_team_id = getattr(team_row, 'team_id', None)
-
-    if not _is_placeholder_team_name(current_name):
-        return {'status': 'ok_existing', 'name': current_name}
-
-    if not api_team_id:
-        return {'status': 'missing_api_id'}
-
-    try:
-        info = api_client.get_team_by_id(int(api_team_id), season)
-        new_name = (info.get('team') or {}).get('name') if isinstance(info, dict) else None
-    except Exception as exc:  # pragma: no cover - network failures
-        return {'status': 'error', 'error': str(exc)}
-
-    if not new_name or _is_placeholder_team_name(new_name):
-        return {'status': 'no_name_found'}
-
-    if dry_run:
-        return {'status': 'would_update', 'new_name': new_name}
-
-    team_row.name = new_name
-    return {'status': 'updated', 'new_name': new_name}
+# --- Admin: Missing names helpers (canonical source: utils/team_resolver.py) ---
+from src.utils.team_resolver import (
+    is_placeholder_name as _is_placeholder_name,
+    is_placeholder_team_name as _is_placeholder_team_name,
+    update_team_name_if_missing as _update_team_name_if_missing,
+)
 
 @api_bp.route('/admin/loans/missing-names', methods=['GET'])
 @require_api_key
@@ -9012,7 +8971,7 @@ def admin_sync_player_fixtures(player_id: int):
             player_name = tp.player_name
             if tp.status == 'on_loan' and tp.current_club_api_id:
                 team_api_id = tp.current_club_api_id
-                team_name = tp.current_club_name or f'Team {tp.current_club_api_id}'
+                team_name = tp.current_club_name or resolve_team_name_and_logo(tp.current_club_api_id)[0]
             elif tp.status == 'first_team':
                 parent_team = Team.query.get(tp.team_id)
                 if parent_team:
@@ -10033,7 +9992,7 @@ def _run_team_fixtures_sync(team_id: int, data: dict, job_id: str = None) -> dic
             if tp.status == 'on_loan' and tp.current_club_api_id:
                 players_to_sync.append((
                     tp.player_api_id, tp.player_name,
-                    tp.current_club_api_id, tp.current_club_name or f'Team {tp.current_club_api_id}',
+                    tp.current_club_api_id, tp.current_club_name or resolve_team_name_and_logo(tp.current_club_api_id)[0],
                 ))
             elif tp.status == 'on_loan' and not tp.current_club_api_id:
                 logger.warning(f"[SYNC] Skipping on-loan {tp.player_name} (id={tp.id}): current_club_api_id is null")

--- a/academy-watch-backend/src/routes/teams.py
+++ b/academy-watch-backend/src/routes/teams.py
@@ -721,8 +721,11 @@ def get_academy_network(team_identifier):
         # Find the parent team for name/logo
         parent_team = Team.query.filter_by(team_id=team_api_id, is_active=True)\
             .order_by(Team.season.desc()).first()
-        parent_name = parent_team.name if parent_team else f'Team {team_api_id}'
-        parent_logo = parent_team.logo if parent_team else None
+        if parent_team and parent_team.name:
+            parent_name, parent_logo = parent_team.name, parent_team.logo
+        else:
+            from src.utils.team_resolver import resolve_team_name_and_logo
+            parent_name, parent_logo = resolve_team_name_and_logo(team_api_id)
 
         # Query 1: Academy products — prefer TrackedPlayer, fallback to JSONB
         tp_lookup = {}

--- a/academy-watch-backend/src/services/big6_seeding_service.py
+++ b/academy-watch-backend/src/services/big6_seeding_service.py
@@ -17,10 +17,10 @@ from src.services.cohort_service import CohortService
 from src.services.journey_sync import JourneySyncService
 from src.services.youth_competition_resolver import (
     get_default_youth_league_map,
-    resolve_team_name,
     resolve_youth_leagues,
     resolve_youth_team_for_parent,
 )
+from src.utils.team_resolver import resolve_team_name
 from src.utils.background_jobs import update_job, is_job_cancelled
 
 logger = logging.getLogger(__name__)
@@ -152,7 +152,7 @@ def run_big6_seed(job_id, seasons=None, team_ids=None, league_ids=None,
     )
 
     parent_names = {
-        team_id: resolve_team_name(api_client, team_id, fallback_name=BIG_6.get(team_id))
+        team_id: BIG_6.get(team_id) or resolve_team_name(team_id)
         for team_id in team_ids
     }
     teams_cache = {}

--- a/academy-watch-backend/src/services/gol_sandbox.py
+++ b/academy-watch-backend/src/services/gol_sandbox.py
@@ -389,7 +389,12 @@ def _build_helpers(dataframes: dict) -> dict:
             if not match.empty:
                 return match.iloc[0]['name']
 
-        return f'Team {tid}'
+        # 3. Centralized resolver (DB + API fallback, caches to TeamProfile)
+        try:
+            from src.utils.team_resolver import resolve_team_name as _central_resolve
+            return _central_resolve(tid)
+        except Exception:
+            return f'Team {tid}'
 
     def _resolve_team_name_or_fallback(value):
         """Resolve a current_club_name that might be a raw API ID or a real name."""

--- a/academy-watch-backend/src/services/youth_competition_resolver.py
+++ b/academy-watch-backend/src/services/youth_competition_resolver.py
@@ -322,20 +322,6 @@ def build_academy_league_seed_rows(api_client=None, season: int | None = None) -
     return rows
 
 
-def resolve_team_name(api_client, team_api_id: int, fallback_name: str | None = None) -> str:
-    """Resolve parent team display name, with fallback to provided name or ID."""
-    if fallback_name:
-        return fallback_name
-    try:
-        data = api_client.get_team_by_id(int(team_api_id))
-        team_obj = data.get("team", {}) if isinstance(data, dict) else {}
-        name = team_obj.get("name")
-        if name:
-            return name
-    except Exception:
-        pass
-    return str(team_api_id)
-
 
 def resolve_youth_team_for_parent(
     api_client,

--- a/academy-watch-backend/src/utils/team_resolver.py
+++ b/academy-watch-backend/src/utils/team_resolver.py
@@ -137,6 +137,61 @@ def resolve_latest_team_id(identifier: int, *, assume_api_id: bool = False) -> i
         return None
 
 
+def is_placeholder_name(name: str | None) -> bool:
+    """Return True if a player name looks like a placeholder (e.g. 'Player 12345', 'Unknown')."""
+    if not name:
+        return True
+    s = str(name).strip()
+    if not s:
+        return True
+    low = s.lower()
+    return low.startswith('player ') or low.startswith('unknown')
+
+
+def is_placeholder_team_name(name: str | None) -> bool:
+    """Return True if a team name looks like a placeholder (e.g. 'Team 12345')."""
+    if not name:
+        return True
+    s = str(name).strip()
+    if not s:
+        return True
+    return s.lower().startswith('team ')
+
+
+def update_team_name_if_missing(team_row, *, season: int, dry_run: bool = False) -> dict:
+    """Update a Team row's name when it is a placeholder.
+
+    Uses the centralized resolve_team_name_and_logo fallback chain
+    (Team table → TeamProfile → API-Football → placeholder).
+    Returns a dict with status and optional new_name/error for logging.
+    """
+    if not team_row:
+        return {'status': 'no_team_row'}
+
+    current_name = getattr(team_row, 'name', None)
+    api_team_id = getattr(team_row, 'team_id', None)
+
+    if not is_placeholder_team_name(current_name):
+        return {'status': 'ok_existing', 'name': current_name}
+
+    if not api_team_id:
+        return {'status': 'missing_api_id'}
+
+    try:
+        new_name, _ = resolve_team_name_and_logo(api_team_id, season)
+    except Exception as exc:
+        return {'status': 'error', 'error': str(exc)}
+
+    if not new_name or is_placeholder_team_name(new_name):
+        return {'status': 'no_name_found'}
+
+    if dry_run:
+        return {'status': 'would_update', 'new_name': new_name}
+
+    team_row.name = new_name
+    return {'status': 'updated', 'new_name': new_name}
+
+
 def resolve_team_by_identifier(identifier: str):
     """Look up a Team by slug or numeric DB primary-key ID. Aborts with 404 if not found."""
     if identifier.isdigit():


### PR DESCRIPTION
## Summary
- **Fix newsletter opponent names** showing raw API IDs (1350, 1379, 748) instead of team names — enrichment functions now use centralized resolver (Team → TeamProfile → API-Football)
- **Consolidate** all team name resolution to `utils/team_resolver.py` — moved placeholder helpers, eliminated duplicate in youth resolver, added resolver fallback to GOL sandbox
- **Replace 6 inline** `f"Team {id}"` fallbacks across routes/agents with centralized resolver calls

## Test plan
- [ ] Generate a newsletter for a team with lower-league loan players — confirm opponent names resolve (no raw IDs)
- [ ] Test GOL chatbot query referencing a team only in TeamProfile
- [ ] Verify placeholder backfill endpoints still work (`/admin/loans/missing-names`, `/admin/teams/backfill-placeholder-names`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)