### PR TITLE
ci: fast frontend-only deploy workflow for UI iteration

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,112 @@
+# Fast frontend-only deployment for The Academy Watch
+#
+# This workflow exists as a TEMPORARY escape hatch for rapid iteration on
+# UI / frontend designs. It deploys only the React/Vite app to Azure
+# Static Web App and skips the ~6 minute backend container rebuild +
+# Container App update that the full `deploy.yml` workflow does.
+#
+# When you no longer need the fast iteration loop:
+#   1. Delete this file
+#   2. Remove the `paths-ignore` block from `.github/workflows/deploy.yml`
+# That restores the original full-checks-on-every-push behaviour exactly.
+#
+# Required secrets (already configured for the full deploy workflow):
+#   AZURE_CREDENTIALS     - Service principal JSON
+#   SWA_DEPLOYMENT_TOKEN  - Static Web App deployment token
+
+name: Deploy Frontend (fast)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'academy-watch-frontend/**'
+      - '.github/workflows/deploy-frontend.yml'
+  workflow_dispatch:
+
+# Only one frontend deploy may run at a time. If a second commit lands
+# while one is still in progress, the in-flight run is cancelled and the
+# newer one takes its place — there's no value in deploying yesterday's
+# bundle after today's commit lands.
+concurrency:
+  group: deploy-frontend-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  SUBSCRIPTION_ID: 63ceeeac-fe3f-4bcb-b6d2-b7aa7fd6bf52
+  RESOURCE_GROUP: rg-loan-army-westus2
+  APP_BACKEND: ca-loan-army-backend
+
+jobs:
+  deploy-frontend:
+    name: Deploy Frontend (no backend rebuild)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Set subscription
+        run: az account set --subscription "${{ env.SUBSCRIPTION_ID }}"
+
+      - name: Get backend FQDN
+        id: get-fqdn
+        run: |
+          FQDN=$(az containerapp show \
+            -g "${{ env.RESOURCE_GROUP }}" \
+            -n "${{ env.APP_BACKEND }}" \
+            --query properties.configuration.ingress.fqdn -o tsv)
+          if [ -z "$FQDN" ]; then
+            echo "::error::Failed to fetch backend FQDN — refusing to ship a frontend bundle with an empty VITE_API_BASE"
+            exit 1
+          fi
+          echo "fqdn=$FQDN" >> $GITHUB_OUTPUT
+          echo "Backend FQDN: $FQDN"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: academy-watch-frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: academy-watch-frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Build frontend
+        working-directory: academy-watch-frontend
+        env:
+          VITE_API_BASE: https://${{ steps.get-fqdn.outputs.fqdn }}/api
+        run: |
+          echo "Building with VITE_API_BASE=$VITE_API_BASE"
+          pnpm run build
+
+      - name: Deploy to Azure Static Web App
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.SWA_DEPLOYMENT_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: 'upload'
+          app_location: 'academy-watch-frontend/dist'
+          skip_app_build: true
+          skip_api_build: true
+
+      - name: Print summary
+        run: |
+          echo "## Fast Frontend Deployment" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- Frontend: deployed to Azure Static Web App" >> $GITHUB_STEP_SUMMARY
+          echo "- Backend FQDN baked in: ${{ steps.get-fqdn.outputs.fqdn }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Skipped: backend container rebuild, scheduled job updates, RLS security checks" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "_For full backend+frontend deploys (with security checks), push backend changes or run \`Deploy\` workflow manually._" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,15 @@ name: Deploy
 on:
   push:
     branches: [main]
+    # Frontend-only changes are handled by the faster `deploy-frontend.yml`
+    # workflow, which skips the backend container rebuild and the scheduled
+    # job updates. Mixed PRs (touching both backend and frontend files)
+    # still run this full workflow because they fall outside paths-ignore.
+    # To disable the fast path entirely, delete `deploy-frontend.yml` and
+    # remove this paths-ignore block.
+    paths-ignore:
+      - 'academy-watch-frontend/**'
+      - '.github/workflows/deploy-frontend.yml'
   workflow_dispatch:
     inputs:
       skip_security_checks:


### PR DESCRIPTION
## Summary
Frontend changes were going through the full Deploy workflow which rebuilds the backend Container App image and updates scheduled jobs (~6 minutes) even when nothing about the backend has changed. This is a temporary escape hatch for rapid UI iteration.

## Changes
- **New: \`.github/workflows/deploy-frontend.yml\`** — runs on push to main with \`paths: ['academy-watch-frontend/**', '.github/workflows/deploy-frontend.yml']\`. Fetches the backend FQDN via \`az containerapp show\`, builds + deploys to Azure Static Web App. Concurrency group cancels in-flight runs when newer commits land. Total time: ~2 minutes.
- **Modified: \`.github/workflows/deploy.yml\`** — added \`paths-ignore\` matching the same prefixes so the full Deploy doesn't double-fire on frontend-only pushes.

## How the trigger logic shakes out
| Push touches | \`deploy.yml\` runs? | \`deploy-frontend.yml\` runs? |
|---|---|---|
| Only \`academy-watch-frontend/**\` | No (paths-ignore matches) | Yes |
| Only backend files | Yes | No (no frontend paths) |
| Both backend + frontend | Yes (non-frontend files violate paths-ignore) | No |
| Workflow files only | Depends on which workflow file | — |
| \`workflow_dispatch\` | Yes (path filters don't apply) | Manual trigger only |

The mixed-PR case is intentionally handled by the full Deploy — it already rebuilds the frontend from the backend FQDN output, so no value in running both workflows in parallel.

## Reverting to full-checks-on-every-push
This is a TEMPORARY tool. When UI iteration is done:
1. Delete \`.github/workflows/deploy-frontend.yml\`
2. Remove the \`paths-ignore\` block from \`.github/workflows/deploy.yml\`

Both files have that recipe documented in their headers.

## Test plan
- [x] Both workflow YAMLs parse cleanly via PyYAML
- [x] Cross-checked \`SUBSCRIPTION_ID\`, \`RESOURCE_GROUP\`, \`APP_BACKEND\` env vars match between the two files (so the FQDN lookup hits the same container app the full deploy uses)
- [x] All 8 expected job steps present in the new workflow in the right order
- [ ] **Self-test on merge:** this PR touches \`.github/workflows/deploy.yml\` which is NOT in the new paths-ignore list, so merging it triggers the full Deploy once — confirms the existing path still works post-change
- [ ] **Then a tiny frontend-only commit** to verify the fast path: only \`deploy-frontend.yml\` runs, ~2 minute total

🤖 Generated with [Claude Code](https://claude.com/claude-code)