### PR TITLE
fix: render newsletter subsections + drop PL fallback + wider match summary

### DIFF
--- a/academy-watch-backend/src/agents/weekly_newsletter_agent.py
+++ b/academy-watch-backend/src/agents/weekly_newsletter_agent.py
@@ -1516,7 +1516,9 @@ def _generate_player_charts(player_api_id: int, player_name: str,
             player_api_id, 'match_card', stat_keys, 'week',
             week_start=ws, week_end=we)
         if card_data and card_data.get('fixtures'):
-            charts['match_card_url'] = render_chart_to_base64('match_card', card_data, 500, 200)
+            # Wider canvas (760×220) so the five-stat row doesn't crowd
+            # itself — see render_match_cards_summary.
+            charts['match_card_url'] = render_chart_to_base64('match_card', card_data, 760, 220)
     except Exception:
         pass
 

--- a/academy-watch-backend/src/services/chart_renderer.py
+++ b/academy-watch-backend/src/services/chart_renderer.py
@@ -398,39 +398,45 @@ def render_line_chart(data: Dict[str, Any], width: int = 560, height: int = 320)
     return buf.read()
 
 
-def render_match_cards_summary(data: Dict[str, Any], width: int = 500, height: int = 200) -> bytes:
+def render_match_cards_summary(data: Dict[str, Any], width: int = 760, height: int = 220) -> bytes:
     """
     Render a summary visualization for match cards.
     Since match cards are detailed, we render a summary bar showing key stats.
-    
+
+    The default canvas is intentionally wide (760×220) because the row carries
+    five stat columns, and the rightmost "Results" column is text-heavy
+    (`1W 0D 1L`). At the previous 500px width the columns collided into each
+    other on retina renders. The columns are also slightly inset and the
+    label/value font sizes are tuned so nothing crowds the neighbours.
+
     Args:
         data: Chart data from the API including 'fixtures' array
-        width: Image width in pixels  
+        width: Image width in pixels
         height: Image height in pixels
-        
+
     Returns:
         PNG image as bytes
     """
     fixtures = data.get('fixtures', [])
     player_name = data.get('player', {}).get('name', 'Player')
-    
+
     if not fixtures:
         return _render_empty_chart("No matches found", width, height)
-    
+
     # Aggregate stats from fixtures
     total_minutes = sum(f.get('stats', {}).get('minutes', 0) or 0 for f in fixtures)
     total_goals = sum(f.get('stats', {}).get('goals', 0) or 0 for f in fixtures)
     total_assists = sum(f.get('stats', {}).get('assists', 0) or 0 for f in fixtures)
-    
+
     ratings = [f.get('stats', {}).get('rating') for f in fixtures if f.get('stats', {}).get('rating')]
     avg_rating = sum(ratings) / len(ratings) if ratings else 0
-    
+
     # Count results
     wins = sum(1 for f in fixtures if (f.get('is_home') and f['home_team']['score'] > f['away_team']['score']) or
                (not f.get('is_home') and f['away_team']['score'] > f['home_team']['score']))
     draws = sum(1 for f in fixtures if f['home_team']['score'] == f['away_team']['score'])
     losses = len(fixtures) - wins - draws
-    
+
     # Setup figure with dark Tactical Lens facecolor.
     fig, ax = plt.subplots(figsize=(width/100, height/100), dpi=DPI)
     fig.patch.set_facecolor(TL_CARD)
@@ -438,7 +444,7 @@ def render_match_cards_summary(data: Dict[str, Any], width: int = 500, height: i
     ax.axis('off')
 
     # Title
-    ax.text(0.5, 0.95, f"{player_name} - {len(fixtures)} Match Summary",
+    ax.text(0.5, 0.92, f"{player_name} - {len(fixtures)} Match Summary",
             fontsize=12, fontweight='bold', ha='center', transform=ax.transAxes,
             color=TL_TEXT)
 
@@ -452,11 +458,18 @@ def render_match_cards_summary(data: Dict[str, Any], width: int = 500, height: i
         (f"{wins}W {draws}D {losses}L", "Results", CHART_COLORS['primary']),
     ]
 
-    x_positions = np.linspace(0.1, 0.9, len(stats))
+    # Inset the row a touch from the left/right edges so labels at the
+    # extremes don't get clipped by bbox_inches='tight'.
+    x_positions = np.linspace(0.08, 0.92, len(stats))
     for i, (value, label, color) in enumerate(stats):
-        ax.text(x_positions[i], 0.55, str(value), fontsize=17, fontweight='bold',
-                ha='center', transform=ax.transAxes, color=color)
-        ax.text(x_positions[i], 0.3, label, fontsize=9, ha='center',
+        # The Results column carries 8 characters of text — drop its font
+        # size a touch so it doesn't crash into the neighbouring Avg Rating
+        # column at narrow chart widths.
+        is_results = (label == 'Results')
+        value_size = 14 if is_results else 18
+        ax.text(x_positions[i], 0.52, str(value), fontsize=value_size, fontweight='bold',
+                ha='center', va='center', transform=ax.transAxes, color=color)
+        ax.text(x_positions[i], 0.22, label, fontsize=9, ha='center', va='center',
                 transform=ax.transAxes, color=CHART_COLORS['gray'])
 
     # Convert to bytes
@@ -612,7 +625,9 @@ def render_chart(chart_type: str, data: Dict[str, Any], width: int = 500, height
     elif chart_type == 'line':
         return render_line_chart(data, width, height)
     elif chart_type == 'match_card':
-        return render_match_cards_summary(data, width, min(height, 200))
+        # Cap height at 240 — anything taller wastes vertical space since the
+        # match card is a single row of stats with a title.
+        return render_match_cards_summary(data, width, min(height, 240))
     elif chart_type == 'stat_table':
         return render_stat_table(data, width, height)
     else:

--- a/academy-watch-backend/src/services/radar_stats_service.py
+++ b/academy-watch-backend/src/services/radar_stats_service.py
@@ -406,14 +406,18 @@ def resolve_player_league(player_api_id: int) -> Optional[Tuple[int, str]]:
 
     Returns (league_api_id, league_name) or None.
 
-    Priority (intentionally current-club first for ALL statuses, not just
-    on_loan): the league we compare a player against in the radar must be the
-    league he is *currently* playing in. A loanee at Barrow → League Two. A
-    first-team breakthrough at Forest → Premier League. Falling back to fixture
-    raw_json or parent-club lookups can mis-attribute a player's stats to the
-    wrong league (e.g. a Barrow loanee with stale Forest U21 fixtures showing
-    "Premier League Avg" in his radar), so we drop to those fallbacks only if
-    the current club itself has no league row.
+    Priority (intentionally current-club ONLY): the league we compare a
+    player against in the radar must be the league he is *currently*
+    playing in. A loanee at Barrow → League Two. A first-team breakthrough
+    at Forest → Premier League.
+
+    We deliberately do NOT fall back to the parent academy club if the
+    current club has no league row in our DB. That fallback is the literal
+    source of "Barrow loanee compared to Premier League" — the parent club
+    (Forest) is in the PL, so the radar would silently use PL averages
+    even though the player is in League Two. It's better to render no
+    league overlay (the chart says "League comparison unavailable for X")
+    than to mis-attribute the comparison to the wrong league.
     """
     from src.models.league import Team, League
     from src.models.tracked_player import TrackedPlayer
@@ -447,17 +451,15 @@ def resolve_player_league(player_api_id: int) -> Optional[Tuple[int, str]]:
             if result:
                 return result
 
-        # 3. Most recent fixture's raw_json league
+        # 3. Most recent fixture's raw_json league for this player. Only
+        #    used as a last sanity-check fallback because for limited-
+        #    coverage leagues (League Two etc.) FixturePlayerStats may be
+        #    empty entirely.
         result = _league_from_fixtures(player_api_id)
         if result:
             return result
 
-        # 4. Last resort: parent academy club
-        team = Team.query.filter_by(id=tp.team_id).first()
-        result = _league_from_team(team)
-        if result:
-            return result
-
+    # Intentionally NO parent-club fallback — see docstring.
     return None
 
 

--- a/academy-watch-frontend/src/components/newsletter/SectionGroup.jsx
+++ b/academy-watch-frontend/src/components/newsletter/SectionGroup.jsx
@@ -4,10 +4,18 @@ import { PlayerCommentaryCard } from './PlayerCommentaryCard'
  * One section in the detailed report — title + count + a list of player
  * commentary cards.
  *
- * Layout: when a section has 2+ players, render the cards in a 2-column
- * grid at lg+ (1024px+) so wide monitors don't show lonely single cards
- * with empty space on either side. Sections with exactly one player keep
- * a single full-width card.
+ * Two backend shapes are supported:
+ *   1. Flat:        { title, items: [...] }
+ *   2. Subsectioned: { title, subsections: [{ label, items: [...] }, ...] }
+ *
+ * The subsectioned shape is emitted when players span multiple loan
+ * leagues or academy levels (see weekly_newsletter_agent._group_items_by).
+ * If we ignore subsections we silently drop entire sections of players —
+ * exactly what was happening before this fix.
+ *
+ * Layout: when a (sub)section has 2+ players, render the cards in a
+ * 2-column grid at lg+ (1024px+) so wide monitors don't show lonely
+ * single cards with empty space on either side.
  *
  * Props:
  *   - onExpand({ item, twitterTakes }) — fired when a card's expand button
@@ -15,6 +23,31 @@ import { PlayerCommentaryCard } from './PlayerCommentaryCard'
  *   - onZoomChart({ url, alt, caption }) — fired when a chart image inside
  *     a card is clicked. Also owned by NewsletterView.
  */
+function PlayerGrid({ items, twitterTakesByPlayer, publicBaseUrl, onExpand, onZoomChart }) {
+  const gridClass =
+    items.length > 1
+      ? 'grid grid-cols-1 lg:grid-cols-2 gap-5 lg:gap-6'
+      : 'grid grid-cols-1'
+  return (
+    <div className={gridClass}>
+      {items.map((item, idx) => {
+        const playerKey = item.player_api_id || item.player_id
+        const tweets = playerKey ? twitterTakesByPlayer[playerKey] || [] : []
+        return (
+          <PlayerCommentaryCard
+            key={playerKey || idx}
+            item={item}
+            twitterTakes={tweets}
+            publicBaseUrl={publicBaseUrl}
+            onExpand={onExpand}
+            onZoomChart={onZoomChart}
+          />
+        )
+      })}
+    </div>
+  )
+}
+
 export function SectionGroup({
   section,
   twitterTakesByPlayer = {},
@@ -24,21 +57,24 @@ export function SectionGroup({
 }) {
   if (!section || typeof section !== 'object') return null
 
-  const items = Array.isArray(section.items) ? section.items : []
-  if (items.length === 0) return null
+  const subsections = Array.isArray(section.subsections)
+    ? section.subsections.filter((s) => Array.isArray(s?.items) && s.items.length > 0)
+    : []
+  const flatItems = Array.isArray(section.items) ? section.items : []
 
-  // Multi-column grid for sections with 2+ players. Single-column otherwise.
-  const gridClass =
-    items.length > 1
-      ? 'grid grid-cols-1 lg:grid-cols-2 gap-5 lg:gap-6'
-      : 'grid grid-cols-1'
+  const totalItems =
+    subsections.length > 0
+      ? subsections.reduce((sum, s) => sum + s.items.length, 0)
+      : flatItems.length
+
+  if (totalItems === 0) return null
 
   return (
     <section className="mb-12 sm:mb-14 lg:mb-16">
       <div className="flex items-baseline gap-3 mb-5 sm:mb-6">
         <h2 className="tl-eyebrow m-0">{section.title}</h2>
         <span className="text-[11px] font-extrabold text-[var(--tl-text-faint)]">
-          ({items.length})
+          ({totalItems})
         </span>
       </div>
 
@@ -48,22 +84,35 @@ export function SectionGroup({
         </p>
       )}
 
-      <div className={gridClass}>
-        {items.map((item, idx) => {
-          const playerKey = item.player_api_id || item.player_id
-          const tweets = playerKey ? twitterTakesByPlayer[playerKey] || [] : []
-          return (
-            <PlayerCommentaryCard
-              key={playerKey || idx}
-              item={item}
-              twitterTakes={tweets}
-              publicBaseUrl={publicBaseUrl}
-              onExpand={onExpand}
-              onZoomChart={onZoomChart}
-            />
-          )
-        })}
-      </div>
+      {subsections.length > 0 ? (
+        <div className="space-y-8 sm:space-y-10">
+          {subsections.map((sub, subIdx) => (
+            <div key={sub.label || subIdx}>
+              <h3 className="text-[13px] sm:text-sm font-bold text-[var(--tl-text)] m-0 mb-4 flex items-baseline gap-2">
+                <span>{sub.label}</span>
+                <span className="text-[11px] font-extrabold text-[var(--tl-text-faint)]">
+                  ({sub.items.length})
+                </span>
+              </h3>
+              <PlayerGrid
+                items={sub.items}
+                twitterTakesByPlayer={twitterTakesByPlayer}
+                publicBaseUrl={publicBaseUrl}
+                onExpand={onExpand}
+                onZoomChart={onZoomChart}
+              />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <PlayerGrid
+          items={flatItems}
+          twitterTakesByPlayer={twitterTakesByPlayer}
+          publicBaseUrl={publicBaseUrl}
+          onExpand={onExpand}
+          onZoomChart={onZoomChart}
+        />
+      )}
     </section>
   )
 }


### PR DESCRIPTION
## Summary

Three demo-blocking issues from the latest Forest screenshots:

1. **Web newsletter showed only header + summary, no players.** The backend emits sections with a `subsections` shape (one per loan league) whenever players span multiple leagues. \`SectionGroup.jsx\` only handled \`section.items\` and silently dropped everything else. Now it renders both shapes with a per-subsection sub-heading.

2. **Match Summary chart cramped in email.** Five stat columns at 500px width were colliding — the rightmost \"Results\" column (\`1W 0D 1L\`) crashed into \"Avg Rating\". Bumped the default canvas to 760×220, inset the row, and dropped the Results-column font size to give it room.

3. **League Two players still compared to the Premier League.** \`resolve_player_league()\` had a \"last resort: parent academy club\" branch that returned Forest's PL whenever Barrow's \`Team.league_id\` was null. Removed that fallback so the chart now renders \"League comparison unavailable\" instead of mis-attributing.

## Test plan
- [x] \`pnpm lint\` clean (0 errors, 23 pre-existing warnings)
- [x] \`pnpm build\` succeeds
- [x] \`pytest tests/test_radar_stats_service.py\` (19 passed)
- [x] Smoke-tested \`render_match_cards_summary()\` produces a valid PNG at the new dimensions
- [ ] After merge: regenerate the Forest newsletter via admin sandbox \`force_refresh=true\`
- [ ] Verify on live site: web view shows all player sections, Match Summary chart no longer cramped, J. Thompson radar footer says \"League comparison unavailable\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)