### PR TITLE
fix(radar): first-team players should compare against parent club's league

### DIFF
--- a/academy-watch-backend/src/services/radar_stats_service.py
+++ b/academy-watch-backend/src/services/radar_stats_service.py
@@ -541,6 +541,18 @@ def resolve_player_league(
         if current_team:
             current_api_id = current_team.team_id
 
+    # First-team players are at the parent academy club by definition. The
+    # loan classifier only populates current_club_api_id from transfer
+    # entries, so a first-team player who never had an explicit transfer
+    # event (academy → first-team promotion) will have NULL current_club_*.
+    # Falling back to the parent club is correct ONLY for status='first_team'
+    # — for loanees we explicitly do NOT do this (see the "Barrow loanee
+    # compared to Premier League" guard in the docstring above). Academy
+    # players are also excluded because they play in U18/U21/PL2 leagues
+    # that are separate from the parent's senior league.
+    if not current_api_id and tp.status == 'first_team' and tp.team:
+        current_api_id = tp.team.team_id
+
     if current_api_id:
         # 1. Ground truth via API-Football (cached).
         api_result = _team_league_from_api(current_api_id, season)


### PR DESCRIPTION
## Summary

K. Mainoo (Manchester United, Premier League first-team, 28 PL appearances) shows "League comparison unavailable" instead of being compared against PL midfielders. The user's hypothesis was exactly right: the radar logic doesn't fall back to the parent academy club when `status='first_team'`. Same bug visible across **25/25 ManU first-team TrackedPlayer rows** (verified on prod) and **8 of 22 non-academy Forest rows** from the earlier verification.

## Root cause

`tracked_players.current_club_api_id` is **NULL across the board** for `status='first_team'`. The loan classifier only writes the field from transfer entries; a player promoted internally academy → first team never has a transfer event to populate it from. `resolve_player_league` then has nothing to look up, the fixture-based last-resort fallback only works for the ~1 in 25 whose `Fixture.raw_json` happens to have populated `league.id`/`league.name` (de Ligt for ManU; secondary ingest-layer bug).

The radar service was deliberately written without a parent-club fallback to protect loanees from "Barrow loanee compared to Premier League". That guard is still correct for `status='on_loan'` — but for `status='first_team'` the parent academy club **IS** where the player is by definition. Gating the fallback on `status='first_team'` preserves the loanee protection.

## The fix

`services/radar_stats_service.py:resolve_player_league` — 12 lines (5 logic, 7 comment):

```python
if not current_api_id and tp.status == 'first_team' and tp.team:
    current_api_id = tp.team.team_id
```

Status gating:
- ✅ `'first_team'` — fall back to parent
- ❌ `'on_loan'` — protected (the original Osong-class bug)
- ❌ `'academy'` — they play in U18/U21/PL2 leagues separate from senior PL
- ❌ `'sold'`/`'released'` — current club genuinely unknown if not set

## Test plan

- [x] Syntax + import-time check
- [x] `pytest tests/test_radar_stats_service.py` — 19/19 pass
- [ ] After deploy: `GET /api/journalists/chart-data?player_id=284322&chart_type=radar&date_range=season` → `league_name = "Premier League"`, `league_peers ≈ 137`
- [ ] Loop all 25 ManU first-team players via chart-data → all 25 return Premier League
- [ ] Re-run Forest verification for the 8 previously NO_LEAGUE rows → all 8 now resolve to Premier League
- [ ] **Negative test:** loanees still resolve to their loan club's league, not parent (Osong → League Two, Bowler → League One, Berry → Pro League, Amass → Championship)

## Sequencing

This is **Part A** of a 3-part plan:
- **Part A** (this PR) — radar defensive fallback
- **Part B** — classifier hygiene fix so the underlying data stops being NULL (`classify_tracked_player` post-process + `refresh_and_heal` + `_seed_single_team` populate `current_club_api_id`/`current_club_db_id` for first-team status)
- **Part C** — idempotent `POST /admin/teams/<id>/track-and-verify` pipeline that re-runs every consistency check on track or re-track, with structured audit report

Plan file: `.claude/plans/delightful-painting-gem.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)