### PR TITLE
fix: bump pydantic-core to 2.46.1 (resolves deploy failure)

### DIFF
--- a/academy-watch-backend/requirements.txt
+++ b/academy-watch-backend/requirements.txt
@@ -57,7 +57,7 @@ psycopg==3.3.3
 psycopg-binary==3.3.3
 pydantic==2.13.1
 pydantic-settings==2.13.1
-pydantic_core==2.46.0
+pydantic_core==2.46.1
 pydyf==0.12.1
 Pygments==2.20.0
 pyparsing==3.3.2


### PR DESCRIPTION
## Summary
Unblocks production deploy. pydantic 2.13.1 requires pydantic-core==2.46.1, but requirements.txt was pinned to 2.46.0 → ResolutionImpossible during Docker build.

## Why this came up now
This is the bump that PR #171 was bringing. I closed #171 assuming Dependabot would recreate it, but the deploy pipeline revealed the existing pin was already broken — the next deploy after #172's merge surfaced it.

## Test plan
- [ ] CI passes
- [ ] Backend deploys successfully to Azure

🤖 Generated with [Claude Code](https://claude.com/claude-code)