### PR TITLE
fix(radar): parent-club fallback requires actual senior FixturePlayerStats

### DIFF
--- a/academy-watch-backend/src/services/radar_stats_service.py
+++ b/academy-watch-backend/src/services/radar_stats_service.py
@@ -551,17 +551,37 @@ def resolve_player_league(
         if current_team:
             current_api_id = current_team.team_id
 
-    # First-team players are at the parent academy club by definition. The
-    # loan classifier only populates current_club_api_id from transfer
-    # entries, so a first-team player who never had an explicit transfer
-    # event (academy → first-team promotion) will have NULL current_club_*.
-    # Falling back to the parent club is correct ONLY for status='first_team'
-    # — for loanees we explicitly do NOT do this (see the "Barrow loanee
-    # compared to Premier League" guard in the docstring above). Academy
-    # players are also excluded because they play in U18/U21/PL2 leagues
-    # that are separate from the parent's senior league.
+    # First-team players are at the parent academy club by definition —
+    # BUT "first_team" is a journey/squad-level label that doesn't always
+    # mean the player actually plays senior matches. Clubs like Manchester
+    # United tag academy goalkeepers and some U21 players with
+    # current_level='First Team' for squad numbering purposes, even though
+    # their actual matches are in U21/PL2. Blindly falling back to the
+    # parent senior league for those players mis-compares their U21 stats
+    # against senior PL averages.
+    #
+    # Gate the fallback on "has the player actually played at least one
+    # senior match for the parent club this season?" — checked via
+    # FixturePlayerStats, where team_api_id is the team the player played
+    # FOR in that fixture. If they have senior appearances, use the parent
+    # league. If not, return None (no overlay) — the chart self-normalises
+    # to player peak and at least doesn't lie about the comparison league.
+    #
+    # Loanees still don't fall back to parent (see docstring). Academy
+    # players are excluded because their matches are in separate U18/U21
+    # leagues we don't have comparison data for.
     if not current_api_id and tp.status == 'first_team' and tp.team:
-        current_api_id = tp.team.team_id
+        from src.models.weekly import FixturePlayerStats, Fixture
+        has_senior_this_season = db.session.query(FixturePlayerStats.id).join(
+            Fixture, FixturePlayerStats.fixture_id == Fixture.id,
+        ).filter(
+            FixturePlayerStats.player_api_id == player_api_id,
+            FixturePlayerStats.team_api_id == tp.team.team_id,
+            Fixture.season == season,
+        ).limit(1).first() is not None
+
+        if has_senior_this_season:
+            current_api_id = tp.team.team_id
 
     if current_api_id:
         # 1. Ground truth via API-Football (cached).


### PR DESCRIPTION
## Summary

**Bug exposed by newsletter dry-run.** User pointed out: "those players are not in the premier league. we've completely goofed it up". They were right.

The parent-club fallback in #104 was over-eager. It blindly assumed `status='first_team'` means "plays in the parent club's senior league". But clubs like Manchester United tag academy goalkeepers and some U21 players with `current_level='First Team'` for squad numbering purposes even though their actual matches are in U21/PL2.

Symptom: E. Harrison (ManU U21 GK), S. Aljofree (U21), H. Ogunneye (U21) all show "Premier League Avg" on their radar charts when those players have never played a Premier League match. Their U21 per-90 numbers get compared against senior PL averages. Fictional.

## Fix

Gate the parent-club fallback on "has the player actually played at least one senior `FixturePlayerStats` match for the parent club this season?". SQL:

```python
has_senior_this_season = db.session.query(FixturePlayerStats.id).join(
    Fixture, FixturePlayerStats.fixture_id == Fixture.id,
).filter(
    FixturePlayerStats.player_api_id == player_api_id,
    FixturePlayerStats.team_api_id == tp.team.team_id,
    Fixture.season == season,
).limit(1).first() is not None
```

- If the player has senior appearances → use parent league (Mainoo, Murillo, Williams, Abbott, McAtee, etc. still resolve correctly).
- If not → return None, chart falls through to self-normalized player-only view. At least it doesn't lie about the comparison league.

Loanees (`status='on_loan'`) are unchanged — they're protected by the existing guard and don't hit this code path.

## Test plan

- [x] `pytest tests/test_radar_stats_service.py` — 19/19 pass
- [ ] After deploy: re-dry-run ManU newsletter 192 — Harrison/Aljofree/Ogunneye should show `league='(none)'` and Mainoo should still show `Premier League 138 peers`
- [ ] Negative test: D. Osong still resolves to League Two (141 peers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)