### PR TITLE
fix: refresh-radar-charts endpoint should not swallow 404 as 500

### DIFF
--- a/academy-watch-backend/src/routes/api.py
+++ b/academy-watch-backend/src/routes/api.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, request, jsonify, make_response, render_template, Response, current_app, g, send_file
+from werkzeug.exceptions import HTTPException
 from src.models.league import db, League, Team, Newsletter, UserSubscription, EmailToken, PlayerFlag, FLAG_CATEGORIES, FLAG_STATUSES, AdminSetting, NewsletterComment, UserAccount, NewsletterPlayerYoutubeLink, NewsletterCommentary, Player, JournalistTeamAssignment, CommentaryApplause, TeamTrackingRequest, StripeSubscription, NewsletterDigestQueue, JournalistSubscription, BackgroundJob, TeamSubreddit, RedditPost, TeamAlias, ManualPlayerSubmission, CommunityTake, AcademyAppearance, PlayerComment, PlayerLink, _as_utc
 from src.models.tracked_player import TrackedPlayer
 from src.models.sponsor import Sponsor
@@ -7437,6 +7438,10 @@ def admin_refresh_newsletter_radar_charts(newsletter_id: int):
             'any_failed': any_failed,
             'players': results,
         })
+    except HTTPException:
+        # Let Flask render 404/etc. normally — get_or_404 raises NotFound and
+        # we don't want to swallow it as a generic 500.
+        raise
     except Exception as e:
         logger.exception('admin_refresh_newsletter_radar_charts failed')
         return jsonify(_safe_error_payload(e, 'Failed to refresh radar charts. Please try again later.')), 500


### PR DESCRIPTION
## Summary

Tiny follow-up to #102. The new `admin_refresh_newsletter_radar_charts` endpoint wraps its body in `try / except Exception`, which catches werkzeug's `NotFound` (raised by `get_or_404`) and converts it to a generic 500. Caller-visible 404s become 500s.

Hit while refreshing radar charts for Forest newsletter drafts that had been deleted between the LIST call and the POST. Prod logs clearly showed `404 Not Found` from `get_or_404`, but the curl client got HTTP 500 with a reference ID. Misleading.

## Fix

Re-raise `HTTPException` before the catch-all handler, so Flask returns the original status (404, 409, etc.) untouched. Real exceptions still get the safe payload + 500.

```python
except HTTPException:
    raise
except Exception as e:
    ...
    return jsonify(_safe_error_payload(...)), 500
```

## Test plan

- [x] Syntax + import-time check on `api.py`
- [ ] After deploy: `POST /api/admin/newsletters/9999999/refresh-radar-charts` should return HTTP 404 (not 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)