### PR TITLE
fix(radar): parent fallback needs 90+ senior minutes, not just a row

### DIFF
--- a/academy-watch-backend/src/services/radar_stats_service.py
+++ b/academy-watch-backend/src/services/radar_stats_service.py
@@ -571,16 +571,27 @@ def resolve_player_league(
     # players are excluded because their matches are in separate U18/U21
     # leagues we don't have comparison data for.
     if not current_api_id and tp.status == 'first_team' and tp.team:
+        from sqlalchemy import func as _sa_func
         from src.models.weekly import FixturePlayerStats, Fixture
-        has_senior_this_season = db.session.query(FixturePlayerStats.id).join(
+        # Sum of minutes played for the parent senior team this season.
+        # "Row exists" isn't enough because youth GKs regularly get
+        # bench-called for senior cup matches (FA Cup, League Cup) with
+        # 0 minutes — those produce a FixturePlayerStats row with
+        # team_api_id=parent and minutes=0. Without a minutes threshold,
+        # an academy GK on loan at a League Two club gets "Premier
+        # League Avg" because of 3 bench rows. Require at least one full
+        # senior match (>=90 minutes) to count as genuinely first-team.
+        senior_minutes = db.session.query(
+            _sa_func.coalesce(_sa_func.sum(FixturePlayerStats.minutes), 0)
+        ).join(
             Fixture, FixturePlayerStats.fixture_id == Fixture.id,
         ).filter(
             FixturePlayerStats.player_api_id == player_api_id,
             FixturePlayerStats.team_api_id == tp.team.team_id,
             Fixture.season == season,
-        ).limit(1).first() is not None
+        ).scalar() or 0
 
-        if has_senior_this_season:
+        if senior_minutes >= 90:
             current_api_id = tp.team.team_id
 
     if current_api_id:


### PR DESCRIPTION
## Summary

Follow-up to #110. Previous attempt checked for ANY `FixturePlayerStats` row at `team_api_id=parent` — but that passed for players like Elyh Harrison (ManU U21 GK on loan to a League Two club) because youth GKs get called to the ManU senior bench for FA Cup / League Cup matches with 0 minutes, producing rows with `team_api_id=33` that don't represent actual senior football.

## The real data for Harrison / Aljofree / Ogunneye

- 21 League Two matches (on-loan)
- 3 FA Cup bench calls at ManU (0 minutes each)
- 1 League Cup bench call at ManU (0 minutes)

Row-existence check let them through → radar claimed "Premier League Avg" with 28–137 peers for players who've played ZERO senior PL minutes. User called this out: *"those players are not in the premier league. we've completely goofed it up."*

## Fix

Sum `FixturePlayerStats.minutes` for parent-team rows this season, require `>= 90` (one full senior match). Bench-only youth players fail the check → no overlay → chart falls through to self-normalized player view. Mainoo (1291 senior minutes) still passes → Premier League overlay stays correct.

## Deeper issue (tracked, not fixed here)

The real fix is to correct these players' `TrackedPlayer.status` from `'first_team'` to `'on_loan'` — a loan classifier issue. The radar-side minute-threshold stops the symptom regardless.

## Test plan

- [x] `pytest tests/test_radar_stats_service.py` — 19/19 pass
- [ ] After deploy: re-dry-run ManU newsletter 192, Harrison/Aljofree/Ogunneye should show `league=(none)`
- [ ] Mainoo still shows Premier League 138
- [ ] Osong still resolves to League Two 141

🤖 Generated with [Claude Code](https://claude.com/claude-code)