### PR TITLE
fix: GOL chat PDF overflow — landscape + fixed table layout

### DIFF
--- a/academy-watch-backend/src/services/pdf_renderer.py
+++ b/academy-watch-backend/src/services/pdf_renderer.py
@@ -633,6 +633,12 @@ def _normalize_gol_messages(
 def render_gol_chat_pdf(messages: list[dict[str, Any]]) -> tuple[bytes, str]:
     """Render a GOL chat transcript to a PDF.
 
+    Calls WeasyPrint directly rather than going through :func:`html_to_pdf`
+    because the GOL template owns its own ``@page`` rule (landscape A4, to
+    give data tables enough horizontal room) — the newsletter print CSS
+    injected by :func:`html_to_pdf` forces portrait A4 and would override
+    it.
+
     Parameters
     ----------
     messages:
@@ -644,8 +650,9 @@ def render_gol_chat_pdf(messages: list[dict[str, Any]]) -> tuple[bytes, str]:
     tuple[bytes, str]
         PDF bytes and a suggested download filename.
     """
-    # Imported lazily to match the behaviour of html_to_pdf — avoids import
-    # errors when WeasyPrint's system libraries aren't installed in dev.
+    # Imported lazily to avoid import errors when WeasyPrint's system
+    # libraries aren't installed in dev.
+    from weasyprint import HTML  # type: ignore
     from flask import render_template, request
 
     normalized = _normalize_gol_messages(messages)
@@ -662,7 +669,7 @@ def render_gol_chat_pdf(messages: list[dict[str, Any]]) -> tuple[bytes, str]:
     except RuntimeError:
         base_url = None
 
-    pdf_bytes = html_to_pdf(html, base_url=base_url)
+    pdf_bytes = HTML(string=html, base_url=base_url).write_pdf()
     filename = (
         "gol-chat-"
         + datetime.utcnow().strftime("%Y-%m-%d-%H%M%S")

--- a/academy-watch-backend/src/templates/gol_chat_export.html
+++ b/academy-watch-backend/src/templates/gol_chat_export.html
@@ -6,33 +6,49 @@
   <title>GOL Analytics Chat — {{ exported_date }}</title>
   <style>
     /* The Academy Watch — Tactical Lens (GOL Chat Export)
-       Dark navy base with primary royal-blue accents. Single-column layout
-       designed for A4/Letter PDF output via WeasyPrint. Styling intentionally
-       mirrors newsletter_email.html so the exported chat feels like the same
-       brand family. */
+       Dark navy base with primary royal-blue accents. Uses landscape A4
+       because GOL responses are data-dense (wide player stat tables with
+       10+ columns) and portrait's ~575px content width is too cramped. */
+    @page {
+      size: A4 landscape;
+      margin: 14mm 16mm 18mm 16mm;
+      @bottom-center {
+        content: "The Academy Watch · GOL Analytics · Page " counter(page) " of " counter(pages);
+        font-family: 'Inter', 'DejaVu Sans', sans-serif;
+        font-size: 9pt;
+        color: #64748b;
+      }
+    }
+
+    html, body {
+      background: #0b1326 !important;
+      color-adjust: exact;
+    }
+
     body {
       margin: 0;
       padding: 0;
-      background: #0b1326;
       color: #e2e8f0;
       font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
       line-height: 1.6;
     }
 
+    /* Full-page single column: no horizontal centering, no max-width.
+       Tables are what need the room, and the prose column is constrained
+       separately via .assistant-body max-width below for readability. */
     .wrapper {
       width: 100%;
       background: #0b1326;
-      padding: 24px 0;
+      padding: 18px 0;
     }
 
     .main {
-      max-width: 640px;
-      margin: 0 auto;
+      width: 100%;
       background: #0b1326;
     }
 
     .content {
-      padding: 36px 32px 44px;
+      padding: 18px 16px 26px;
       color: #e2e8f0;
     }
 
@@ -73,23 +89,30 @@
 
     /* Chat turns */
     .turn {
-      margin: 0 0 20px;
+      margin: 0 0 18px;
+      break-inside: avoid;
+      page-break-inside: avoid;
     }
 
+    /* WeasyPrint's flex support is limited — use text-align for right
+       alignment of the user bubble instead. ``display: inline-block``
+       lets the bubble shrink to its content up to ``max-width``. */
     .turn-user {
-      display: flex;
-      justify-content: flex-end;
+      text-align: right;
     }
 
     .user-bubble {
       display: inline-block;
-      max-width: 82%;
+      max-width: 75%;
       background: #2563EB;
       color: #ffffff;
       padding: 12px 16px;
       border-radius: 14px 14px 4px 14px;
       font-size: 14px;
       line-height: 1.55;
+      text-align: left;
+      word-wrap: break-word;
+      overflow-wrap: break-word;
     }
 
     .user-bubble .speaker {
@@ -120,13 +143,19 @@
     }
 
     .assistant-body {
-      font-size: 14px;
+      font-size: 13.5px;
       color: #e2e8f0;
       line-height: 1.65;
+      /* Keep prose narrower than the full landscape width for reading
+         comfort — ~75ch is the sweet spot. Data cards below are siblings
+         and are NOT constrained by this rule. */
+      max-width: 75ch;
     }
 
     .assistant-body p {
       margin: 0 0 10px;
+      word-wrap: break-word;
+      overflow-wrap: break-word;
     }
 
     .assistant-body p:last-child {
@@ -194,43 +223,60 @@
     .data-card {
       background: #222a3d;
       border-radius: 8px;
-      padding: 14px 16px;
-      margin-top: 14px;
+      padding: 12px 14px;
+      margin-top: 12px;
+      break-inside: avoid;
+      page-break-inside: avoid;
+      /* Override the prose column width — data cards should use the
+         full assistant-card width, even when they happen to sit next to
+         a narrow markdown paragraph. */
+      max-width: none;
     }
 
     .data-card .description {
-      font-size: 11px;
+      font-size: 10px;
       text-transform: uppercase;
-      letter-spacing: 1.2px;
+      letter-spacing: 1.1px;
       color: #94a3b8;
       margin-bottom: 10px;
       font-weight: 600;
     }
 
-    /* Tables */
+    /* Tables — CRITICAL: table-layout: fixed forces columns to share the
+       container width equally, so a 10-column table can never blow
+       through the right margin. word-wrap on cells lets long strings
+       ("SHOTS ON TARGET", long player names) wrap inside their column
+       instead of forcing the column wider. */
     table.gol-table {
       width: 100%;
+      table-layout: fixed;
       border-collapse: collapse;
-      font-size: 12px;
+      font-size: 10.5px;
       color: #e2e8f0;
     }
 
     table.gol-table th {
       text-align: left;
-      padding: 8px 10px;
+      padding: 6px 7px;
       background: #2563EB;
       color: #ffffff;
       font-weight: 700;
       text-transform: uppercase;
-      font-size: 10px;
-      letter-spacing: 0.8px;
+      font-size: 9px;
+      letter-spacing: 0.6px;
       border-bottom: none;
+      word-wrap: break-word;
+      overflow-wrap: break-word;
+      vertical-align: bottom;
     }
 
     table.gol-table td {
-      padding: 8px 10px;
+      padding: 5px 7px;
       border-bottom: 1px solid #2d3449;
       color: #e2e8f0;
+      word-wrap: break-word;
+      overflow-wrap: break-word;
+      vertical-align: top;
     }
 
     table.gol-table tr:nth-child(even) td {
@@ -239,6 +285,12 @@
 
     table.gol-table tr:last-child td {
       border-bottom: none;
+    }
+
+    table.gol-table a {
+      color: #93c5fd;
+      text-decoration: none;
+      border-bottom: 1px dotted rgba(147, 197, 253, 0.45);
     }
 
     /* Chart image */


### PR DESCRIPTION
## Summary
Hotfix for the overflow issues in the GOL chat PDF shipped in #87. Screenshots from the user showed:
- Wide player-stats tables (10+ columns) bleeding past the right page margin, clipping the \`SHOTS ON TARGET\`/\`PASSES\`/\`KEY PASSES\` columns.
- User message bubbles clipped on the right, mid-sentence.

Three root causes, three fixes:

1. **Newsletter print CSS was overriding the GOL template's @page rule.** The GOL renderer was calling \`html_to_pdf()\` which unconditionally injects the newsletter's portrait-A4 print CSS. The GOL template tried to set its own \`@page\` rule but the injected one won the cascade. **Fix**: \`render_gol_chat_pdf()\` now calls WeasyPrint directly, bypassing the newsletter CSS injection.
2. **.main container was max-width 640px but tables weren't constrained.** Child tables defaulted to \`table-layout: auto\` which expanded to fit natural content width, busting through the container. **Fix**: \`.main { width: 100% }\` (full page) + \`table.gol-table { table-layout: fixed; width: 100%; word-wrap: break-word }\` on cells.
3. **User bubble used flex which is finicky in WeasyPrint.** The \`max-width: 82%\` was being measured against a flex parent that had itself escaped the printable area. **Fix**: dropped flex, use \`text-align: right\` on \`.turn-user\` and \`display: inline-block; max-width: 75%\` on the bubble.

Also switched the page orientation to **A4 landscape** — GOL responses are data-dense by nature (wide player stat tables, 10+ columns) and portrait A4 only gives ~575px of usable content width, which is cramped even for small tables. Landscape gives ~950px which fits most tables naturally.

## Test plan
- [x] Jinja2 template parse + render against a fixture mirroring the user's Forest-loanees scenario (6-row player profile table + 11-column match stats table + long user messages).
- [x] CSS assertions: \`@page A4 landscape\`, \`table-layout: fixed\`, \`word-wrap: break-word\`, user bubble \`max-width: 75%\` + \`text-align: right\`, no flex on \`.turn-user\`.
- [x] Clickable links still present in rendered output.
- [ ] Post-deploy: re-run the same Forest loanees query that produced the screenshots, export PDF, confirm tables fit within the page and user messages aren't clipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)