### PR TITLE
fix(radar): pick most recent TrackedPlayer row when player has multiple

### DIFF
--- a/academy-watch-backend/src/services/radar_stats_service.py
+++ b/academy-watch-backend/src/services/radar_stats_service.py
@@ -522,9 +522,19 @@ def resolve_player_league(
             return None
         return league.league_id, league.name
 
+    # A player can have multiple active TrackedPlayer rows (one per parent
+    # academy club they've passed through — e.g. J. Fletcher has rows under
+    # both Manchester United and a former club). Without an ordering hint,
+    # SQLAlchemy's .first() picks an implementation-defined row, which can
+    # silently surface a stale 'released' row instead of the live
+    # 'first_team' / 'on_loan' row at the player's current parent. Order by
+    # updated_at DESC so the most recently classified row wins. (Mirrors the
+    # ordering used by routes/journalist.py:get_chart_data when it resolves
+    # current_club_api_id.)
     tp = (
         TrackedPlayer.query
         .filter_by(player_api_id=player_api_id, is_active=True)
+        .order_by(TrackedPlayer.updated_at.desc())
         .first()
     )
     if not tp:


### PR DESCRIPTION
## Summary

Fast follow-up to #104. After Part A landed, 24 of 25 ManU first-team players resolved correctly. The lone holdout — **J. Fletcher** — has TWO active TrackedPlayer rows:

| id | team | status | updated_at |
|---|---|---|---|
| 20253 | (former club) | released | 15:08:12 |
| 20252 | Man United | first_team | 15:18:42 |

`resolve_player_league` did `.filter_by(player_api_id=...).first()` with no `.order_by()`, so SQLAlchemy returned an implementation-defined row. On prod it picked the `released` row, then the first-team parent-club fallback from #104 didn't fire (correctly — `released` shouldn't fall back to anything), and `chart-data` returned `league_name=null`.

## Fix

One-line `.order_by(TrackedPlayer.updated_at.desc())` so the most recently classified row wins. Mirrors the ordering already used by `routes/journalist.py:get_chart_data` (added in PR #101) when it resolves `current_club_api_id` for the same player.

## Test plan

- [x] `pytest tests/test_radar_stats_service.py` — 19/19 pass
- [ ] After deploy: `chart-data?player_id=383770` returns `league_name="Premier League"`
- [ ] Re-run the 25-player ManU sweep — all 25 should now show OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)