### PR TITLE
feat: GOL chat PDF export with clickable player/club/tweet links

### DIFF
--- a/academy-watch-backend/requirements.txt
+++ b/academy-watch-backend/requirements.txt
@@ -38,6 +38,7 @@ jsonschema==4.25.0
 jsonschema-specifications==2025.4.1
 kiwisolver==1.4.9
 limits==5.5.0
+linkify-it-py==2.0.3
 Mako==1.3.10
 markdown-it-py==4.0.0
 MarkupSafe==3.0.2

--- a/academy-watch-backend/src/routes/gol.py
+++ b/academy-watch-backend/src/routes/gol.py
@@ -2,9 +2,10 @@
 
 Provides SSE streaming chat endpoint and conversation suggestions.
 """
-from flask import Blueprint, request, Response, jsonify, stream_with_context
+from flask import Blueprint, request, Response, jsonify, stream_with_context, send_file
 from src.extensions import limiter
 from src.auth import require_api_key
+import io
 import json
 import logging
 
@@ -72,6 +73,50 @@ def gol_suggestions():
             "Who are the top-performing loan players this season?",
             "Tell me about Chelsea's academy pipeline",
         ]})
+
+
+@gol_bp.route('/gol/export-pdf', methods=['POST'])
+@limiter.limit("10/minute")
+def gol_export_pdf():
+    """Render a GOL chat transcript to a downloadable PDF.
+
+    The frontend posts the full client-side message array because the chat
+    has no server-side persistence. Rate-limited more strictly than
+    ``/gol/chat`` because each export spawns matplotlib chart renders and a
+    WeasyPrint pass — cheap but not free.
+    """
+    try:
+        from src.services.pdf_renderer import render_gol_chat_pdf
+    except ImportError:
+        logger.exception("WeasyPrint not available for GOL PDF export")
+        return jsonify({
+            'error': 'pdf_renderer_unavailable',
+            'message': 'PDF export is not configured on this server.',
+        }), 503
+
+    data = request.get_json(silent=True) or {}
+    messages = data.get('messages') or []
+    if not isinstance(messages, list) or not messages:
+        return jsonify({'error': 'messages array is required'}), 400
+
+    # Soft cap: a single chat should never need more than ~200 turns. Beyond
+    # that we're almost certainly looking at a bug or an abuse pattern, and
+    # WeasyPrint will happily consume memory trying to paginate it.
+    if len(messages) > 200:
+        return jsonify({'error': 'too many messages in chat export'}), 413
+
+    try:
+        pdf_bytes, filename = render_gol_chat_pdf(messages)
+    except Exception as e:
+        logger.exception("Failed to render GOL chat PDF")
+        return jsonify({'error': 'pdf_render_failed', 'message': str(e)}), 500
+
+    return send_file(
+        io.BytesIO(pdf_bytes),
+        mimetype='application/pdf',
+        as_attachment=True,
+        download_name=filename,
+    )
 
 
 @gol_bp.route('/admin/gol/refresh-cache', methods=['POST'])

--- a/academy-watch-backend/src/services/chart_renderer.py
+++ b/academy-watch-backend/src/services/chart_renderer.py
@@ -605,6 +605,214 @@ def _render_empty_chart(message: str, width: int, height: int) -> bytes:
     return buf.read()
 
 
+def render_generic_bar_chart(
+    columns: List[str],
+    rows: List[List[Any]],
+    title: Optional[str] = None,
+    width: int = 640,
+    height: int = 340,
+) -> bytes:
+    """Render a bar chart from a generic ``{columns, rows}`` shape.
+
+    The first column is treated as the category axis (x) and every subsequent
+    numeric column becomes a bar series. Non-numeric cells in series columns
+    are coerced to 0. If there is only one value column the chart renders a
+    single bar per category with no legend clutter.
+
+    Styling is deliberately identical to :func:`render_bar_chart` (dark
+    Tactical Lens facecolor, light slate labels) so the chart reads as part
+    of the same brand family as the newsletter charts.
+    """
+    if not columns or not rows:
+        return _render_empty_chart("No data available", width, height)
+
+    category_col = columns[0]
+    series_cols = columns[1:]
+
+    if not series_cols:
+        return _render_empty_chart("No numeric series to plot", width, height)
+
+    categories = [str(row[0]) if len(row) > 0 and row[0] is not None else "" for row in rows]
+
+    # Coerce series values to floats, substituting 0 for anything that can't
+    # be parsed — this keeps matplotlib from crashing on mixed-type columns.
+    def _coerce(value: Any) -> float:
+        if value is None:
+            return 0.0
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return 0.0
+
+    series_values = {
+        col: [_coerce(row[idx + 1]) if idx + 1 < len(row) else 0.0 for row in rows]
+        for idx, col in enumerate(series_cols)
+    }
+
+    fig, ax = plt.subplots(figsize=(width / 100, height / 100), dpi=DPI)
+    fig.patch.set_facecolor(TL_CARD)
+    ax.set_facecolor(TL_CARD)
+
+    x = np.arange(len(categories))
+    num_series = len(series_cols)
+    width_bar = 0.8 / max(num_series, 1)
+    palette = [
+        CHART_COLORS['primary'],
+        CHART_COLORS['success'],
+        CHART_COLORS['info'],
+        CHART_COLORS['warning'],
+        CHART_COLORS['danger'],
+    ]
+
+    for i, col in enumerate(series_cols):
+        offset = (i - num_series / 2 + 0.5) * width_bar
+        ax.bar(
+            x + offset,
+            series_values[col],
+            width_bar,
+            label=col.replace('_', ' ').title(),
+            color=palette[i % len(palette)],
+            alpha=0.9,
+        )
+
+    # Axes + labels.
+    ax.set_xlabel(category_col.replace('_', ' ').title(), fontsize=9, color=CHART_COLORS['gray'])
+    if len(series_cols) == 1:
+        ax.set_ylabel(series_cols[0].replace('_', ' ').title(), fontsize=9, color=CHART_COLORS['gray'])
+    ax.set_xticks(x)
+    ax.set_xticklabels(categories, rotation=35, ha='right', fontsize=8, color=CHART_COLORS['gray'])
+
+    if num_series > 1:
+        legend = ax.legend(
+            loc='upper right',
+            fontsize=8,
+            facecolor=TL_INNER,
+            edgecolor=TL_GRID,
+            labelcolor=TL_TEXT,
+        )
+        if legend is not None:
+            legend.get_frame().set_alpha(0.85)
+
+    if title:
+        ax.set_title(title, fontsize=11, fontweight='bold', color=TL_TEXT)
+
+    ax.spines['top'].set_visible(False)
+    ax.spines['right'].set_visible(False)
+    ax.spines['bottom'].set_color(TL_GRID)
+    ax.spines['left'].set_color(TL_GRID)
+    ax.tick_params(colors=CHART_COLORS['gray'])
+    ax.yaxis.label.set_color(CHART_COLORS['gray'])
+    ax.xaxis.label.set_color(CHART_COLORS['gray'])
+    ax.grid(True, axis='y', alpha=0.25, color=TL_GRID, linewidth=0.6)
+
+    plt.tight_layout()
+
+    buf = io.BytesIO()
+    plt.savefig(buf, format='png', bbox_inches='tight', facecolor=TL_CARD, edgecolor='none')
+    plt.close(fig)
+    buf.seek(0)
+    return buf.read()
+
+
+def render_generic_line_chart(
+    columns: List[str],
+    rows: List[List[Any]],
+    title: Optional[str] = None,
+    width: int = 640,
+    height: int = 340,
+) -> bytes:
+    """Render a line chart from a generic ``{columns, rows}`` shape.
+
+    Column semantics match :func:`render_generic_bar_chart`: column 0 is the
+    x-axis category (typically a date, season, or ordered label) and every
+    subsequent column is a numeric line series.
+    """
+    if not columns or not rows:
+        return _render_empty_chart("No data available", width, height)
+
+    category_col = columns[0]
+    series_cols = columns[1:]
+
+    if not series_cols:
+        return _render_empty_chart("No numeric series to plot", width, height)
+
+    categories = [str(row[0]) if len(row) > 0 and row[0] is not None else "" for row in rows]
+
+    def _coerce_or_nan(value: Any) -> float:
+        if value is None:
+            return float('nan')
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return float('nan')
+
+    series_values = {
+        col: [_coerce_or_nan(row[idx + 1]) if idx + 1 < len(row) else float('nan') for row in rows]
+        for idx, col in enumerate(series_cols)
+    }
+
+    fig, ax = plt.subplots(figsize=(width / 100, height / 100), dpi=DPI)
+    fig.patch.set_facecolor(TL_CARD)
+    ax.set_facecolor(TL_CARD)
+
+    x = np.arange(len(categories))
+    palette = [
+        CHART_COLORS['primary'],
+        CHART_COLORS['success'],
+        CHART_COLORS['info'],
+        CHART_COLORS['warning'],
+        CHART_COLORS['danger'],
+    ]
+
+    for i, col in enumerate(series_cols):
+        ax.plot(
+            x,
+            series_values[col],
+            'o-',
+            label=col.replace('_', ' ').title(),
+            color=palette[i % len(palette)],
+            linewidth=2.2,
+            markersize=6,
+        )
+
+    ax.set_xlabel(category_col.replace('_', ' ').title(), fontsize=9, color=CHART_COLORS['gray'])
+    if len(series_cols) == 1:
+        ax.set_ylabel(series_cols[0].replace('_', ' ').title(), fontsize=9, color=CHART_COLORS['gray'])
+    ax.set_xticks(x)
+    ax.set_xticklabels(categories, rotation=35, ha='right', fontsize=8, color=CHART_COLORS['gray'])
+
+    if len(series_cols) > 1:
+        legend = ax.legend(
+            loc='upper right',
+            fontsize=8,
+            facecolor=TL_INNER,
+            edgecolor=TL_GRID,
+            labelcolor=TL_TEXT,
+        )
+        if legend is not None:
+            legend.get_frame().set_alpha(0.85)
+
+    if title:
+        ax.set_title(title, fontsize=11, fontweight='bold', color=TL_TEXT)
+
+    ax.spines['top'].set_visible(False)
+    ax.spines['right'].set_visible(False)
+    ax.spines['bottom'].set_color(TL_GRID)
+    ax.spines['left'].set_color(TL_GRID)
+    ax.tick_params(colors=CHART_COLORS['gray'])
+    ax.yaxis.label.set_color(CHART_COLORS['gray'])
+    ax.xaxis.label.set_color(CHART_COLORS['gray'])
+    ax.grid(True, alpha=0.3, color=TL_GRID, linewidth=0.6)
+
+    plt.tight_layout()
+
+    buf = io.BytesIO()
+    plt.savefig(buf, format='png', bbox_inches='tight', facecolor=TL_CARD, edgecolor='none')
+    plt.close(fig)
+    buf.seek(0)
+    return buf.read()
+
+
 def render_chart(chart_type: str, data: Dict[str, Any], width: int = 500, height: int = 300) -> bytes:
     """
     Main entry point to render a chart based on type.

--- a/academy-watch-backend/src/services/pdf_renderer.py
+++ b/academy-watch-backend/src/services/pdf_renderer.py
@@ -23,8 +23,28 @@ dependencies on the routes module.
 
 from __future__ import annotations
 
+import base64
+import html as html_lib
+import logging
+import os
 import re
 from datetime import date, datetime
+from typing import Any, Iterable
+
+logger = logging.getLogger(__name__)
+
+# Public origin used to absolutize links inside the exported chat PDF so that
+# ``/players/123`` inside an LLM response becomes a clickable link when the
+# PDF is opened outside the browser. Falls back to the production host if the
+# env var isn't set so local dev exports still produce reachable links.
+_DEFAULT_PUBLIC_BASE_URL = "https://theacademywatch.com"
+
+
+def _public_base_url() -> str:
+    base = (os.getenv("PUBLIC_BASE_URL") or os.getenv("PUBLIC_API_BASE_URL") or "").strip()
+    if not base:
+        base = _DEFAULT_PUBLIC_BASE_URL
+    return base.rstrip("/")
 
 
 # Print stylesheet injected before </head> prior to handing HTML to WeasyPrint.
@@ -191,3 +211,461 @@ def build_pdf_filename(
         parts.append(date_part)
     parts.append(f"issue-{int(newsletter_id)}")
     return "-".join(parts) + ".pdf"
+
+
+# ---------------------------------------------------------------------------
+# GOL chat export
+# ---------------------------------------------------------------------------
+
+# Columns that the frontend/backend treat as internal plumbing and should
+# never appear in an exported artifact. Mirrors the HIDDEN_COLUMNS list in
+# `academy-watch-frontend/src/components/gol/exportChat.js`.
+_GOL_HIDDEN_COLUMNS = {"player_api_id"}
+
+
+_REL_HREF_PATTERN = re.compile(
+    r'(<a\b[^>]*\bhref=")(/[^"#][^"]*)"',
+    flags=re.IGNORECASE,
+)
+
+# Recognises bare ``http(s)://…`` URLs so that plain-text cells (e.g. a
+# DataFrame column containing a tweet URL) get wrapped in a clickable
+# anchor. Deliberately narrow: we only match URLs that stand alone in a
+# text context, and we rely on the caller to apply this to already-escaped
+# text so there's no HTML-injection risk.
+_BARE_URL_PATTERN = re.compile(
+    r"(https?://[^\s<>\"'()]+[^\s<>\"'().,;!?])",
+    flags=re.IGNORECASE,
+)
+
+
+def _absolutize_links(html: str, base_url: str) -> str:
+    """Rewrite root-relative ``href="/..."`` links to use ``base_url``.
+
+    WeasyPrint turns any ``<a href>`` into a clickable PDF link annotation,
+    but if the href is relative the link is effectively dead once the PDF
+    leaves the browser. This helper rewrites only root-relative hrefs
+    (``/players/123``) — fragment-only (``#section``), scheme-relative
+    (``//cdn...``) and already-absolute hrefs are left alone.
+    """
+    if not html or not base_url:
+        return html
+    base = base_url.rstrip("/")
+
+    def _replace(match: re.Match[str]) -> str:
+        prefix = match.group(1)
+        path = match.group(2)
+        return f'{prefix}{base}{path}"'
+
+    return _REL_HREF_PATTERN.sub(_replace, html)
+
+
+def _markdown_to_html(text: str) -> str:
+    """Render GOL markdown content to safe HTML.
+
+    Uses ``markdown-it-py`` with a GFM-like preset so tables, autolinks and
+    strikethrough work. If ``linkify-it-py`` is installed we also turn bare
+    ``https://…`` URLs (including tweet / x.com links) into clickable
+    anchors. Any relative links emitted by the LLM are absolutized to the
+    public origin so they remain clickable once the PDF leaves the browser.
+
+    The renderer degrades gracefully in three stages:
+      1. markdown-it + linkify  (production, best fidelity)
+      2. markdown-it alone      (explicit ``[text](url)`` still works)
+      3. plain escape + wrap    (last resort so the PDF is never broken)
+    """
+    if not text:
+        return ""
+
+    rendered: str | None = None
+    try:
+        from markdown_it import MarkdownIt  # type: ignore
+
+        # linkify-it-py is optional. The ``gfm-like`` preset enables the
+        # linkify rule by default; if the backing module is missing,
+        # md.render() itself raises, so we must explicitly *disable*
+        # linkify when linkify-it-py isn't importable.
+        try:
+            import linkify_it  # type: ignore  # noqa: F401
+
+            has_linkify = True
+        except ImportError:
+            has_linkify = False
+
+        md = MarkdownIt("gfm-like")
+        if has_linkify:
+            md.options["linkify"] = True
+        else:
+            md.disable("linkify")
+        rendered = md.render(text)
+    except Exception:
+        logger.warning("markdown-it-py unavailable, falling back to plain wrap")
+
+    if rendered is None:
+        escaped = (
+            text.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+        )
+        # Post-process the escaped plain text to wrap bare http(s) URLs in
+        # anchors — important for the fallback path because without
+        # markdown-it we'd otherwise lose every link.
+        escaped = _BARE_URL_PATTERN.sub(
+            lambda m: f'<a href="{m.group(1)}">{m.group(1)}</a>',
+            escaped,
+        )
+        paragraphs = [p.strip() for p in escaped.split("\n\n") if p.strip()]
+        rendered = "\n".join(
+            f"<p>{p.replace(chr(10), '<br/>')}</p>" for p in paragraphs
+        )
+
+    return _absolutize_links(rendered, _public_base_url())
+
+
+def _filter_hidden_columns(
+    columns: list[str], rows: list[list[Any]]
+) -> tuple[list[str], list[list[Any]]]:
+    """Drop any column whose header is in the internal-only allowlist."""
+    visible_indices = [
+        idx for idx, col in enumerate(columns) if col not in _GOL_HIDDEN_COLUMNS
+    ]
+    filtered_cols = [columns[idx] for idx in visible_indices]
+    filtered_rows = [
+        [row[idx] if idx < len(row) else None for idx in visible_indices]
+        for row in rows
+    ]
+    return filtered_cols, filtered_rows
+
+
+# Column-name patterns that identify "link anchor" cells and the ID column
+# that should be used to build the destination URL. The first entry that
+# matches both a name column and an id column wins; the id column is
+# subsequently hidden from the visible output so stakeholders don't see raw
+# API ids in the exported table.
+_LINK_RULES: list[tuple[tuple[str, ...], tuple[str, ...], str]] = [
+    # (name column candidates, id column candidates, url path prefix)
+    (
+        ("player_name", "player", "name"),
+        ("player_api_id", "player_id"),
+        "/players/",
+    ),
+    (
+        (
+            "team_name",
+            "club_name",
+            "loan_club",
+            "loan_team",
+            "loan_team_name",
+            "parent_club",
+            "academy_club",
+            "current_club_name",
+            "origin_club_name",
+        ),
+        ("team_api_id", "club_api_id", "team_id"),
+        "/teams/",
+    ),
+]
+
+
+def _build_linkified_table(
+    raw_columns: list[str],
+    raw_rows: list[list[Any]],
+) -> tuple[list[str], list[list[str]]]:
+    """Return (visible_columns, rendered_rows) for a GOL table card.
+
+    Each cell in ``rendered_rows`` is an HTML-safe string. Cells under
+    linkable name columns are wrapped in ``<a href>`` tags pointing at the
+    public site, using the corresponding ID column from the raw row. The ID
+    columns themselves are then hidden from the visible output, joining the
+    standard hidden-column allowlist.
+    """
+    base_url = _public_base_url()
+
+    # Work out which columns should become link anchors and which columns
+    # provide the IDs for them. A single table can have both player and
+    # team links.
+    name_to_id_idx: dict[int, tuple[int, str]] = {}
+    extra_hidden_indices: set[int] = set()
+    lower_cols = [c.lower() for c in raw_columns]
+    for name_candidates, id_candidates, prefix in _LINK_RULES:
+        name_idx = next(
+            (i for i, c in enumerate(lower_cols) if c in name_candidates),
+            None,
+        )
+        id_idx = next(
+            (i for i, c in enumerate(lower_cols) if c in id_candidates),
+            None,
+        )
+        if name_idx is not None and id_idx is not None:
+            name_to_id_idx[name_idx] = (id_idx, prefix)
+            extra_hidden_indices.add(id_idx)
+
+    # Build the visible column list (hidden columns + id columns used for
+    # links are removed). We keep the original indices so we can still read
+    # the id cell when rendering.
+    visible_indices = [
+        i
+        for i, col in enumerate(raw_columns)
+        if col not in _GOL_HIDDEN_COLUMNS and i not in extra_hidden_indices
+    ]
+    visible_columns = [raw_columns[i] for i in visible_indices]
+
+    def _fmt(cell: Any) -> str:
+        if cell is None:
+            return "\u2013"
+        escaped = html_lib.escape(str(cell))
+        # Wrap bare http(s) URLs (e.g. tweet/x.com links sitting in a
+        # DataFrame column) in an anchor so they're clickable in the PDF.
+        return _BARE_URL_PATTERN.sub(
+            lambda m: f'<a href="{m.group(1)}">{m.group(1)}</a>',
+            escaped,
+        )
+
+    rendered_rows: list[list[str]] = []
+    for row in raw_rows:
+        out_row: list[str] = []
+        for i in visible_indices:
+            cell = row[i] if i < len(row) else None
+            link_info = name_to_id_idx.get(i)
+            if link_info is not None:
+                id_idx, prefix = link_info
+                id_value = row[id_idx] if id_idx < len(row) else None
+                if id_value is not None and cell is not None:
+                    href = f"{base_url}{prefix}{html_lib.escape(str(id_value))}"
+                    out_row.append(
+                        f'<a href="{href}">{_fmt(cell)}</a>'
+                    )
+                    continue
+            out_row.append(_fmt(cell))
+        rendered_rows.append(out_row)
+
+    return visible_columns, rendered_rows
+
+
+def _normalize_gol_data_card(card: dict[str, Any]) -> dict[str, Any] | None:
+    """Convert a raw SSE ``data_card`` payload into a flat dict the Jinja2
+    template can iterate over.
+
+    The SSE shape is::
+
+        {
+          "type": "analysis_result",
+          "payload": {
+            "result_type": "table" | "scalar" | "list" | "dict" | "error",
+            "display":     "table" | "bar_chart" | "line_chart" | "number" | "list" | ...,
+            "columns":     [...],   # table / chart only
+            "rows":        [...],   # table / chart only
+            "value":       ...,     # scalar only
+            "items":       [...],   # list only
+            "data":        {...},   # dict only
+            "error":       str,     # error only
+            "meta":        {"description": str},
+            "total_rows":  int,
+            "truncated":   bool,
+          }
+        }
+
+    Chart renderings are produced eagerly here so the returned dict carries a
+    ``chart_image_data_uri`` ready to splice into an ``<img src>`` tag.
+    """
+    if not isinstance(card, dict):
+        return None
+    payload = card.get("payload") or {}
+    if not isinstance(payload, dict):
+        return None
+
+    result_type = payload.get("result_type")
+    display = payload.get("display")
+    meta = payload.get("meta") or {}
+    description = meta.get("description") if isinstance(meta, dict) else None
+
+    # Charts. The backend sandbox emits bar/line charts as tables with a
+    # ``display`` hint, so we detect them from display rather than
+    # result_type. Render the PNG via the generic matplotlib helpers and
+    # embed it as a data URI. We also keep the raw table data so a small
+    # summary table can appear beneath the chart — useful for stakeholders
+    # who want the numbers behind the picture.
+    if display in ("bar_chart", "line_chart"):
+        columns = payload.get("columns") or []
+        rows = payload.get("rows") or []
+        if not columns or not rows:
+            return {
+                "kind": "empty",
+                "description": description,
+            }
+
+        # The chart is rendered from the numeric-first cells, so we use the
+        # hidden-column-filtered copy for matplotlib. The summary table
+        # under the chart, however, is linkified like a regular table card.
+        chart_columns, chart_rows = _filter_hidden_columns(columns, rows)
+        try:
+            from src.services.chart_renderer import (
+                render_generic_bar_chart,
+                render_generic_line_chart,
+            )
+
+            renderer = (
+                render_generic_bar_chart
+                if display == "bar_chart"
+                else render_generic_line_chart
+            )
+            png_bytes = renderer(chart_columns, chart_rows, title=description or None)
+            data_uri = "data:image/png;base64," + base64.b64encode(png_bytes).decode("ascii")
+        except Exception:
+            logger.exception("Failed to render GOL chart; falling back to table")
+            visible_cols, rendered_rows = _build_linkified_table(columns, rows)
+            return {
+                "kind": "table",
+                "description": description,
+                "columns": visible_cols,
+                "rendered_rows": rendered_rows,
+                "total_rows": payload.get("total_rows"),
+                "truncated": bool(payload.get("truncated")),
+            }
+
+        # Keep the numeric summary table alongside the chart only when it's
+        # small enough to be useful — more than ~8 rows and it starts to
+        # overwhelm the chart visually.
+        if len(rows) <= 8:
+            visible_cols, rendered_rows = _build_linkified_table(columns, rows)
+        else:
+            visible_cols, rendered_rows = None, None
+        return {
+            "kind": "chart",
+            "description": description,
+            "chart_image_data_uri": data_uri,
+            "table_columns": visible_cols,
+            "rendered_rows": rendered_rows,
+        }
+
+    # Tables.
+    if result_type == "table" or display == "table":
+        columns = payload.get("columns") or []
+        rows = payload.get("rows") or []
+        visible_cols, rendered_rows = _build_linkified_table(columns, rows)
+        return {
+            "kind": "table",
+            "description": description,
+            "columns": visible_cols,
+            "rendered_rows": rendered_rows,
+            "total_rows": payload.get("total_rows"),
+            "truncated": bool(payload.get("truncated")),
+        }
+
+    # Scalars.
+    if result_type == "scalar" or display == "number":
+        columns = payload.get("columns") or []
+        label = columns[0] if columns else None
+        return {
+            "kind": "number",
+            "description": description,
+            "label": label,
+            "value": payload.get("value"),
+        }
+
+    # Lists.
+    if result_type == "list":
+        return {
+            "kind": "list",
+            "description": description,
+            "items": [str(item) for item in (payload.get("items") or [])],
+        }
+
+    # Dicts.
+    if result_type == "dict":
+        data = payload.get("data") or {}
+        return {
+            "kind": "dict",
+            "description": description,
+            "data": data if isinstance(data, dict) else {},
+        }
+
+    # Errors.
+    if result_type == "error":
+        return {
+            "kind": "error",
+            "description": description,
+            "error": payload.get("error") or "Analysis error",
+        }
+
+    return None
+
+
+def _normalize_gol_messages(
+    messages: Iterable[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Filter + normalize the raw client-side message list for templating.
+
+    - Drops empty assistant messages (tool-call placeholders with no text
+      and no data cards).
+    - Renders markdown bodies to HTML once, so the template can simply
+      ``{{ content_html | safe }}``.
+    - Normalizes every data card to a flat dict keyed by ``kind``.
+    """
+    normalized: list[dict[str, Any]] = []
+    for msg in messages or []:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        if role not in ("user", "assistant"):
+            continue
+        content = (msg.get("content") or "").strip()
+        raw_cards = msg.get("dataCards") or msg.get("data_cards") or []
+        cards: list[dict[str, Any]] = []
+        if role == "assistant":
+            for raw in raw_cards:
+                norm = _normalize_gol_data_card(raw)
+                if norm is not None:
+                    cards.append(norm)
+            if not content and not cards:
+                # Skip loading placeholders that carry neither text nor data.
+                continue
+        normalized.append(
+            {
+                "role": role,
+                "content_html": _markdown_to_html(content) if content else "",
+                "data_cards": cards if role == "assistant" else [],
+            }
+        )
+    return normalized
+
+
+def render_gol_chat_pdf(messages: list[dict[str, Any]]) -> tuple[bytes, str]:
+    """Render a GOL chat transcript to a PDF.
+
+    Parameters
+    ----------
+    messages:
+        The client-side message array (role / content / dataCards) as sent
+        by the frontend chat state.
+
+    Returns
+    -------
+    tuple[bytes, str]
+        PDF bytes and a suggested download filename.
+    """
+    # Imported lazily to match the behaviour of html_to_pdf — avoids import
+    # errors when WeasyPrint's system libraries aren't installed in dev.
+    from flask import render_template, request
+
+    normalized = _normalize_gol_messages(messages)
+    exported_date = datetime.utcnow().strftime("%d %B %Y")
+    html = render_template(
+        "gol_chat_export.html",
+        messages=normalized,
+        exported_date=exported_date,
+        site_url=_public_base_url(),
+    )
+
+    try:
+        base_url = request.url_root
+    except RuntimeError:
+        base_url = None
+
+    pdf_bytes = html_to_pdf(html, base_url=base_url)
+    filename = (
+        "gol-chat-"
+        + datetime.utcnow().strftime("%Y-%m-%d-%H%M%S")
+        + ".pdf"
+    )
+    return pdf_bytes, filename

--- a/academy-watch-backend/src/templates/gol_chat_export.html
+++ b/academy-watch-backend/src/templates/gol_chat_export.html
@@ -1,0 +1,488 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>GOL Analytics Chat — {{ exported_date }}</title>
+  <style>
+    /* The Academy Watch — Tactical Lens (GOL Chat Export)
+       Dark navy base with primary royal-blue accents. Single-column layout
+       designed for A4/Letter PDF output via WeasyPrint. Styling intentionally
+       mirrors newsletter_email.html so the exported chat feels like the same
+       brand family. */
+    body {
+      margin: 0;
+      padding: 0;
+      background: #0b1326;
+      color: #e2e8f0;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      line-height: 1.6;
+    }
+
+    .wrapper {
+      width: 100%;
+      background: #0b1326;
+      padding: 24px 0;
+    }
+
+    .main {
+      max-width: 640px;
+      margin: 0 auto;
+      background: #0b1326;
+    }
+
+    .content {
+      padding: 36px 32px 44px;
+      color: #e2e8f0;
+    }
+
+    /* Masthead */
+    .brand {
+      font-size: 11px;
+      letter-spacing: 3px;
+      text-transform: uppercase;
+      color: #2563EB;
+      font-weight: 700;
+      margin-bottom: 10px;
+    }
+
+    h1 {
+      font-size: 26px;
+      margin: 0 0 10px;
+      color: #f1f5f9;
+      font-family: 'Manrope', 'Inter', sans-serif;
+      font-weight: 800;
+      letter-spacing: -0.02em;
+    }
+
+    .meta {
+      font-size: 12px;
+      color: #94a3b8;
+      text-transform: uppercase;
+      letter-spacing: 1.2px;
+      margin-bottom: 18px;
+      font-weight: 500;
+    }
+
+    .divider {
+      width: 32px;
+      height: 2px;
+      background: #2563EB;
+      margin: 10px 0 26px;
+    }
+
+    /* Chat turns */
+    .turn {
+      margin: 0 0 20px;
+    }
+
+    .turn-user {
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    .user-bubble {
+      display: inline-block;
+      max-width: 82%;
+      background: #2563EB;
+      color: #ffffff;
+      padding: 12px 16px;
+      border-radius: 14px 14px 4px 14px;
+      font-size: 14px;
+      line-height: 1.55;
+    }
+
+    .user-bubble .speaker {
+      display: block;
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 1.2px;
+      opacity: 0.85;
+      margin-bottom: 4px;
+      font-weight: 700;
+    }
+
+    .assistant-card {
+      background: #131b2e;
+      border-radius: 12px;
+      padding: 18px 20px;
+      border-left: 3px solid #2563EB;
+    }
+
+    .assistant-card .speaker {
+      display: block;
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 1.6px;
+      color: #2563EB;
+      font-weight: 700;
+      margin-bottom: 8px;
+    }
+
+    .assistant-body {
+      font-size: 14px;
+      color: #e2e8f0;
+      line-height: 1.65;
+    }
+
+    .assistant-body p {
+      margin: 0 0 10px;
+    }
+
+    .assistant-body p:last-child {
+      margin-bottom: 0;
+    }
+
+    .assistant-body h1,
+    .assistant-body h2,
+    .assistant-body h3,
+    .assistant-body h4 {
+      color: #f1f5f9;
+      font-family: 'Manrope', 'Inter', sans-serif;
+      font-weight: 700;
+      margin: 14px 0 6px;
+      line-height: 1.3;
+    }
+
+    .assistant-body h1 { font-size: 18px; }
+    .assistant-body h2 { font-size: 16px; }
+    .assistant-body h3 { font-size: 14px; }
+
+    .assistant-body ul,
+    .assistant-body ol {
+      margin: 6px 0 10px;
+      padding-left: 22px;
+    }
+
+    .assistant-body li {
+      margin: 3px 0;
+    }
+
+    .assistant-body a {
+      color: #60a5fa;
+      text-decoration: none;
+      border-bottom: 1px solid rgba(96, 165, 250, 0.4);
+    }
+
+    .assistant-body code {
+      background: #222a3d;
+      padding: 1px 6px;
+      border-radius: 4px;
+      font-size: 12px;
+      color: #cbd5e1;
+    }
+
+    .assistant-body pre {
+      background: #222a3d;
+      padding: 12px 14px;
+      border-radius: 6px;
+      overflow-x: auto;
+      font-size: 12px;
+      color: #cbd5e1;
+      margin: 8px 0;
+    }
+
+    .assistant-body blockquote {
+      border-left: 2px solid rgba(37, 99, 235, 0.4);
+      padding-left: 12px;
+      margin: 8px 0;
+      color: #cbd5e1;
+      font-style: italic;
+    }
+
+    /* Data cards */
+    .data-card {
+      background: #222a3d;
+      border-radius: 8px;
+      padding: 14px 16px;
+      margin-top: 14px;
+    }
+
+    .data-card .description {
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 1.2px;
+      color: #94a3b8;
+      margin-bottom: 10px;
+      font-weight: 600;
+    }
+
+    /* Tables */
+    table.gol-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 12px;
+      color: #e2e8f0;
+    }
+
+    table.gol-table th {
+      text-align: left;
+      padding: 8px 10px;
+      background: #2563EB;
+      color: #ffffff;
+      font-weight: 700;
+      text-transform: uppercase;
+      font-size: 10px;
+      letter-spacing: 0.8px;
+      border-bottom: none;
+    }
+
+    table.gol-table td {
+      padding: 8px 10px;
+      border-bottom: 1px solid #2d3449;
+      color: #e2e8f0;
+    }
+
+    table.gol-table tr:nth-child(even) td {
+      background: #1a2235;
+    }
+
+    table.gol-table tr:last-child td {
+      border-bottom: none;
+    }
+
+    /* Chart image */
+    .chart-image {
+      display: block;
+      width: 100%;
+      max-width: 560px;
+      height: auto;
+      margin: 0 auto;
+      border-radius: 6px;
+    }
+
+    /* Number card (scalar display) */
+    .number-card {
+      text-align: center;
+      padding: 10px 0 4px;
+    }
+
+    .number-card .value {
+      font-family: 'Manrope', 'Inter', sans-serif;
+      font-size: 36px;
+      font-weight: 800;
+      color: #60a5fa;
+      letter-spacing: -0.03em;
+      line-height: 1.1;
+    }
+
+    .number-card .label {
+      display: block;
+      margin-top: 6px;
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 1.2px;
+      color: #94a3b8;
+      font-weight: 600;
+    }
+
+    /* List display */
+    .data-list {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      counter-reset: gol-list;
+    }
+
+    .data-list li {
+      counter-increment: gol-list;
+      padding: 6px 0 6px 28px;
+      position: relative;
+      font-size: 13px;
+      color: #e2e8f0;
+      border-bottom: 1px solid #2d3449;
+    }
+
+    .data-list li::before {
+      content: counter(gol-list);
+      position: absolute;
+      left: 0;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 20px;
+      height: 20px;
+      background: #2563EB;
+      color: #ffffff;
+      border-radius: 50%;
+      text-align: center;
+      font-size: 10px;
+      font-weight: 700;
+      line-height: 20px;
+    }
+
+    .data-list li:last-child {
+      border-bottom: none;
+    }
+
+    /* Dict display (key → value grid) */
+    .data-dict {
+      margin: 0;
+    }
+
+    .data-dict .dict-row {
+      display: table;
+      width: 100%;
+      padding: 6px 0;
+      border-bottom: 1px solid #2d3449;
+    }
+
+    .data-dict .dict-row:last-child {
+      border-bottom: none;
+    }
+
+    .data-dict .dict-key {
+      display: table-cell;
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.8px;
+      color: #94a3b8;
+      font-weight: 600;
+      width: 40%;
+      padding-right: 12px;
+    }
+
+    .data-dict .dict-value {
+      display: table-cell;
+      font-size: 13px;
+      color: #e2e8f0;
+      text-align: right;
+      font-weight: 600;
+    }
+
+    /* Empty / error data card */
+    .data-empty {
+      color: #94a3b8;
+      font-style: italic;
+      font-size: 12px;
+    }
+
+    /* Footer */
+    .footer {
+      margin-top: 28px;
+      padding-top: 18px;
+      border-top: 1px solid #1a2235;
+      text-align: center;
+      color: #94a3b8;
+      font-size: 11px;
+    }
+
+    .footer .brand-line {
+      color: #60a5fa;
+      font-weight: 700;
+      letter-spacing: 1.2px;
+      text-transform: uppercase;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="wrapper">
+    <div class="main">
+      <div class="content">
+        <div class="brand">THE ACADEMY WATCH</div>
+        <h1>GOL Analytics Chat</h1>
+        <div class="meta">Exported {{ exported_date }}</div>
+        <div class="divider"></div>
+
+        {% for msg in messages %}
+          {% if msg.role == 'user' %}
+            <div class="turn turn-user">
+              <div class="user-bubble">
+                <span class="speaker">You</span>
+                {{ msg.content_html|safe }}
+              </div>
+            </div>
+          {% else %}
+            <div class="turn turn-assistant">
+              <div class="assistant-card">
+                <span class="speaker">GOL</span>
+                {% if msg.content_html %}
+                  <div class="assistant-body">{{ msg.content_html|safe }}</div>
+                {% endif %}
+
+                {% for card in msg.data_cards %}
+                  <div class="data-card">
+                    {% if card.description %}
+                      <div class="description">{{ card.description }}</div>
+                    {% endif %}
+
+                    {% if card.kind == 'chart' %}
+                      <img class="chart-image" src="{{ card.chart_image_data_uri }}" alt="{{ card.description or 'Chart' }}" />
+                      {% if card.table_columns and card.rendered_rows %}
+                        <table class="gol-table" style="margin-top:12px;">
+                          <thead>
+                            <tr>
+                              {% for col in card.table_columns %}<th>{{ col }}</th>{% endfor %}
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {% for row in card.rendered_rows %}
+                              <tr>
+                                {% for cell in row %}<td>{{ cell|safe }}</td>{% endfor %}
+                              </tr>
+                            {% endfor %}
+                          </tbody>
+                        </table>
+                      {% endif %}
+
+                    {% elif card.kind == 'table' %}
+                      <table class="gol-table">
+                        <thead>
+                          <tr>
+                            {% for col in card.columns %}<th>{{ col }}</th>{% endfor %}
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {% for row in card.rendered_rows %}
+                            <tr>
+                              {% for cell in row %}<td>{{ cell|safe }}</td>{% endfor %}
+                            </tr>
+                          {% endfor %}
+                        </tbody>
+                      </table>
+                      {% if card.truncated %}
+                        <div class="data-empty" style="margin-top:8px;">Showing first {{ card.rendered_rows|length }} of {{ card.total_rows }} rows.</div>
+                      {% endif %}
+
+                    {% elif card.kind == 'number' %}
+                      <div class="number-card">
+                        <div class="value">{{ card.value }}</div>
+                        {% if card.label %}<span class="label">{{ card.label }}</span>{% endif %}
+                      </div>
+
+                    {% elif card.kind == 'list' %}
+                      <ol class="data-list">
+                        {% for item in card.items %}<li>{{ item }}</li>{% endfor %}
+                      </ol>
+
+                    {% elif card.kind == 'dict' %}
+                      <div class="data-dict">
+                        {% for key, value in card.data.items() %}
+                          <div class="dict-row">
+                            <span class="dict-key">{{ key }}</span>
+                            <span class="dict-value">{{ value if value is not none else '–' }}</span>
+                          </div>
+                        {% endfor %}
+                      </div>
+
+                    {% elif card.kind == 'error' %}
+                      <div class="data-empty">{{ card.error }}</div>
+
+                    {% endif %}
+                  </div>
+                {% endfor %}
+              </div>
+            </div>
+          {% endif %}
+        {% endfor %}
+
+        <div class="footer">
+          <a href="{{ site_url }}" class="brand-line" style="text-decoration:none;color:#60a5fa;">THE ACADEMY WATCH</a>
+          <div style="margin-top:4px;">Generated by GOL Analytics · {{ exported_date }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/academy-watch-frontend/src/components/gol/GolChatWindow.jsx
+++ b/academy-watch-frontend/src/components/gol/GolChatWindow.jsx
@@ -4,11 +4,14 @@ import { GolInput } from './GolInput'
 import { GolSuggestions } from './GolSuggestions'
 import { PlayerPreviewDrawer } from './PlayerPreviewDrawer'
 import { exportChatAsMarkdown } from './exportChat'
+import { APIService } from '@/lib/api'
 import { Button } from '@/components/ui/button'
-import { Download, Trash2 } from 'lucide-react'
+import { Download, FileDown, Loader2, Trash2 } from 'lucide-react'
 
 export function GolChatWindow({ messages, isStreaming, sendMessage, clearChat, stopStreaming, expanded }) {
   const [previewPlayerId, setPreviewPlayerId] = useState(null)
+  const [pdfExporting, setPdfExporting] = useState(false)
+  const [pdfError, setPdfError] = useState(null)
   const scrollRef = useRef(null)
   const bottomRef = useRef(null)
   const prefersReducedMotion = useRef(
@@ -18,6 +21,19 @@ export function GolChatWindow({ messages, isStreaming, sendMessage, clearChat, s
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: prefersReducedMotion.current ? 'instant' : 'smooth' })
   }, [messages])
+
+  const handleExportPdf = async () => {
+    setPdfError(null)
+    setPdfExporting(true)
+    try {
+      await APIService.golExportPdf(messages)
+    } catch (err) {
+      console.error('GOL PDF export failed', err)
+      setPdfError(err?.message || 'PDF export failed')
+    } finally {
+      setPdfExporting(false)
+    }
+  }
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -39,28 +55,50 @@ export function GolChatWindow({ messages, isStreaming, sendMessage, clearChat, s
 
       <div className="border-t px-4 py-3">
         {messages.length > 0 && (
-          <div className="flex justify-end gap-1 mb-2">
-            <Button
-              variant="ghost"
-              size="sm"
-              className="text-xs text-muted-foreground"
-              onClick={() => {
-                const md = exportChatAsMarkdown(messages)
-                const blob = new Blob([md], { type: 'text/markdown' })
-                const url = URL.createObjectURL(blob)
-                const a = document.createElement('a')
-                a.href = url
-                a.download = `gol-chat-${new Date().toISOString().slice(0, 10)}.md`
-                a.click()
-                URL.revokeObjectURL(url)
-              }}
-            >
-              <Download className="h-3 w-3 mr-1" /> Save
-            </Button>
-            <Button variant="ghost" size="sm" onClick={clearChat} className="text-xs text-muted-foreground">
-              <Trash2 className="h-3 w-3 mr-1" /> Clear
-            </Button>
-          </div>
+          <>
+            <div className="flex justify-end gap-1 mb-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-xs text-muted-foreground"
+                onClick={() => {
+                  const md = exportChatAsMarkdown(messages)
+                  const blob = new Blob([md], { type: 'text/markdown' })
+                  const url = URL.createObjectURL(blob)
+                  const a = document.createElement('a')
+                  a.href = url
+                  a.download = `gol-chat-${new Date().toISOString().slice(0, 10)}.md`
+                  a.click()
+                  URL.revokeObjectURL(url)
+                }}
+              >
+                <Download className="h-3 w-3 mr-1" /> Save
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-xs text-muted-foreground"
+                onClick={handleExportPdf}
+                disabled={pdfExporting || isStreaming}
+                title="Download as PDF"
+              >
+                {pdfExporting ? (
+                  <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                ) : (
+                  <FileDown className="h-3 w-3 mr-1" />
+                )}
+                PDF
+              </Button>
+              <Button variant="ghost" size="sm" onClick={clearChat} className="text-xs text-muted-foreground">
+                <Trash2 className="h-3 w-3 mr-1" /> Clear
+              </Button>
+            </div>
+            {pdfError && (
+              <div className="text-xs text-rose-500 mb-2 text-right" role="alert">
+                {pdfError}
+              </div>
+            )}
+          </>
         )}
         <GolInput onSend={sendMessage} isStreaming={isStreaming} onStop={stopStreaming} />
       </div>

--- a/academy-watch-frontend/src/lib/api.js
+++ b/academy-watch-frontend/src/lib/api.js
@@ -1860,6 +1860,47 @@ export class APIService {
         })
     }
 
+    static async golExportPdf(messages) {
+        if (!Array.isArray(messages) || messages.length === 0) {
+            throw new Error('Nothing to export — start a chat first')
+        }
+        const headers = { 'Content-Type': 'application/json', 'Accept': 'application/pdf' }
+        if (this.userToken) headers['Authorization'] = `Bearer ${this.userToken}`
+        const res = await fetch(`${API_BASE_URL}/gol/export-pdf`, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({ messages }),
+        })
+        if (!res.ok) {
+            let message = `HTTP ${res.status}`
+            try {
+                const body = await res.text()
+                if (body) message = body
+            } catch (_) { /* ignore */ }
+            const err = new Error(message)
+            err.status = res.status
+            throw err
+        }
+        const blob = await res.blob()
+        const disposition = res.headers.get('content-disposition') || ''
+        let filename = `gol-chat-${new Date().toISOString().slice(0, 10)}.pdf`
+        const match = disposition.match(/filename\*?=(?:UTF-8'')?"?([^";]+)"?/i)
+        if (match && match[1]) {
+            try { filename = decodeURIComponent(match[1]) } catch (_) { filename = match[1] }
+        }
+        if (typeof document !== 'undefined' && typeof URL !== 'undefined' && URL.createObjectURL) {
+            const objectUrl = URL.createObjectURL(blob)
+            const a = document.createElement('a')
+            a.href = objectUrl
+            a.download = filename
+            document.body.appendChild(a)
+            a.click()
+            a.remove()
+            setTimeout(() => URL.revokeObjectURL(objectUrl), 0)
+        }
+        return { blob, filename }
+    }
+
     // ==========================================================================
     // Academy Network
     // ==========================================================================


### PR DESCRIPTION
## Summary
- New **POST /gol/export-pdf** endpoint (rate-limited 10/min, no auth — matches the public `/gol/chat` surface). Accepts the full client-side message array since the GOL chat has no server-side persistence.
- New `src/services/pdf_renderer.py :: render_gol_chat_pdf(messages)` that normalizes the SSE data-card shapes, pre-renders markdown to HTML via markdown-it-py, calls the new generic matplotlib helpers for bar/line charts, and runs the result through the existing WeasyPrint pipeline from the newsletter PDF.
- New `src/services/chart_renderer.py :: render_generic_bar_chart / render_generic_line_chart` — reusable primitives that take the `{columns, rows}` shape the GOL sandbox emits and produce Tactical Lens-themed PNGs. Left the existing player-specific chart renderers untouched.
- New `src/templates/gol_chat_export.html` — Tactical Lens dark-theme single-column Jinja2 template. User turns render as right-aligned blue bubbles, assistant turns as dark cards with data card blocks below.
- Frontend `APIService.golExportPdf(messages)` streams the blob and triggers a browser download. A new **"PDF"** button lives next to the existing markdown "Save" button in `GolChatWindow.jsx`.

## Clickable links (the user-asked-for bit)
- **Markdown explicit links** (`[Rice](/players/12345)`) are absolutized to `https://theacademywatch.com/players/12345` via a regex rewrite after markdown-it.
- **Bare https URLs in markdown** (e.g. a tweet URL the LLM pasted inline) are auto-wrapped as anchors via `linkify-it-py` (added to requirements.txt).
- **Bare https URLs inside table cells** (a `source_url` column) are wrapped via a plain-text regex in the cell formatter.
- **Player and club names in tables** are wrapped in `<a href>` tags using the hidden `player_api_id` / `team_api_id` / `club_api_id` columns — those id columns are dropped from the visible output so stakeholders see just the names.
- **Footer brand** is a clickable link to the site.
- WeasyPrint converts all `<a href>` tags into real PDF link annotations — no extra plumbing needed.

## Test plan
- [x] Unit / integration smoke test against the venv Python: absolutizer, table linkifier (player + team), bare-URL cell, markdown explicit relative/external, markdown bare URL, full chat normalization, Jinja2 render with chart embed.
- [x] Python AST parse + frontend lint (0 errors, same 23 pre-existing warnings).
- [ ] Post-deploy: click the new PDF button in the GOL chat after a few turns including a table with player names, a bar-chart-displaying data card, and a message containing a twitter/x URL. Confirm the PDF downloads, opens cleanly, and every link is clickable.
- [ ] Tail container logs for any weasyprint / matplotlib errors on first render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)