### PR TITLE
fix: newsletter player cards squeezed on medium screens

### DIFF
--- a/academy-watch-frontend/src/components/newsletter/PlayerCommentaryCard.jsx
+++ b/academy-watch-frontend/src/components/newsletter/PlayerCommentaryCard.jsx
@@ -113,6 +113,7 @@ export function PlayerCommentaryCard({
     { url: item.radar_chart_url, alt: 'Performance Radar' },
     { url: item.trend_chart_url, alt: 'Season Rating Trend' },
   ].filter((c) => c.url)
+  const hasCharts = inlineCharts.length > 0
 
   const handleExpand = () => {
     if (onExpand) {
@@ -148,10 +149,16 @@ export function PlayerCommentaryCard({
         </button>
       )}
 
-      <div className="grid grid-cols-1 md:grid-cols-12 gap-0">
+      <div className={hasCharts ? 'grid grid-cols-1 md:grid-cols-12 gap-0' : ''}>
         {/* LEFT — identity, stats, narrative, tweets, CTA */}
-        <div className="md:col-span-7 p-5 sm:p-6 md:p-7 lg:p-8">
-          <div className="flex items-start gap-4 mb-4 pr-12">
+        <div
+          className={
+            hasCharts
+              ? 'md:col-span-7 min-w-0 p-5 sm:p-6 md:p-7 lg:p-8'
+              : 'min-w-0 p-5 sm:p-6 md:p-7 lg:p-8'
+          }
+        >
+          <div className="flex items-start gap-4 mb-4 pr-10">
             {photo ? (
               <img
                 src={photo}
@@ -169,12 +176,12 @@ export function PlayerCommentaryCard({
                   to={`/players/${playerLinkId}`}
                   className="block"
                 >
-                  <h3 className="tl-headline text-lg sm:text-xl lg:text-2xl text-[var(--tl-text)] m-0 break-words hover:text-[var(--tl-primary)] transition-colors">
+                  <h3 className="tl-headline text-lg sm:text-xl lg:text-2xl text-[var(--tl-text)] m-0 hover:text-[var(--tl-primary)] transition-colors">
                     {item.player_name}
                   </h3>
                 </Link>
               ) : (
-                <h3 className="tl-headline text-lg sm:text-xl lg:text-2xl text-[var(--tl-text)] m-0 break-words">
+                <h3 className="tl-headline text-lg sm:text-xl lg:text-2xl text-[var(--tl-text)] m-0">
                   {item.player_name}
                 </h3>
               )}
@@ -266,7 +273,7 @@ export function PlayerCommentaryCard({
         {/* RIGHT — slim inline chart set (radar + trend). The full chart
             set lives in the expanded drawer. Each chart is clickable to
             open a lightbox at native resolution. */}
-        {inlineCharts.length > 0 && (
+        {hasCharts && (
           <div
             className="md:col-span-5 p-5 sm:p-6 md:p-7 lg:p-8 space-y-4 border-t md:border-t-0 md:border-l border-[var(--tl-divider)]"
             style={{ background: 'var(--tl-card)' }}


### PR DESCRIPTION
## Summary

Chart-less player commentary cards reserved an empty 5/12 grid track and used \`break-words\` on the player name heading, causing names like "K. McAdam" and "J. Thompson" to wrap **one character per line** at 1024-1400px viewports.

Three fixes in \`PlayerCommentaryCard.jsx\`:

- **Collapse the inner grid** when \`inlineCharts.length === 0\`. The card's \`md:grid-cols-12\` layout always reserved 5/12 of the width for a chart panel that wasn't rendering, squeezing the left content into 7/12 of an already-narrow card in \`lg:grid-cols-2\` sections.
- **Drop \`break-words\`** from the \`<h3>\`. The flex parent already has \`flex-1 min-w-0\`, so normal word wrapping handles long names. \`break-words\` was only kicking in because the column had been squeezed to ~30px, and it then broke per glyph.
- **Add \`min-w-0\`** to the left content div so it can shrink inside the grid track when charts *are* present, and tighten \`pr-12\` → \`pr-10\` around the expand button (36px button didn't need 48px of reserved space).

Most visible on Forest's "Other" academy subsection, where no player has radar/trend chart data.

## Test plan

- [ ] Open the Nottingham Forest pipeline newsletter on the public newsletters listing at 1024px, 1280px, 1440px, 1920px — "K. McAdam" / "J. Thompson" render on a single line, never per character
- [ ] Open a section that DOES have inline charts (PL loanee with radar data) — 7/5 split still renders with the chart on the right
- [ ] Open the player drawer via the expand button — reused \`PlayerCommentaryCard\` still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)