### PR TITLE
fix(classifier): populate current_club_* for first_team status + current_club_db_id everywhere

### DIFF
--- a/academy-watch-backend/src/routes/api.py
+++ b/academy-watch-backend/src/routes/api.py
@@ -11044,10 +11044,20 @@ def _seed_single_team(team, max_age=30, sync_journeys=True, years=4, season=None
                     api_client=_api,
                     latest_season=_get_latest_season(journey.id, parent_api_id=parent_api_id, parent_club_name=team.name) if journey else None,
                 )
-                if existing.status != new_status or existing.current_club_api_id != new_loan_id:
+                # Resolve the local Team FK so consumers that prefer
+                # current_club_db_id (radar comparison, journey badges,
+                # team-loans-out filters) don't have to do their own join.
+                new_db_id = None
+                if new_loan_id:
+                    target_team = Team.query.filter_by(team_id=new_loan_id).first()
+                    new_db_id = target_team.id if target_team else None
+                if (existing.status != new_status
+                        or existing.current_club_api_id != new_loan_id
+                        or existing.current_club_db_id != new_db_id):
                     existing.status = new_status
                     existing.current_club_api_id = new_loan_id
                     existing.current_club_name = new_loan_name
+                    existing.current_club_db_id = new_db_id
                 skipped += 1
                 continue
 
@@ -11083,6 +11093,13 @@ def _seed_single_team(team, max_age=30, sync_journeys=True, years=4, season=None
             if journey and journey.current_level:
                 current_level = journey.current_level
 
+            # Resolve the local Team FK alongside the API id so newly seeded
+            # rows have current_club_db_id populated from day one.
+            current_club_db_id_val = None
+            if current_club_api_id:
+                target_team_row = Team.query.filter_by(team_id=current_club_api_id).first()
+                current_club_db_id_val = target_team_row.id if target_team_row else None
+
             tp = TrackedPlayer(
                 player_api_id=pid,
                 player_name=player_name,
@@ -11096,6 +11113,7 @@ def _seed_single_team(team, max_age=30, sync_journeys=True, years=4, season=None
                 current_level=current_level,
                 current_club_api_id=current_club_api_id,
                 current_club_name=current_club_name,
+                current_club_db_id=current_club_db_id_val,
                 data_source='api-football',
                 data_depth='full_stats',
                 journey_id=journey.id if journey else None,

--- a/academy-watch-backend/src/services/transfer_heal_service.py
+++ b/academy-watch-backend/src/services/transfer_heal_service.py
@@ -223,6 +223,19 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False,
             tp.current_level = journey.current_level
             changed = True
 
+        # Resolve and write the local Team FK alongside the API id, so
+        # downstream consumers that prefer current_club_db_id (e.g. radar
+        # comparison resolution, team-loans-out filters, journey badges)
+        # don't have to do their own join. None is allowed when the API
+        # id points at a club we haven't ingested locally yet.
+        new_db_id = None
+        if new_loan_id:
+            target_team = Team.query.filter_by(team_id=new_loan_id).first()
+            new_db_id = target_team.id if target_team else None
+        if tp.current_club_db_id != new_db_id:
+            tp.current_club_db_id = new_db_id
+            changed = True
+
         if changed:
             updated += 1
             # Track loan club changes for fixture sync cascade

--- a/academy-watch-backend/src/utils/academy_classifier.py
+++ b/academy-watch-backend/src/utils/academy_classifier.py
@@ -156,9 +156,14 @@ def derive_player_status(
         (status, current_club_api_id, current_club_name)
         where status is one of 'academy', 'first_team', 'on_loan'
     """
-    # No current club info → assume still at academy
+    # No current club info → trust current_level. A first-team player who
+    # was promoted internally (academy → first team) will have NULL
+    # journey.current_club_api_id because there's no transfer event to
+    # write it from, but their current_level is still 'First Team'. The
+    # post-process at the end of classify_tracked_player will then
+    # populate current_club_api_id/name from the parent academy club.
     if not current_club_api_id:
-        return ('academy', None, None)
+        return (_base_status(current_level), None, None)
 
     # 1. International duty is never a loan
     if is_international_level(current_level):
@@ -196,12 +201,17 @@ def derive_player_status_with_reasoning(
     reasoning: List[Dict] = []
 
     if not current_club_api_id:
+        base = _base_status(current_level)
         reasoning.append({
             'rule': 'no_current_club', 'result': 'match',
             'check': 'current_club_api_id is null',
-            'detail': 'No current club info — defaulting to academy',
+            'detail': (
+                f'No current club info — falling back to current_level '
+                f'"{current_level}" → status="{base}". Will be populated '
+                f'from parent club by post-process if status is first_team.'
+            ),
         })
-        return 'academy', None, None, reasoning
+        return base, None, None, reasoning
     reasoning.append({
         'rule': 'no_current_club', 'result': 'pass',
         'check': 'current_club_api_id is not null',
@@ -571,6 +581,29 @@ def classify_tracked_player(
             status = 'released'
             loan_id = None
             loan_name = None
+
+    # ── Step 4: first-team current-club default ───────────────────────
+    # If the classifier resolved status='first_team' but left
+    # current_club_api_id/name unset (no transfer event ever wrote them —
+    # the player was promoted academy → first team internally), default to
+    # the parent academy club. The parent IS the player's current club for
+    # first-team status by definition. Keeping these fields NULL is what
+    # breaks downstream consumers (radar comparison league, journey
+    # "current club" badge, team-loans-out filters) — see PR #104 for the
+    # radar-side defensive fix.
+    if status == 'first_team' and not loan_id:
+        loan_id = parent_api_id
+        loan_name = parent_club_name
+        if with_reasoning:
+            reasoning.append({
+                'rule': 'first_team_parent_default',
+                'result': 'match',
+                'check': "status='first_team' and current_club_api_id is None",
+                'detail': (
+                    f'Defaulted current_club to parent academy club '
+                    f'{parent_api_id} ({parent_club_name})'
+                ),
+            })
 
     if with_reasoning:
         return (status, loan_id, loan_name, reasoning)


### PR DESCRIPTION
## Summary

**Part B** of the 3-part radar/classifier plan. Companion to PR #104/#105 (Part A — radar defensive fallback). This PR fixes the underlying data hygiene issue at the source: the loan classifier flow leaves first-team TrackedPlayer rows with NULL `current_club_api_id` / `current_club_name`, and the local FK `current_club_db_id` is never written by the main classifier callers at all (only by 3 special-case paths). Verified on prod: 25/25 ManU first-team rows and 8/22 Forest first-team rows have NULL current_club_*.

After this PR + a one-shot `POST /admin/tracked-players/refresh-statuses` against every tracked team, the radar's defensive fallback from PR #104 becomes a no-op for healthy data — every consumer of `current_club_api_id` / `current_club_db_id` (radar, journey badges, team-loans-out filters) gets correct data.

## Three small patches

### B1 — `academy_classifier.derive_player_status` early-return must consult `current_level`
The early `if not current_club_api_id: return ('academy', None, None)` ignored `current_level` entirely, so a first-team player with NULL `journey.current_club_api_id` was misclassified as 'academy'. Now falls back to `_base_status(current_level)`, which correctly maps `'First Team'` → `'first_team'`. Same fix applied to `derive_player_status_with_reasoning`.

### B1 — `academy_classifier.classify_tracked_player` Step 4 post-process
Catches the `(status='first_team', loan_id=None)` case from any of the five `derive_player_status` return paths and writes `parent_api_id` / `parent_club_name` as the `current_club` fields. The parent academy club IS the player's current club for first-team status by definition. Reasoning step `first_team_parent_default` is appended when `with_reasoning=True`.

### B2 — `transfer_heal_service.refresh_and_heal` also writes `current_club_db_id`
After writing `current_club_api_id` from the classifier result, resolve the local Team FK and write `current_club_db_id` too. None is allowed when the api_id points at a club we haven't ingested locally yet. This is the prod admin path triggered by `POST /admin/tracked-players/refresh-statuses`, so re-running it after this PR will repair every tracked team's first-team rows in one shot.

### B3 — `_seed_single_team` same treatment for fresh and existing rows
Both the existing-row update path and the new-row construction path now resolve and write `current_club_db_id`. Newly tracked teams get clean data on day one.

## Test plan

- [x] Direct unit tests on `classify_tracked_player` covering 5 cases:
  - `first_team / NULL current_club → first_team @ parent` ✅
  - `first_team / parent already set → unchanged` ✅
  - `academy / NULL current_club → academy, NOT defaulted to parent` ✅
  - `on_loan / different club → loan_id preserved` ✅
  - `with_reasoning` variant includes `first_team_parent_default` ✅
- [x] `pytest tests/test_radar_stats_service.py` — 19/19 pass
- [ ] After deploy: `POST /admin/tracked-players/refresh-statuses` body `{"team_id": <forest_db_id>}` — expect `rows_updated > 0`, then `GET /admin/tracked-players?team_id=<forest>&status=first_team` shows every row with `current_club_api_id=65` and `current_club_db_id=18`
- [ ] Same for ManU — 25 first-team rows updated
- [ ] Negative test: loanees still have their loan club's `current_club_*` (not parent)

## Sequencing

- ✅ Part A — radar defensive fallback (PR #104, #105)
- 👉 **Part B** (this PR) — classifier hygiene
- ⏭️ Part C — `POST /admin/teams/<id>/track-and-verify` idempotent pipeline (next PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)