### PR TITLE
fix(chart-data): scope fixtures by current_club only for loanees, not first_team

### DIFF
--- a/academy-watch-backend/src/routes/journalist.py
+++ b/academy-watch-backend/src/routes/journalist.py
@@ -1060,13 +1060,21 @@ def get_chart_data():
         # Validate stat keys
         stat_keys = [k for k in stat_keys if k in ALL_STAT_KEYS]
 
-        # Resolve the player's current club so all chart fixtures are scoped
-        # to it. Loanee at Barrow → only Barrow fixtures. First-team player at
-        # Forest → only Forest fixtures. Without this filter the radar would
-        # average a loanee's lower-tier appearances together with their
-        # parent-club U21 appearances — and the league overlay would be
-        # picked from whichever fixture happened to be most recent.
-        # (Mirrors _fetch_chart_data_for_rendering's scoping for newsletters.)
+        # Resolve the player's current club so chart fixtures for LOANEES are
+        # scoped to the loan/buying club. Loanee at Barrow → only Barrow
+        # fixtures. This protects against the original "parent-club U21
+        # fixtures leaking into the radar" bug (see PR #101 and the
+        # Osong/Fleetwood investigation).
+        #
+        # We deliberately do NOT scope for status='first_team' or 'academy'.
+        # A "First Team" player's current_club_api_id points at the parent
+        # senior team, but academy-level players classified as first-team
+        # (e.g. ManU youth GKs on the first-team sheet) have their actual
+        # FixturePlayerStats records under a youth team_api_id — scoping to
+        # the senior team's id returns zero fixtures and makes the radar
+        # empty. For these statuses we pull all fixtures and let the
+        # league-resolution logic in resolve_player_league (which uses
+        # API-Football as the source of truth) handle the overlay.
         current_club_api_id: int | None = None
         try:
             tp_for_scope = (
@@ -1075,7 +1083,9 @@ def get_chart_data():
                 .order_by(TrackedPlayer.updated_at.desc())
                 .first()
             )
-            if tp_for_scope and tp_for_scope.current_club_api_id:
+            if (tp_for_scope
+                    and tp_for_scope.current_club_api_id
+                    and tp_for_scope.status in ('on_loan', 'sold')):
                 current_club_api_id = tp_for_scope.current_club_api_id
         except Exception:
             pass
@@ -1799,10 +1809,18 @@ def _fetch_chart_data_for_rendering(player_id: int, chart_type: str, stat_keys: 
 
         from datetime import date, timedelta
 
-        # Resolve the player's current club so all chart fixtures are scoped to
-        # it. Loanee at Barrow → only Barrow fixtures. First-team player at
-        # Forest → only Forest fixtures. None means "no filter" (public API
-        # callers that don't go through this internal helper).
+        # Scope chart fixtures to the current club ONLY for loanees / sold
+        # players — those are the cases where fixture leakage from the
+        # parent club is a real bug (see PR #101 and the Osong/Fleetwood
+        # investigation). For status='first_team' or 'academy', the
+        # TrackedPlayer's current_club_api_id points at the parent senior
+        # team, but academy-level players classified as first-team have
+        # their actual FixturePlayerStats records under a youth
+        # team_api_id. Scoping to the senior team returns zero fixtures
+        # and makes the radar empty. For those statuses we leave
+        # current_club_api_id=None so all fixtures are pulled, and the
+        # league overlay still comes from resolve_player_league (which
+        # uses API-Football as the source of truth).
         current_club_api_id = None
         try:
             tp = (
@@ -1811,7 +1829,7 @@ def _fetch_chart_data_for_rendering(player_id: int, chart_type: str, stat_keys: 
                 .order_by(TrackedPlayer.updated_at.desc())
                 .first()
             )
-            if tp and tp.current_club_api_id:
+            if tp and tp.current_club_api_id and tp.status in ('on_loan', 'sold'):
                 current_club_api_id = tp.current_club_api_id
         except Exception:
             pass


### PR DESCRIPTION
## Summary

Regression fix discovered while dry-running the newsletter radar refresh for ManU 189-192: 3 of 11 player radars return `no radar data returned` (Elyh Harrison, Sonny Aljofree, H. Ogunneye). Mainoo is fine. All three are ManU academy-level players tagged `current_level='First Team'` for squad purposes — Part B correctly set their `current_club_api_id=33`, but their actual `FixturePlayerStats` records are under a youth `team_api_id`, not 33. The scoped query returns empty.

## Root cause

The fixture-scoping from #101 was built for the loanee case — where `current_club_api_id` is where the player actually plays. For first-team-tagged academy players, `current_club_api_id` points at the senior team but their matches are at youth level.

## Fix

Scope only when `tp.status in ('on_loan', 'sold')`. For `status='first_team'` or `'academy'`, leave `current_club_api_id=None` so all fixtures are pulled. The league overlay still comes from `resolve_player_league`, which uses API-Football as the source of truth, so senior ManU players still resolve to "Premier League" and pure academy players still get no overlay (correct).

Applied in both callsites:
- `routes/journalist.py:get_chart_data` (public `/journalists/chart-data` endpoint)
- `routes/journalist.py:_fetch_chart_data_for_rendering` (newsletter pre-render helper — used by `POST /admin/newsletters/<id>/refresh-radar-charts`)

## Does this reintroduce the Osong bug?

No. Osong is `status='on_loan'`, so scoping still applies for him — his radar still only pulls Fleetwood fixtures. Only `first_team` / `academy` lose the scoping, and for those statuses the "parent club leakage" concern doesn't apply (the parent IS where they are).

## Test plan

- [x] Syntax + import check
- [x] `pytest tests/test_radar_stats_service.py` — 19/19 pass
- [ ] After deploy: dry-run refresh of ManU newsletter 192 — Harrison/Aljofree/Ogunneye should no longer be `no radar data returned`
- [ ] **Negative test:** chart-data for D. Osong still returns League Two (141 peers), not Premier League

🤖 Generated with [Claude Code](https://claude.com/claude-code)