### PR TITLE
fix: pin pydyf==0.10.0 for weasyprint 62.3 PDF render

### DIFF
--- a/academy-watch-backend/requirements.txt
+++ b/academy-watch-backend/requirements.txt
@@ -57,6 +57,7 @@ psycopg-binary==3.2.9
 pydantic==2.11.7
 pydantic-settings==2.10.1
 pydantic_core==2.33.2
+pydyf==0.10.0
 Pygments==2.19.2
 pyparsing==3.3.1
 pytest==8.4.1

--- a/academy-watch-backend/src/services/pdf_renderer.py
+++ b/academy-watch-backend/src/services/pdf_renderer.py
@@ -64,8 +64,7 @@ _PRINT_CSS = """
    WeasyPrint honours backgrounds by default, but we make the intent explicit. */
 html, body {
     background: #0b1326 !important;
-    -weasy-color-adjust: exact;
-    print-color-adjust: exact;
+    color-adjust: exact;
 }
 
 /* Atomic content units — never split these across pages. If any block is


### PR DESCRIPTION
## Summary
Hotfix for 500s on the newly-deployed `GET /newsletters/<id>/download.pdf` endpoint. Prod traceback:

\`\`\`
File "/usr/local/lib/python3.11/site-packages/weasyprint/pdf/stream.py", line 246, in transform
AttributeError: 'super' object has no attribute 'transform'
\`\`\`

pip resolved a pydyf newer than the one weasyprint 62.3 was built against, and pydyf renamed/removed a method weasyprint's stream subclass delegates to via \`super().transform\`. Pinning \`pydyf==0.10.0\` (the version shipped with weasyprint 62.3) restores the API contract.

Also drops the deprecated \`-weasy-color-adjust\` / \`print-color-adjust\` pair in the injected print CSS in favour of the standardized \`color-adjust\` — weasyprint was logging a warning for both on every render.

## Test plan
- [ ] Post-deploy: click Download PDF on a newsletter in the admin — expect a valid PDF, no 500.
- [ ] Tail container logs for any lingering weasyprint errors.
- [ ] Confirm the \`Ignored \\\`-weasy-color-adjust\\\`\` / \`Ignored \\\`print-color-adjust\\\`\` warnings are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)