### PR TITLE
feat: dark-theme charts, wider canvas, click-to-zoom drawer + lightbox

### DIFF
--- a/academy-watch-backend/src/agents/weekly_agent.py
+++ b/academy-watch-backend/src/agents/weekly_agent.py
@@ -2094,12 +2094,46 @@ def lint_and_enrich(news: dict) -> dict:
         if it.get('stats')  # Only include items that have stats
     ]
 
-    # by-numbers blocks
-    mins_leaders = sorted(items, key=lambda x: int(x.get('stats',{}).get('minutes',0) or 0), reverse=True)[:3]
-    ga_leaders = sorted(items, key=lambda x: (int(x.get('stats',{}).get('goals',0) or 0) + int(x.get('stats',{}).get('assists',0) or 0)), reverse=True)[:3]
+    # by-numbers blocks — extended with rating, key passes, clean sheets so the
+    # newsletter "By the Numbers" row can show 4-5 callouts on desktop instead
+    # of just 2. Each list is filtered to items that actually have the metric
+    # so we don't surface spurious zeros.
+    def _stat(it, key, cast=int):
+        try:
+            return cast(it.get('stats', {}).get(key) or 0)
+        except (TypeError, ValueError):
+            return cast(0)
+
+    mins_leaders = sorted(items, key=lambda x: _stat(x, 'minutes'), reverse=True)[:3]
+    ga_leaders = sorted(items, key=lambda x: _stat(x, 'goals') + _stat(x, 'assists'), reverse=True)[:3]
+    rating_pool = [i for i in items if (i.get('stats', {}).get('rating') or 0)]
+    rating_leaders = sorted(rating_pool, key=lambda x: _stat(x, 'rating', float), reverse=True)[:3]
+    key_passes_pool = [i for i in items if (i.get('stats', {}).get('passes_key') or 0)]
+    key_passes_leaders = sorted(key_passes_pool, key=lambda x: _stat(x, 'passes_key'), reverse=True)[:3]
+    clean_sheets_pool = [i for i in items if (i.get('stats', {}).get('clean_sheets') or 0)]
+    clean_sheets_leaders = sorted(clean_sheets_pool, key=lambda x: _stat(x, 'clean_sheets'), reverse=True)[:3]
+
     news["by_numbers"] = {
-        "minutes_leaders": [{"player": _display_name(i.get("player_name")), "minutes": int(i.get("stats",{}).get("minutes",0) or 0)} for i in mins_leaders],
-        "ga_leaders": [{"player": _display_name(i.get("player_name")), "g": int(i.get("stats",{}).get("goals",0) or 0), "a": int(i.get("stats",{}).get("assists",0) or 0)} for i in ga_leaders],
+        "minutes_leaders": [
+            {"player": _display_name(i.get("player_name")), "minutes": _stat(i, 'minutes')}
+            for i in mins_leaders
+        ],
+        "ga_leaders": [
+            {"player": _display_name(i.get("player_name")), "g": _stat(i, 'goals'), "a": _stat(i, 'assists')}
+            for i in ga_leaders
+        ],
+        "rating_leaders": [
+            {"player": _display_name(i.get("player_name")), "rating": round(_stat(i, 'rating', float), 1)}
+            for i in rating_leaders
+        ],
+        "key_passes_leaders": [
+            {"player": _display_name(i.get("player_name")), "key_passes": _stat(i, 'passes_key')}
+            for i in key_passes_leaders
+        ],
+        "clean_sheets_leaders": [
+            {"player": _display_name(i.get("player_name")), "clean_sheets": _stat(i, 'clean_sheets')}
+            for i in clean_sheets_leaders
+        ],
     }
 
     return news

--- a/academy-watch-backend/src/services/chart_renderer.py
+++ b/academy-watch-backend/src/services/chart_renderer.py
@@ -18,22 +18,42 @@ import matplotlib.patches as mpatches
 from matplotlib.patches import Polygon
 import numpy as np
 
-# Chart styling constants
+# Chart styling constants — Tactical Lens dark theme.
+# These charts are embedded in newsletter cards over a deep navy background;
+# light surfaces would look like islands of glare. The figure facecolor and
+# axes facecolor are both set to TL_CARD so the chart blends into the
+# surrounding card. Text is light slate (`gray` token, kept for backwards
+# compat with existing render functions).
 CHART_COLORS = {
-    'primary': '#7c3aed',      # Violet
-    'success': '#10b981',      # Green
-    'warning': '#f59e0b',      # Amber
-    'danger': '#ef4444',       # Red
-    'info': '#3b82f6',         # Blue
-    'gray': '#6b7280',
+    'primary': '#60a5fa',      # Royal blue (brighter for dark bg)
+    'success': '#4ade80',      # Green
+    'warning': '#fbbf24',      # Amber
+    'danger': '#f87171',       # Red
+    'info': '#38bdf8',         # Sky
+    'gray': '#cbd5e1',         # Light slate — used for ALL labels/titles
+    'gray_dim': '#94a3b8',     # Muted slate for secondary labels
 }
 
+# Tactical Lens surface tiers — used as facecolor for figures and axes so
+# the chart drawing area blends into the card background instead of being
+# a white rectangle on a dark page.
+TL_CARD = '#222a3d'
+TL_INNER = '#2d3449'
+TL_GRID = '#475569'
+TL_TEXT = '#e2e8f0'
+
 POSITION_COLORS = {
-    'Forward': '#ef4444',
-    'Midfielder': '#3b82f6',
-    'Defender': '#10b981',
-    'Goalkeeper': '#f59e0b',
+    'Forward': '#f87171',
+    'Midfielder': '#60a5fa',
+    'Defender': '#4ade80',
+    'Goalkeeper': '#fbbf24',
 }
+
+# Standard DPI bumped from 100 → 150 for crisp retina rendering. The figure
+# pixel dimensions in newsletters stay valid because we still divide width/
+# height by 100 for the figsize argument (logical inches). matplotlib then
+# rasterises at 150dpi, producing a 1.5× sharper PNG at the same display size.
+DPI = 150
 
 # Directory to store generated chart images
 CHARTS_DIR = os.path.join(os.path.dirname(__file__), '..', 'static', 'charts')
@@ -58,7 +78,7 @@ def generate_chart_id(block: dict, player_id: Optional[int], week_start: Optiona
     return hashlib.md5(key.encode()).hexdigest()[:12]
 
 
-def render_radar_chart(data: Dict[str, Any], width: int = 400, height: int = 400) -> bytes:
+def render_radar_chart(data: Dict[str, Any], width: int = 480, height: int = 480) -> bytes:
     """
     Render a radar/spider chart as PNG bytes.
 
@@ -81,9 +101,13 @@ def render_radar_chart(data: Dict[str, Any], width: int = 400, height: int = 400
     if not radar_data:
         return _render_empty_chart("No data available", width, height)
 
-    # Setup figure
-    fig = plt.figure(figsize=(width/100, height/100), dpi=100)
+    # Setup figure with dark Tactical Lens facecolor so the polar plot blends
+    # into the surrounding player card. The axes facecolor must also be set
+    # explicitly — savefig facecolor only paints the area outside the axes.
+    fig = plt.figure(figsize=(width/100, height/100), dpi=DPI)
+    fig.patch.set_facecolor(TL_CARD)
     ax = fig.add_subplot(111, polar=True)
+    ax.set_facecolor(TL_CARD)
 
     # Prepare data
     categories = [item.get('label', item.get('stat', '')) for item in radar_data]
@@ -100,7 +124,7 @@ def render_radar_chart(data: Dict[str, Any], width: int = 400, height: int = 400
         position_group_label = data.get('position_group_label', 'Position')
         position_category = _group_to_category(data.get('position_group', 'CM'))
         color = POSITION_COLORS.get(position_category, CHART_COLORS['primary'])
-        avg_color = '#94a3b8'
+        avg_color = '#94a3b8'  # Muted slate dashes for league avg overlay
 
         player_values = [item.get('player_normalized', 0) for item in radar_data]
         avg_values = [item.get('league_avg_normalized') for item in radar_data]
@@ -158,19 +182,26 @@ def render_radar_chart(data: Dict[str, Any], width: int = 400, height: int = 400
         league_peers = 0
         position_group_label = None
 
-    # Configure axes
+    # Configure axes — light slate labels + dark grid lines that are visible
+    # against the deep navy facecolor without being noisy.
     ax.set_xticks(angles[:-1])
     ax.set_xticklabels(categories, size=8, color=CHART_COLORS['gray'])
     ax.set_ylim(0, 100)
     ax.set_yticks([25, 50, 75, 100])
-    ax.set_yticklabels(['25%', '50%', '75%', '100%'], size=6, color=CHART_COLORS['gray'])
+    ax.set_yticklabels(['25%', '50%', '75%', '100%'], size=6, color=CHART_COLORS['gray_dim'])
     ax.set_rlabel_position(30)
+    ax.tick_params(colors=CHART_COLORS['gray'])
+    ax.grid(color=TL_GRID, alpha=0.45, linewidth=0.8)
+    # Polar plot's outer ring spine
+    for spine in ax.spines.values():
+        spine.set_color(TL_GRID)
+        spine.set_alpha(0.6)
 
     # Title
     title = f"{player_name}"
     if matches_count:
         title += f" - {matches_count} match{'es' if matches_count != 1 else ''}"
-    ax.set_title(title, size=10, color=CHART_COLORS['gray'], y=1.1, fontweight='bold')
+    ax.set_title(title, size=11, color=TL_TEXT, y=1.1, fontweight='bold')
 
     # Footer — always explain what the chart is showing. When league averages
     # are unavailable for the player's league, say so explicitly rather than
@@ -191,11 +222,11 @@ def render_radar_chart(data: Dict[str, Any], width: int = 400, height: int = 400
                 "League comparison unavailable. "
                 "Showing player-only per 90 stats normalised to peak axis."
             )
-        fig.text(0.5, -0.02, footer, ha='center', fontsize=7, color=CHART_COLORS['gray'])
+        fig.text(0.5, -0.02, footer, ha='center', fontsize=8, color=CHART_COLORS['gray_dim'])
 
     # Convert to bytes
     buf = io.BytesIO()
-    plt.savefig(buf, format='png', bbox_inches='tight', facecolor='white', edgecolor='none')
+    plt.savefig(buf, format='png', bbox_inches='tight', facecolor=TL_CARD, edgecolor='none')
     plt.close(fig)
     buf.seek(0)
     return buf.read()
@@ -210,75 +241,84 @@ def _group_to_category(group: str) -> str:
     }.get(group, 'Midfielder')
 
 
-def render_bar_chart(data: Dict[str, Any], width: int = 500, height: int = 300) -> bytes:
+def render_bar_chart(data: Dict[str, Any], width: int = 560, height: int = 320) -> bytes:
     """
     Render a bar chart as PNG bytes.
-    
+
     Args:
         data: Chart data from the API including 'data' array with match stats
         width: Image width in pixels
         height: Image height in pixels
-        
+
     Returns:
         PNG image as bytes
     """
     bar_data = data.get('data', [])
     stat_keys = data.get('stat_keys', ['goals', 'assists', 'rating'])
     player_name = data.get('player', {}).get('name', 'Player')
-    
+
     if not bar_data:
         return _render_empty_chart("No data available", width, height)
-    
-    # Setup figure
-    fig, ax = plt.subplots(figsize=(width/100, height/100), dpi=100)
-    
+
+    # Setup figure with dark Tactical Lens facecolor.
+    fig, ax = plt.subplots(figsize=(width/100, height/100), dpi=DPI)
+    fig.patch.set_facecolor(TL_CARD)
+    ax.set_facecolor(TL_CARD)
+
     # Prepare data
     matches = [d.get('match', d.get('date', ''))[:20] for d in bar_data]
     x = np.arange(len(matches))
     width_bar = 0.8 / len(stat_keys)
-    
-    colors = [CHART_COLORS['primary'], CHART_COLORS['success'], CHART_COLORS['info'], 
+
+    colors = [CHART_COLORS['primary'], CHART_COLORS['success'], CHART_COLORS['info'],
               CHART_COLORS['warning'], CHART_COLORS['danger']]
-    
+
     # Plot bars for each stat
     for i, stat in enumerate(stat_keys):
         values = [d.get(stat, 0) or 0 for d in bar_data]
         offset = (i - len(stat_keys)/2 + 0.5) * width_bar
-        bars = ax.bar(x + offset, values, width_bar, label=stat.replace('_', ' ').title(),
-                      color=colors[i % len(colors)], alpha=0.8)
-    
-    # Configure axes
+        ax.bar(x + offset, values, width_bar, label=stat.replace('_', ' ').title(),
+               color=colors[i % len(colors)], alpha=0.85)
+
+    # Configure axes — light slate labels on dark, subtle grid.
     ax.set_xlabel('Match', fontsize=9, color=CHART_COLORS['gray'])
     ax.set_ylabel('Value', fontsize=9, color=CHART_COLORS['gray'])
     ax.set_xticks(x)
-    ax.set_xticklabels(matches, rotation=45, ha='right', fontsize=7)
-    ax.legend(loc='upper right', fontsize=8)
-    ax.set_title(f"{player_name} - Per Match Stats", fontsize=10, fontweight='bold', color=CHART_COLORS['gray'])
-    
-    # Style
+    ax.set_xticklabels(matches, rotation=45, ha='right', fontsize=7, color=CHART_COLORS['gray'])
+    legend = ax.legend(loc='upper right', fontsize=8, facecolor=TL_INNER, edgecolor=TL_GRID, labelcolor=TL_TEXT)
+    if legend is not None:
+        legend.get_frame().set_alpha(0.85)
+    ax.set_title(f"{player_name} - Per Match Stats", fontsize=11, fontweight='bold', color=TL_TEXT)
+
+    # Style — hide top/right spines, dark grid lines, light tick marks.
     ax.spines['top'].set_visible(False)
     ax.spines['right'].set_visible(False)
+    ax.spines['bottom'].set_color(TL_GRID)
+    ax.spines['left'].set_color(TL_GRID)
     ax.tick_params(colors=CHART_COLORS['gray'])
-    
+    ax.yaxis.label.set_color(CHART_COLORS['gray'])
+    ax.xaxis.label.set_color(CHART_COLORS['gray'])
+    ax.grid(True, axis='y', alpha=0.25, color=TL_GRID, linewidth=0.6)
+
     plt.tight_layout()
-    
+
     # Convert to bytes
     buf = io.BytesIO()
-    plt.savefig(buf, format='png', bbox_inches='tight', facecolor='white', edgecolor='none')
+    plt.savefig(buf, format='png', bbox_inches='tight', facecolor=TL_CARD, edgecolor='none')
     plt.close(fig)
     buf.seek(0)
     return buf.read()
 
 
-def render_line_chart(data: Dict[str, Any], width: int = 500, height: int = 300) -> bytes:
+def render_line_chart(data: Dict[str, Any], width: int = 560, height: int = 320) -> bytes:
     """
     Render a line chart as PNG bytes.
-    
+
     Args:
         data: Chart data from the API including 'data' array with time series stats
         width: Image width in pixels
         height: Image height in pixels
-        
+
     Returns:
         PNG image as bytes
     """
@@ -302,17 +342,19 @@ def render_line_chart(data: Dict[str, Any], width: int = 500, height: int = 300)
         return _render_empty_chart(
             f"No {', '.join(stat_keys)} data available", width, height,
         )
-    
-    # Setup figure
-    fig, ax = plt.subplots(figsize=(width/100, height/100), dpi=100)
-    
+
+    # Setup figure with dark Tactical Lens facecolor.
+    fig, ax = plt.subplots(figsize=(width/100, height/100), dpi=DPI)
+    fig.patch.set_facecolor(TL_CARD)
+    ax.set_facecolor(TL_CARD)
+
     # Prepare data
     dates = [d.get('date', '')[:10] for d in line_data]
     x = np.arange(len(dates))
-    
+
     colors = [CHART_COLORS['primary'], CHART_COLORS['success'], CHART_COLORS['info'],
               CHART_COLORS['warning'], CHART_COLORS['danger']]
-    
+
     # Plot line for each stat, skipping missing/zero values
     for i, stat in enumerate(stat_keys):
         raw_values = [d.get(stat) for d in line_data]
@@ -324,27 +366,33 @@ def render_line_chart(data: Dict[str, Any], width: int = 500, height: int = 300)
             else:
                 values.append(float('nan'))
         ax.plot(x, values, 'o-', label=stat.replace('_', ' ').title(),
-                color=colors[i % len(colors)], linewidth=2, markersize=6)
-    
-    # Configure axes
+                color=colors[i % len(colors)], linewidth=2.2, markersize=6)
+
+    # Configure axes — light slate labels + dark grid lines.
     ax.set_xlabel('Date', fontsize=9, color=CHART_COLORS['gray'])
     ax.set_ylabel('Value', fontsize=9, color=CHART_COLORS['gray'])
     ax.set_xticks(x)
-    ax.set_xticklabels(dates, rotation=45, ha='right', fontsize=7)
-    ax.legend(loc='upper right', fontsize=8)
-    ax.set_title(f"{player_name} - Performance Trend", fontsize=10, fontweight='bold', color=CHART_COLORS['gray'])
-    
+    ax.set_xticklabels(dates, rotation=45, ha='right', fontsize=7, color=CHART_COLORS['gray'])
+    legend = ax.legend(loc='upper right', fontsize=8, facecolor=TL_INNER, edgecolor=TL_GRID, labelcolor=TL_TEXT)
+    if legend is not None:
+        legend.get_frame().set_alpha(0.85)
+    ax.set_title(f"{player_name} - Performance Trend", fontsize=11, fontweight='bold', color=TL_TEXT)
+
     # Style
     ax.spines['top'].set_visible(False)
     ax.spines['right'].set_visible(False)
+    ax.spines['bottom'].set_color(TL_GRID)
+    ax.spines['left'].set_color(TL_GRID)
     ax.tick_params(colors=CHART_COLORS['gray'])
-    ax.grid(True, alpha=0.3)
-    
+    ax.yaxis.label.set_color(CHART_COLORS['gray'])
+    ax.xaxis.label.set_color(CHART_COLORS['gray'])
+    ax.grid(True, alpha=0.3, color=TL_GRID, linewidth=0.6)
+
     plt.tight_layout()
-    
+
     # Convert to bytes
     buf = io.BytesIO()
-    plt.savefig(buf, format='png', bbox_inches='tight', facecolor='white', edgecolor='none')
+    plt.savefig(buf, format='png', bbox_inches='tight', facecolor=TL_CARD, edgecolor='none')
     plt.close(fig)
     buf.seek(0)
     return buf.read()
@@ -383,34 +431,37 @@ def render_match_cards_summary(data: Dict[str, Any], width: int = 500, height: i
     draws = sum(1 for f in fixtures if f['home_team']['score'] == f['away_team']['score'])
     losses = len(fixtures) - wins - draws
     
-    # Setup figure
-    fig, ax = plt.subplots(figsize=(width/100, height/100), dpi=100)
+    # Setup figure with dark Tactical Lens facecolor.
+    fig, ax = plt.subplots(figsize=(width/100, height/100), dpi=DPI)
+    fig.patch.set_facecolor(TL_CARD)
+    ax.set_facecolor(TL_CARD)
     ax.axis('off')
-    
+
     # Title
-    ax.text(0.5, 0.95, f"{player_name} - {len(fixtures)} Match Summary", 
-            fontsize=11, fontweight='bold', ha='center', transform=ax.transAxes,
-            color=CHART_COLORS['gray'])
-    
-    # Stats in a row
+    ax.text(0.5, 0.95, f"{player_name} - {len(fixtures)} Match Summary",
+            fontsize=12, fontweight='bold', ha='center', transform=ax.transAxes,
+            color=TL_TEXT)
+
+    # Stats in a row — use brighter primary tones for highlights, light slate
+    # for neutral values, since the background is now dark navy.
     stats = [
-        (f"{total_minutes}'", "Minutes", CHART_COLORS['gray']),
-        (f"{total_goals}", "Goals", CHART_COLORS['success'] if total_goals else CHART_COLORS['gray']),
-        (f"{total_assists}", "Assists", CHART_COLORS['info'] if total_assists else CHART_COLORS['gray']),
+        (f"{total_minutes}'", "Minutes", TL_TEXT),
+        (f"{total_goals}", "Goals", CHART_COLORS['success'] if total_goals else CHART_COLORS['gray_dim']),
+        (f"{total_assists}", "Assists", CHART_COLORS['info'] if total_assists else CHART_COLORS['gray_dim']),
         (f"{avg_rating:.1f}" if avg_rating else "-", "Avg Rating", CHART_COLORS['warning']),
         (f"{wins}W {draws}D {losses}L", "Results", CHART_COLORS['primary']),
     ]
-    
+
     x_positions = np.linspace(0.1, 0.9, len(stats))
     for i, (value, label, color) in enumerate(stats):
-        ax.text(x_positions[i], 0.55, str(value), fontsize=16, fontweight='bold', 
+        ax.text(x_positions[i], 0.55, str(value), fontsize=17, fontweight='bold',
                 ha='center', transform=ax.transAxes, color=color)
-        ax.text(x_positions[i], 0.3, label, fontsize=9, ha='center', 
+        ax.text(x_positions[i], 0.3, label, fontsize=9, ha='center',
                 transform=ax.transAxes, color=CHART_COLORS['gray'])
-    
+
     # Convert to bytes
     buf = io.BytesIO()
-    plt.savefig(buf, format='png', bbox_inches='tight', facecolor='white', edgecolor='none')
+    plt.savefig(buf, format='png', bbox_inches='tight', facecolor=TL_CARD, edgecolor='none')
     plt.close(fig)
     buf.seek(0)
     return buf.read()
@@ -439,10 +490,12 @@ def render_stat_table(data: Dict[str, Any], width: int = 500, height: int = 250)
     # Limit rows for image size
     display_data = table_data[:6]  # Show max 6 matches
     
-    # Setup figure
-    fig, ax = plt.subplots(figsize=(width/100, height/100), dpi=100)
+    # Setup figure with dark Tactical Lens facecolor.
+    fig, ax = plt.subplots(figsize=(width/100, height/100), dpi=DPI)
+    fig.patch.set_facecolor(TL_CARD)
+    ax.set_facecolor(TL_CARD)
     ax.axis('off')
-    
+
     # Build table data
     headers = ['Date', 'Opponent', 'Result', 'Min', 'G', 'A', 'Rating']
     rows = []
@@ -456,7 +509,7 @@ def render_stat_table(data: Dict[str, Any], width: int = 500, height: int = 250)
             str(d.get('assists', 0) or 0),
             f"{d.get('rating', 0):.1f}" if d.get('rating') else '-',
         ])
-    
+
     # Add totals row if we have totals
     if totals:
         rows.append([
@@ -466,7 +519,7 @@ def render_stat_table(data: Dict[str, Any], width: int = 500, height: int = 250)
             str(totals.get('assists', 0)),
             '-',
         ])
-    
+
     # Create table
     table = ax.table(
         cellText=rows,
@@ -475,48 +528,65 @@ def render_stat_table(data: Dict[str, Any], width: int = 500, height: int = 250)
         loc='center',
         colWidths=[0.15, 0.2, 0.1, 0.1, 0.08, 0.08, 0.1]
     )
-    
+
     # Style table
     table.auto_set_font_size(False)
     table.set_fontsize(8)
     table.scale(1.2, 1.5)
-    
-    # Header styling
+
+    # Header styling — primary blue with white text. Body cells get the
+    # tier-3 inner background so the table reads as a card-on-card.
     for i, key in enumerate(headers):
-        table[(0, i)].set_facecolor(CHART_COLORS['primary'])
-        table[(0, i)].set_text_props(color='white', fontweight='bold')
-    
+        cell = table[(0, i)]
+        cell.set_facecolor(CHART_COLORS['primary'])
+        cell.set_text_props(color='#0b1326', fontweight='bold')
+        cell.set_edgecolor(TL_GRID)
+
+    # Body row styling — dark cells with light text.
+    body_count = len(rows) - (1 if totals else 0)
+    for r in range(1, body_count + 1):
+        for c in range(len(headers)):
+            cell = table[(r, c)]
+            cell.set_facecolor(TL_INNER)
+            cell.set_text_props(color=TL_TEXT)
+            cell.set_edgecolor(TL_GRID)
+
     # Totals row styling
     if totals and rows:
         for i in range(len(headers)):
-            table[(len(rows), i)].set_facecolor('#f3f4f6')
-            table[(len(rows), i)].set_text_props(fontweight='bold')
-    
+            cell = table[(len(rows), i)]
+            cell.set_facecolor('#1a2235')  # slightly darker than TL_INNER
+            cell.set_text_props(fontweight='bold', color=CHART_COLORS['primary'])
+            cell.set_edgecolor(TL_GRID)
+
     # Title
     title = f"{player_name} - {matches_count} Match Stats"
     if len(table_data) > 6:
         title += f" (showing {len(display_data)})"
-    ax.set_title(title, fontsize=10, fontweight='bold', color=CHART_COLORS['gray'], y=0.95)
-    
+    ax.set_title(title, fontsize=11, fontweight='bold', color=TL_TEXT, y=0.95)
+
     plt.tight_layout()
-    
+
     # Convert to bytes
     buf = io.BytesIO()
-    plt.savefig(buf, format='png', bbox_inches='tight', facecolor='white', edgecolor='none')
+    plt.savefig(buf, format='png', bbox_inches='tight', facecolor=TL_CARD, edgecolor='none')
     plt.close(fig)
     buf.seek(0)
     return buf.read()
 
 
 def _render_empty_chart(message: str, width: int, height: int) -> bytes:
-    """Render an empty chart placeholder with a message."""
-    fig, ax = plt.subplots(figsize=(width/100, height/100), dpi=100)
+    """Render an empty chart placeholder with a message — dark Tactical Lens
+    surface so it blends into the surrounding card."""
+    fig, ax = plt.subplots(figsize=(width/100, height/100), dpi=DPI)
+    fig.patch.set_facecolor(TL_CARD)
+    ax.set_facecolor(TL_CARD)
     ax.axis('off')
     ax.text(0.5, 0.5, message, fontsize=12, ha='center', va='center',
             color=CHART_COLORS['gray'], transform=ax.transAxes)
-    
+
     buf = io.BytesIO()
-    plt.savefig(buf, format='png', bbox_inches='tight', facecolor='#f9fafb', edgecolor='none')
+    plt.savefig(buf, format='png', bbox_inches='tight', facecolor=TL_CARD, edgecolor='none')
     plt.close(fig)
     buf.seek(0)
     return buf.read()

--- a/academy-watch-frontend/src/components/newsletter/ByTheNumbersGrid.jsx
+++ b/academy-watch-frontend/src/components/newsletter/ByTheNumbersGrid.jsx
@@ -1,19 +1,25 @@
 /**
- * "By the numbers" — three stat callouts in a responsive grid.
+ * "By the numbers" — up to 5 stat callouts in a responsive grid.
  *
- * Reads `byNumbers.minutes_leaders` (array of {player, minutes}) and
- * `byNumbers.ga_leaders` (array of {player, g, a}). The third tile is a
- * "Top rating" surface if any item carries a rating; otherwise hidden.
+ * Reads:
+ *   - byNumbers.minutes_leaders   [{player, minutes}]
+ *   - byNumbers.ga_leaders        [{player, g, a}]
+ *   - byNumbers.rating_leaders    [{player, rating}]            (post-PR-A)
+ *   - byNumbers.key_passes_leaders [{player, key_passes}]       (post-PR-A)
+ *   - byNumbers.clean_sheets_leaders [{player, clean_sheets}]   (post-PR-A)
+ *
+ * Each section is optional — only callouts whose source list has data are
+ * rendered. On small screens the grid collapses to 2 / 1 columns.
  */
 
 function StatCallout({ label, headline, sub }) {
   return (
     <div
-      className="rounded-lg p-5"
+      className="rounded-lg p-5 lg:p-6"
       style={{ background: 'var(--tl-section)' }}
     >
       <p className="tl-eyebrow m-0 mb-2">{label}</p>
-      <p className="tl-headline text-2xl sm:text-3xl text-[var(--tl-text)] m-0 leading-tight">
+      <p className="tl-headline text-xl sm:text-2xl text-[var(--tl-text)] m-0 leading-tight truncate">
         {headline}
       </p>
       {sub && (
@@ -28,31 +34,51 @@ export function ByTheNumbersGrid({ byNumbers }) {
 
   const minutes = Array.isArray(byNumbers.minutes_leaders) ? byNumbers.minutes_leaders : []
   const ga = Array.isArray(byNumbers.ga_leaders) ? byNumbers.ga_leaders : []
+  const rating = Array.isArray(byNumbers.rating_leaders) ? byNumbers.rating_leaders : []
+  const keyPasses = Array.isArray(byNumbers.key_passes_leaders) ? byNumbers.key_passes_leaders : []
+  const cleanSheets = Array.isArray(byNumbers.clean_sheets_leaders) ? byNumbers.clean_sheets_leaders : []
 
-  if (minutes.length === 0 && ga.length === 0) return null
-
-  const minutesTop = minutes[0]
-  const gaTop = ga[0]
   const tiles = []
-  if (minutesTop) {
+  if (minutes[0]) {
     tiles.push({
       label: 'Minutes Leader',
-      headline: minutesTop.player,
-      sub: `${minutesTop.minutes}'`,
+      headline: minutes[0].player,
+      sub: `${minutes[0].minutes}'`,
     })
   }
-  if (gaTop) {
+  if (ga[0]) {
     tiles.push({
       label: 'Goal Contributors',
-      headline: gaTop.player,
-      sub: `${gaTop.g || 0}G ${gaTop.a || 0}A`,
+      headline: ga[0].player,
+      sub: `${ga[0].g || 0}G ${ga[0].a || 0}A`,
+    })
+  }
+  if (rating[0]) {
+    tiles.push({
+      label: 'Top Rating',
+      headline: rating[0].player,
+      sub: `${rating[0].rating}`,
+    })
+  }
+  if (keyPasses[0]) {
+    tiles.push({
+      label: 'Top Key Passes',
+      headline: keyPasses[0].player,
+      sub: `${keyPasses[0].key_passes} KP`,
+    })
+  }
+  if (cleanSheets[0]) {
+    tiles.push({
+      label: 'Clean Sheets',
+      headline: cleanSheets[0].player,
+      sub: `${cleanSheets[0].clean_sheets}`,
     })
   }
 
-  // Optional third tile from the next minutes leader if we have one
-  if (minutes[1]) {
+  // Fall back to a runner-up minutes leader if we still only have 2 tiles
+  if (tiles.length === 2 && minutes[1]) {
     tiles.push({
-      label: 'Runner Up',
+      label: 'Runner Up Minutes',
       headline: minutes[1].player,
       sub: `${minutes[1].minutes}'`,
     })
@@ -61,9 +87,9 @@ export function ByTheNumbersGrid({ byNumbers }) {
   if (tiles.length === 0) return null
 
   return (
-    <section className="mb-10 sm:mb-12">
+    <section className="mb-12 sm:mb-14 lg:mb-16">
       <h2 className="tl-eyebrow m-0 mb-4">By the Numbers</h2>
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 sm:gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3 sm:gap-4">
         {tiles.map((tile, idx) => (
           <StatCallout key={idx} {...tile} />
         ))}

--- a/academy-watch-frontend/src/components/newsletter/ChartLightbox.jsx
+++ b/academy-watch-frontend/src/components/newsletter/ChartLightbox.jsx
@@ -1,0 +1,45 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog'
+
+/**
+ * ChartLightbox — opens a single chart at native resolution in a centered
+ * modal. Click-outside / ESC / X-button all close (free from Radix).
+ *
+ * Used by NewsletterView when a user clicks a chart image inside any
+ * PlayerCommentaryCard or PlayerCardDrawer. The chart src is the same
+ * base64 data URI baked into the newsletter content — no separate fetch.
+ */
+export function ChartLightbox({ open, onOpenChange, url, alt, caption }) {
+  if (!url) return null
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="newsletter-tactical-lens max-w-[min(95vw,1100px)] sm:max-w-[min(92vw,1100px)] p-0 overflow-hidden border-0 bg-[var(--tl-card)]"
+      >
+        <DialogHeader className="px-5 pt-5 pb-3 text-left">
+          <DialogTitle className="tl-headline text-base sm:text-lg text-[var(--tl-text)] m-0">
+            {caption || alt || 'Chart'}
+          </DialogTitle>
+          <DialogDescription className="text-[12px] text-[var(--tl-text-muted)] m-0">
+            Click outside or press ESC to close.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="px-5 pb-6">
+          <img
+            src={url}
+            alt={alt || 'Chart'}
+            className="block w-full h-auto max-h-[78vh] object-contain rounded-md"
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default ChartLightbox

--- a/academy-watch-frontend/src/components/newsletter/NewsletterHeader.jsx
+++ b/academy-watch-frontend/src/components/newsletter/NewsletterHeader.jsx
@@ -16,20 +16,20 @@ export function NewsletterHeader({
   editionLabel = 'Pipeline Update',
 }) {
   return (
-    <header className="mb-10 sm:mb-12">
-      <div className="flex items-start gap-4">
+    <header className="mb-8 sm:mb-10">
+      <div className="flex items-start gap-4 sm:gap-5">
         {teamLogo && (
           <img
             src={teamLogo}
             alt={teamName ? `${teamName} crest` : 'Team crest'}
-            className="h-12 w-12 sm:h-14 sm:w-14 rounded-full object-cover bg-[var(--tl-card)] flex-shrink-0"
+            className="h-14 w-14 sm:h-16 sm:w-16 rounded-full object-cover bg-[var(--tl-card)] flex-shrink-0"
           />
         )}
-        <div className="flex-1 min-w-0 space-y-2">
+        <div className="flex-1 min-w-0 space-y-1.5">
           <p className="tl-eyebrow m-0 text-[var(--tl-primary)]">
             The Academy Watch &middot; {editionLabel}
           </p>
-          <h1 className="tl-headline text-3xl sm:text-4xl md:text-5xl text-[var(--tl-text)] m-0 leading-tight break-words">
+          <h1 className="tl-headline text-2xl sm:text-3xl md:text-4xl text-[var(--tl-text)] m-0 leading-[1.15] break-words">
             {title}
           </h1>
           {(range || teamName) && (

--- a/academy-watch-frontend/src/components/newsletter/NewsletterView.jsx
+++ b/academy-watch-frontend/src/components/newsletter/NewsletterView.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { NewsletterHeader } from './NewsletterHeader'
 import { EditorsNote } from './EditorsNote'
 import { KeyHighlightsList } from './KeyHighlightsList'
@@ -7,25 +7,26 @@ import { SectionGroup } from './SectionGroup'
 import { TeamTwitterSection } from './TeamTwitterSection'
 import { CommunityTakesList } from './CommunityTakesList'
 import { NewsletterFooter } from './NewsletterFooter'
+import { PlayerCardDrawer } from './PlayerCardDrawer'
+import { ChartLightbox } from './ChartLightbox'
 
 /**
  * The Academy Watch newsletter — Tactical Lens edition.
  *
- * Replaces the legacy 360-line inline JSX block in `App.jsx` (lines
- * 9012-9372) with a properly componentised, mobile-first responsive
- * editorial layout that pulls from the existing newsletter JSON shape.
+ * Replaces the legacy 360-line inline JSX block in `App.jsx` with a
+ * componentised, mobile-first responsive editorial layout. The container
+ * is wide (1280px max) so big monitors don't show acres of empty space,
+ * but text-heavy reading blocks (editor's note, highlights) are capped
+ * to ~68 characters wide for editorial readability.
  *
- * Theming is scoped to the `.newsletter-tactical-lens` wrapper — the rest
- * of the app keeps its warm burgundy palette unchanged.
+ * Two interactive primitives are owned at this top level:
+ *   - `PlayerCardDrawer` — opens when a card's expand button fires; shows
+ *     the same player content at 1.5–2× scale with all charts.
+ *   - `ChartLightbox`    — opens when a chart image is clicked; shows that
+ *     one chart at native resolution.
  *
- * Props:
- *   - newsletter: full newsletter record from /api/newsletters/:id
- *     (used for top-level metadata: title, team, dates)
- *   - enrichedContent: parsed structured_content JSON
- *   - twitterTakesByPlayer: { [player_api_id]: tweet[] } from API
- *   - twitterTakes: full tweet list (for team-level section)
- *   - communityTakes: full community-takes list (for non-twitter section)
- *   - publicBaseUrl: base URL for "view player" links (passed through)
+ * Theming is scoped to `.newsletter-tactical-lens` — the rest of the app
+ * keeps its warm burgundy palette unchanged.
  */
 export function NewsletterView({
   newsletter,
@@ -37,8 +38,6 @@ export function NewsletterView({
 }) {
   const obj = enrichedContent || {}
 
-  // Filter out the legacy "what the internet is saying" section — surfaced
-  // separately by Twitter / Community Takes sections.
   const detailedSections = useMemo(() => {
     if (!Array.isArray(obj.sections)) return []
     return obj.sections.filter(
@@ -49,9 +48,26 @@ export function NewsletterView({
   const teamLogo = obj.team_logo || newsletter?.team_logo
   const teamName = obj.team_name || newsletter?.team?.name || newsletter?.team_name
 
+  // Drawer state — only one player drawer can be open at a time.
+  const [drawerPlayer, setDrawerPlayer] = useState(null)
+  const handleExpand = useCallback((payload) => {
+    setDrawerPlayer(payload)
+  }, [])
+  const handleCloseDrawer = useCallback(() => setDrawerPlayer(null), [])
+
+  // Chart lightbox state — receives a single chart at a time.
+  const [lightboxChart, setLightboxChart] = useState(null)
+  const handleZoomChart = useCallback((payload) => {
+    setLightboxChart(payload)
+  }, [])
+  const handleCloseLightbox = useCallback(() => setLightboxChart(null), [])
+
   return (
     <div className="newsletter-tactical-lens min-h-full">
-      <div className="max-w-[820px] mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12">
+      {/* Wide canvas — uses up to 1280px on big monitors. The text-heavy
+          editorial blocks below cap themselves at ~68ch internally for
+          readability. */}
+      <div className="max-w-[1280px] mx-auto px-4 sm:px-6 lg:px-10 py-8 sm:py-10 lg:py-12">
         <NewsletterHeader
           title={obj.title || newsletter?.title}
           range={obj.range}
@@ -59,9 +75,11 @@ export function NewsletterView({
           teamLogo={teamLogo}
         />
 
-        <EditorsNote summary={obj.summary} />
-
-        <KeyHighlightsList highlights={obj.highlights} />
+        {/* Editorial reading blocks — capped width inside the wide canvas. */}
+        <div className="max-w-[68ch]">
+          <EditorsNote summary={obj.summary} />
+          <KeyHighlightsList highlights={obj.highlights} />
+        </div>
 
         <ByTheNumbersGrid byNumbers={obj.by_numbers} />
 
@@ -72,6 +90,8 @@ export function NewsletterView({
               section={section}
               twitterTakesByPlayer={twitterTakesByPlayer}
               publicBaseUrl={publicBaseUrl}
+              onExpand={handleExpand}
+              onZoomChart={handleZoomChart}
             />
           ))}
 
@@ -87,6 +107,25 @@ export function NewsletterView({
           newsletterId={newsletter?.id}
         />
       </div>
+
+      {/* Player card drawer — full content of one player at 1.5–2× scale. */}
+      <PlayerCardDrawer
+        open={Boolean(drawerPlayer)}
+        onOpenChange={(open) => !open && handleCloseDrawer()}
+        item={drawerPlayer?.item || null}
+        twitterTakes={drawerPlayer?.twitterTakes || []}
+        publicBaseUrl={publicBaseUrl}
+        onZoomChart={handleZoomChart}
+      />
+
+      {/* Chart lightbox — single chart at native resolution. */}
+      <ChartLightbox
+        open={Boolean(lightboxChart)}
+        onOpenChange={(open) => !open && handleCloseLightbox()}
+        url={lightboxChart?.url || ''}
+        alt={lightboxChart?.alt || ''}
+        caption={lightboxChart?.caption || ''}
+      />
     </div>
   )
 }

--- a/academy-watch-frontend/src/components/newsletter/PlayerCardDrawer.jsx
+++ b/academy-watch-frontend/src/components/newsletter/PlayerCardDrawer.jsx
@@ -1,0 +1,265 @@
+import { Link } from 'react-router-dom'
+import { ArrowRight, ExternalLink } from 'lucide-react'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from '@/components/ui/sheet'
+import { InlinePlayerWriteups } from '@/components/NewsletterWriterOverlay'
+import { MatchCardsStrip } from './MatchCardsStrip'
+import { UpcomingFixturesList } from './UpcomingFixturesList'
+import { TweetCard } from './TweetCard'
+
+/**
+ * PlayerCardDrawer — opens when a user clicks the expand button on a
+ * PlayerCommentaryCard. Renders the SAME player content but at much
+ * larger scale, with the FULL chart set (radar, trend, match summary,
+ * stat table, rating graph, minutes graph) stacked vertically and the
+ * full tweet list (no truncation cap).
+ *
+ * Uses a Sheet primitive sliding from the right on desktop. On mobile
+ * the Sheet's default `w-3/4` becomes the bottom-most ~75% width — still
+ * usable. (We chose Sheet over Drawer because Drawer's bottom-only
+ * direction feels weird for a side panel of editorial content.)
+ *
+ * Wraps content in `.newsletter-tactical-lens` so the local CSS variables
+ * cascade into the portal-rendered Sheet content (otherwise they'd live
+ * in the React tree of the page but not in the actual DOM ancestor of
+ * the Sheet content, since Radix portals append to <body>).
+ */
+
+function StatCell({ label, value }) {
+  if (value === undefined || value === null || value === '') return null
+  return (
+    <div className="flex flex-col items-center justify-center px-4 py-3.5 min-w-[80px] flex-1">
+      <div className="text-[11px] uppercase tracking-wide text-[var(--tl-text-muted)] font-semibold">
+        {label}
+      </div>
+      <div className="text-lg sm:text-xl font-bold text-[var(--tl-text)] mt-1">{value}</div>
+    </div>
+  )
+}
+
+function StatRibbonLarge({ stats }) {
+  if (!stats || typeof stats !== 'object') return null
+  const cells = [
+    { label: 'Mins', value: stats.minutes != null ? `${stats.minutes}'` : null },
+    { label: 'Goals', value: stats.goals != null ? stats.goals : null },
+    { label: 'Assists', value: stats.assists != null ? stats.assists : null },
+    { label: 'Key Passes', value: stats.passes_key != null ? stats.passes_key : null },
+    {
+      label: 'Rating',
+      value:
+        stats.rating != null && Number(stats.rating) > 0
+          ? Number(stats.rating).toFixed(1)
+          : null,
+    },
+  ].filter((c) => c.value !== null)
+  if (cells.length === 0) return null
+  return (
+    <div
+      className="flex flex-wrap rounded-lg mb-6 divide-x divide-[var(--tl-divider)]"
+      style={{ background: 'var(--tl-inner)' }}
+    >
+      {cells.map((c, i) => (
+        <StatCell key={i} {...c} />
+      ))}
+    </div>
+  )
+}
+
+function StatusPill({ status, level, loanTeam }) {
+  if (!status && !loanTeam) return null
+  const labelMap = {
+    on_loan: 'On Loan',
+    first_team: 'First Team',
+    academy: level || 'Academy',
+    released: 'Released',
+    sold: 'Sold',
+  }
+  const label = labelMap[status] || (loanTeam ? 'On Loan' : null)
+  if (!label) return null
+  return (
+    <span
+      className="inline-flex items-center px-2.5 py-1 rounded text-[11px] font-extrabold uppercase tracking-wide"
+      style={{ background: 'var(--tl-primary-soft)', color: 'var(--tl-primary)' }}
+    >
+      {label}
+    </span>
+  )
+}
+
+export function PlayerCardDrawer({
+  open,
+  onOpenChange,
+  item,
+  twitterTakes = [],
+  publicBaseUrl: _publicBaseUrl,
+  onZoomChart,
+}) {
+  if (!item) return null
+
+  const playerLinkId = item.player_api_id || item.player_id
+  const loanTeam = item.loan_team || item.loan_team_name
+
+  // Full chart set — every available image, in a sensible reading order.
+  const allCharts = [
+    { url: item.match_card_url, alt: 'Match Performance Summary' },
+    { url: item.stat_table_url, alt: 'Recent Match Stats' },
+    { url: item.radar_chart_url, alt: 'Performance Radar' },
+    { url: item.trend_chart_url, alt: 'Season Rating Trend' },
+    { url: item.rating_graph_url, alt: 'Rating Graph' },
+    { url: item.minutes_graph_url, alt: 'Minutes Graph' },
+  ].filter((c) => c.url)
+
+  const handleChartClick = (chart) => {
+    if (onZoomChart) {
+      onZoomChart({
+        url: chart.url,
+        alt: chart.alt,
+        caption: `${item.player_name} — ${chart.alt}`,
+      })
+    }
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="newsletter-tactical-lens w-full sm:max-w-[640px] md:max-w-[760px] lg:max-w-[860px] !max-w-[100vw] sm:!max-w-[640px] md:!max-w-[760px] lg:!max-w-[860px] border-l-0 p-0 overflow-y-auto bg-[var(--tl-page)] text-[var(--tl-text-body)]"
+      >
+        <SheetHeader className="px-6 sm:px-8 pt-8 pb-4 text-left border-b border-[var(--tl-divider)]">
+          <div className="flex items-start gap-4 sm:gap-5">
+            {item.player_photo ? (
+              <img
+                src={item.player_photo}
+                alt={item.player_name || 'Player'}
+                className="h-20 w-20 sm:h-24 sm:w-24 rounded-full object-cover bg-[var(--tl-card)] flex-shrink-0"
+              />
+            ) : (
+              <div className="h-20 w-20 sm:h-24 sm:w-24 rounded-full bg-[var(--tl-card)] flex items-center justify-center text-[var(--tl-text-muted)] text-base font-bold flex-shrink-0">
+                {(item.player_name || '?').slice(0, 1)}
+              </div>
+            )}
+            <div className="flex-1 min-w-0">
+              <SheetTitle className="tl-headline text-2xl sm:text-3xl text-[var(--tl-text)] m-0 break-words">
+                {item.player_name}
+              </SheetTitle>
+              <SheetDescription className="text-[12px] text-[var(--tl-text-muted)] m-0 mt-1">
+                Click any chart to zoom in.
+              </SheetDescription>
+              <div className="flex flex-wrap items-center gap-2 mt-3">
+                <StatusPill
+                  status={item.pathway_status}
+                  level={item.current_level}
+                  loanTeam={loanTeam}
+                />
+                {loanTeam && (
+                  <div className="inline-flex items-center gap-1.5 text-[12px] text-[var(--tl-text-muted)] font-semibold">
+                    {item.loan_team_logo && (
+                      <img
+                        src={item.loan_team_logo}
+                        alt={loanTeam}
+                        className="h-4 w-4 rounded-full object-cover bg-[var(--tl-card)]"
+                      />
+                    )}
+                    <span>{loanTeam}</span>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </SheetHeader>
+
+        <div className="px-6 sm:px-8 py-6 sm:py-8 space-y-6">
+          <StatRibbonLarge stats={item.stats} />
+
+          {item.week_summary && (
+            <div>
+              <p className="tl-eyebrow m-0 mb-2">This Week</p>
+              <p className="text-[15px] sm:text-base leading-[1.75] text-[var(--tl-text-body)] m-0">
+                {item.week_summary}
+              </p>
+            </div>
+          )}
+
+          {item.matches && item.matches.length > 0 && (
+            <div>
+              <MatchCardsStrip matches={item.matches} />
+            </div>
+          )}
+
+          {item.upcoming_fixtures && item.upcoming_fixtures.length > 0 && (
+            <div>
+              <UpcomingFixturesList fixtures={item.upcoming_fixtures} />
+            </div>
+          )}
+
+          {/* Full chart set, stacked vertically at full width. Each chart
+              is clickable to open the lightbox at native res. */}
+          {allCharts.length > 0 && (
+            <div className="space-y-5">
+              <p className="tl-eyebrow m-0">Performance Visuals</p>
+              {allCharts.map((c, idx) => (
+                <button
+                  key={idx}
+                  type="button"
+                  onClick={() => handleChartClick(c)}
+                  aria-label={`Zoom ${c.alt}`}
+                  className="block w-full cursor-zoom-in p-0 border-0 bg-transparent rounded-lg overflow-hidden hover:opacity-95 transition-opacity"
+                >
+                  <img
+                    src={c.url}
+                    alt={c.alt}
+                    loading="lazy"
+                    className="block w-full h-auto"
+                  />
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Inline writer commentary */}
+          {playerLinkId && (
+            <div>
+              <InlinePlayerWriteups
+                playerId={playerLinkId}
+                playerName={item.player_name}
+              />
+            </div>
+          )}
+
+          {/* Full tweet list — no slice cap */}
+          {twitterTakes && twitterTakes.length > 0 && (
+            <div>
+              <p className="tl-eyebrow m-0 mb-3">
+                Twitter &middot; about {item.player_name} ({twitterTakes.length})
+              </p>
+              <div className="space-y-3">
+                {twitterTakes.map((tweet, idx) => (
+                  <TweetCard key={tweet.id || idx} tweet={tweet} />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {playerLinkId && (
+            <div className="pt-4 border-t border-[var(--tl-divider)]">
+              <Link
+                to={`/players/${playerLinkId}`}
+                onClick={() => onOpenChange?.(false)}
+                className="inline-flex items-center gap-2 text-[12px] uppercase tracking-wider font-bold text-[var(--tl-primary)] no-underline hover:gap-3 transition-all"
+              >
+                View full player profile <ArrowRight className="h-3.5 w-3.5" />
+              </Link>
+            </div>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+export default PlayerCardDrawer

--- a/academy-watch-frontend/src/components/newsletter/PlayerCommentaryCard.jsx
+++ b/academy-watch-frontend/src/components/newsletter/PlayerCommentaryCard.jsx
@@ -1,36 +1,38 @@
 import { Link } from 'react-router-dom'
-import { ArrowRight } from 'lucide-react'
+import { ArrowRight, Maximize2 } from 'lucide-react'
 import { InlinePlayerWriteups } from '@/components/NewsletterWriterOverlay'
 import { MatchCardsStrip } from './MatchCardsStrip'
 import { UpcomingFixturesList } from './UpcomingFixturesList'
 import { TweetCard } from './TweetCard'
 
 /**
- * Player commentary card — the unit of value in the newsletter. Renders one
- * loanee/first-team/academy player with all of their data slots:
- *   - photo + name + status pill + parent/current club
- *   - stat ribbon (mins, G, A, KP, rating)
- *   - chart images (radar, trend, stat table, match card)
- *   - week summary text
- *   - this-week's-matches strip
- *   - coming-up fixtures
- *   - inline curator commentary via InlinePlayerWriteups
- *   - inline tweets about this player (twitter_takes_by_player[player_id])
- *   - "View full player profile" CTA
+ * Player commentary card — the unit of value in the newsletter.
  *
  * Layout:
  *   - Mobile: stacked single column
  *   - md+:   2-column inside the card (info left / charts right)
+ *
+ * Inline view shows a slim chart set (radar + trend) so the card stays
+ * scannable. The full chart set (match summary + stat table + radar +
+ * trend + rating + minutes) lives in the expanded drawer.
+ *
+ * Click affordances:
+ *   - "Expand" button (top right) → opens PlayerCardDrawer with full data
+ *     at 1.5–2× scale.
+ *   - Click on any inline chart → opens ChartLightbox at native resolution.
+ *
+ * Both callbacks (`onExpand`, `onZoomChart`) are owned by NewsletterView
+ * so the drawer/lightbox can be controlled centrally.
  */
 
 function StatPill({ label, value }) {
   if (value === undefined || value === null || value === '') return null
   return (
-    <div className="flex flex-col items-center justify-center px-3 py-2 min-w-[60px] flex-1">
+    <div className="flex flex-col items-center justify-center px-3 py-2.5 min-w-[60px] flex-1">
       <div className="text-[10px] uppercase tracking-wide text-[var(--tl-text-muted)] font-semibold">
         {label}
       </div>
-      <div className="text-sm font-bold text-[var(--tl-text)] mt-0.5">{value}</div>
+      <div className="text-sm sm:text-[15px] font-bold text-[var(--tl-text)] mt-0.5">{value}</div>
     </div>
   )
 }
@@ -92,38 +94,72 @@ function StatusPill({ status, level, loanTeam }) {
   )
 }
 
-export function PlayerCommentaryCard({ item, twitterTakes = [], publicBaseUrl }) {
+export function PlayerCommentaryCard({
+  item,
+  twitterTakes = [],
+  publicBaseUrl,
+  onExpand,
+  onZoomChart,
+}) {
   if (!item) return null
 
   const playerLinkId = item.player_api_id || item.player_id
   const loanTeam = item.loan_team || item.loan_team_name
   const photo = item.player_photo
-  const charts = [
-    { url: item.match_card_url, alt: 'Match Performance Summary' },
-    { url: item.stat_table_url, alt: 'Recent Match Stats' },
+
+  // Inline view shows a slim chart set so the card stays scannable. The
+  // expanded drawer surfaces ALL the charts at full size.
+  const inlineCharts = [
     { url: item.radar_chart_url, alt: 'Performance Radar' },
     { url: item.trend_chart_url, alt: 'Season Rating Trend' },
-    { url: item.rating_graph_url, alt: 'Rating Graph' },
-    { url: item.minutes_graph_url, alt: 'Minutes Graph' },
   ].filter((c) => c.url)
+
+  const handleExpand = () => {
+    if (onExpand) {
+      onExpand({ item, twitterTakes })
+    }
+  }
+
+  const handleChartClick = (chart) => {
+    if (onZoomChart) {
+      onZoomChart({
+        url: chart.url,
+        alt: chart.alt,
+        caption: `${item.player_name} — ${chart.alt}`,
+      })
+    }
+  }
 
   return (
     <article
-      className="tl-card-hover rounded-xl mb-5 sm:mb-6"
+      className="tl-card-hover rounded-xl mb-5 sm:mb-6 lg:mb-0 relative"
       style={{ background: 'var(--tl-section)' }}
     >
+      {/* Expand affordance — top-right corner. Only renders when an
+          onExpand handler is provided. */}
+      {onExpand && (
+        <button
+          type="button"
+          onClick={handleExpand}
+          aria-label={`Expand ${item.player_name || 'player'} details`}
+          className="absolute top-3 right-3 z-10 inline-flex items-center justify-center h-9 w-9 rounded-full text-[var(--tl-text-muted)] hover:text-[var(--tl-text)] hover:bg-[var(--tl-card)] transition-colors"
+        >
+          <Maximize2 className="h-4 w-4" />
+        </button>
+      )}
+
       <div className="grid grid-cols-1 md:grid-cols-12 gap-0">
         {/* LEFT — identity, stats, narrative, tweets, CTA */}
-        <div className="md:col-span-7 p-5 sm:p-6 md:p-7">
-          <div className="flex items-start gap-4 mb-4">
+        <div className="md:col-span-7 p-5 sm:p-6 md:p-7 lg:p-8">
+          <div className="flex items-start gap-4 mb-4 pr-12">
             {photo ? (
               <img
                 src={photo}
                 alt={item.player_name || 'Player'}
-                className="h-14 w-14 sm:h-16 sm:w-16 rounded-full object-cover bg-[var(--tl-card)] flex-shrink-0"
+                className="h-16 w-16 sm:h-18 sm:w-18 lg:h-20 lg:w-20 rounded-full object-cover bg-[var(--tl-card)] flex-shrink-0"
               />
             ) : (
-              <div className="h-14 w-14 sm:h-16 sm:w-16 rounded-full bg-[var(--tl-card)] flex items-center justify-center text-[var(--tl-text-muted)] text-xs font-bold flex-shrink-0">
+              <div className="h-16 w-16 sm:h-18 sm:w-18 lg:h-20 lg:w-20 rounded-full bg-[var(--tl-card)] flex items-center justify-center text-[var(--tl-text-muted)] text-sm font-bold flex-shrink-0">
                 {(item.player_name || '?').slice(0, 1)}
               </div>
             )}
@@ -133,16 +169,16 @@ export function PlayerCommentaryCard({ item, twitterTakes = [], publicBaseUrl })
                   to={`/players/${playerLinkId}`}
                   className="block"
                 >
-                  <h3 className="tl-headline text-lg sm:text-xl text-[var(--tl-text)] m-0 break-words hover:text-[var(--tl-primary)] transition-colors">
+                  <h3 className="tl-headline text-lg sm:text-xl lg:text-2xl text-[var(--tl-text)] m-0 break-words hover:text-[var(--tl-primary)] transition-colors">
                     {item.player_name}
                   </h3>
                 </Link>
               ) : (
-                <h3 className="tl-headline text-lg sm:text-xl text-[var(--tl-text)] m-0 break-words">
+                <h3 className="tl-headline text-lg sm:text-xl lg:text-2xl text-[var(--tl-text)] m-0 break-words">
                   {item.player_name}
                 </h3>
               )}
-              <div className="flex flex-wrap items-center gap-2 mt-1.5">
+              <div className="flex flex-wrap items-center gap-2 mt-2">
                 <StatusPill
                   status={item.pathway_status}
                   level={item.current_level}
@@ -193,16 +229,26 @@ export function PlayerCommentaryCard({ item, twitterTakes = [], publicBaseUrl })
             />
           )}
 
-          {/* Inline tweets about this player */}
+          {/* Inline tweets about this player — capped at 2 in the inline
+              view; the drawer surfaces the full list. */}
           {twitterTakes && twitterTakes.length > 0 && (
             <div className="mb-4">
               <p className="tl-eyebrow m-0 mb-2">
                 Twitter &middot; about {item.player_name}
               </p>
               <div className="space-y-3">
-                {twitterTakes.slice(0, 3).map((tweet, idx) => (
+                {twitterTakes.slice(0, 2).map((tweet, idx) => (
                   <TweetCard key={tweet.id || idx} tweet={tweet} />
                 ))}
+                {twitterTakes.length > 2 && (
+                  <button
+                    type="button"
+                    onClick={handleExpand}
+                    className="text-[11px] font-semibold text-[var(--tl-primary)] hover:underline"
+                  >
+                    + {twitterTakes.length - 2} more in expanded view
+                  </button>
+                )}
               </div>
             </div>
           )}
@@ -217,21 +263,40 @@ export function PlayerCommentaryCard({ item, twitterTakes = [], publicBaseUrl })
           )}
         </div>
 
-        {/* RIGHT — chart images stack. Hidden on mobile if charts are absent. */}
-        {charts.length > 0 && (
+        {/* RIGHT — slim inline chart set (radar + trend). The full chart
+            set lives in the expanded drawer. Each chart is clickable to
+            open a lightbox at native resolution. */}
+        {inlineCharts.length > 0 && (
           <div
-            className="md:col-span-5 p-5 sm:p-6 md:p-7 space-y-4 border-t md:border-t-0 md:border-l border-[var(--tl-divider)]"
+            className="md:col-span-5 p-5 sm:p-6 md:p-7 lg:p-8 space-y-4 border-t md:border-t-0 md:border-l border-[var(--tl-divider)]"
             style={{ background: 'var(--tl-card)' }}
           >
-            {charts.map((c, idx) => (
-              <img
+            {inlineCharts.map((c, idx) => (
+              <button
                 key={idx}
-                src={c.url}
-                alt={c.alt}
-                loading="lazy"
-                className="block w-full h-auto rounded-md"
-              />
+                type="button"
+                onClick={() => handleChartClick(c)}
+                aria-label={`Zoom ${c.alt}`}
+                className="block w-full cursor-zoom-in p-0 border-0 bg-transparent hover:opacity-90 transition-opacity"
+              >
+                <img
+                  src={c.url}
+                  alt={c.alt}
+                  loading="lazy"
+                  className="block w-full h-auto rounded-md"
+                />
+              </button>
             ))}
+            {/* Subtle hint that the card has more behind the expand button. */}
+            {(item.match_card_url || item.stat_table_url || item.rating_graph_url) && (
+              <button
+                type="button"
+                onClick={handleExpand}
+                className="block w-full text-[11px] font-semibold text-[var(--tl-text-muted)] hover:text-[var(--tl-primary)] mt-2 text-center"
+              >
+                Click expand for match summary, stat table, and more &rarr;
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/academy-watch-frontend/src/components/newsletter/SectionGroup.jsx
+++ b/academy-watch-frontend/src/components/newsletter/SectionGroup.jsx
@@ -2,17 +2,39 @@ import { PlayerCommentaryCard } from './PlayerCommentaryCard'
 
 /**
  * One section in the detailed report — title + count + a list of player
- * commentary cards. Each section corresponds to "Loanees", "First Team",
- * "Academy", etc.
+ * commentary cards.
+ *
+ * Layout: when a section has 2+ players, render the cards in a 2-column
+ * grid at lg+ (1024px+) so wide monitors don't show lonely single cards
+ * with empty space on either side. Sections with exactly one player keep
+ * a single full-width card.
+ *
+ * Props:
+ *   - onExpand({ item, twitterTakes }) — fired when a card's expand button
+ *     is clicked. Owned by NewsletterView.
+ *   - onZoomChart({ url, alt, caption }) — fired when a chart image inside
+ *     a card is clicked. Also owned by NewsletterView.
  */
-export function SectionGroup({ section, twitterTakesByPlayer = {}, publicBaseUrl }) {
+export function SectionGroup({
+  section,
+  twitterTakesByPlayer = {},
+  publicBaseUrl,
+  onExpand,
+  onZoomChart,
+}) {
   if (!section || typeof section !== 'object') return null
 
   const items = Array.isArray(section.items) ? section.items : []
   if (items.length === 0) return null
 
+  // Multi-column grid for sections with 2+ players. Single-column otherwise.
+  const gridClass =
+    items.length > 1
+      ? 'grid grid-cols-1 lg:grid-cols-2 gap-5 lg:gap-6'
+      : 'grid grid-cols-1'
+
   return (
-    <section className="mb-12 sm:mb-16">
+    <section className="mb-12 sm:mb-14 lg:mb-16">
       <div className="flex items-baseline gap-3 mb-5 sm:mb-6">
         <h2 className="tl-eyebrow m-0">{section.title}</h2>
         <span className="text-[11px] font-extrabold text-[var(--tl-text-faint)]">
@@ -21,12 +43,12 @@ export function SectionGroup({ section, twitterTakesByPlayer = {}, publicBaseUrl
       </div>
 
       {section.content && (
-        <p className="text-[14px] text-[var(--tl-text-muted)] leading-relaxed mb-5">
+        <p className="text-[14px] text-[var(--tl-text-muted)] leading-relaxed mb-5 max-w-[68ch]">
           {section.content}
         </p>
       )}
 
-      <div>
+      <div className={gridClass}>
         {items.map((item, idx) => {
           const playerKey = item.player_api_id || item.player_id
           const tweets = playerKey ? twitterTakesByPlayer[playerKey] || [] : []
@@ -36,6 +58,8 @@ export function SectionGroup({ section, twitterTakesByPlayer = {}, publicBaseUrl
               item={item}
               twitterTakes={tweets}
               publicBaseUrl={publicBaseUrl}
+              onExpand={onExpand}
+              onZoomChart={onZoomChart}
             />
           )
         })}


### PR DESCRIPTION
## Summary

Visual refinement pass after PR #79 based on user feedback. Four complaints addressed.

### 1. Charts looked like white islands on the dark page
**`chart_renderer.py` — full dark theme conversion.** Every matplotlib chart (radar, line, bar, match-summary, stat-table, empty placeholder) now renders on the Tactical Lens `#222a3d` surface instead of white. Both `fig.patch` and the axes facecolor are set explicitly so the polar plot and the data cells are dark. `CHART_COLORS['gray']` swapped from `#6b7280` to `#cbd5e1` so labels are legible against dark; data viz palette brightened (`primary` → royal blue `#60a5fa`, etc.). Stat-table body cells now dark with light text and a primary-blue header. DPI bumped from 100 to 150 for sharper retina output. Default sizes bumped slightly (radar 400→480, line/bar 500→560).

**Note:** existing newsletters keep the old white charts because charts are baked into `structured_content` at compose time. **Regenerate** any newsletter you plan to demo from for the new charts to surface.

### 2. Massive empty space on a big monitor
- `NewsletterView` container `max-w-[820px]` → `max-w-[1280px]`. Editorial reading blocks (`EditorsNote`, `KeyHighlightsList`) capped at `max-w-[68ch]` internally so long-form prose still has a comfortable line length inside the wider canvas.
- `SectionGroup` wraps player cards in `lg:grid-cols-2` for sections with 2+ players. Sections with one player keep a full-width single card.
- `ByTheNumbersGrid` expanded to show 4-5 callouts at `lg:grid-cols-5` — pulls from the new backend fields `rating_leaders`, `key_passes_leaders`, `clean_sheets_leaders`.
- `NewsletterHeader` masthead toned down (`text-2xl sm:text-3xl md:text-4xl`) so it stops dominating the page.

### 3. No way to "zoom in" on a player card to see the data clearly
**Two new primitives, both wired into `NewsletterView`:**

- **`PlayerCardDrawer.jsx`** — Sheet sliding from the right with the FULL player content at 1.5–2x scale. Larger photo, larger stat ribbon, all SIX possible chart images stacked vertically at full width, full match cards strip, all upcoming fixtures, all writer commentary, full tweet list (no truncation cap). Wrapped in `.newsletter-tactical-lens` so theme tokens cascade through the Radix portal. Triggered by a `Maximize2` icon button in the top-right corner of each `PlayerCommentaryCard`.

- **`ChartLightbox.jsx`** — Dialog modal showing one clicked chart at native resolution. Click outside / ESC / X-button to close. Triggered by clicking any chart image in either the inline card or the drawer.

`PlayerCommentaryCard` slimmed in the inline view: only radar + trend show inline now, with a hint that clicking expand surfaces the rest. Tweet list capped at 2 inline with a "+N more in expanded view" prompt that also opens the drawer.

### 4. Mobile felt cramped
Section margins bumped (`mb-12 sm:mb-14 lg:mb-16`). Player photo bumped one size at every breakpoint. Stat ribbon padding increased from `py-2` to `py-2.5`. Player card padding bumped at lg+ (`p-7` → `p-8`).

## Critical files

| File | What changed |
|---|---|
| `academy-watch-backend/src/services/chart_renderer.py` | Dark theme across all 6 chart functions, DPI 150, size bumps, brighter palette |
| `academy-watch-backend/src/agents/weekly_agent.py` | `by_numbers` extended with rating/key passes/clean sheets leaders |
| `academy-watch-frontend/src/components/newsletter/NewsletterView.jsx` | Wider canvas, drawer + lightbox state owners |
| `academy-watch-frontend/src/components/newsletter/NewsletterHeader.jsx` | Toned-down masthead |
| `academy-watch-frontend/src/components/newsletter/ByTheNumbersGrid.jsx` | 5-column grid, new tile sources |
| `academy-watch-frontend/src/components/newsletter/SectionGroup.jsx` | `lg:grid-cols-2` player grid, expand prop wiring |
| `academy-watch-frontend/src/components/newsletter/PlayerCommentaryCard.jsx` | Expand button, click-to-zoom on inline charts, slimmer chart set |
| `academy-watch-frontend/src/components/newsletter/PlayerCardDrawer.jsx` | NEW — Sheet with full player data at 1.5–2x |
| `academy-watch-frontend/src/components/newsletter/ChartLightbox.jsx` | NEW — Dialog showing one chart at native res |

## Test plan
- [x] `pytest tests/test_weekly_newsletter_agent.py` — 6 passed (1 pre-existing skip)
- [x] Backend syntax check on chart_renderer.py and weekly_agent.py
- [x] Smoke render of all 5 chart types — verified dark theme visually via PNG output (radar polygon legible, stat table fully dark, line chart dark grid, etc.)
- [x] Frontend `pnpm lint` — 0 errors, 23 pre-existing warnings unchanged
- [x] Frontend `pnpm build` — successful
- [ ] **Post-merge:** regenerate Forest newsletter via admin sandbox `force_refresh=true` and verify dark charts surface
- [ ] **Post-merge:** visit `/newsletters/<id>` on 1600px desktop — confirm wide canvas, 2-col player grid, 5-callout by-numbers row
- [ ] **Post-merge:** click expand on a player card → drawer slides in with full data
- [ ] **Post-merge:** click any chart → lightbox opens at native res
- [ ] **Post-merge:** mobile (375px) — single column, more breathing room than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)