### PR TITLE
fix: also strip raw content/structured_content from newsletters LIST

### DIFF
--- a/academy-watch-backend/src/routes/api.py
+++ b/academy-watch-backend/src/routes/api.py
@@ -928,23 +928,30 @@ def get_newsletters():
         payload: list[dict] = []
         for newsletter in newsletters:
             row = newsletter.to_dict()
+            # The LIST endpoint must NOT return the heavy fields. Each
+            # newsletter carries ~6 base64-encoded chart PNGs per player AND
+            # the pre-rendered HTML inside both `content` and
+            # `structured_content` (which Newsletter.to_dict() includes as
+            # raw strings). For ~10 newsletters this combines into a 25-30
+            # MB payload that takes 30-40 seconds to download, making the
+            # newsletter list page (and the focused-view URL that gates on
+            # the LIST loading) effectively unusable.
+            #
+            # Strip:
+            #  - the raw `content` and `structured_content` strings (the
+            #    largest contributors — ~2 MB EACH per newsletter)
+            #  - the chart_url base64s nested inside enriched_content
+            #  - the `rendered` field (also ~MB of embedded HTML)
+            #
+            # Detail consumers must call GET /newsletters/<id> for the full
+            # content including charts.
+            row.pop('content', None)
+            row.pop('structured_content', None)
             try:
                 enriched = _load_newsletter_json(newsletter)
-                # The LIST endpoint must NOT return the full enriched_content —
-                # each newsletter carries ~6 base64-encoded chart PNGs per
-                # player which add ~2 MB / newsletter. With 10+ newsletters
-                # this turns into a 25-30 MB payload that takes 30-40 seconds
-                # to download even on fast connections, which made the
-                # newsletter list page (and the focused-view URL that gates
-                # on it) effectively unusable. Strip the chart URLs and any
-                # embedded HTML before serialising. Detail consumers should
-                # call GET /newsletters/<id> for the full content.
                 row['enriched_content'] = _strip_heavy_fields_for_list(enriched)
             except Exception:
                 row['enriched_content'] = None
-            # Skip `row['rendered']` entirely — the rendered web/email HTML
-            # blobs also embed the chart images and add several MB. The
-            # focused-view detail endpoint still returns them.
             payload.append(row)
         return jsonify(payload)
     except Exception as e:


### PR DESCRIPTION
## Summary

Follow-up to #96. The previous slim-down stripped \`chart_url\` base64s and the \`rendered\` field from \`enriched_content\` — but the raw \`content\` and \`structured_content\` fields (returned by \`Newsletter.to_dict()\`) still contained the same chart base64 data inside the JSON string. Each one is ~2 MB per newsletter, so the LIST response was still 15 MB / 38 seconds after #96.

This PR also drops both raw text fields from the LIST response. The React list view reads from \`enriched_content\` as an object via \`extractNewsletterExcerpt\` / \`estimateReadingTime\` (both fall back to plain-text only when enriched_content is null), and the render path at App.jsx:9003 short-circuits on the object check. So the raw strings are unused in the list view.

Detail endpoint at \`GET /newsletters/<id>\` continues to return everything.

## Expected impact

LIST endpoint: **15 MB → ~1 MB**, **38s → ~2s**

🤖 Generated with [Claude Code](https://claude.com/claude-code)