### PR TITLE
feat: admin newsletter PDF download via WeasyPrint

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -103,6 +103,7 @@ CONTINUITY.md
 
 ## Trivial Log
 
+- 2026-04-08: Added admin-only newsletter PDF download (WeasyPrint) — endpoint `GET /newsletters/<id>/download.pdf`, reuses existing `newsletter_email.html` template with injected print CSS (`@page`, `break-inside: avoid` on `.item`/`.highlights`/`.toc`/`.matches-section`, `break-before: page` on section `<h2>`s). Dockerfile gains libpango/libcairo/libgdk-pixbuf/shared-mime-info (~80MB). Download buttons in `AdminNewsletters.jsx` row actions and `NewsletterPreviewDialog.jsx` control panel. Plan file at `.claude/plans/staged-wibbling-cocoa.md`.
 - 2026-02-12: Academy data audit — all Big 6 teams show 0% conversion due to journey sync never completing
 - 2026-02-12: Fixed Full Rebuild journey sync: added RateLimiter, quota-exceeded break, non-fatal Stage 3, empty-journey bug fix
 - 2026-02-12: Added Phase 2 journey sync timeout guard (`PLAYER_SYNC_TIMEOUT=90`) and verified a live constrained rebuild completes without hangs

--- a/academy-watch-backend/Dockerfile
+++ b/academy-watch-backend/Dockerfile
@@ -4,12 +4,19 @@ FROM python:3.11-slim
 # Set working directory
 WORKDIR /app
 
-# Install system dependencies (including curl for health checks)
+# Install system dependencies (including curl for health checks,
+# and Pango/Cairo/GDK-pixbuf for WeasyPrint PDF generation).
 RUN apt-get update && apt-get install -y \
     gcc \
     curl \
     fontconfig \
     fonts-dejavu-core \
+    libpango-1.0-0 \
+    libpangoft2-1.0-0 \
+    libharfbuzz0b \
+    libcairo2 \
+    libgdk-pixbuf-2.0-0 \
+    shared-mime-info \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements first for better Docker layer caching

--- a/academy-watch-backend/requirements.txt
+++ b/academy-watch-backend/requirements.txt
@@ -80,6 +80,7 @@ typing-inspection==0.4.1
 typing_extensions==4.14.0
 urllib3==2.5.0
 uvicorn==0.35.0
+weasyprint==62.3
 webencodings==0.5.1
 Werkzeug==3.1.3
 wrapt==1.17.3

--- a/academy-watch-backend/src/routes/api.py
+++ b/academy-watch-backend/src/routes/api.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, request, jsonify, make_response, render_template, Response, current_app, g
+from flask import Blueprint, request, jsonify, make_response, render_template, Response, current_app, g, send_file
 from src.models.league import db, League, Team, Newsletter, UserSubscription, EmailToken, PlayerFlag, FLAG_CATEGORIES, FLAG_STATUSES, AdminSetting, NewsletterComment, UserAccount, NewsletterPlayerYoutubeLink, NewsletterCommentary, Player, JournalistTeamAssignment, CommentaryApplause, TeamTrackingRequest, StripeSubscription, NewsletterDigestQueue, JournalistSubscription, BackgroundJob, TeamSubreddit, RedditPost, TeamAlias, ManualPlayerSubmission, CommunityTake, AcademyAppearance, PlayerComment, PlayerLink, _as_utc
 from src.models.tracked_player import TrackedPlayer
 from src.models.sponsor import Sponsor
@@ -3743,6 +3743,51 @@ def render_newsletter(newsletter_id: int, fmt: str):
     except Exception as e:
         logger.exception('Error rendering newsletter')
         return jsonify(_safe_error_payload(e, 'An unexpected error occurred. Please try again later.')), 500
+
+
+@api_bp.route('/newsletters/<int:newsletter_id>/download.pdf', methods=['GET'])
+@require_api_key
+def download_newsletter_pdf(newsletter_id: int):
+    """Render a newsletter as a paginated PDF and return it as an attachment.
+
+    Reuses the existing Tactical Lens email template as the rendering source,
+    then hands the HTML to ``pdf_renderer.html_to_pdf`` which injects print
+    CSS (``@page`` margins, ``break-inside: avoid`` on player cards, etc.)
+    before calling WeasyPrint. Admin-only via ``@require_api_key``.
+    """
+    try:
+        from src.services.pdf_renderer import html_to_pdf, build_pdf_filename
+    except ImportError:
+        logger.exception('WeasyPrint not available for PDF rendering')
+        return jsonify({
+            'error': 'pdf_renderer_unavailable',
+            'message': 'PDF generation is not configured on this server.',
+        }), 503
+
+    try:
+        n = Newsletter.query.get_or_404(newsletter_id)
+        context = _newsletter_render_context(n)
+        html = render_template('newsletter_email.html', **context)
+        try:
+            base_url = request.url_root
+        except RuntimeError:
+            base_url = None
+        pdf_bytes = html_to_pdf(html, base_url=base_url)
+        filename = build_pdf_filename(
+            team_name=n.team.name if n.team else None,
+            week_end_date=n.week_end_date or n.issue_date,
+            newsletter_id=n.id,
+        )
+        return send_file(
+            BytesIO(pdf_bytes),
+            mimetype='application/pdf',
+            as_attachment=True,
+            download_name=filename,
+        )
+    except Exception as e:
+        logger.exception('Error rendering newsletter PDF')
+        return jsonify(_safe_error_payload(e, 'Failed to generate PDF')), 500
+
 
 @api_bp.route('/newsletters/<int:newsletter_id>/send', methods=['POST'])
 @require_api_key

--- a/academy-watch-backend/src/services/pdf_renderer.py
+++ b/academy-watch-backend/src/services/pdf_renderer.py
@@ -1,0 +1,194 @@
+"""PDF rendering for newsletters.
+
+Converts rendered newsletter HTML (from ``newsletter_email.html`` Jinja2
+template) into a paginated PDF via WeasyPrint. The email template is already
+narrow (600px), single-column, and styled in the Tactical Lens design system,
+which makes it ideal as a PDF source: we only need to inject a small print
+stylesheet that enforces clean page breaks around atomic content units
+(player cards, highlights, the table of contents, match blocks, etc.).
+
+Public API:
+    html_to_pdf(html, base_url=None) -> bytes
+        Inject print CSS and render the provided HTML string to PDF bytes.
+
+    build_pdf_filename(team_name, week_end_date, newsletter_id) -> str
+        Deterministic, filesystem-safe filename for downloads.
+
+The renderer is deliberately unaware of the Newsletter model and the Jinja2
+context. The route in ``api.py`` is responsible for loading the newsletter,
+building the template context, and calling ``render_template``; it then hands
+the resulting HTML here. This keeps the pdf_renderer free of circular
+dependencies on the routes module.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date, datetime
+
+
+# Print stylesheet injected before </head> prior to handing HTML to WeasyPrint.
+#
+# The class names referenced below are verified against
+# ``src/templates/newsletter_email.html``:
+#   .item            — a single player card (atomic; do not split across pages)
+#   .item-header     — player card header row (name, loan club, headshot)
+#   .highlights      — top-of-issue highlights panel
+#   .toc             — in-this-issue table of contents block
+#   .matches-section — per-player "this week's matches" block
+#   .match-row       — individual match row inside .matches-section
+#   .es-card         — expanded stats subcard (attacking/passing/defending/etc.)
+#   .tweet-card      — embedded tweet reaction
+#   .footer          — email footer (kept in PDF, including unsubscribe link)
+#
+# Sections in the email template are bare <h2> tags followed by flat .item
+# divs — there is no wrapping .section element. The rule
+# ``.content h2 { break-before: page }`` therefore forces a page break at the
+# start of each section (First Team, On Loan, Academy Rising). The first <h2>
+# naturally appears after the highlights + TOC on page 1, so it correctly
+# starts the first section on page 2.
+_PRINT_CSS = """
+<style id="pdf-print-css">
+@page {
+    size: A4;
+    margin: 18mm 16mm 22mm 16mm;
+    @bottom-center {
+        content: "The Academy Watch \\00B7 Page " counter(page) " of " counter(pages);
+        font-family: 'Inter', 'DejaVu Sans', sans-serif;
+        font-size: 9pt;
+        color: #64748b;
+    }
+}
+
+/* Force the dark Tactical Lens background to render in print.
+   WeasyPrint honours backgrounds by default, but we make the intent explicit. */
+html, body {
+    background: #0b1326 !important;
+    -weasy-color-adjust: exact;
+    print-color-adjust: exact;
+}
+
+/* Atomic content units — never split these across pages. If any block is
+   genuinely taller than a page WeasyPrint will fall back to splitting it,
+   which is the correct behaviour. */
+.item,
+.item-header,
+.highlights,
+.toc,
+.matches-section,
+.match-row,
+.es-card,
+.tweet-card,
+.sofascore-card,
+.notes,
+img,
+table {
+    break-inside: avoid;
+    page-break-inside: avoid;
+}
+
+/* Keep section headings with their next sibling so we never orphan a title
+   at the bottom of a page. */
+h1, h2, h3 {
+    break-after: avoid-page;
+    page-break-after: avoid;
+}
+
+/* Force each top-level newsletter section onto a fresh page for
+   stakeholder scan-ability. The first <h2> lives after the highlights/TOC
+   on page 1, so this naturally starts the first section on page 2. */
+.content h2 {
+    break-before: page;
+    page-break-before: always;
+}
+
+/* Widows and orphans on body copy. */
+p, li {
+    orphans: 3;
+    widows: 3;
+}
+
+/* Give the expanded stats grid a little more room to lay out cleanly. */
+.expanded-stats {
+    page-break-inside: auto;
+    break-inside: auto;
+}
+</style>
+"""
+
+
+def _inject_print_css(html: str) -> str:
+    """Splice the print stylesheet into the document ``<head>``.
+
+    Falls back to prepending the style block if no ``</head>`` is found — that
+    shouldn't happen with the current Jinja2 template but makes the function
+    robust against template changes.
+    """
+    if not html:
+        return _PRINT_CSS
+    # Case-insensitive replace of the first </head>.
+    match = re.search(r"</head\s*>", html, flags=re.IGNORECASE)
+    if match:
+        idx = match.start()
+        return html[:idx] + _PRINT_CSS + html[idx:]
+    return _PRINT_CSS + html
+
+
+def html_to_pdf(html: str, base_url: str | None = None) -> bytes:
+    """Render newsletter HTML to a PDF byte string.
+
+    Parameters
+    ----------
+    html:
+        Fully rendered newsletter HTML (typically the output of
+        ``render_template('newsletter_email.html', **context)``).
+    base_url:
+        Base URL used by WeasyPrint to resolve any relative asset references.
+        For newsletters generated from an HTTP request this should be
+        ``request.url_root`` so that team logos and chart images load
+        correctly when the template emits relative URLs. Absolute URLs and
+        data URIs are unaffected.
+
+    Returns
+    -------
+    bytes
+        A complete PDF document.
+    """
+    # Imported lazily so that the module can be imported in environments where
+    # WeasyPrint's system libraries (libpango, libcairo, …) are not yet
+    # installed — e.g. during static analysis or partial local runs.
+    from weasyprint import HTML  # type: ignore
+
+    augmented = _inject_print_css(html)
+    return HTML(string=augmented, base_url=base_url).write_pdf()
+
+
+_FILENAME_SAFE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _slugify_filename_component(value: str) -> str:
+    cleaned = _FILENAME_SAFE.sub("-", (value or "").strip()).strip("-")
+    return cleaned or "newsletter"
+
+
+def build_pdf_filename(
+    team_name: str | None,
+    week_end_date: date | datetime | None,
+    newsletter_id: int,
+) -> str:
+    """Return a deterministic, filesystem-safe PDF filename.
+
+    Example: ``nottingham-forest-2026-04-06-issue-42.pdf``
+    """
+    team_slug = _slugify_filename_component(team_name or "newsletter").lower()
+    if isinstance(week_end_date, datetime):
+        date_part = week_end_date.date().isoformat()
+    elif isinstance(week_end_date, date):
+        date_part = week_end_date.isoformat()
+    else:
+        date_part = ""
+    parts = [team_slug]
+    if date_part:
+        parts.append(date_part)
+    parts.append(f"issue-{int(newsletter_id)}")
+    return "-".join(parts) + ".pdf"

--- a/academy-watch-frontend/src/components/admin/NewsletterPreviewDialog.jsx
+++ b/academy-watch-frontend/src/components/admin/NewsletterPreviewDialog.jsx
@@ -7,7 +7,7 @@ import { Label } from '@/components/ui/label'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Switch } from '@/components/ui/switch'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { Loader2, RefreshCw, Monitor, Mail, ExternalLink, Send } from 'lucide-react'
+import { Loader2, RefreshCw, Monitor, Mail, ExternalLink, Send, Download } from 'lucide-react'
 import { ScrollArea } from '@/components/ui/scroll-area'
 
 export function NewsletterPreviewDialog({ open, onOpenChange, newsletter, onStatus }) {
@@ -20,6 +20,7 @@ export function NewsletterPreviewDialog({ open, onOpenChange, newsletter, onStat
     const [simulateSubscription, setSimulateSubscription] = useState(false)
     const [sendingAdminPreview, setSendingAdminPreview] = useState(false)
     const [sendStatus, setSendStatus] = useState(null)
+    const [downloadingPdf, setDownloadingPdf] = useState(false)
 
     // Load journalists for the team
     useEffect(() => {
@@ -127,6 +128,24 @@ export function NewsletterPreviewDialog({ open, onOpenChange, newsletter, onStat
             newWindow.document.write(htmlContent)
             newWindow.document.close()
             newWindow.document.title = `Preview - ${newsletter?.team_name}`
+        }
+    }
+
+    const downloadPdf = async () => {
+        if (!newsletter?.id) return
+        setDownloadingPdf(true)
+        setSendStatus(null)
+        try {
+            await APIService.adminNewsletterDownloadPdf(newsletter.id)
+            const text = `Downloaded PDF for newsletter #${newsletter.id}.`
+            setSendStatus({ type: 'success', text })
+            onStatus?.({ type: 'success', text })
+        } catch (error) {
+            const text = error?.body?.message || error?.message || 'Failed to download PDF.'
+            setSendStatus({ type: 'error', text })
+            onStatus?.({ type: 'error', text })
+        } finally {
+            setDownloadingPdf(false)
         }
     }
 
@@ -301,6 +320,19 @@ export function NewsletterPreviewDialog({ open, onOpenChange, newsletter, onStat
                                         <Send className="mr-2 h-4 w-4" />
                                     )}
                                     Send to Admins for Review
+                                </Button>
+                                <Button
+                                    onClick={downloadPdf}
+                                    className="w-full"
+                                    variant="outline"
+                                    disabled={loading || downloadingPdf}
+                                >
+                                    {downloadingPdf ? (
+                                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                    ) : (
+                                        <Download className="mr-2 h-4 w-4" />
+                                    )}
+                                    {downloadingPdf ? 'Preparing PDF…' : 'Download PDF'}
                                 </Button>
                                 <Button onClick={handleRefresh} className="w-full" variant="outline" disabled={loading}>
                                     {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}

--- a/academy-watch-frontend/src/lib/api.js
+++ b/academy-watch-frontend/src/lib/api.js
@@ -954,6 +954,49 @@ export class APIService {
         return text
     }
 
+    static async adminNewsletterDownloadPdf(id) {
+        const numericId = parseNewsletterId(id)
+        if (!numericId) {
+            throw new Error('Newsletter id must be a positive integer')
+        }
+        const headers = { 'Accept': 'application/pdf' }
+        const key = this.adminKey || (typeof localStorage !== 'undefined' && localStorage.getItem('academy_watch_admin_key'))
+        if (key) headers['X-API-Key'] = key
+        const token = this.userToken || (typeof localStorage !== 'undefined' && localStorage.getItem('academy_watch_user_token'))
+        if (token) headers['Authorization'] = `Bearer ${token}`
+        const res = await fetch(`${API_BASE_URL}/newsletters/${numericId}/download.pdf`, { headers, method: 'GET' })
+        if (!res.ok) {
+            let message = `HTTP ${res.status}`
+            try {
+                const body = await res.text()
+                if (body) message = body
+            } catch (_) { /* ignore */ }
+            const err = new Error(message)
+            err.status = res.status
+            throw err
+        }
+        const blob = await res.blob()
+        // Parse filename from Content-Disposition header; fall back to a sensible default.
+        const disposition = res.headers.get('content-disposition') || ''
+        let filename = `newsletter-${numericId}.pdf`
+        const match = disposition.match(/filename\*?=(?:UTF-8'')?"?([^";]+)"?/i)
+        if (match && match[1]) {
+            try { filename = decodeURIComponent(match[1]) } catch (_) { filename = match[1] }
+        }
+        // Trigger browser download via a temporary object URL + anchor click.
+        if (typeof document !== 'undefined' && typeof URL !== 'undefined' && URL.createObjectURL) {
+            const objectUrl = URL.createObjectURL(blob)
+            const a = document.createElement('a')
+            a.href = objectUrl
+            a.download = filename
+            document.body.appendChild(a)
+            a.click()
+            a.remove()
+            setTimeout(() => URL.revokeObjectURL(objectUrl), 0)
+        }
+        return { blob, filename }
+    }
+
     static async listNewsletterComments(newsletterId) {
         const numericId = parseNewsletterId(newsletterId)
         if (!numericId) {

--- a/academy-watch-frontend/src/pages/admin/AdminNewsletters.jsx
+++ b/academy-watch-frontend/src/pages/admin/AdminNewsletters.jsx
@@ -21,7 +21,7 @@ import {
     DialogFooter,
 } from '@/components/ui/dialog'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { Mail, Calendar, Send, Trash2, AlertCircle, CheckCircle2, FileJson, Loader2, Monitor, Copy, Check, FileText } from 'lucide-react'
+import { Mail, Calendar, Send, Trash2, AlertCircle, CheckCircle2, FileJson, Loader2, Monitor, Copy, Check, FileText, Download } from 'lucide-react'
 import { convertNewsletterToMarkdown, convertNewsletterToCompactMarkdown } from '@/lib/newsletter-markdown'
 import TeamMultiSelect from '@/components/ui/TeamMultiSelect.jsx'
 import TeamSelect from '@/components/ui/TeamSelect.jsx'
@@ -92,6 +92,7 @@ export function AdminNewsletters() {
     // Preview dialog
     const [previewOpen, setPreviewOpen] = useState(false)
     const [previewNewsletter, setPreviewNewsletter] = useState(null)
+    const [pdfDownloadingId, setPdfDownloadingId] = useState(null)
 
     // Delete confirmation
     const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
@@ -299,6 +300,20 @@ export function AdminNewsletters() {
         setPreviewNewsletter(newsletter)
         setPreviewOpen(true)
     }
+
+    const downloadPdf = useCallback(async (newsletter) => {
+        if (!newsletter || !newsletter.id) return
+        setPdfDownloadingId(newsletter.id)
+        try {
+            await APIService.adminNewsletterDownloadPdf(newsletter.id)
+            setMessage({ type: 'success', text: 'PDF downloaded' })
+        } catch (error) {
+            console.error('Failed to download PDF:', error)
+            setMessage({ type: 'error', text: `PDF download failed: ${error.message || 'Unknown error'}` })
+        } finally {
+            setPdfDownloadingId(null)
+        }
+    }, [])
 
     // Publish/unpublish
     const togglePublish = useCallback(async (newsletter) => {
@@ -1152,6 +1167,19 @@ export function AdminNewsletters() {
                                                                 title="View JSON"
                                                             >
                                                                 <FileJson className="h-4 w-4" />
+                                                            </Button>
+                                                            <Button
+                                                                size="sm"
+                                                                variant="outline"
+                                                                onClick={() => downloadPdf(newsletter)}
+                                                                title="Download PDF"
+                                                                disabled={pdfDownloadingId === newsletter.id}
+                                                            >
+                                                                {pdfDownloadingId === newsletter.id ? (
+                                                                    <Loader2 className="h-4 w-4 animate-spin" />
+                                                                ) : (
+                                                                    <Download className="h-4 w-4" />
+                                                                )}
                                                             </Button>
                                                             <Button
                                                                 size="sm"


### PR DESCRIPTION
## Summary
- Adds admin-only `GET /newsletters/<id>/download.pdf` endpoint that reuses the existing `newsletter_email.html` Tactical Lens template as the PDF source.
- New `src/services/pdf_renderer.py` injects print CSS (`@page` margins with `Page N of M` counter, `break-inside: avoid` on `.item`/`.highlights`/`.toc`/`.matches-section`/`.es-card`/`.tweet-card`, `break-before: page` on section `<h2>`s, widow/orphan protection) before handing HTML to WeasyPrint.
- Dockerfile gains `libpango`, `libcairo`, `libgdk-pixbuf`, `libharfbuzz`, `shared-mime-info` (~80 MB image growth — much lighter than the headless-Chromium alternative).
- Frontend `APIService.adminNewsletterDownloadPdf(id)` handles blob fetch + `Content-Disposition` filename parsing + anchor-click download.
- Download buttons wired into both admin touchpoints: row action cluster in `AdminNewsletters.jsx` (next to Monitor/FileJson/Send/Trash) and the control panel in `NewsletterPreviewDialog.jsx` (alongside Send / Refresh). Both show a spinner while rendering.

Motivated by the Nottingham Forest demo — Chris McGuane (Head of Academy) needs a portable artifact to share, and browser print-to-PDF produces wonky mid-card page breaks.

## Test plan
- [ ] Docker image builds with the new apt packages (`docker build academy-watch-backend`) — note size delta.
- [ ] Local backend `curl -H "X-API-Key: $ADMIN_API_KEY" -H "Authorization: Bearer $ADMIN_TOKEN" -o /tmp/nl.pdf http://localhost:5001/api/newsletters/<id>/download.pdf` → opens in Preview.
- [ ] Visual check: Tactical Lens dark background renders; no player card sliced across pages; no orphaned section heading at page bottom; page footer shows "Page N of M"; team logo + charts render.
- [ ] Forest newsletter specifically — the demo target — scanned for any visual issue.
- [ ] Admin table row → Download icon → file downloads with sensible filename.
- [ ] Preview dialog → Download PDF button → file downloads.
- [ ] Post-deploy: tail container logs for any WeasyPrint native-library errors on first request (they surface at runtime, not import time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)