### PR TITLE
feat(seed): auto-run consistency audit after every track/seed

### DIFF
--- a/academy-watch-backend/src/routes/api.py
+++ b/academy-watch-backend/src/routes/api.py
@@ -11252,6 +11252,23 @@ def _run_seed_team_process(job_id, team_id, max_age=30, sync_journeys=True, year
             update_job(job_id, current_player=f'Seeding {team.name}...')
             result = _seed_single_team(team, max_age=max_age,
                                        sync_journeys=sync_journeys, years=years)
+
+            # Phase 3: Consistency audit — surfaces any rows that didn't
+            # end up in a clean state after seed+classify, so a newly
+            # tracked team gets a "clean data" guarantee (or a clear
+            # report of what needs operator attention). Read-only —
+            # _seed_single_team already runs the classifier, so we don't
+            # need a second repair pass here.
+            update_job(job_id, current_player=f'Auditing {team.name}...')
+            try:
+                from src.services.team_verify import audit_team_consistency
+                audit = audit_team_consistency(team.id)
+                result['audit'] = audit
+            except Exception as audit_err:
+                logger.warning('Post-seed audit failed for team %s: %s',
+                               team.name, audit_err)
+                result['audit_error'] = str(audit_err)
+
             update_job(job_id, status='completed', progress=1, total=1,
                        results=result,
                        completed_at=datetime.now(timezone.utc).isoformat())
@@ -11334,11 +11351,36 @@ def _run_seed_teams_process(job_id, team_db_ids, max_age=30, sync_journeys=True,
                 try:
                     team_result = _seed_single_team(team, max_age=max_age,
                                                      sync_journeys=sync_journeys, years=years)
-                    results['teams'][team.name] = {
+                    team_summary = {
                         'created': team_result.get('created', 0),
                         'skipped': team_result.get('skipped', 0),
                         'candidates': team_result.get('candidates_found', 0),
                     }
+                    # Post-seed audit — same "clean data guarantee" as the
+                    # single-team worker. Per-team audit summary keeps the
+                    # bulk job result small; callers can re-run per-team
+                    # verify to get full row details.
+                    try:
+                        from src.services.team_verify import audit_team_consistency
+                        audit = audit_team_consistency(team.id)
+                        team_summary['audit'] = {
+                            'total_active': audit.get('total_active'),
+                            'ok': audit.get('ok'),
+                            'suspect_total': audit.get('suspect_total'),
+                            'suspect_first_team_null_current_club': audit
+                                .get('suspect_first_team_null_current_club', {}).get('count'),
+                            'suspect_loanee_null_current_club': audit
+                                .get('suspect_loanee_null_current_club', {}).get('count'),
+                            'suspect_db_id_unresolved': audit
+                                .get('suspect_db_id_unresolved', {}).get('count'),
+                            'parent_league_drift': audit
+                                .get('parent_league', {}).get('drift'),
+                        }
+                    except Exception as audit_err:
+                        logger.warning('Post-seed audit failed for team %s: %s',
+                                       team.name, audit_err)
+                        team_summary['audit_error'] = str(audit_err)
+                    results['teams'][team.name] = team_summary
                 except Exception as team_err:
                     logger.warning('seed_teams: failed for %s: %s', team.name, team_err)
                     results['errors'].append(f'{team.name}: {team_err}')


### PR DESCRIPTION
## Summary

Closes the "one-button track" loop from the Part C plan. When a team is newly tracked (or re-tracked after being untracked), the seed worker already seeds `TrackedPlayer` rows via `_seed_single_team → classify_tracked_player` — and #106 made both the classifier and the seed flow write `current_club_api_id` / `current_club_db_id` correctly for first-team status.

This PR adds a **Phase 3 audit step** at the end of both seed workers. The audit is **read-only** — it calls `audit_team_consistency()` from #107's `team_verify` service and attaches the result to the seed job's `results` payload.

- `_run_seed_team_process` (single-team, used by `PUT /admin/teams/<id>/tracking` auto-seed and `POST /admin/tracked-players/seed-team`): full audit report in `results.audit`
- `_run_seed_teams_process` (bulk, used by `PUT /admin/teams/bulk-track`): per-team audit **summary** (counts + drift flag only, no per-row detail) to keep the job result small. Operators can re-run `/verify` per team for full diagnostics.

## End-to-end promise (after this lands)

1. Flip `is_tracked=True` → auto-seed kicks off
2. Seed worker seeds + classifies (#104/#106 correctness)
3. Seed worker runs `audit_team_consistency` (this PR)
4. Job result includes audit report with 0 suspects for clean data
5. If a new bug class slips in, the audit shows exactly which rows and why — visible at the job-status poll

## Test plan

- [x] Syntax + import-time check
- [x] `pytest tests/test_radar_stats_service.py` — 19/19 pass
- [ ] After deploy: flip `is_tracked` on a test team, poll seed job, confirm `results.audit` block is populated with the expected structure
- [ ] Bulk track 2-3 teams, confirm each `results.teams[name].audit` is a counts-only summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)