### PR TITLE
fix(radar): trust API-Football for player's current-club league

### DIFF
--- a/academy-watch-backend/src/routes/journalist.py
+++ b/academy-watch-backend/src/routes/journalist.py
@@ -1059,10 +1059,30 @@ def get_chart_data():
         
         # Validate stat keys
         stat_keys = [k for k in stat_keys if k in ALL_STAT_KEYS]
-        
+
+        # Resolve the player's current club so all chart fixtures are scoped
+        # to it. Loanee at Barrow → only Barrow fixtures. First-team player at
+        # Forest → only Forest fixtures. Without this filter the radar would
+        # average a loanee's lower-tier appearances together with their
+        # parent-club U21 appearances — and the league overlay would be
+        # picked from whichever fixture happened to be most recent.
+        # (Mirrors _fetch_chart_data_for_rendering's scoping for newsletters.)
+        current_club_api_id: int | None = None
+        try:
+            tp_for_scope = (
+                TrackedPlayer.query
+                .filter_by(player_api_id=player_id, is_active=True)
+                .order_by(TrackedPlayer.updated_at.desc())
+                .first()
+            )
+            if tp_for_scope and tp_for_scope.current_club_api_id:
+                current_club_api_id = tp_for_scope.current_club_api_id
+        except Exception:
+            pass
+
         # Get fixtures data based on date range
         fixtures_data = []
-        
+
         if date_range == 'week':
             week_start = request.args.get('week_start')
             week_end = request.args.get('week_end')
@@ -1071,25 +1091,28 @@ def get_chart_data():
                 try:
                     start_date = datetime.fromisoformat(week_start).date() if isinstance(week_start, str) else week_start
                     end_date = datetime.fromisoformat(week_end).date() if isinstance(week_end, str) else week_end
-                    fixtures_data = _get_player_week_stats(player_id, start_date, end_date)
+                    fixtures_data = _get_player_week_stats(player_id, start_date, end_date,
+                                                           current_club_api_id=current_club_api_id)
                 except (ValueError, TypeError) as e:
                     logger.warning(f"Invalid date format: {e}")
             else:
                 return jsonify({'error': 'week_start and week_end required for date_range=week'}), 400
-        
+
         elif date_range == 'month':
             from datetime import timedelta
             end_date = datetime.now(timezone.utc).date()
             start_date = end_date - timedelta(days=30)
-            fixtures_data = _get_player_week_stats(player_id, start_date, end_date)
-        
+            fixtures_data = _get_player_week_stats(player_id, start_date, end_date,
+                                                   current_club_api_id=current_club_api_id)
+
         elif date_range == 'season':
             # Get current season (assume July-June cycle)
             now_utc = datetime.now(timezone.utc)
             current_year = now_utc.year
             current_month = now_utc.month
             season = current_year if current_month >= 7 else current_year - 1
-            fixtures_data = _get_season_stats(player_id, season)
+            fixtures_data = _get_season_stats(player_id, season,
+                                              current_club_api_id=current_club_api_id)
         
         # Get player info
         player_info = None

--- a/academy-watch-backend/src/scripts/verify_forest_player_leagues.py
+++ b/academy-watch-backend/src/scripts/verify_forest_player_leagues.py
@@ -1,0 +1,249 @@
+"""Verify radar league resolution for every active TrackedPlayer at a parent club.
+
+For each player, prints what `resolve_player_league` returns and flags rows
+that look suspicious — e.g. a loanee at a sub-Premier-League club whose radar
+would still compare against Premier League peers.
+
+Usage:
+    ../.loan/bin/python -m src.scripts.verify_forest_player_leagues
+    ../.loan/bin/python -m src.scripts.verify_forest_player_leagues --team "Manchester United"
+    ../.loan/bin/python -m src.scripts.verify_forest_player_leagues --team-api-id 65
+
+Read-only. Safe to run against production. Hits API-Football for any team it
+hasn't already resolved this session.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import dotenv
+from flask import Flask
+from sqlalchemy.engine.url import URL, make_url
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.models.league import db, Team, League  # noqa: E402
+from src.models.tracked_player import TrackedPlayer  # noqa: E402
+from src.models.journey import PlayerJourney  # noqa: E402,F401  # mapper init
+from src.services.radar_stats_service import (  # noqa: E402
+    resolve_player_league,
+    _team_league_from_api,
+)
+
+dotenv.load_dotenv(dotenv.find_dotenv())
+
+
+def _env_value(key: str) -> str | None:
+    raw = os.getenv(key)
+    if raw is None:
+        return None
+    value = raw.strip()
+    return value or None
+
+
+def _build_db_uri() -> str:
+    raw = _env_value("SQLALCHEMY_DATABASE_URI")
+    if raw:
+        candidate = raw.strip().strip('"').strip("'")
+        try:
+            make_url(candidate)
+            return candidate
+        except Exception:
+            pass
+
+    port_raw = _env_value("DB_PORT") or ""
+    port_value = None
+    if port_raw:
+        try:
+            port_value = int(port_raw)
+        except ValueError:
+            port_value = None
+    url = URL.create(
+        drivername="postgresql+psycopg",
+        username=_env_value("DB_USER"),
+        password=_env_value("DB_PASSWORD"),
+        host=_env_value("DB_HOST"),
+        port=port_value,
+        database=_env_value("DB_NAME"),
+        query={"sslmode": _env_value("DB_SSLMODE") or "require"},
+    )
+    return url.render_as_string(hide_password=False)
+
+
+def _make_app() -> Flask:
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = _build_db_uri()
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    db.init_app(app)
+    return app
+
+
+def _resolve_team(team_name: str | None, team_api_id: int | None) -> Team:
+    query = Team.query
+    if team_api_id is not None:
+        team = query.filter_by(team_id=team_api_id).order_by(Team.season.desc()).first()
+        if not team:
+            raise SystemExit(f"No Team row for team_api_id={team_api_id}")
+        return team
+    name = team_name or "Nottingham Forest"
+    team = query.filter(Team.name.ilike(name)).order_by(Team.season.desc()).first()
+    if not team:
+        team = query.filter(Team.name.ilike(f"%{name}%")).order_by(Team.season.desc()).first()
+    if not team:
+        raise SystemExit(f"No Team row matching name ILIKE '%{name}%'")
+    return team
+
+
+def _local_team_league(team_api_id: int | None) -> tuple[int | None, str | None]:
+    """Return (league_api_id, league_name) from the local teams/leagues join."""
+    if not team_api_id:
+        return None, None
+    team = Team.query.filter_by(team_id=team_api_id).first()
+    if not team or not team.league_id:
+        return None, None
+    league = League.query.filter_by(id=team.league_id).first()
+    if not league:
+        return None, None
+    return league.league_id, league.name
+
+
+def _verdict(
+    parent_api_id: int,
+    parent_name: str,
+    status: str,
+    current_api_id: int | None,
+    current_name: str | None,
+    resolved: tuple[int, str] | None,
+) -> str:
+    """Heuristic flag for rows that look wrong at a glance."""
+    if resolved is None:
+        return "NO_LEAGUE"
+    _, league_name = resolved
+    league_lower = league_name.lower()
+
+    # If the player is on loan/sold/released and we're returning the parent's
+    # likely league (Premier League for Forest), that's the bug we just fixed.
+    if status in ("on_loan", "sold", "released") and current_api_id and current_api_id != parent_api_id:
+        if "premier league" in league_lower and "premier league 2" not in league_lower:
+            return "SUSPECT"
+
+    # If "current club" is None or matches the parent club, returning the
+    # parent league is correct.
+    return "OK"
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--team", default="Nottingham Forest",
+                    help="Parent club name (ILIKE match). Default: Nottingham Forest")
+    ap.add_argument("--team-api-id", type=int, default=None,
+                    help="Parent club API-Football ID (overrides --team if set)")
+    ap.add_argument("--season", type=int, default=None,
+                    help="Season for league resolution. Defaults to current Jul-Jun cycle.")
+    ap.add_argument("--only-suspect", action="store_true",
+                    help="Only print rows flagged SUSPECT or NO_LEAGUE.")
+    args = ap.parse_args()
+
+    app = _make_app()
+    with app.app_context():
+        team = _resolve_team(args.team, args.team_api_id)
+        print("=" * 100)
+        print(
+            f"VERIFY radar league resolution for: {team.name}  "
+            f"(Team.id={team.id}, team_api_id={team.team_id})"
+        )
+        if args.season:
+            print(f"Season: {args.season}")
+        print("=" * 100)
+
+        tracked = (
+            TrackedPlayer.query
+            .filter(TrackedPlayer.team_id == team.id, TrackedPlayer.is_active.is_(True))
+            .order_by(TrackedPlayer.status, TrackedPlayer.player_name)
+            .all()
+        )
+        print(f"\nActive TrackedPlayer rows: {len(tracked)}\n")
+
+        counts = {"OK": 0, "SUSPECT": 0, "NO_LEAGUE": 0}
+        suspects: list[tuple[TrackedPlayer, tuple[int, str] | None, tuple[int | None, str | None]]] = []
+
+        header = (
+            f"  {'flag':<9} {'status':<11} {'name':<26} {'current club':<26} "
+            f"{'resolved league':<26} {'local-DB league':<26}"
+        )
+        print(header)
+        print("  " + "-" * (len(header) - 2))
+
+        for tp in tracked:
+            resolved = resolve_player_league(tp.player_api_id, season=args.season)
+            local = _local_team_league(tp.current_club_api_id)
+            verdict = _verdict(
+                team.team_id,
+                team.name,
+                tp.status or "",
+                tp.current_club_api_id,
+                tp.current_club_name,
+                resolved,
+            )
+            counts[verdict] += 1
+
+            if args.only_suspect and verdict == "OK":
+                continue
+
+            current_label = f"{tp.current_club_name or '-'}"[:25]
+            resolved_label = f"{resolved[1]} ({resolved[0]})" if resolved else "-"
+            local_label = f"{local[1]} ({local[0]})" if local[0] else "-"
+
+            line = (
+                f"  [{verdict:<7}] {tp.status or '?':<11} "
+                f"{(tp.player_name or '?')[:25]:<26} "
+                f"{current_label:<26} "
+                f"{resolved_label[:25]:<26} "
+                f"{local_label[:25]:<26}"
+            )
+            print(line)
+
+            if verdict in ("SUSPECT", "NO_LEAGUE"):
+                suspects.append((tp, resolved, local))
+
+        print("\nCounts:")
+        for k, v in counts.items():
+            print(f"  {k:<10} {v}")
+
+        if suspects:
+            print(f"\nDetail on {len(suspects)} flagged row(s):")
+            for tp, resolved, local in suspects:
+                print(
+                    f"  - id={tp.id} api={tp.player_api_id} {tp.player_name}  "
+                    f"status={tp.status}  pinned_parent={tp.pinned_parent}"
+                )
+                print(
+                    f"      current_club_api_id={tp.current_club_api_id}  "
+                    f"current_club_db_id={tp.current_club_db_id}  "
+                    f"current_club_name={tp.current_club_name!r}"
+                )
+                print(f"      resolve_player_league → {resolved}")
+                print(f"      local teams.league_id → {local}")
+                if tp.current_club_api_id:
+                    api_lookup = _team_league_from_api(
+                        tp.current_club_api_id, args.season or _default_season()
+                    )
+                    print(f"      API-Football says   → {api_lookup}")
+
+        print("\nDONE")
+
+
+def _default_season() -> int:
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc)
+    return now.year if now.month >= 7 else now.year - 1
+
+
+if __name__ == "__main__":
+    main()

--- a/academy-watch-backend/src/services/radar_stats_service.py
+++ b/academy-watch-backend/src/services/radar_stats_service.py
@@ -127,6 +127,67 @@ def _cache_set(key: Tuple, data: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
+# In-memory cache for team→domestic-league lookups via API-Football
+# ---------------------------------------------------------------------------
+_team_league_cache: Dict[Tuple[int, int], Tuple[float, Optional[Tuple[int, str]]]] = {}
+_TEAM_LEAGUE_CACHE_TTL = 24 * 3600  # 24 hours; league membership is stable across a season
+
+
+def _team_league_from_api(team_api_id: int, season: int) -> Optional[Tuple[int, str]]:
+    """Ground-truth lookup of a team's primary domestic league via API-Football.
+
+    Used as the *first* step in resolve_player_league so we don't trust local
+    teams.league_id, which can drift (cup competitions, promotion/relegation,
+    teams first ingested via a friendly mean a single FK can disagree with
+    reality). Returns (league_api_id, league_name) for the first domestic
+    "League"-type competition the team is in for that season, or None if the
+    API is unavailable / the team has no domestic league. Result (including
+    None) is cached in-process for 24h.
+    """
+    if not team_api_id or not season:
+        return None
+
+    key = (int(team_api_id), int(season))
+    entry = _team_league_cache.get(key)
+    if entry and (time.time() - entry[0]) < _TEAM_LEAGUE_CACHE_TTL:
+        return entry[1]
+
+    api_key = os.getenv("API_FOOTBALL_KEY")
+    if not api_key:
+        logger.debug(
+            "API_FOOTBALL_KEY not set — cannot resolve team %s league via API", team_api_id
+        )
+        return None
+
+    try:
+        from src.api_football_client import APIFootballClient
+        client = APIFootballClient(api_key=api_key)
+        resp = client._make_request("leagues", {"team": team_api_id, "season": season})
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "Failed to resolve team %s league via API-Football: %s", team_api_id, e
+        )
+        # Don't cache failures — let the next call retry.
+        return None
+
+    leagues = (resp or {}).get("response", []) or []
+
+    # Prefer first "League"-type domestic competition; skip Cups, Friendlies, etc.
+    resolved: Optional[Tuple[int, str]] = None
+    for league_entry in leagues:
+        league_info = (league_entry or {}).get("league", {}) or {}
+        if league_info.get("type") == "League":
+            lid = league_info.get("id")
+            lname = league_info.get("name")
+            if lid and lname:
+                resolved = (int(lid), str(lname))
+                break
+
+    _team_league_cache[key] = (time.time(), resolved)
+    return resolved
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -372,21 +433,32 @@ def _league_from_fixture_dicts(fixtures_data: List[dict]) -> Optional[Tuple[int,
     return None
 
 
-def _league_from_fixtures(player_api_id: int) -> Optional[Tuple[int, str]]:
-    """Extract league from the player's most recent fixture raw_json."""
+def _league_from_fixtures(
+    player_api_id: int,
+    current_club_api_id: Optional[int] = None,
+) -> Optional[Tuple[int, str]]:
+    """Extract league from the player's most recent fixture raw_json.
+
+    If `current_club_api_id` is provided, only fixtures the player played
+    *for that club* are considered — this stops a Forest U21 PL2 fixture
+    from leaking into the radar of a player who is currently on loan at a
+    lower-tier club.
+    """
     import json
     from src.models.weekly import Fixture, FixturePlayerStats
 
-    row = (
+    query = (
         db.session.query(Fixture.raw_json)
         .join(FixturePlayerStats, FixturePlayerStats.fixture_id == Fixture.id)
         .filter(
             FixturePlayerStats.player_api_id == player_api_id,
             Fixture.raw_json.isnot(None),
         )
-        .order_by(Fixture.date_utc.desc())
-        .first()
     )
+    if current_club_api_id:
+        query = query.filter(FixturePlayerStats.team_api_id == current_club_api_id)
+
+    row = query.order_by(Fixture.date_utc.desc()).first()
     if not row or not row.raw_json:
         return None
     try:
@@ -401,8 +473,11 @@ def _league_from_fixtures(player_api_id: int) -> Optional[Tuple[int, str]]:
     return None
 
 
-def resolve_player_league(player_api_id: int) -> Optional[Tuple[int, str]]:
-    """Resolve a player's league from their tracked club.
+def resolve_player_league(
+    player_api_id: int,
+    season: Optional[int] = None,
+) -> Optional[Tuple[int, str]]:
+    """Resolve a player's current-league for the radar comparison.
 
     Returns (league_api_id, league_name) or None.
 
@@ -411,16 +486,33 @@ def resolve_player_league(player_api_id: int) -> Optional[Tuple[int, str]]:
     playing in. A loanee at Barrow → League Two. A first-team breakthrough
     at Forest → Premier League.
 
-    We deliberately do NOT fall back to the parent academy club if the
-    current club has no league row in our DB. That fallback is the literal
-    source of "Barrow loanee compared to Premier League" — the parent club
-    (Forest) is in the PL, so the radar would silently use PL averages
-    even though the player is in League Two. It's better to render no
-    league overlay (the chart says "League comparison unavailable for X")
-    than to mis-attribute the comparison to the wrong league.
+    Resolution order:
+      1. API-Football `/leagues?team=...&season=...` for the player's
+         current_club_api_id. This is ground truth and bypasses any local
+         data drift (`teams.league_id` can be wrong if the team was first
+         ingested via a cup competition or hasn't been re-keyed after
+         promotion/relegation). Cached in-process for 24h.
+      2. Local Team→League join as a safety net when the API is unreachable
+         or returns nothing.
+      3. The player's most-recent FixturePlayerStats fixture, scoped to
+         their current club so we don't accidentally surface a parent-club
+         fixture's league.
+
+    We deliberately do NOT fall back to the parent academy club if all
+    three steps fail. That fallback is the literal source of "Barrow
+    loanee compared to Premier League" — the parent club (Forest) is in
+    the PL, so the radar would silently use PL averages even though the
+    player is in League Two. It's better to render no league overlay
+    (the chart says "League comparison unavailable for X") than to
+    mis-attribute the comparison to the wrong league.
     """
     from src.models.league import Team, League
     from src.models.tracked_player import TrackedPlayer
+
+    if season is None:
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc)
+        season = now.year if now.month >= 7 else now.year - 1
 
     def _league_from_team(team: "Team") -> Optional[Tuple[int, str]]:
         if not team or not team.league_id:
@@ -435,29 +527,39 @@ def resolve_player_league(player_api_id: int) -> Optional[Tuple[int, str]]:
         .filter_by(player_api_id=player_api_id, is_active=True)
         .first()
     )
-    if tp:
-        # 1. Current club via DB id (canonical relationship)
-        if tp.current_club_db_id:
-            team = Team.query.filter_by(id=tp.current_club_db_id).first()
-            result = _league_from_team(team)
-            if result:
-                return result
+    if not tp:
+        # No TrackedPlayer → no current club known → no comparison.
+        return None
 
-        # 2. Current club via API id (fallback when current_club_db_id wasn't
-        #    populated by the classifier — common for older records)
-        if tp.current_club_api_id:
-            team = Team.query.filter_by(team_id=tp.current_club_api_id).first()
-            result = _league_from_team(team)
-            if result:
-                return result
+    # Determine the player's current-club API id. Prefer current_club_api_id
+    # (set directly by the classifier from API-Football), fall back to
+    # current_club_db_id → Team.team_id for older records that only have the
+    # local FK populated.
+    current_api_id: Optional[int] = tp.current_club_api_id
+    if not current_api_id and tp.current_club_db_id:
+        current_team = Team.query.filter_by(id=tp.current_club_db_id).first()
+        if current_team:
+            current_api_id = current_team.team_id
 
-        # 3. Most recent fixture's raw_json league for this player. Only
-        #    used as a last sanity-check fallback because for limited-
-        #    coverage leagues (League Two etc.) FixturePlayerStats may be
-        #    empty entirely.
-        result = _league_from_fixtures(player_api_id)
+    if current_api_id:
+        # 1. Ground truth via API-Football (cached).
+        api_result = _team_league_from_api(current_api_id, season)
+        if api_result:
+            return api_result
+
+        # 2. Local DB safety net — used only if the API is unavailable or
+        #    the team has no domestic league in API-Football for this season.
+        team = Team.query.filter_by(team_id=current_api_id).first()
+        result = _league_from_team(team)
         if result:
             return result
+
+    # 3. Last-resort: scan the player's most recent FixturePlayerStats row
+    #    *scoped to their current club* so we never surface a parent-club
+    #    fixture's league.
+    result = _league_from_fixtures(player_api_id, current_club_api_id=current_api_id)
+    if result:
+        return result
 
     # Intentionally NO parent-club fallback — see docstring.
     return None
@@ -509,11 +611,14 @@ def get_radar_chart_data(
         (f.get("stats", {}).get("minutes") or 0) for f in fixtures_data
     )
 
-    # Resolve league: prefer the canonical current-club league from DB so the
-    # comparison is always against the player's actual league, even when
-    # fixture data is sparse or mis-attributed. Fixture-dict league is a
-    # sanity-check fallback only.
-    league_info = resolve_player_league(player_id) or _league_from_fixture_dicts(fixtures_data)
+    # Resolve league: prefer the canonical current-club league (API-Football
+    # ground truth, then local DB) so the comparison is always against the
+    # player's actual league, even when fixture data is sparse or mis-
+    # attributed. Fixture-dict league is a sanity-check fallback only.
+    league_info = (
+        resolve_player_league(player_id, season=season)
+        or _league_from_fixture_dicts(fixtures_data)
+    )
     league_name = None
     league_peers = 0
     league_avg: Dict[str, float] = {}


### PR DESCRIPTION
## Summary

D. Osong (loaned from Forest to Fleetwood Town) was being compared against Premier League peers in the radar player card. The protective parent-club fallback already existed in `resolve_player_league` — but local `teams.league_id` can drift (cup competitions, promotion/relegation, teams first ingested via a friendly), so the canonical Team→League join could still return the wrong league. We now treat the local FK as a hint and use API-Football as ground truth.

## What's in this PR

Three additive backend changes, no refactor:

1. **`resolve_player_league` asks API-Football first** (`services/radar_stats_service.py`).
   - New helper `_team_league_from_api(team_api_id, season)` calls `/leagues?team={id}&season={season}` and returns the first `type == "League"` (domestic, non-cup) result.
   - In-process cache (24h TTL) keyed by `(team_api_id, season)` so a Forest loanee modal opening 50 times only costs one API call.
   - Local Team→League join becomes the safety net for when the API is unreachable.
   - Verified end-to-end against API-Football locally:
     - Forest (65) → `Premier League (39)` ✓
     - Fleetwood Town (1336) → `League Two (42)` ✓

2. **Public `/journalists/chart-data` endpoint now scopes fixtures by `current_club_api_id`** (`routes/journalist.py`).
   - Mirrors the scoping `_fetch_chart_data_for_rendering` already does for the newsletter pre-render path.
   - Closes an asymmetry: the frontend modal (which hits this endpoint) was averaging a loanee's parent-club U21 fixtures together with their loan-club appearances, and the league overlay was picked from whichever fixture happened to be most recent.
   - Applied to `week`, `month`, and `season` date ranges.

3. **`_league_from_fixtures` (last-resort fallback) now accepts a `current_club_api_id` filter** so it never surfaces a parent-club fixture's league.

Also adds `src/scripts/verify_forest_player_leagues.py` — read-only audit that loops every active TrackedPlayer for a parent club and prints what `resolve_player_league` returns, flagging rows where a sub-PL loanee still resolves to Premier League. Modeled on the existing `audit_forest_tracked_players.py`. Will be runnable inside the prod container after deploy.

## Will existing data update?

- **Frontend modal**: yes, immediately. `/journalists/chart-data` re-runs the full pipeline on every request (no caching). The next time anyone opens Osong's card, it will be correct.
- **Newsletter PNGs**: no — those are baked at creation time (`weekly_newsletter_agent.py:1484`). Already-sent emails are frozen. Future newsletters generated after deploy will be correct.

## What this does NOT fix

If `tracked_players.current_club_api_id` is genuinely stale (e.g., the loan classifier never updated it from Forest to Fleetwood), the API will tell us "this player's club is Forest → Premier League" and the radar will reflect that — because that's what our source data says. That's a loan-classifier concern, not a radar concern. The verification script will surface any such rows for follow-up.

## Test plan

- [x] Local syntax + import-time check on `radar_stats_service.py` and `journalist.py`
- [x] Direct invocation of `_team_league_from_api(65, 2025)` → `(39, 'Premier League')`
- [x] Direct invocation of `_team_league_from_api(1336, 2025)` → `(42, 'League Two')`
- [x] Verification script smoke test against local DB (2 Forest rows, both released/sold with no current club, correctly resolve to `NO_LEAGUE`)
- [x] `pytest tests/test_radar_stats_service.py` — 19/19 pass (the one pre-existing failure in `test_radar_stats_e2e.py::test_full_radar_chart_data` references a key `peers_count` that the service has never returned; failure pre-dates this PR)
- [ ] After deploy: run `python -m src.scripts.verify_forest_player_leagues` inside prod container and confirm all Forest loanees resolve to their actual loan-club league (or `NO_LEAGUE` for sold/released)
- [ ] After deploy: open Osong's player card modal and confirm the legend reads "League Two Avg" (or no overlay), not "Premier League Avg"

🤖 Generated with [Claude Code](https://claude.com/claude-code)