### PR TITLE
fix: strip chart base64 + rendered HTML from newsletters LIST endpoint

### DIFF
--- a/academy-watch-backend/src/routes/api.py
+++ b/academy-watch-backend/src/routes/api.py
@@ -929,21 +929,22 @@ def get_newsletters():
         for newsletter in newsletters:
             row = newsletter.to_dict()
             try:
-                raw_structured = newsletter.structured_content or newsletter.content or "{}"
-                raw_obj = json.loads(raw_structured)
-            except Exception:
-                raw_obj = None
-            if isinstance(raw_obj, dict):
-                rendered = raw_obj.get('rendered')
-                if isinstance(rendered, dict):
-                    row['rendered'] = {
-                        key: value if isinstance(value, str) else ''
-                        for key, value in rendered.items()
-                    }
-            try:
-                row['enriched_content'] = _load_newsletter_json(newsletter)
+                enriched = _load_newsletter_json(newsletter)
+                # The LIST endpoint must NOT return the full enriched_content —
+                # each newsletter carries ~6 base64-encoded chart PNGs per
+                # player which add ~2 MB / newsletter. With 10+ newsletters
+                # this turns into a 25-30 MB payload that takes 30-40 seconds
+                # to download even on fast connections, which made the
+                # newsletter list page (and the focused-view URL that gates
+                # on it) effectively unusable. Strip the chart URLs and any
+                # embedded HTML before serialising. Detail consumers should
+                # call GET /newsletters/<id> for the full content.
+                row['enriched_content'] = _strip_heavy_fields_for_list(enriched)
             except Exception:
                 row['enriched_content'] = None
+            # Skip `row['rendered']` entirely — the rendered web/email HTML
+            # blobs also embed the chart images and add several MB. The
+            # focused-view detail endpoint still returns them.
             payload.append(row)
         return jsonify(payload)
     except Exception as e:
@@ -2884,6 +2885,73 @@ def _load_newsletter_json(n: Newsletter) -> dict | None:
         return None
     except Exception:
         return None
+
+
+# Field names inside player items that hold base64 chart data URIs.
+# Each one is typically 50-200 KB; with 6 charts × 10 players × 10 newsletters
+# they push the LIST endpoint payload past 25 MB. Strip them in any context
+# that doesn't actually render the charts (i.e. the LIST endpoint).
+_HEAVY_CHART_FIELDS = (
+    'radar_chart_url',
+    'trend_chart_url',
+    'match_card_url',
+    'stat_table_url',
+    'rating_graph_url',
+    'minutes_graph_url',
+)
+
+
+def _strip_heavy_fields_for_list(enriched: dict | None) -> dict | None:
+    """Return a slimmed copy of `enriched_content` with chart base64s and
+    embedded rendered HTML removed.
+
+    Used by the LIST endpoint so a 28 MB response shrinks to ~1 MB. The
+    detail endpoint still returns the full payload via _load_newsletter_json.
+    Walks both the flat `items` shape and the `subsections` shape that the
+    weekly agent emits when players span multiple loan leagues.
+    """
+    if not isinstance(enriched, dict):
+        return enriched
+
+    # Shallow copy then mutate. The original dict is cached by SQLAlchemy
+    # so we must not strip from it in-place.
+    out: dict = dict(enriched)
+
+    # Drop the rendered HTML blobs (web_html / email_html). They embed the
+    # same chart images and add several MB on top of the chart_url fields.
+    if 'rendered' in out:
+        out.pop('rendered', None)
+
+    sections = out.get('sections')
+    if isinstance(sections, list):
+        new_sections: list = []
+        for sec in sections:
+            if not isinstance(sec, dict):
+                new_sections.append(sec)
+                continue
+            new_sec = dict(sec)
+            if 'subsections' in new_sec and isinstance(new_sec['subsections'], list):
+                new_sec['subsections'] = [
+                    {**sub, 'items': [_strip_item(i) for i in (sub.get('items') or [])]}
+                    if isinstance(sub, dict) else sub
+                    for sub in new_sec['subsections']
+                ]
+            elif isinstance(new_sec.get('items'), list):
+                new_sec['items'] = [_strip_item(i) for i in new_sec['items']]
+            new_sections.append(new_sec)
+        out['sections'] = new_sections
+    return out
+
+
+def _strip_item(item: dict) -> dict:
+    """Drop chart base64 fields from a single player item."""
+    if not isinstance(item, dict):
+        return item
+    new_item = dict(item)
+    for field in _HEAVY_CHART_FIELDS:
+        new_item.pop(field, None)
+    return new_item
+
 
 def _plain_text_from_news(data: dict, meta: Newsletter) -> str:
     team = meta.team.name if meta.team else ""


### PR DESCRIPTION
## Summary

The public \`GET /api/newsletters\` LIST endpoint was returning each newsletter's full \`enriched_content\` including ~6 base64-encoded chart PNGs per player AND the pre-rendered \`web_html\` / \`email_html\` blobs. With 10+ newsletters in the list this produced a **~28 MB payload** that took **30-40 seconds** to download even on fast connections, making the newsletter list page (and critically the focused-view URL like \`/newsletters/nottingham-forest-weekly-2026-03-15-218\` which gates render on the LIST loading) effectively unusable.

This was discovered while investigating \"tweets aren't appearing on the live newsletter page\". The tweets were actually rendering correctly — but only after the user waited ~40 seconds for the giant payload, which nobody does.

## Fix

Add \`_strip_heavy_fields_for_list()\` helper that returns a slimmed copy of \`enriched_content\` with:

- All \`radar_chart_url\`, \`trend_chart_url\`, \`match_card_url\`, \`stat_table_url\`, \`rating_graph_url\`, \`minutes_graph_url\` fields removed from every player item (handles both flat \`items\` and \`subsections\` shapes)
- The \`rendered\` field (web/email HTML blobs that embed the same charts) removed entirely

The LIST endpoint uses the slim version. The detail endpoint \`/api/newsletters/<id>\` continues to return the full content for the focused view that actually renders charts.

## Expected impact

- LIST endpoint payload: **~28 MB → ~1 MB**
- LIST endpoint latency: **~38s → ~2s**
- Focused-view URL render time: from \"page sits on Loading newsletters... for 40s\" to \"renders almost immediately because the focused detail endpoint is fast on its own\"

## Test plan
- [x] Backend code review — no other consumer reads chart_url fields from the LIST response (the React list-card view only uses metadata + excerpt text, and the focused expansion path uses \`focusedNewsletterDetail\` from the detail endpoint)
- [ ] After deploy: verify \`curl ...api/newsletters?published_only=true | wc -c\` is ~1 MB instead of ~28 MB
- [ ] After deploy: verify \`/newsletters/nottingham-forest-weekly-2026-03-15-218\` renders within seconds instead of waiting 30-40s
- [ ] Verify tweets show in the player cards on that page

🤖 Generated with [Claude Code](https://claude.com/claude-code)