### PR TITLE
fix: journey-sync transfer-override treating stale transfers as current

### DIFF
--- a/academy-watch-backend/src/agents/weekly_newsletter_agent.py
+++ b/academy-watch-backend/src/agents/weekly_newsletter_agent.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import json
 import re
@@ -42,11 +43,19 @@ dotenv.load_dotenv(dotenv.find_dotenv())
 #     base_url="https://openrouter.ai/api/v1",
 #     api_key=os.getenv("OPENROUTER_API_KEY")
 # )
+logger = logging.getLogger(__name__)
+
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 set_default_openai_client(client)
 api_client = APIFootballClient()
 graph_service = GraphService()
 _GROQ_CLIENT: Optional["Groq"] = None
+
+# Maximum age (days) a PlayerJourney's last_synced_at can be before the
+# newsletter pipeline logs a staleness warning. Added after the O. Hammond
+# incident, where stale 2024 journey data drove a wrong classification and
+# a departed player ended up in a live newsletter.
+NEWSLETTER_JOURNEY_STALE_DAYS = 14
 
 def _get_groq_client() -> Groq:
     global _GROQ_CLIENT
@@ -1758,6 +1767,70 @@ def fetch_pipeline_report_tool(parent_team_db_id: int, season_start_year: int, s
         TrackedPlayer.is_active.is_(True),
         TrackedPlayer.status.notin_(['released', 'sold']),
     ).all()
+
+    # Pre-flight: warn loudly about any player whose linked PlayerJourney
+    # last_synced_at is older than NEWSLETTER_JOURNEY_STALE_DAYS. Added after
+    # the O. Hammond incident — generating a newsletter against stale journey
+    # data is exactly how a departed player ends up in a live newsletter, and
+    # the pipeline previously did not surface this at all.
+    try:
+        _now = datetime.now(timezone.utc)
+        _stale_threshold = timedelta(days=NEWSLETTER_JOURNEY_STALE_DAYS)
+        _journey_ids = [tp.journey_id for tp in tracked if tp.journey_id]
+        _journey_map: Dict[int, PlayerJourney] = {}
+        if _journey_ids:
+            _journey_map = {
+                j.id: j for j in PlayerJourney.query.filter(
+                    PlayerJourney.id.in_(_journey_ids)
+                ).all()
+            }
+        _stale_entries: List[Dict[str, Any]] = []
+        _missing_journeys: List[Dict[str, Any]] = []
+        for tp in tracked:
+            journey = _journey_map.get(tp.journey_id) if tp.journey_id else None
+            if journey is None:
+                _missing_journeys.append({
+                    'player_api_id': tp.player_api_id,
+                    'player_name': tp.player_name,
+                    'status': tp.status,
+                })
+                continue
+            last_synced = journey.last_synced_at
+            if last_synced is None:
+                _stale_entries.append({
+                    'player_api_id': tp.player_api_id,
+                    'player_name': tp.player_name,
+                    'status': tp.status,
+                    'last_synced_at': None,
+                    'stale_days': None,
+                })
+                continue
+            if last_synced.tzinfo is None:
+                last_synced = last_synced.replace(tzinfo=timezone.utc)
+            age = _now - last_synced
+            if age > _stale_threshold:
+                _stale_entries.append({
+                    'player_api_id': tp.player_api_id,
+                    'player_name': tp.player_name,
+                    'status': tp.status,
+                    'last_synced_at': last_synced.isoformat(),
+                    'stale_days': age.days,
+                })
+        if _stale_entries or _missing_journeys:
+            logger.warning(
+                'newsletter pre-flight: team=%s (db_id=%d) has %d stale journey(s) '
+                '(>%dd) and %d player(s) missing a linked journey. '
+                'Consider running POST /admin/tracked-players/refresh-statuses '
+                '{team_id:%d} before publishing. stale=%s missing=%s',
+                team.name, parent_team_db_id, len(_stale_entries),
+                NEWSLETTER_JOURNEY_STALE_DAYS, len(_missing_journeys),
+                parent_team_db_id, _stale_entries, _missing_journeys,
+            )
+    except Exception as _stale_check_err:
+        logger.warning(
+            'newsletter pre-flight staleness check failed for team=%s: %s',
+            team.name, _stale_check_err,
+        )
 
     groups: Dict[str, list] = {'first_team': [], 'on_loan': [], 'academy': []}
 

--- a/academy-watch-backend/src/routes/api.py
+++ b/academy-watch-backend/src/routes/api.py
@@ -10518,11 +10518,17 @@ def admin_refresh_tracked_player_statuses():
     Body: { team_id?: int, resync_journeys?: bool } — if omitted, refreshes all active TrackedPlayers.
     When resync_journeys is true, re-syncs each player's journey data from API-Football
     before re-deriving statuses (fixes stale current_club data).
+
+    Default changed 2026-04 (post O. Hammond incident): resync_journeys now
+    defaults to True. The previous default of False silently ran the classifier
+    against cached journey data, so a naive "refresh statuses" click did
+    nothing useful for stale rows. Operators who explicitly want the
+    cache-only behaviour must now pass resync_journeys=false.
     """
     try:
         data = request.get_json(force=True) or {}
         team_id = data.get('team_id')
-        resync_journeys = data.get('resync_journeys', False)
+        resync_journeys = data.get('resync_journeys', True)
 
         from src.services.transfer_heal_service import refresh_and_heal
         result = refresh_and_heal(
@@ -10531,10 +10537,14 @@ def admin_refresh_tracked_player_statuses():
             cascade_fixtures=False,
         )
 
-        # Return the same shape as before for backwards compatibility
+        # Return the same shape as before for backwards compatibility,
+        # plus the new fail-loud prefetch fields so operators can see at a
+        # glance whether any players were deliberately skipped.
         response = {
             'total': result['total'],
             'updated': result['updated'],
+            'skipped_by_failed_prefetch': result.get('skipped_by_failed_prefetch', 0),
+            'failed_squad_clubs': result.get('failed_squad_clubs', []),
         }
         if resync_journeys:
             response['journeys_resynced'] = result['journeys_resynced']

--- a/academy-watch-backend/src/services/journey_sync.py
+++ b/academy-watch-backend/src/services/journey_sync.py
@@ -29,6 +29,50 @@ from src.utils.academy_classifier import (
 logger = logging.getLogger(__name__)
 
 
+# Regex to extract a specific level token from a club name.
+# Ordered so longer / more specific tokens match first (U23 before U2, etc).
+_CLUB_NAME_LEVEL_RE = re.compile(
+    r'\b(U15|U16|U17|U18|U19|U21|U23|Reserves?|Development|Youth|Academy|II|B)\b',
+    re.IGNORECASE,
+)
+
+
+def _derive_current_level_from_club_name(
+    club_name: Optional[str], fallback: str = 'First Team'
+) -> str:
+    """Infer a player's level from their destination club name.
+
+    Used on the transfer-override path in _update_journey_aggregates so a
+    return to a youth/reserve team does not get mislabelled as First Team.
+    Before this helper existed the override path hardcoded 'First Team',
+    which caused players whose journey was overridden to a '<Club> U21'
+    destination to be classified as first_team at the parent club
+    (see the O. Hammond incident).
+
+    >>> _derive_current_level_from_club_name('Nottingham Forest U21')
+    'U21'
+    >>> _derive_current_level_from_club_name('Arsenal Reserves')
+    'Reserve'
+    >>> _derive_current_level_from_club_name('Nottingham Forest')
+    'First Team'
+    """
+    if not club_name:
+        return fallback
+    match = _CLUB_NAME_LEVEL_RE.search(club_name)
+    if not match:
+        return fallback
+    token = match.group(1).lower()
+    mapping = {
+        'u15': 'U15', 'u16': 'U16', 'u17': 'U17',
+        'u18': 'U18', 'u19': 'U19', 'u21': 'U21', 'u23': 'U23',
+        'reserve': 'Reserve', 'reserves': 'Reserve',
+        'ii': 'Reserve', 'b': 'Reserve',
+        'youth': 'U18', 'academy': 'U18',
+        'development': 'U21',
+    }
+    return mapping.get(token, fallback)
+
+
 class JourneySyncService:
     """Service for syncing player journey data from API-Football"""
     
@@ -876,43 +920,90 @@ class JourneySyncService:
 
         # Cross-reference transfers: if the most recent transfer goes to a
         # DIFFERENT club than what stats show, override current_club.
-        # Handles both permanent transfers and loans where the player's
-        # stats still show the old club (e.g., Endrick: stats show Real Madrid
-        # but he's on loan at Lyon).
-        if transfers:
-            most_recent_transfer = None
-            for t in sorted(transfers, key=lambda x: x.get('date', ''), reverse=True):
-                transfer_type = (t.get('type') or '').strip().lower()
-                if transfer_type in LOAN_RETURN_TYPES:
-                    # Most recent move is a loan return — player is back at parent.
-                    dest = t.get('teams', {}).get('in', {})
+        # Handles cases like "stats still show Real Madrid but player is on
+        # loan at Lyon" — where the transfer is NEWER than the stats window.
+        #
+        # Safety rules (added after the O. Hammond incident, where a stale
+        # 2024 "N/A" return-from-loan transfer was letting the override
+        # overwrite much more recent 2025 entries at a different club):
+        #
+        #   1. Skip the override when the most recent transfer is OLDER
+        #      than the latest domestic journey-entry date. Stats entries
+        #      that post-date the transfer are authoritative — the player
+        #      has moved on since the recorded transfer.
+        #   2. Skip N/A-typed transfers entirely. API-Football uses "N/A"
+        #      for loan-returns they cannot cleanly classify; they are
+        #      too ambiguous to drive aggregation.
+        #   3. Never hardcode current_level='First Team'. Derive the level
+        #      from the destination club name so a return to a youth /
+        #      reserve team is not mislabelled.
+        if transfers and domestic_entries:
+            sorted_transfers = sorted(
+                transfers, key=lambda x: x.get('date', ''), reverse=True
+            )
+            most_recent_transfer = sorted_transfers[0] if sorted_transfers else None
+
+            # Compute latest domestic-entry date for the staleness check.
+            # Prefer explicit transfer_date on entries; fall back to a
+            # start-of-season proxy when entries have no recorded date.
+            dated_entries = [
+                e.transfer_date for e in domestic_entries if e.transfer_date
+            ]
+            if dated_entries:
+                latest_entry_date = max(dated_entries)
+            else:
+                latest_entry_season = max(e.season for e in domestic_entries)
+                latest_entry_date = f'{latest_entry_season}-07-01'
+
+            if most_recent_transfer:
+                transfer_type_raw = (most_recent_transfer.get('type') or '').strip()
+                transfer_type = transfer_type_raw.lower()
+                transfer_date = most_recent_transfer.get('date', '') or ''
+                dest = most_recent_transfer.get('teams', {}).get('in', {}) or {}
+
+                stale_override = bool(
+                    latest_entry_date and transfer_date
+                    and transfer_date < latest_entry_date
+                )
+                ambiguous_type = transfer_type in ('n/a', '')
+
+                if stale_override:
+                    logger.info(
+                        'Journey %d: skipping transfer override — most recent transfer %s older than latest entry %s',
+                        journey.id, transfer_date, latest_entry_date,
+                    )
+                elif ambiguous_type:
+                    logger.info(
+                        'Journey %d: skipping ambiguous transfer override (type=%r date=%s)',
+                        journey.id, transfer_type_raw, transfer_date,
+                    )
+                elif transfer_type in LOAN_RETURN_TYPES:
+                    # Loan return: player is back at parent club.
                     if (dest.get('id') and dest.get('name')
                             and dest['id'] != journey.current_club_api_id):
+                        derived_level = _derive_current_level_from_club_name(dest.get('name'))
                         logger.info(
-                            'Journey %d: loan return → updating current_club to %s (%s)',
-                            journey.id, dest['name'], t.get('date'),
+                            'Journey %d: loan return → updating current_club to %s (level=%s, %s)',
+                            journey.id, dest['name'], derived_level, transfer_date,
                         )
                         journey.current_club_api_id = dest['id']
                         journey.current_club_name = dest['name']
-                        journey.current_level = 'First Team'
-                    break
-                most_recent_transfer = t
-                break
-
-            if most_recent_transfer:
-                transfer_type = (most_recent_transfer.get('type') or '').strip().lower()
-                dest = most_recent_transfer.get('teams', {}).get('in', {})
-                if (dest.get('id') and dest.get('name')
-                        and dest['id'] != journey.current_club_api_id):
-                    logger.info(
-                        'Journey %d: overriding current_club from transfer %s → %s (%s, type=%s)',
-                        journey.id, journey.current_club_name, dest['name'],
-                        most_recent_transfer.get('date'), transfer_type,
-                    )
-                    journey.current_club_api_id = dest['id']
-                    journey.current_club_name = dest['name']
-                    if not is_new_loan_transfer(transfer_type):
-                        journey.current_level = 'First Team'
+                        journey.current_level = derived_level
+                else:
+                    # Permanent or unspecified non-loan-return transfer.
+                    if (dest.get('id') and dest.get('name')
+                            and dest['id'] != journey.current_club_api_id):
+                        logger.info(
+                            'Journey %d: overriding current_club from transfer %s → %s (%s, type=%s)',
+                            journey.id, journey.current_club_name, dest['name'],
+                            transfer_date, transfer_type,
+                        )
+                        journey.current_club_api_id = dest['id']
+                        journey.current_club_name = dest['name']
+                        if not is_new_loan_transfer(transfer_type):
+                            journey.current_level = _derive_current_level_from_club_name(
+                                dest.get('name')
+                            )
 
         # Find first team debut
         first_team_entries = [e for e in entries if e.level == 'First Team' and not e.is_international]

--- a/academy-watch-backend/src/services/transfer_heal_service.py
+++ b/academy-watch-backend/src/services/transfer_heal_service.py
@@ -68,8 +68,16 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False,
         for pid, raw in raw_transfers_map.items()
     }
 
-    # Batch pre-fetch squads for loan + parent clubs
+    # Batch pre-fetch squads for loan + parent clubs.
+    # Squads that fail to fetch are tracked in `failed_squad_clubs` so we can
+    # SKIP status classification for any player whose classification would
+    # otherwise depend on a silently-missing squad. Previously a single
+    # failed club would just be a warning and the squad cross-reference
+    # rule inside classify_tracked_player would silently not fire for any
+    # player at that club — an exactly-the-kind-of-silent-miss that let the
+    # O. Hammond class of bug persist. Now those players are left untouched.
     squad_members_by_club = {}
+    failed_squad_clubs: set[int] = set()
     loan_club_ids = {tp.current_club_api_id for tp in players if tp.current_club_api_id}
     parent_club_ids = set()
     _team_cache = {}
@@ -87,9 +95,38 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False,
                 if e and e.get('player', {}).get('id')
             }
         except Exception as exc:
-            logger.warning('Squad fetch failed for club %d: %s', club_id, exc)
+            failed_squad_clubs.add(club_id)
+            logger.warning(
+                'transfer-heal: squad fetch failed for club %d: %s — '
+                'classification will be SKIPPED for players at this club',
+                club_id, exc,
+            )
+
+    if failed_squad_clubs:
+        logger.warning(
+            'transfer-heal: %d squad fetch(es) failed (clubs=%s); affected '
+            'players will have their status left untouched.',
+            len(failed_squad_clubs), sorted(failed_squad_clubs),
+        )
+
+    # Also track players whose transfer batch came back empty in a way that
+    # suggests a fetch failure rather than a genuinely empty history. We
+    # cannot distinguish a real empty list from a failed fetch for a
+    # batch-call, so we only flag players we received NO key for at all.
+    transfer_fetch_missing = {
+        tp.player_api_id for tp in players
+        if tp.player_api_id and tp.player_api_id not in raw_transfers_map
+    }
+    if transfer_fetch_missing:
+        logger.warning(
+            'transfer-heal: %d player(s) missing from transfer batch response — '
+            'their classification will be SKIPPED to avoid basing it on partial data. '
+            'player_api_ids=%s',
+            len(transfer_fetch_missing), sorted(transfer_fetch_missing),
+        )
 
     # Process each player
+    skipped_by_failed_prefetch = 0
     for tp in players:
         journey = None
 
@@ -120,6 +157,27 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False,
 
         parent_team = _team_cache.get(tp.team_id) or Team.query.get(tp.team_id)
         if not parent_team:
+            continue
+
+        # Skip classification if any of the data the classifier needs for
+        # this specific player failed to pre-fetch. Running the classifier
+        # against a known-partial squad dict or missing transfer list is
+        # exactly how wrong statuses silently persist — we prefer leaving
+        # the row untouched over writing a guess.
+        player_parent_id = parent_team.team_id
+        player_loan_id = tp.current_club_api_id
+        if (player_parent_id in failed_squad_clubs
+                or (player_loan_id and player_loan_id in failed_squad_clubs)
+                or tp.player_api_id in transfer_fetch_missing):
+            skipped_by_failed_prefetch += 1
+            logger.info(
+                'transfer-heal: skipping player %d (%s) — prefetch incomplete '
+                '(parent_squad_failed=%s loan_squad_failed=%s transfers_missing=%s)',
+                tp.player_api_id, tp.player_name,
+                player_parent_id in failed_squad_clubs,
+                bool(player_loan_id and player_loan_id in failed_squad_clubs),
+                tp.player_api_id in transfer_fetch_missing,
+            )
             continue
 
         new_status, new_loan_id, new_loan_name = classify_tracked_player(
@@ -240,4 +298,6 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False,
         'journeys_resynced': journeys_resynced,
         'players_changed': players_changed,
         'fixture_syncs_triggered': fixture_syncs_triggered,
+        'skipped_by_failed_prefetch': skipped_by_failed_prefetch,
+        'failed_squad_clubs': sorted(failed_squad_clubs),
     }

--- a/academy-watch-backend/tests/test_journey.py
+++ b/academy-watch-backend/tests/test_journey.py
@@ -593,6 +593,208 @@ class TestCurrentClubTiebreaker:
         assert mock_journey.current_club_name == 'Manchester United'
 
 
+class TestDeriveCurrentLevelFromClubName:
+    """Test the helper that derives current_level from a destination club name.
+
+    Added after the O. Hammond incident where the transfer-override path in
+    _update_journey_aggregates was hardcoding current_level='First Team'
+    even when the destination was a youth team.
+    """
+
+    def test_u21_destination(self):
+        from src.services.journey_sync import _derive_current_level_from_club_name
+        assert _derive_current_level_from_club_name('Nottingham Forest U21') == 'U21'
+
+    def test_u18_destination(self):
+        from src.services.journey_sync import _derive_current_level_from_club_name
+        assert _derive_current_level_from_club_name('Arsenal U18') == 'U18'
+
+    def test_reserves_destination(self):
+        from src.services.journey_sync import _derive_current_level_from_club_name
+        assert _derive_current_level_from_club_name('Manchester City Reserves') == 'Reserve'
+
+    def test_plain_club_returns_first_team(self):
+        from src.services.journey_sync import _derive_current_level_from_club_name
+        assert _derive_current_level_from_club_name('Nottingham Forest') == 'First Team'
+
+    def test_none_falls_back(self):
+        from src.services.journey_sync import _derive_current_level_from_club_name
+        assert _derive_current_level_from_club_name(None) == 'First Team'
+
+    def test_custom_fallback(self):
+        from src.services.journey_sync import _derive_current_level_from_club_name
+        assert _derive_current_level_from_club_name('Arsenal', fallback='U21') == 'U21'
+
+
+@pytest.mark.usefixtures("app")
+class TestTransferOverrideStaleness:
+    """Regression tests for the O. Hammond bug in _update_journey_aggregates.
+
+    Before the fix, a stale 2024 'N/A' transfer from Cheltenham to
+    'Nottingham Forest U21' was overriding 2025 Oldham entries, causing
+    O. Hammond (api 325967) to be classified as first_team at Nottingham
+    Forest even though his latest actual stats are at Oldham.
+
+    Uses the `app` fixture from conftest.py so _update_journey_aggregates
+    (which touches db.session via helpers like _compute_academy_club_ids)
+    has a Flask application context.
+    """
+
+    def _mock_entry(self, *, season, club_api_id, club_name, level='First Team',
+                    entry_type='first_team', appearances=1, sort_priority=None,
+                    transfer_date=None):
+        from src.models.journey import LEVEL_PRIORITY
+        e = MagicMock()
+        e.season = season
+        e.club_api_id = club_api_id
+        e.club_name = club_name
+        e.level = level
+        e.entry_type = entry_type
+        e.is_youth = level != 'First Team'
+        e.is_international = False
+        e.appearances = appearances
+        e.goals = 0
+        e.assists = 0
+        e.minutes = 0
+        e.sort_priority = sort_priority if sort_priority is not None else LEVEL_PRIORITY.get(level, 0)
+        e.transfer_date = transfer_date
+        return e
+
+    def test_stale_transfer_does_not_override_fresher_entries(self):
+        """The Hammond scenario: a 2024 N/A transfer back to Forest U21 must
+        NOT overwrite 2025 Oldham entries."""
+        from src.services.journey_sync import JourneySyncService
+        service = JourneySyncService(api_client=Mock())
+
+        # 2025 Oldham first-team entries (the true latest state)
+        oldham_2025 = self._mock_entry(
+            season=2025, club_api_id=1349, club_name='Oldham',
+            level='First Team', entry_type='first_team',
+            appearances=16, transfer_date='2025-08-15',
+        )
+        # 2023 Forest U21 entry (earlier)
+        forest_u21_2023 = self._mock_entry(
+            season=2023, club_api_id=19746, club_name='Nottingham Forest U21',
+            level='U21', entry_type='development', appearances=1,
+            transfer_date='2024-01-02',
+        )
+
+        transfers = [
+            # The exact pathological transfer Hammond has on prod
+            {'date': '2024-01-02', 'type': 'N/A',
+             'teams': {'out': {'id': 1943, 'name': 'Cheltenham'},
+                       'in':  {'id': 19746, 'name': 'Nottingham Forest U21'}}},
+            {'date': '2023-08-01', 'type': 'Loan',
+             'teams': {'out': {'id': 65, 'name': 'Nottingham Forest'},
+                       'in':  {'id': 1943, 'name': 'Cheltenham'}}},
+        ]
+
+        journey = MagicMock()
+        journey.id = 1
+        journey.player_api_id = 325967
+
+        with patch('src.services.journey_sync.PlayerJourneyEntry') as MockEntry, \
+             patch.object(service, '_compute_academy_club_ids'):
+            MockEntry.query.filter_by.return_value.all.return_value = [
+                oldham_2025, forest_u21_2023,
+            ]
+            service._update_journey_aggregates(journey, transfers=transfers)
+
+        # The stale 2024 transfer must NOT pull current_club back to Forest U21.
+        assert journey.current_club_api_id == 1349
+        assert journey.current_club_name == 'Oldham'
+        assert journey.current_level == 'First Team'
+
+    def test_na_typed_transfer_is_ignored(self):
+        """N/A transfer types are ambiguous and must never drive overrides,
+        even when they are newer than the latest entry."""
+        from src.services.journey_sync import JourneySyncService
+        service = JourneySyncService(api_client=Mock())
+
+        entry = self._mock_entry(
+            season=2024, club_api_id=1349, club_name='Oldham',
+            transfer_date='2024-08-01',
+        )
+        transfers = [
+            # Newer than the entry, but type=N/A — must be skipped
+            {'date': '2025-01-15', 'type': 'N/A',
+             'teams': {'out': {'id': 1349, 'name': 'Oldham'},
+                       'in':  {'id': 19746, 'name': 'Nottingham Forest U21'}}},
+        ]
+
+        journey = MagicMock()
+        journey.id = 2
+        journey.player_api_id = 2
+
+        with patch('src.services.journey_sync.PlayerJourneyEntry') as MockEntry, \
+             patch.object(service, '_compute_academy_club_ids'):
+            MockEntry.query.filter_by.return_value.all.return_value = [entry]
+            service._update_journey_aggregates(journey, transfers=transfers)
+
+        assert journey.current_club_api_id == 1349
+        assert journey.current_club_name == 'Oldham'
+
+    def test_loan_return_derives_level_from_destination(self):
+        """A loan return to a youth team must set current_level from the
+        destination, not hardcode 'First Team'."""
+        from src.services.journey_sync import JourneySyncService
+        service = JourneySyncService(api_client=Mock())
+
+        entry = self._mock_entry(
+            season=2024, club_api_id=1234, club_name='Some Loan Club',
+            transfer_date='2024-08-01',
+        )
+        transfers = [
+            {'date': '2025-12-30', 'type': 'Return from loan',
+             'teams': {'out': {'id': 1234, 'name': 'Some Loan Club'},
+                       'in':  {'id': 19746, 'name': 'Nottingham Forest U21'}}},
+        ]
+
+        journey = MagicMock()
+        journey.id = 3
+        journey.player_api_id = 3
+
+        with patch('src.services.journey_sync.PlayerJourneyEntry') as MockEntry, \
+             patch.object(service, '_compute_academy_club_ids'):
+            MockEntry.query.filter_by.return_value.all.return_value = [entry]
+            service._update_journey_aggregates(journey, transfers=transfers)
+
+        assert journey.current_club_api_id == 19746
+        assert journey.current_club_name == 'Nottingham Forest U21'
+        # Level must reflect that the destination is a U21 team
+        assert journey.current_level == 'U21'
+
+    def test_newer_valid_transfer_still_overrides(self):
+        """The existing 'stats show Real Madrid but on loan at Lyon' use case
+        must keep working — a valid newer transfer still overrides stats."""
+        from src.services.journey_sync import JourneySyncService
+        service = JourneySyncService(api_client=Mock())
+
+        # Stats show player at Real Madrid in 2025
+        entry = self._mock_entry(
+            season=2025, club_api_id=541, club_name='Real Madrid',
+            transfer_date='2025-07-01',
+        )
+        # Jan 2026 loan to Lyon — newer than stats, valid loan type
+        transfers = [
+            {'date': '2026-01-15', 'type': 'Loan',
+             'teams': {'out': {'id': 541, 'name': 'Real Madrid'},
+                       'in':  {'id': 80, 'name': 'Lyon'}}},
+        ]
+
+        journey = MagicMock()
+        journey.id = 4
+        journey.player_api_id = 4
+
+        with patch('src.services.journey_sync.PlayerJourneyEntry') as MockEntry, \
+             patch.object(service, '_compute_academy_club_ids'):
+            MockEntry.query.filter_by.return_value.all.return_value = [entry]
+            service._update_journey_aggregates(journey, transfers=transfers)
+
+        assert journey.current_club_api_id == 80
+        assert journey.current_club_name == 'Lyon'
+
+
 class TestUpdateAggregatesWithLoans:
     """Test that _update_journey_aggregates counts loan apps"""
 


### PR DESCRIPTION
## Summary

Root cause of the O. Hammond newsletter false-positive — a departed Forest player appearing in the generated academy newsletter because the journey-sync layer was letting a stale 2024 \`N/A\`-typed return-from-loan transfer overwrite much fresher 2025 stats entries, and hardcoding \`current_level='First Team'\` on a youth-team destination.

## What's happening (the bug chain)

1. **API-Football returns a \`type=\"N/A\"\` transfer** on \`2024-01-02: Cheltenham → Nottingham Forest U21\` (their catch-all for unclassifiable loan returns).
2. \`_update_journey_aggregates\` correctly computes \`current_club = Oldham\` from O. Hammond's 2025 entries (19 apps across League Two / League Cup / EFL Trophy).
3. The transfer cross-reference step then takes the single most-recent transfer (that 2024 N/A one) and — because of an unconditional \`break\` — uses it to **overwrite** \`current_club_api_id = 19746 (\"Nottingham Forest U21\")\`, ignoring the 2025 Oldham entries that are ~18 months newer.
4. The same block **hardcodes \`current_level = 'First Team'\`** on the override path, even though the destination is a U21 team.
5. \`classify_tracked_player\`'s \`same_club_name\` rule then strips the \"U21\" suffix → \`\"Nottingham Forest\" == \"Nottingham Forest\"\` → returns \`_base_status('First Team') = 'first_team'\`.
6. Newsletter pulls him in (\`status NOT IN ('released','sold')\` ✓; \`is_academy_product\` ✓ because \`journey.academy_club_ids=[65]\`).
7. First-team stats enrichment finds 0 minutes for Forest this season → reclassifies him into the **academy** group with \`first_team_cameo=True\` — exactly where the Forest demo spotted him.

The stale 2024 transfer is the only one API-Football has for him post-2023; there is **no** transfer record for his move to Oldham, so nothing upstream could flag it.

## Changes

### Root cause fix — \`services/journey_sync.py\`

- New \`_derive_current_level_from_club_name(club_name, fallback='First Team')\` helper — regex-based level extractor for \`U15/16/17/18/19/21/23 | Reserves | II | Youth | Academy | Development\` suffixes.
- \`_update_journey_aggregates\` transfer cross-reference rewritten with three safety rules:
  1. **Skip the override** when the most recent transfer is older than the latest domestic journey-entry date (stats that post-date the transfer are authoritative).
  2. **Skip \`N/A\`-typed transfers entirely** (too ambiguous — API-Football uses this for unclassifiable loan-returns).
  3. **Derive \`current_level\` from the destination club name** instead of hardcoding \`'First Team'\`. A return to a U21/Reserve team now stays at that level.

### Supporting fixes so the pipeline fails loud instead of silently drifting

- **\`routes/api.py\`** — \`POST /admin/tracked-players/refresh-statuses\` now defaults \`resync_journeys=True\`. The previous \`False\` default made the endpoint deceptive (a click ran the classifier against the same cached journey that was already wrong). Response now also includes \`skipped_by_failed_prefetch\` and \`failed_squad_clubs\` so operators can see at a glance whether any players were deliberately skipped.
- **\`services/transfer_heal_service.py\`** — squad and transfer pre-fetches are now fail-loud. Players whose parent-club or loan-club squad fetch failed, or who are missing from the transfer batch response, are now **SKIPPED** for classification with a warning. Previously a single failed \`get_team_players\` call silently disabled the squad cross-reference for every affected player. New \`skipped_by_failed_prefetch\` and \`failed_squad_clubs\` counts in the return dict.
- **\`agents/weekly_newsletter_agent.py\`** — pre-flight staleness check logs a \`WARNING\` for every tracked player whose linked \`PlayerJourney.last_synced_at\` is older than \`NEWSLETTER_JOURNEY_STALE_DAYS\` (14), with the team name, player list, and a hint to run the refresh endpoint before publishing. Previously the newsletter pipeline had no staleness guard at all.

### Tests — \`tests/test_journey.py\`

10 new passing tests, all isolated to the changed code path:

- \`TestDeriveCurrentLevelFromClubName\` (6 tests) — verifies the helper for \`U21\`, \`U18\`, \`Reserves\`, plain club, \`None\`, and a custom fallback.
- \`TestTransferOverrideStaleness\` (4 tests):
  - \`test_stale_transfer_does_not_override_fresher_entries\` — exact reproduction of the O. Hammond scenario, using the real transfer payload from prod.
  - \`test_na_typed_transfer_is_ignored\` — N/A is never allowed to drive overrides, even when newer than entries.
  - \`test_loan_return_derives_level_from_destination\` — a loan return to \`\"Nottingham Forest U21\"\` now sets \`current_level='U21'\`, not \`'First Team'\`.
  - \`test_newer_valid_transfer_still_overrides\` — regression-guards the original use case (\"stats show Real Madrid but on loan at Lyon\" — newer valid non-loan-return transfers still override stats).

Tests use the \`app\` pytest fixture for Flask context and patch \`_compute_academy_club_ids\` to avoid downstream DB writes.

## Not in this PR (scoped separately)

- Diagnostic / one-off: no Phase-1 audit script — kept local.
- Admin UI staleness surface (showing \`last_journey_sync\` per player in the Tracked Players view) — follow-up task.
- Scheduled weekly \`refresh_and_heal(resync_journeys=True)\` cron — follow-up task.
- Pre-existing failing tests in \`test_journey.py\` (TestCurrentClubTiebreaker, TestUpdateAggregatesWithLoans, TestComputeAcademyClubIdsExcludesIntegration, TestUpsertTrackedPlayersDeactivatesStaleRows) — confirmed pre-existing on main via \`git stash\`, not caused by this PR. Worth fixing separately.

## Test plan

- [x] New unit tests pass: \`pnpm exec python -m pytest tests/test_journey.py::TestDeriveCurrentLevelFromClubName tests/test_journey.py::TestTransferOverrideStaleness -v\` → 10 passed
- [x] Full \`test_journey.py\` run: 0 new regressions vs main
- [x] Broader collectible-test run (test_journey + auth + routes_api + user_auth + migration_heads + api_client_stats): all pre-existing failures confirmed via \`git stash\`, my commit adds 10 new passes with 0 regressions
- [ ] After merge + deploy, run: \`POST /admin/tracked-players/refresh-statuses { \"team_id\": 18, \"resync_journeys\": true }\` for Nottingham Forest
- [ ] Verify response shows \`total\`, \`updated\`, \`journeys_resynced\`, \`skipped_by_failed_prefetch\`, \`failed_squad_clubs\`
- [ ] Regenerate the Forest weekly newsletter for the demo window, confirm O. Hammond is absent
- [ ] Spot-check G. Murray-Jones (legitimately returned from loan to Forest per 2025-12-30 transfer) and Z. Abbott (has real 2025 Forest first-team entries) still classify sensibly
- [ ] Cross-reference final newsletter output against Forest's live API-Football squad and Transfermarkt before Chris McGuane demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)