### PR TITLE
fix: newsletter PDF flows like email (drop forced section page breaks)

### DIFF
--- a/academy-watch-backend/src/services/pdf_renderer.py
+++ b/academy-watch-backend/src/services/pdf_renderer.py
@@ -113,13 +113,16 @@ h1, h2, h3 {
     page-break-after: avoid;
 }
 
-/* Force each top-level newsletter section onto a fresh page for
-   stakeholder scan-ability. The first <h2> lives after the highlights/TOC
-   on page 1, so this naturally starts the first section on page 2. */
-.content h2 {
-    break-before: page;
-    page-break-before: always;
-}
+/* Intentionally NOT forcing a page break on .content h2. The earlier
+   design forced each top-level section ("First Team", "On Loan",
+   "Academy Rising") onto a fresh page for stakeholder scan-ability,
+   but on sparse sections that produced huge dark whitespace below the
+   last card to the bottom of the page, making the PDF feel cramped
+   and wasteful. Letting content flow continuously matches how the
+   same newsletter renders in email — stakeholders get the same visual
+   experience subscribers get, just paginated at the natural overflow
+   points. The break-inside:avoid rules above still guarantee cards
+   and highlights can't be sliced mid-content. */
 
 /* Widows and orphans on body copy. */
 p, li {


### PR DESCRIPTION
## Summary
User-reported: the newsletter PDF looked cramped — narrow content column with a big empty dark region below the last player card on sparse sections. Screenshot showed a well-styled D. Osong card sitting in roughly the top third of an A4 page with the rest of the page blank.

## Root cause
Not the container width. The \`.main { max-width: 600px }\` from \`newsletter_email.html\` is fine on its own — the visible whitespace around it just matches how the same email renders on a wide email client. The cramped feeling came from \`_PRINT_CSS\`'s \`.content h2 { break-before: page }\` rule, which was forcing every top-level newsletter section ("First Team", "On Loan", "Academy Rising") onto its own fresh page. For Nottingham Forest — where sections have only a handful of items — that left most of each page blank.

I originally added that rule for "stakeholder scan-ability" (each section on a clean page), but in practice it just produced lots of wasted space. The user's ask — "why not lean towards the same format as what we get in email?" — is the right call: email renders flow continuously, the PDF should too. Pagination happens at the natural overflow points; \`break-inside: avoid\` on cards / highlights / match blocks still guarantees no mid-card slicing.

## Change
One rule removed from \`_PRINT_CSS\` in \`pdf_renderer.py\`. No container-width override, no padding change, no \`@page\` margin change. The PDF now renders visually identical to the email newsletter, just paginated where content overflows.

## Test plan
- [x] Python AST parse
- [ ] Post-deploy: download the latest Nottingham Forest newsletter PDF. Expect:
  - D. Osong and other loanee cards still render at the same width as before (matches email)
  - No more huge dark whitespace below the last card when sections are sparse
  - Content flows continuously, pages break naturally when content would overflow
  - Player cards, highlights, TOC blocks are still never sliced mid-content
- [ ] Tail container logs for any weasyprint warnings about the removed rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)