### PR TITLE
Video analysis Phase A: match upload, processing lifecycle, tag review

### DIFF
--- a/academy-watch-backend/migrations/versions/vid01_add_video_analysis_tables.py
+++ b/academy-watch-backend/migrations/versions/vid01_add_video_analysis_tables.py
@@ -1,0 +1,183 @@
+"""Add video-analysis tables (Phase A concierge MVP)
+
+Revision ID: vid01
+Revises: aw13
+Create Date: 2026-06-12
+
+Tables: video_matches, video_analysis_jobs, video_roster_entries,
+video_tracklets, video_player_reports, video_credit_ledger.
+Spec: ledgers/CONTINUITY_video-analysis.md "Data model" section.
+All DDL is guarded — the production DB has had objects created out-of-band.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from migrations._migration_helpers import create_index_safe, table_exists
+
+# revision identifiers, used by Alembic.
+revision = "vid01"
+down_revision = "aw13"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if not table_exists("video_matches"):
+        op.create_table(
+            "video_matches",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("team_id", sa.Integer(), sa.ForeignKey("teams.id"), nullable=False),
+            sa.Column("opponent_name", sa.String(200), nullable=True),
+            sa.Column("match_date", sa.Date(), nullable=True),
+            sa.Column("competition", sa.String(200), nullable=True),
+            sa.Column("our_kit_color", sa.String(50), nullable=True),
+            sa.Column("opponent_kit_color", sa.String(50), nullable=True),
+            sa.Column("capture_meta", sa.JSON(), nullable=True),
+            sa.Column("blob_path", sa.String(500), nullable=True),
+            sa.Column("blob_etag", sa.String(100), nullable=True),
+            sa.Column("duration_s", sa.Float(), nullable=True),
+            sa.Column("kickoff_s", sa.Float(), nullable=True),
+            sa.Column("halftime_s", sa.Float(), nullable=True),
+            sa.Column("second_half_kickoff_s", sa.Float(), nullable=True),
+            sa.Column("our_team_cluster", sa.Integer(), nullable=True),
+            sa.Column("status", sa.String(20), nullable=False, server_default="created"),
+            sa.Column("quality_score", sa.Float(), nullable=True),
+            sa.Column("quality_flags", sa.JSON(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("uploaded_at", sa.DateTime(), nullable=True),
+            sa.Column("finalized_at", sa.DateTime(), nullable=True),
+            sa.Column("expires_at", sa.DateTime(), nullable=True),
+        )
+    create_index_safe("ix_video_matches_team_id", "video_matches", ["team_id"])
+    create_index_safe("ix_video_matches_status", "video_matches", ["status"])
+
+    if not table_exists("video_analysis_jobs"):
+        op.create_table(
+            "video_analysis_jobs",
+            sa.Column("id", sa.String(36), primary_key=True),
+            sa.Column("video_match_id", sa.Integer(), sa.ForeignKey("video_matches.id"), nullable=False),
+            sa.Column("status", sa.String(20), nullable=False, server_default="queued"),
+            sa.Column("stage", sa.String(30), nullable=True),
+            sa.Column("progress", sa.Integer(), nullable=True, server_default="0"),
+            sa.Column("attempt", sa.Integer(), nullable=False, server_default="1"),
+            sa.Column("worker_id", sa.String(100), nullable=True),
+            sa.Column("error", sa.Text(), nullable=True),
+            sa.Column("gpu_seconds", sa.Float(), nullable=True),
+            sa.Column("pipeline_version", sa.String(40), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("started_at", sa.DateTime(), nullable=True),
+            sa.Column("heartbeat_at", sa.DateTime(), nullable=True),
+            sa.Column("completed_at", sa.DateTime(), nullable=True),
+        )
+    create_index_safe("ix_video_analysis_jobs_match", "video_analysis_jobs", ["video_match_id"])
+    create_index_safe("ix_video_analysis_jobs_status", "video_analysis_jobs", ["status"])
+
+    if not table_exists("video_roster_entries"):
+        op.create_table(
+            "video_roster_entries",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("video_match_id", sa.Integer(), sa.ForeignKey("video_matches.id"), nullable=False),
+            sa.Column("player_name", sa.String(200), nullable=False),
+            sa.Column("jersey_number", sa.Integer(), nullable=False),
+            sa.Column("position", sa.String(50), nullable=True),
+            sa.Column(
+                "tracked_player_id",
+                sa.Integer(),
+                sa.ForeignKey("tracked_players.id"),
+                nullable=True,
+            ),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.UniqueConstraint("video_match_id", "jersey_number", name="uq_video_roster_match_number"),
+        )
+    create_index_safe("ix_video_roster_entries_match", "video_roster_entries", ["video_match_id"])
+
+    if not table_exists("video_tracklets"):
+        op.create_table(
+            "video_tracklets",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("video_match_id", sa.Integer(), sa.ForeignKey("video_matches.id"), nullable=False),
+            sa.Column("kind", sa.String(10), nullable=False, server_default="fragment"),
+            sa.Column("pipeline_key", sa.String(40), nullable=True),
+            sa.Column("team_cluster", sa.Integer(), nullable=True),
+            sa.Column("suggested_number", sa.Integer(), nullable=True),
+            sa.Column("suggested_role", sa.String(20), nullable=True),
+            sa.Column("confidence", sa.String(10), nullable=True),
+            sa.Column("merge_confidence", sa.Float(), nullable=True),
+            sa.Column("contaminated", sa.Boolean(), nullable=False, server_default="false"),
+            sa.Column("first_s", sa.Float(), nullable=True),
+            sa.Column("last_s", sa.Float(), nullable=True),
+            sa.Column("visible_s", sa.Float(), nullable=True),
+            sa.Column("thumbnail_paths", sa.JSON(), nullable=True),
+            sa.Column("evidence", sa.JSON(), nullable=True),
+            sa.Column(
+                "roster_entry_id",
+                sa.Integer(),
+                sa.ForeignKey("video_roster_entries.id"),
+                nullable=True,
+            ),
+            sa.Column("tag_source", sa.String(10), nullable=True),
+            sa.Column("dismissed", sa.Boolean(), nullable=False, server_default="false"),
+        )
+    create_index_safe("ix_video_tracklets_match", "video_tracklets", ["video_match_id"])
+    create_index_safe("ix_video_tracklets_roster", "video_tracklets", ["roster_entry_id"])
+
+    if not table_exists("video_player_reports"):
+        op.create_table(
+            "video_player_reports",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("video_match_id", sa.Integer(), sa.ForeignKey("video_matches.id"), nullable=False),
+            sa.Column(
+                "roster_entry_id",
+                sa.Integer(),
+                sa.ForeignKey("video_roster_entries.id"),
+                nullable=False,
+            ),
+            sa.Column(
+                "tracked_player_id",
+                sa.Integer(),
+                sa.ForeignKey("tracked_players.id"),
+                nullable=True,
+            ),
+            sa.Column("minutes_visible", sa.Float(), nullable=True),
+            sa.Column("distance_m", sa.Float(), nullable=True),
+            sa.Column("distance_confidence", sa.String(10), nullable=True),
+            sa.Column("fastest_sustained_kmh", sa.Float(), nullable=True),
+            sa.Column("sprint_count", sa.Integer(), nullable=True),
+            sa.Column("speed_bands", sa.JSON(), nullable=True),
+            sa.Column("heatmap_path", sa.String(500), nullable=True),
+            sa.Column("touches", sa.Integer(), nullable=True),
+            sa.Column("touches_is_beta", sa.Boolean(), nullable=False, server_default="true"),
+            sa.Column("model_version", sa.String(40), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.UniqueConstraint("video_match_id", "roster_entry_id", name="uq_video_report_match_roster"),
+        )
+    create_index_safe("ix_video_player_reports_match", "video_player_reports", ["video_match_id"])
+    create_index_safe("ix_video_player_reports_tracked", "video_player_reports", ["tracked_player_id"])
+
+    if not table_exists("video_credit_ledger"):
+        op.create_table(
+            "video_credit_ledger",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("team_id", sa.Integer(), sa.ForeignKey("teams.id"), nullable=False),
+            sa.Column("delta", sa.Integer(), nullable=False),
+            sa.Column("reason", sa.String(20), nullable=False),
+            sa.Column("note", sa.String(500), nullable=True),
+            sa.Column("video_match_id", sa.Integer(), sa.ForeignKey("video_matches.id"), nullable=True),
+            sa.Column("stripe_session_id", sa.String(255), nullable=True, unique=True),
+            sa.Column("created_by", sa.String(100), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+        )
+    create_index_safe("ix_video_credit_ledger_team", "video_credit_ledger", ["team_id"])
+
+
+def downgrade():
+    for table in (
+        "video_player_reports",
+        "video_tracklets",
+        "video_roster_entries",
+        "video_credit_ledger",
+        "video_analysis_jobs",
+        "video_matches",
+    ):
+        if table_exists(table):
+            op.drop_table(table)

--- a/academy-watch-backend/requirements.txt
+++ b/academy-watch-backend/requirements.txt
@@ -4,6 +4,7 @@ anyio==4.13.0
 attrs==26.1.0
 azure-identity==1.25.3
 azure-keyvault-secrets==4.11.0
+azure-storage-blob==12.27.1
 bleach==6.4.0
 blinker==1.9.0
 certifi==2026.5.20

--- a/academy-watch-backend/src/main.py
+++ b/academy-watch-backend/src/main.py
@@ -30,6 +30,7 @@ from src.routes.journey import journey_bp
 from src.routes.newsletter_deadline import newsletter_deadline_bp
 from src.routes.players import players_bp
 from src.routes.teams import teams_bp
+from src.routes.video import video_bp
 
 dotenv.load_dotenv(dotenv.find_dotenv())
 # Configure logging
@@ -100,6 +101,7 @@ app.register_blueprint(formation_bp, url_prefix="/api")
 app.register_blueprint(teams_bp, url_prefix="/api")
 app.register_blueprint(feeder_bp, url_prefix="/api")
 app.register_blueprint(curator_bp, url_prefix="/api")
+app.register_blueprint(video_bp, url_prefix="/api")
 
 csp = {
     "default-src": ["'self'"],

--- a/academy-watch-backend/src/models/video.py
+++ b/academy-watch-backend/src/models/video.py
@@ -1,0 +1,341 @@
+"""
+Video Analysis Models (Phase A — concierge MVP)
+
+Match-video upload → GPU pipeline → tag review → per-player reports.
+Spec: ledgers/CONTINUITY_video-analysis.md "Data model" section.
+
+Key invariants:
+- VideoMatch.team_id is the PAYING club (NOT NULL). Opposition is free text and
+  is only ever identified by jersey number — never names (legal posture).
+- VideoCreditLedger is append-only; a team's balance is SUM(delta). The Stripe
+  session id carries a unique constraint so webhook replays cannot double-credit.
+- VideoTracklet rows are what human tags bind to. `kind` distinguishes
+  number-anchored chains (pre-merged players) from leftover fragments the
+  review UI may still attach.
+- VideoPlayerReport carries model_version so Phase D trend views never silently
+  mix numbers produced by different pipeline versions.
+"""
+
+import uuid
+from datetime import UTC, datetime
+
+from src.models.league import db
+
+# VideoMatch.status lifecycle (forward-only except admin requeue)
+VIDEO_MATCH_STATUSES = (
+    "created",  # row exists, SAS issued, nothing uploaded yet
+    "uploaded",  # client reported upload-complete; blob verified
+    "preflight",  # CPU sample quality gate running
+    "queued",  # debited, waiting for a GPU worker
+    "processing",  # GPU worker owns it
+    "needs_tagging",  # pipeline done; awaiting human tag review
+    "finalized",  # tags confirmed; reports generated
+    "failed",  # terminal error (credit refunded by admin/auto policy)
+    "expired",  # raw footage past retention; derived data kept
+)
+
+VIDEO_JOB_STATUSES = ("queued", "running", "succeeded", "failed", "cancelled")
+
+# Pipeline stages reported by the worker for progress display
+VIDEO_JOB_STAGES = (
+    "claimed",
+    "decode",
+    "detect",
+    "track",
+    "team_cluster",
+    "merge",
+    "identity",
+    "artifacts",
+    "persist",
+)
+
+CREDIT_REASONS = ("purchase", "debit", "refund", "grant")
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+class VideoMatch(db.Model):
+    __tablename__ = "video_matches"
+
+    id = db.Column(db.Integer, primary_key=True)
+    team_id = db.Column(db.Integer, db.ForeignKey("teams.id"), nullable=False, index=True)
+
+    # Match metadata (opponent stays free text — opposition players are numbers only)
+    opponent_name = db.Column(db.String(200))
+    match_date = db.Column(db.Date)
+    competition = db.Column(db.String(200))
+    our_kit_color = db.Column(db.String(50))
+    opponent_kit_color = db.Column(db.String(50))
+    capture_meta = db.Column(db.JSON)  # camera questionnaire: type, position, resolution
+
+    # Footage
+    blob_path = db.Column(db.String(500))  # container-relative path of the raw upload
+    blob_etag = db.Column(db.String(100))  # recorded at upload-complete, verified at job start
+    duration_s = db.Column(db.Float)
+    # Uploader-marked timeline points (10s of human input beats fragile inference)
+    kickoff_s = db.Column(db.Float)
+    halftime_s = db.Column(db.Float)
+    second_half_kickoff_s = db.Column(db.Float)
+
+    # Which KMeans cluster (0/1) is the uploader's team — confirmed during tagging
+    our_team_cluster = db.Column(db.Integer)
+
+    status = db.Column(db.String(20), nullable=False, default="created", index=True)
+    quality_score = db.Column(db.Float)  # preflight + pipeline quality signal, 0..1
+    quality_flags = db.Column(db.JSON)  # e.g. ["kit_clash", "pitch_level_camera"]
+
+    created_at = db.Column(db.DateTime, default=_utcnow)
+    uploaded_at = db.Column(db.DateTime)
+    finalized_at = db.Column(db.DateTime)
+    expires_at = db.Column(db.DateTime)  # raw-footage retention deadline (90d policy)
+
+    team = db.relationship("Team", foreign_keys=[team_id])
+    jobs = db.relationship(
+        "VideoAnalysisJob",
+        backref="match",
+        lazy="dynamic",
+        order_by="VideoAnalysisJob.created_at.desc()",
+    )
+    roster_entries = db.relationship("VideoRosterEntry", backref="match", lazy="dynamic")
+    tracklets = db.relationship("VideoTracklet", backref="match", lazy="dynamic")
+
+    def latest_job(self):
+        return self.jobs.first()
+
+    def to_dict(self, include_job: bool = False) -> dict:
+        out = {
+            "id": self.id,
+            "team_id": self.team_id,
+            "opponent_name": self.opponent_name,
+            "match_date": self.match_date.isoformat() if self.match_date else None,
+            "competition": self.competition,
+            "our_kit_color": self.our_kit_color,
+            "opponent_kit_color": self.opponent_kit_color,
+            "capture_meta": self.capture_meta,
+            "blob_path": self.blob_path,
+            "duration_s": self.duration_s,
+            "kickoff_s": self.kickoff_s,
+            "halftime_s": self.halftime_s,
+            "second_half_kickoff_s": self.second_half_kickoff_s,
+            "our_team_cluster": self.our_team_cluster,
+            "status": self.status,
+            "quality_score": self.quality_score,
+            "quality_flags": self.quality_flags,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "uploaded_at": self.uploaded_at.isoformat() if self.uploaded_at else None,
+            "finalized_at": self.finalized_at.isoformat() if self.finalized_at else None,
+            "expires_at": self.expires_at.isoformat() if self.expires_at else None,
+        }
+        if include_job:
+            job = self.latest_job()
+            out["job"] = job.to_dict() if job else None
+        return out
+
+
+class VideoAnalysisJob(db.Model):
+    __tablename__ = "video_analysis_jobs"
+
+    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    video_match_id = db.Column(db.Integer, db.ForeignKey("video_matches.id"), nullable=False, index=True)
+
+    status = db.Column(db.String(20), nullable=False, default="queued", index=True)
+    stage = db.Column(db.String(30))  # one of VIDEO_JOB_STAGES while running
+    progress = db.Column(db.Integer, default=0)  # 0..100 within the current stage
+    attempt = db.Column(db.Integer, nullable=False, default=1)
+    worker_id = db.Column(db.String(100))  # replica name that claimed the job
+    error = db.Column(db.Text)
+
+    # COGS telemetry — the cost dashboard consumes this (ledger requirement)
+    gpu_seconds = db.Column(db.Float)
+    pipeline_version = db.Column(db.String(40))
+
+    created_at = db.Column(db.DateTime, default=_utcnow)
+    started_at = db.Column(db.DateTime)
+    heartbeat_at = db.Column(db.DateTime)  # stale-fail reaper checks this
+    completed_at = db.Column(db.DateTime)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "video_match_id": self.video_match_id,
+            "status": self.status,
+            "stage": self.stage,
+            "progress": self.progress,
+            "attempt": self.attempt,
+            "error": self.error,
+            "gpu_seconds": self.gpu_seconds,
+            "pipeline_version": self.pipeline_version,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "completed_at": self.completed_at.isoformat() if self.completed_at else None,
+        }
+
+
+class VideoRosterEntry(db.Model):
+    """One squad member of the UPLOADING team for one match. Own-side only
+    carries names in v1; opposition is numbers-only and never gets roster rows."""
+
+    __tablename__ = "video_roster_entries"
+    __table_args__ = (db.UniqueConstraint("video_match_id", "jersey_number", name="uq_video_roster_match_number"),)
+
+    id = db.Column(db.Integer, primary_key=True)
+    video_match_id = db.Column(db.Integer, db.ForeignKey("video_matches.id"), nullable=False, index=True)
+    player_name = db.Column(db.String(200), nullable=False)
+    jersey_number = db.Column(db.Integer, nullable=False)
+    position = db.Column(db.String(50))
+    # Optional link into the existing tracking universe (club-owned record → pro journey hook)
+    tracked_player_id = db.Column(db.Integer, db.ForeignKey("tracked_players.id"), nullable=True)
+
+    created_at = db.Column(db.DateTime, default=_utcnow)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "video_match_id": self.video_match_id,
+            "player_name": self.player_name,
+            "jersey_number": self.jersey_number,
+            "position": self.position,
+            "tracked_player_id": self.tracked_player_id,
+        }
+
+
+class VideoTracklet(db.Model):
+    """A merged on-pitch entity the tagging UI binds to a roster entry.
+
+    kind='chain'    number-anchored player chain (pre-merged by the identity pass)
+    kind='fragment' unanchored fragment awaiting human attachment or dismissal
+    """
+
+    __tablename__ = "video_tracklets"
+
+    id = db.Column(db.Integer, primary_key=True)
+    video_match_id = db.Column(db.Integer, db.ForeignKey("video_matches.id"), nullable=False, index=True)
+    kind = db.Column(db.String(10), nullable=False, default="fragment")
+    pipeline_key = db.Column(db.String(40))  # e.g. "T0#10" or "E1234" from the worker
+
+    team_cluster = db.Column(db.Integer)  # 0/1 KMeans side, -1 unknown
+    suggested_number = db.Column(db.Integer)
+    suggested_role = db.Column(db.String(20))  # outfield|goalkeeper|referee|not_a_player
+    confidence = db.Column(db.String(10))  # high|low|None
+    merge_confidence = db.Column(db.Float)
+    contaminated = db.Column(db.Boolean, nullable=False, default=False)  # splice suspect
+
+    first_s = db.Column(db.Float)
+    last_s = db.Column(db.Float)
+    visible_s = db.Column(db.Float)
+    thumbnail_paths = db.Column(db.JSON)  # blob paths of the sharpest crops
+    evidence = db.Column(db.JSON)  # vote tallies, member fragments, conflict flags
+
+    # The tag: binding to a roster entry (own team) — set by human review or
+    # auto-accepted high-confidence suggestion
+    roster_entry_id = db.Column(db.Integer, db.ForeignKey("video_roster_entries.id"), nullable=True, index=True)
+    tag_source = db.Column(db.String(10))  # auto|human|None
+    dismissed = db.Column(db.Boolean, nullable=False, default=False)  # marked not-a-player
+
+    roster_entry = db.relationship("VideoRosterEntry", foreign_keys=[roster_entry_id])
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "video_match_id": self.video_match_id,
+            "kind": self.kind,
+            "pipeline_key": self.pipeline_key,
+            "team_cluster": self.team_cluster,
+            "suggested_number": self.suggested_number,
+            "suggested_role": self.suggested_role,
+            "confidence": self.confidence,
+            "merge_confidence": self.merge_confidence,
+            "contaminated": self.contaminated,
+            "first_s": self.first_s,
+            "last_s": self.last_s,
+            "visible_s": self.visible_s,
+            "thumbnail_paths": self.thumbnail_paths,
+            "evidence": self.evidence,
+            "roster_entry_id": self.roster_entry_id,
+            "tag_source": self.tag_source,
+            "dismissed": self.dismissed,
+        }
+
+
+class VideoPlayerReport(db.Model):
+    __tablename__ = "video_player_reports"
+    __table_args__ = (db.UniqueConstraint("video_match_id", "roster_entry_id", name="uq_video_report_match_roster"),)
+
+    id = db.Column(db.Integer, primary_key=True)
+    video_match_id = db.Column(db.Integer, db.ForeignKey("video_matches.id"), nullable=False, index=True)
+    roster_entry_id = db.Column(db.Integer, db.ForeignKey("video_roster_entries.id"), nullable=False)
+    # Denormalized for the PlayerPage join (authed + team-scoped, never public)
+    tracked_player_id = db.Column(db.Integer, db.ForeignKey("tracked_players.id"), nullable=True, index=True)
+
+    minutes_visible = db.Column(db.Float)  # on-camera minutes — NEVER implied as full-match
+    distance_m = db.Column(db.Float)  # on-camera distance, clamped
+    distance_confidence = db.Column(db.String(10))  # high|low (far-side flagging)
+    fastest_sustained_kmh = db.Column(db.Float)  # sustained only; jitter fakes instantaneous
+    sprint_count = db.Column(db.Integer)
+    speed_bands = db.Column(db.JSON)  # seconds per band
+    heatmap_path = db.Column(db.String(500))
+    touches = db.Column(db.Integer)
+    touches_is_beta = db.Column(db.Boolean, nullable=False, default=True)
+
+    model_version = db.Column(db.String(40), nullable=False)
+    created_at = db.Column(db.DateTime, default=_utcnow)
+
+    roster_entry = db.relationship("VideoRosterEntry", foreign_keys=[roster_entry_id])
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "video_match_id": self.video_match_id,
+            "roster_entry_id": self.roster_entry_id,
+            "tracked_player_id": self.tracked_player_id,
+            "minutes_visible": self.minutes_visible,
+            "distance_m": self.distance_m,
+            "distance_confidence": self.distance_confidence,
+            "fastest_sustained_kmh": self.fastest_sustained_kmh,
+            "sprint_count": self.sprint_count,
+            "speed_bands": self.speed_bands,
+            "heatmap_path": self.heatmap_path,
+            "touches": self.touches,
+            "touches_is_beta": self.touches_is_beta,
+            "model_version": self.model_version,
+        }
+
+
+class VideoCreditLedger(db.Model):
+    """Append-only credit movements. Balance(team) = SUM(delta). Never UPDATE rows."""
+
+    __tablename__ = "video_credit_ledger"
+
+    id = db.Column(db.Integer, primary_key=True)
+    team_id = db.Column(db.Integer, db.ForeignKey("teams.id"), nullable=False, index=True)
+    delta = db.Column(db.Integer, nullable=False)  # +purchase/+grant/+refund, -debit
+    reason = db.Column(db.String(20), nullable=False)  # one of CREDIT_REASONS
+    note = db.Column(db.String(500))
+    video_match_id = db.Column(db.Integer, db.ForeignKey("video_matches.id"), nullable=True)
+    # Unique => a replayed Stripe webhook cannot double-credit
+    stripe_session_id = db.Column(db.String(255), unique=True, nullable=True)
+    created_by = db.Column(db.String(100))  # admin identifier for grants/refunds
+
+    created_at = db.Column(db.DateTime, default=_utcnow)
+
+    @staticmethod
+    def balance(team_id: int) -> int:
+        total = (
+            db.session.query(db.func.coalesce(db.func.sum(VideoCreditLedger.delta), 0))
+            .filter(VideoCreditLedger.team_id == team_id)
+            .scalar()
+        )
+        return int(total or 0)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "team_id": self.team_id,
+            "delta": self.delta,
+            "reason": self.reason,
+            "note": self.note,
+            "video_match_id": self.video_match_id,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+        }

--- a/academy-watch-backend/src/routes/video.py
+++ b/academy-watch-backend/src/routes/video.py
@@ -1,0 +1,567 @@
+"""Video-analysis API (Phase A — concierge MVP).
+
+Lifecycle: create match (mint SAS) → browser uploads direct to blob →
+upload-complete (verify + ETag) → roster upsert → process (debit + enqueue) →
+worker runs pipeline → tag review (tracklets/tags) → finalize → report.
+
+Phase A posture: EVERY endpoint is admin-key gated (concierge — we operate it
+with the club on a call). Phase B introduces VideoTeamAccess + is_team_manager.
+Player video reports are AUTHENTICATED + team-scoped, never public (children's
+performance data).
+
+Credit safety: VideoCreditLedger is append-only; debit + job-create + status
+flip commit atomically in Postgres, THEN the queue signal fires — a lost signal
+degrades to worker DB-polling, never a lost job.
+"""
+
+import logging
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from flask import Blueprint, jsonify, request
+from src.models.league import Team, db
+from src.models.video import (
+    CREDIT_REASONS,
+    VideoAnalysisJob,
+    VideoCreditLedger,
+    VideoMatch,
+    VideoPlayerReport,
+    VideoRosterEntry,
+    VideoTracklet,
+)
+from src.routes.api import require_api_key
+from src.services import video_queue, video_storage
+
+video_bp = Blueprint("video", __name__)
+logger = logging.getLogger(__name__)
+
+RAW_RETENTION_DAYS = 90  # ToS: raw footage deleted at 90d; derived numbers kept
+PIPELINE_VERSION = "phase-a-v1"
+
+
+def _get_match_or_404(match_id: int) -> "VideoMatch | tuple":
+    match = db.session.get(VideoMatch, match_id)
+    if match is None:
+        return None
+    return match
+
+
+def _bad_request(msg: str):
+    return jsonify({"error": msg}), 400
+
+
+# ---------------------------------------------------------------------------
+# Match lifecycle
+# ---------------------------------------------------------------------------
+
+
+@video_bp.route("/admin/video/matches", methods=["POST"])
+@require_api_key
+def create_video_match():
+    """Create a match shell and mint the upload SAS.
+
+    Body: {team_id, opponent_name?, match_date?, competition?, our_kit_color?,
+           opponent_kit_color?, capture_meta?}
+    """
+    data = request.get_json() or {}
+    team_id = data.get("team_id")
+    if not team_id or db.session.get(Team, team_id) is None:
+        return _bad_request("team_id must reference an existing team")
+
+    match_date = None
+    if data.get("match_date"):
+        try:
+            match_date = datetime.strptime(data["match_date"], "%Y-%m-%d").date()
+        except ValueError:
+            return _bad_request("match_date must be YYYY-MM-DD")
+
+    match = VideoMatch(
+        team_id=team_id,
+        opponent_name=data.get("opponent_name"),
+        match_date=match_date,
+        competition=data.get("competition"),
+        our_kit_color=data.get("our_kit_color"),
+        opponent_kit_color=data.get("opponent_kit_color"),
+        capture_meta=data.get("capture_meta"),
+        status="created",
+    )
+    db.session.add(match)
+    db.session.flush()
+    match.blob_path = f"matches/{match.id}/{uuid.uuid4().hex}.mp4"
+    db.session.commit()
+
+    payload = match.to_dict()
+    if video_storage.is_configured():
+        payload["upload"] = video_storage.mint_upload_sas(match.blob_path)
+    else:
+        payload["upload"] = None
+        payload["upload_unavailable"] = "blob storage not configured"
+    return jsonify(payload), 201
+
+
+@video_bp.route("/admin/video/matches/<int:match_id>/sas", methods=["POST"])
+@require_api_key
+def remint_upload_sas(match_id: int):
+    """Re-mint the write SAS — 6GB at club uplink speeds outlives 60 minutes."""
+    match = _get_match_or_404(match_id)
+    if match is None:
+        return jsonify({"error": "match not found"}), 404
+    if match.status not in ("created", "uploaded"):
+        return _bad_request(f"cannot re-mint SAS in status '{match.status}'")
+    if not video_storage.is_configured():
+        return jsonify({"error": "blob storage not configured"}), 503
+    return jsonify(video_storage.mint_upload_sas(match.blob_path))
+
+
+@video_bp.route("/admin/video/matches/<int:match_id>/upload-complete", methods=["POST"])
+@require_api_key
+def upload_complete(match_id: int):
+    """Verify the uploaded blob (exists, size cap), record ETag for the
+    job-start content-swap check, optionally capture timeline markers."""
+    match = _get_match_or_404(match_id)
+    if match is None:
+        return jsonify({"error": "match not found"}), 404
+    if match.status not in ("created", "uploaded"):
+        return _bad_request(f"cannot complete upload in status '{match.status}'")
+    if not video_storage.is_configured():
+        return jsonify({"error": "blob storage not configured"}), 503
+
+    check = video_storage.verify_uploaded_blob(match.blob_path)
+    if not check["ok"]:
+        return jsonify({"error": check["error"]}), 422
+
+    data = request.get_json(silent=True) or {}
+    for field in ("kickoff_s", "halftime_s", "second_half_kickoff_s", "duration_s"):
+        if data.get(field) is not None:
+            try:
+                setattr(match, field, float(data[field]))
+            except (TypeError, ValueError):
+                return _bad_request(f"{field} must be a number")
+
+    match.blob_etag = check["etag"]
+    match.status = "uploaded"
+    match.uploaded_at = datetime.now(UTC)
+    match.expires_at = datetime.now(UTC) + timedelta(days=RAW_RETENTION_DAYS)
+    db.session.commit()
+    return jsonify(match.to_dict() | {"size_bytes": check["size_bytes"]})
+
+
+@video_bp.route("/admin/video/matches/<int:match_id>", methods=["PATCH"])
+@require_api_key
+def update_video_match(match_id: int):
+    """Update metadata / timeline markers / our-team-cluster confirmation."""
+    match = _get_match_or_404(match_id)
+    if match is None:
+        return jsonify({"error": "match not found"}), 404
+    data = request.get_json() or {}
+    for field in ("opponent_name", "competition", "our_kit_color", "opponent_kit_color"):
+        if field in data:
+            setattr(match, field, data[field])
+    for field in ("kickoff_s", "halftime_s", "second_half_kickoff_s"):
+        if field in data:
+            try:
+                setattr(match, field, None if data[field] is None else float(data[field]))
+            except (TypeError, ValueError):
+                return _bad_request(f"{field} must be a number")
+    auto_bound = None
+    if "our_team_cluster" in data:
+        if data["our_team_cluster"] not in (0, 1, None):
+            return _bad_request("our_team_cluster must be 0, 1 or null")
+        match.our_team_cluster = data["our_team_cluster"]
+    if "capture_meta" in data:
+        match.capture_meta = data["capture_meta"]
+    db.session.commit()
+    if data.get("our_team_cluster") in (0, 1) and match.status in ("needs_tagging", "finalized"):
+        from src.services.video_identity import auto_bind
+
+        auto_bound = auto_bind(match)
+    out = match.to_dict()
+    if auto_bound is not None:
+        out["auto_bound"] = auto_bound
+    return jsonify(out)
+
+
+@video_bp.route("/admin/video/matches/<int:match_id>", methods=["GET"])
+@require_api_key
+def get_video_match(match_id: int):
+    match = _get_match_or_404(match_id)
+    if match is None:
+        return jsonify({"error": "match not found"}), 404
+    out = match.to_dict(include_job=True)
+    out["roster"] = [r.to_dict() for r in match.roster_entries]
+    out["credit_balance"] = VideoCreditLedger.balance(match.team_id)
+    return jsonify(out)
+
+
+# ---------------------------------------------------------------------------
+# Roster
+# ---------------------------------------------------------------------------
+
+
+@video_bp.route("/admin/video/matches/<int:match_id>/roster", methods=["PUT"])
+@require_api_key
+def upsert_roster(match_id: int):
+    """Replace-style upsert of the uploading team's squad list.
+
+    Body: {entries: [{player_name, jersey_number, position?, tracked_player_id?}]}
+    Own-side only carries names in v1; opposition never gets roster rows.
+    """
+    match = _get_match_or_404(match_id)
+    if match is None:
+        return jsonify({"error": "match not found"}), 404
+    if match.status == "finalized":
+        return _bad_request("cannot edit roster after finalize")
+
+    entries = (request.get_json() or {}).get("entries")
+    if not isinstance(entries, list) or not entries:
+        return _bad_request("entries must be a non-empty list")
+    seen_numbers: set[int] = set()
+    for e in entries:
+        name = (e.get("player_name") or "").strip()
+        number = e.get("jersey_number")
+        if not name or not isinstance(number, int) or not 1 <= number <= 99:
+            return _bad_request("each entry needs player_name and jersey_number 1-99")
+        if number in seen_numbers:
+            return _bad_request(f"duplicate jersey_number {number}")
+        seen_numbers.add(number)
+
+    existing = {r.jersey_number: r for r in match.roster_entries}
+    kept_numbers = set()
+    for e in entries:
+        number = e["jersey_number"]
+        kept_numbers.add(number)
+        row = existing.get(number)
+        if row is None:
+            row = VideoRosterEntry(video_match_id=match.id, jersey_number=number, player_name=e["player_name"].strip())
+            db.session.add(row)
+        row.player_name = e["player_name"].strip()
+        row.position = e.get("position")
+        row.tracked_player_id = e.get("tracked_player_id")
+    removed = 0
+    for number, row in existing.items():
+        if number not in kept_numbers:
+            # unbind any tracklets pointing at the removed entry first
+            db.session.query(VideoTracklet).filter(VideoTracklet.roster_entry_id == row.id).update(
+                {"roster_entry_id": None, "tag_source": None}, synchronize_session=False
+            )
+            db.session.query(VideoPlayerReport).filter(VideoPlayerReport.roster_entry_id == row.id).delete(
+                synchronize_session=False
+            )
+            db.session.delete(row)
+            removed += 1
+    db.session.commit()
+    return jsonify(
+        {
+            "roster": [r.to_dict() for r in match.roster_entries],
+            "removed": removed,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Processing
+# ---------------------------------------------------------------------------
+
+
+@video_bp.route("/admin/video/matches/<int:match_id>/process", methods=["POST"])
+@require_api_key
+def process_match(match_id: int):
+    """Debit one credit and queue the GPU job. 402 when the team has no credits."""
+    match = _get_match_or_404(match_id)
+    if match is None:
+        return jsonify({"error": "match not found"}), 404
+    if match.status not in ("uploaded", "preflight"):
+        return _bad_request(f"cannot process in status '{match.status}' (upload first)")
+    if match.kickoff_s is None:
+        return _bad_request("kickoff_s must be marked before processing")
+
+    if VideoCreditLedger.balance(match.team_id) < 1:
+        return jsonify({"error": "no credits", "credit_balance": 0}), 402
+
+    job = VideoAnalysisJob(
+        video_match_id=match.id,
+        status="queued",
+        pipeline_version=PIPELINE_VERSION,
+    )
+    db.session.add(job)
+    db.session.add(
+        VideoCreditLedger(
+            team_id=match.team_id,
+            delta=-1,
+            reason="debit",
+            video_match_id=match.id,
+            note=f"processing job {job.id}",
+        )
+    )
+    match.status = "queued"
+    db.session.commit()  # debit + job + status are atomic; signal comes after
+    mode = video_queue.enqueue(job.id)
+    logger.info("video match %s queued as job %s via %s", match.id, job.id, mode)
+    return jsonify({"job": job.to_dict(), "dispatch": mode}), 202
+
+
+@video_bp.route("/admin/video/matches/<int:match_id>/requeue", methods=["POST"])
+@require_api_key
+def requeue_match(match_id: int):
+    """Admin: re-run a failed job WITHOUT a new debit."""
+    match = _get_match_or_404(match_id)
+    if match is None:
+        return jsonify({"error": "match not found"}), 404
+    last = match.latest_job()
+    if last is None or last.status not in ("failed", "cancelled"):
+        return _bad_request("requeue requires a failed or cancelled job")
+    job = VideoAnalysisJob(
+        video_match_id=match.id,
+        status="queued",
+        attempt=last.attempt + 1,
+        pipeline_version=PIPELINE_VERSION,
+    )
+    db.session.add(job)
+    match.status = "queued"
+    db.session.commit()
+    mode = video_queue.enqueue(job.id)
+    return jsonify({"job": job.to_dict(), "dispatch": mode}), 202
+
+
+# ---------------------------------------------------------------------------
+# Tag review
+# ---------------------------------------------------------------------------
+
+
+@video_bp.route("/admin/video/matches/<int:match_id>/tracklets", methods=["GET"])
+@require_api_key
+def list_tracklets(match_id: int):
+    """Tracklets for the review UI, untagged-first then by minutes visible
+    (the queue is ranked uncertainty x visibility)."""
+    match = _get_match_or_404(match_id)
+    if match is None:
+        return jsonify({"error": "match not found"}), 404
+    q = db.session.query(VideoTracklet).filter(VideoTracklet.video_match_id == match.id)
+    kind = request.args.get("kind")
+    if kind in ("chain", "fragment"):
+        q = q.filter(VideoTracklet.kind == kind)
+    if request.args.get("untagged") == "true":
+        q = q.filter(VideoTracklet.roster_entry_id.is_(None), VideoTracklet.dismissed.is_(False))
+    rows = q.order_by(
+        VideoTracklet.roster_entry_id.isnot(None),
+        VideoTracklet.dismissed,
+        VideoTracklet.visible_s.desc().nulls_last(),
+    ).all()
+    return jsonify({"tracklets": [t.to_dict() for t in rows], "count": len(rows)})
+
+
+@video_bp.route("/admin/video/matches/<int:match_id>/tags", methods=["POST"])
+@require_api_key
+def bind_tags(match_id: int):
+    """Bulk tag bindings from the review UI.
+
+    Body: {tags: [{tracklet_id, roster_entry_id?|null, dismissed?}]}
+    roster_entry_id null unbinds; dismissed=true marks not-a-player.
+    """
+    match = _get_match_or_404(match_id)
+    if match is None:
+        return jsonify({"error": "match not found"}), 404
+    if match.status not in ("needs_tagging", "finalized"):
+        return _bad_request(f"tagging unavailable in status '{match.status}'")
+
+    tags = (request.get_json() or {}).get("tags")
+    if not isinstance(tags, list) or not tags:
+        return _bad_request("tags must be a non-empty list")
+
+    tracklets = {t.id: t for t in db.session.query(VideoTracklet).filter(VideoTracklet.video_match_id == match.id)}
+    roster_ids = {r.id for r in match.roster_entries}
+    applied = 0
+    for tag in tags:
+        t = tracklets.get(tag.get("tracklet_id"))
+        if t is None:
+            return _bad_request(f"tracklet {tag.get('tracklet_id')} not in this match")
+        if "roster_entry_id" in tag:
+            rid = tag["roster_entry_id"]
+            if rid is not None and rid not in roster_ids:
+                return _bad_request(f"roster entry {rid} not in this match")
+            t.roster_entry_id = rid
+            t.tag_source = "human" if rid is not None else None
+        if tag.get("dismissed") is not None:
+            t.dismissed = bool(tag["dismissed"])
+            if t.dismissed:
+                t.roster_entry_id = None
+                t.tag_source = None
+        applied += 1
+    db.session.commit()
+    return jsonify({"applied": applied})
+
+
+@video_bp.route("/admin/video/matches/<int:match_id>/finalize", methods=["POST"])
+@require_api_key
+def finalize_match(match_id: int):
+    """Aggregate tagged tracklets into per-player reports (CPU re-aggregation —
+    tag fixes never re-run the GPU). Idempotent: re-finalizing rebuilds reports."""
+    match = _get_match_or_404(match_id)
+    if match is None:
+        return jsonify({"error": "match not found"}), 404
+    if match.status not in ("needs_tagging", "finalized"):
+        return _bad_request(f"cannot finalize in status '{match.status}'")
+
+    job = match.latest_job()
+    model_version = (job.pipeline_version if job else None) or PIPELINE_VERSION
+
+    db.session.query(VideoPlayerReport).filter(VideoPlayerReport.video_match_id == match.id).delete(
+        synchronize_session=False
+    )
+
+    reports = []
+    for entry in match.roster_entries:
+        bound = (
+            db.session.query(VideoTracklet)
+            .filter(
+                VideoTracklet.video_match_id == match.id,
+                VideoTracklet.roster_entry_id == entry.id,
+                VideoTracklet.dismissed.is_(False),
+            )
+            .all()
+        )
+        if not bound:
+            continue
+        visible = sum(t.visible_s or 0.0 for t in bound)
+        # Phase A v1: identity + visibility metrics. Distance/speed/heatmaps land
+        # with the homography stage; columns stay NULL rather than fabricating.
+        report = VideoPlayerReport(
+            video_match_id=match.id,
+            roster_entry_id=entry.id,
+            tracked_player_id=entry.tracked_player_id,
+            minutes_visible=round(visible / 60.0, 1),
+            touches_is_beta=True,
+            model_version=model_version,
+        )
+        db.session.add(report)
+        reports.append(report)
+
+    match.status = "finalized"
+    match.finalized_at = datetime.now(UTC)
+    db.session.commit()
+    return jsonify({"reports": len(reports), "match": match.to_dict()})
+
+
+@video_bp.route("/admin/video/matches/<int:match_id>/report", methods=["GET"])
+@require_api_key
+def get_report(match_id: int):
+    match = _get_match_or_404(match_id)
+    if match is None:
+        return jsonify({"error": "match not found"}), 404
+    reports = db.session.query(VideoPlayerReport).filter(VideoPlayerReport.video_match_id == match.id).all()
+    roster_by_id = {r.id: r for r in match.roster_entries}
+    out = []
+    for rep in reports:
+        d = rep.to_dict()
+        entry = roster_by_id.get(rep.roster_entry_id)
+        d["player_name"] = entry.player_name if entry else None
+        d["jersey_number"] = entry.jersey_number if entry else None
+        out.append(d)
+    out.sort(key=lambda d: -(d["minutes_visible"] or 0))
+    return jsonify({"match": match.to_dict(), "reports": out})
+
+
+# ---------------------------------------------------------------------------
+# Team views + credits
+# ---------------------------------------------------------------------------
+
+
+@video_bp.route("/admin/video/teams/<int:team_id>/matches", methods=["GET"])
+@require_api_key
+def team_matches(team_id: int):
+    rows = (
+        db.session.query(VideoMatch).filter(VideoMatch.team_id == team_id).order_by(VideoMatch.created_at.desc()).all()
+    )
+    return jsonify(
+        {
+            "matches": [m.to_dict(include_job=True) for m in rows],
+            "credit_balance": VideoCreditLedger.balance(team_id),
+        }
+    )
+
+
+@video_bp.route("/admin/video/teams/<int:team_id>/credits", methods=["GET"])
+@require_api_key
+def team_credits(team_id: int):
+    rows = (
+        db.session.query(VideoCreditLedger)
+        .filter(VideoCreditLedger.team_id == team_id)
+        .order_by(VideoCreditLedger.created_at.desc())
+        .limit(100)
+        .all()
+    )
+    return jsonify(
+        {
+            "balance": VideoCreditLedger.balance(team_id),
+            "ledger": [r.to_dict() for r in rows],
+        }
+    )
+
+
+@video_bp.route("/admin/video/teams/<int:team_id>/credits/grant", methods=["POST"])
+@require_api_key
+def grant_credits(team_id: int):
+    """Admin credit movement. Body: {delta, reason?, note?}. Stripe purchases
+    arrive via the webhook in Phase B; concierge sales are recorded here."""
+    if db.session.get(Team, team_id) is None:
+        return _bad_request("team not found")
+    data = request.get_json() or {}
+    delta = data.get("delta")
+    if not isinstance(delta, int) or delta == 0:
+        return _bad_request("delta must be a non-zero integer")
+    reason = data.get("reason", "grant")
+    if reason not in CREDIT_REASONS:
+        return _bad_request(f"reason must be one of {CREDIT_REASONS}")
+    db.session.add(
+        VideoCreditLedger(
+            team_id=team_id,
+            delta=delta,
+            reason=reason,
+            note=data.get("note"),
+            created_by="admin-api",
+        )
+    )
+    db.session.commit()
+    return jsonify({"balance": VideoCreditLedger.balance(team_id)})
+
+
+@video_bp.route("/admin/video/matches/<int:match_id>/refund", methods=["POST"])
+@require_api_key
+def refund_match(match_id: int):
+    """Refund the processing debit for a failed/poor-quality match (one per match)."""
+    match = _get_match_or_404(match_id)
+    if match is None:
+        return jsonify({"error": "match not found"}), 404
+    already = (
+        db.session.query(VideoCreditLedger)
+        .filter(
+            VideoCreditLedger.video_match_id == match.id,
+            VideoCreditLedger.reason == "refund",
+        )
+        .first()
+    )
+    if already:
+        return _bad_request("match already refunded")
+    db.session.add(
+        VideoCreditLedger(
+            team_id=match.team_id,
+            delta=1,
+            reason="refund",
+            video_match_id=match.id,
+            note=(request.get_json(silent=True) or {}).get("note"),
+            created_by="admin-api",
+        )
+    )
+    db.session.commit()
+    return jsonify({"balance": VideoCreditLedger.balance(match.team_id)})
+
+
+# ---------------------------------------------------------------------------
+# Maintenance
+# ---------------------------------------------------------------------------
+
+
+@video_bp.route("/admin/video/reap-stale-jobs", methods=["POST"])
+@require_api_key
+def reap_stale():
+    return jsonify({"stale_failed": video_queue.reap_stale_jobs()})

--- a/academy-watch-backend/src/scripts/load_video_artifacts.py
+++ b/academy-watch-backend/src/scripts/load_video_artifacts.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Load video-pipeline artifacts into the product DB (concierge path).
+
+Phase A runs the GPU pipeline as chunked ACA jobs + a local merge/identity pass
+(spike lineage). This script bridges that world into the product: it takes the
+artifacts directory (fragments.json, votes.json, chains.json — the inverted
+pipeline's outputs) and persists VideoTracklet rows for the tag-review UI.
+
+Usage:
+    cd academy-watch-backend
+    python src/scripts/load_video_artifacts.py --match-id 1 --artifacts-dir /path/to/inverted
+    python src/scripts/load_video_artifacts.py --match-id 1 --artifacts-dir ... --job-id <uuid>
+    # --job-id completes that queued/running job; omitted = a synthetic
+    # succeeded job row is created so reports carry a pipeline_version.
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+log = logging.getLogger(__name__)
+
+
+def load_artifacts_dir(artifacts_dir: Path) -> dict:
+    out: dict = {}
+    frag_path = artifacts_dir / "fragments.json"
+    votes_path = artifacts_dir / "votes.json"
+    if not frag_path.exists() or not votes_path.exists():
+        raise SystemExit(f"{artifacts_dir} must contain fragments.json and votes.json")
+    out["fragments"] = json.loads(frag_path.read_text())
+    out["votes"] = json.loads(votes_path.read_text())
+    chains_path = artifacts_dir / "chains.json"
+    if chains_path.exists():
+        out["chains"] = json.loads(chains_path.read_text())
+    thumbs_path = artifacts_dir / "thumbnails.json"
+    if thumbs_path.exists():
+        out["thumbnails"] = json.loads(thumbs_path.read_text())
+    return out
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--match-id", type=int, required=True)
+    p.add_argument("--artifacts-dir", type=Path, required=True)
+    p.add_argument("--job-id", default=None, help="existing job to complete (default: create one)")
+    p.add_argument("--gpu-seconds", type=float, default=None, help="COGS telemetry from the run")
+    args = p.parse_args()
+
+    artifacts = load_artifacts_dir(args.artifacts_dir)
+    log.info(
+        "loaded artifacts: %d fragments, %d vote rows, %s chains",
+        len(artifacts["fragments"]),
+        len(artifacts["votes"].get("entities", [])),
+        len(artifacts.get("chains", [])) if "chains" in artifacts else "rebuild",
+    )
+
+    from src.main import app
+    from src.models.league import db
+    from src.models.video import VideoAnalysisJob, VideoMatch
+    from src.services.video_identity import complete_job_with_artifacts
+
+    with app.app_context():
+        match = db.session.get(VideoMatch, args.match_id)
+        if match is None:
+            raise SystemExit(f"video match {args.match_id} not found")
+        job_id = args.job_id
+        if job_id is None:
+            job = VideoAnalysisJob(
+                video_match_id=match.id,
+                status="running",
+                stage="persist",
+                pipeline_version="phase-a-v1-concierge",
+            )
+            db.session.add(job)
+            db.session.commit()
+            job_id = job.id
+            log.info("created concierge job %s", job_id)
+        result = complete_job_with_artifacts(job_id, artifacts, gpu_seconds=args.gpu_seconds)
+        log.info("persisted: %s — match now '%s'", result, match.status)
+
+
+if __name__ == "__main__":
+    main()

--- a/academy-watch-backend/src/services/video_identity.py
+++ b/academy-watch-backend/src/services/video_identity.py
@@ -1,0 +1,361 @@
+"""
+Jersey-number identity logic + worker-artifact persistence (Phase A).
+
+The algorithms here were validated on real VEO footage in the Phase 0 spike
+(spike/video-analysis/invert_identity.py — read purity 0.847 -> 0.927):
+
+- A jersey number is NEVER trusted from a single read (MIN_VOTES=2 within a
+  fragment); a fragment with two multiply-attested numbers is a tracker-swap
+  splice and is refused outright.
+- OCR digit-doubling ("4" vs "44") supports the top number rather than
+  rivalling it.
+- Long-gap merging is driven BY NUMBERS: fragments sharing (team, number) with
+  pairwise-disjoint time spans form one player chain. Appearance embeddings are
+  non-discriminative within a team and are never the merge signal.
+- Single-read (weak) fragments may only JOIN a strong-seeded chain; two
+  independent agreeing weak fragments may seed one.
+
+Worker contract: the GPU pipeline produces an artifacts payload
+  {fragments: [...], votes: {entities: [...]}, chains: [...], thumbnails: {...}}
+and `persist_artifacts()` turns it into VideoTracklet rows + flips the match
+to needs_tagging. Human tags and auto-bindings share the same rows.
+"""
+
+import logging
+from collections import Counter
+from datetime import UTC, datetime
+
+from src.models.league import db
+from src.models.video import VideoMatch, VideoRosterEntry, VideoTracklet
+
+logger = logging.getLogger(__name__)
+
+MIN_VOTES = 2  # single-frame reads are never trusted
+GREY_ROLES = {"referee", "not_a_player"}
+MAX_FRAGMENT_ROWS = 200  # cap leftover-fragment rows persisted for review
+MIN_FRAGMENT_VISIBLE_S = 30.0  # leftover fragments below this aren't worth human time
+
+
+# --------------------------------------------------------------------------- voting
+
+
+def norm_number(v) -> int | None:
+    if isinstance(v, bool):
+        return None
+    if isinstance(v, int):
+        return v if 1 <= v <= 99 else None
+    if isinstance(v, float) and v.is_integer():
+        return norm_number(int(v))
+    if isinstance(v, str) and v.strip().isdigit():
+        return norm_number(int(v.strip()))
+    return None
+
+
+def modal_role(roles: Counter) -> str | None:
+    if not roles:
+        return None
+    return max(roles.items(), key=lambda kv: (kv[1], kv[0]))[0]
+
+
+def _is_doubling(a: int, b: int) -> bool:
+    # OCR doubling (4 vs 44) supports the top number. Caveat: 1 vs 11 is
+    # genuinely ambiguous and also matches — accepted, same as the spike.
+    return str(a) * 2 == str(b) or str(b) * 2 == str(a)
+
+
+def vote_fragment(parsed_reads: list[dict]) -> dict:
+    """Vote one fragment's VLM/OCR reads into a jersey decision.
+
+    Returns {number_votes, role_votes, jersey_number, role, anchored,
+    confidence, contaminated, weak_number}.
+    """
+    nums = Counter(n for p in parsed_reads if (n := norm_number(p.get("jersey_number"))) is not None)
+    roles = Counter(p["role"] for p in parsed_reads if isinstance(p.get("role"), str))
+    number, anchored, confidence, contaminated = None, False, None, False
+    if nums:
+        mc = nums.most_common()
+        top, top_n = mc[0]
+        rivals = [(n, c) for n, c in mc[1:] if not _is_doubling(top, n)]
+        second_n = rivals[0][1] if rivals else 0
+        # Two multiply-attested numbers in ONE fragment = tracker-swap splice.
+        contaminated = second_n >= 2
+        anchored = top_n >= MIN_VOTES and top_n > second_n and not contaminated
+        if anchored:
+            number = top
+            confidence = "high" if (second_n == 0 or top_n >= max(3, 2 * second_n)) else "low"
+    weak_number = None
+    if not anchored and not contaminated and sum(nums.values()) == 1:
+        weak_number = next(iter(nums))
+    return {
+        "number_votes": {str(k): v for k, v in sorted(nums.items())},
+        "role_votes": dict(sorted(roles.items())),
+        "jersey_number": number,
+        "role": modal_role(roles),
+        "anchored": anchored,
+        "confidence": confidence,
+        "contaminated": contaminated,
+        "weak_number": weak_number,
+    }
+
+
+# --------------------------------------------------------------------------- chains
+
+
+def _span_overlap(a: dict, b: dict) -> float:
+    return max(0.0, min(a["last_s"], b["last_s"]) - max(a["first_s"], b["first_s"]))
+
+
+def build_chains(
+    vote_by_fragment: dict[int, dict],
+    fragments: list[dict],
+    max_overlap: float = 2.0,
+) -> tuple[list[dict], list[dict]]:
+    """Number-driven long-gap merge over fragment dicts
+    ({entity_id, team, first_s, last_s, visible_s}).
+
+    Returns (chains, conflicts). Chain: {player_key, team, jersey_number, role,
+    confidence, member_fragment_ids, strong_fragment_ids, first_s, last_s,
+    visible_s_total}. Validity: >= 1 strong fragment, or >= 2 weak.
+    """
+    frag_by_id = {f["entity_id"]: f for f in fragments}
+    groups: dict[tuple[int, int], dict[str, list[dict]]] = {}
+    for fid, v in vote_by_fragment.items():
+        f = frag_by_id.get(fid)
+        if f is None or f.get("team") not in (0, 1):
+            continue
+        if v["anchored"]:
+            g = groups.setdefault((f["team"], v["jersey_number"]), {"strong": [], "weak": []})
+            g["strong"].append(f)
+        elif v["weak_number"] is not None:
+            g = groups.setdefault((f["team"], v["weak_number"]), {"strong": [], "weak": []})
+            g["weak"].append(f)
+
+    chains: list[dict] = []
+    conflicts: list[dict] = []
+    for (team, num), g in sorted(groups.items()):
+        strong = sorted(g["strong"], key=lambda f: -f["visible_s"])
+        weak = sorted(g["weak"], key=lambda f: -f["visible_s"])
+        seeds = strong if strong else weak
+        cluster = [seeds[0]]
+        rejected: list[dict] = []
+        for f in seeds[1:]:
+            if max(_span_overlap(f, c) for c in cluster) <= max_overlap:
+                cluster.append(f)
+            else:
+                rejected.append(f)
+        strong_ids = {f["entity_id"] for f in cluster} if strong else set()
+        if strong:  # weak fragments only ever JOIN a strong-seeded chain
+            for f in weak:
+                if max(_span_overlap(f, c) for c in cluster) <= max_overlap:
+                    cluster.append(f)
+                else:
+                    rejected.append(f)
+
+        n_strong = len(strong_ids)
+        if n_strong == 0 and len(cluster) < 2:
+            continue  # one lone read never names a player
+
+        roles: Counter = Counter()
+        for f in cluster:
+            roles.update(vote_by_fragment.get(f["entity_id"], {}).get("role_votes", {}))
+        confidence = "low"
+        if any(vote_by_fragment[i].get("confidence") == "high" for i in strong_ids):
+            confidence = "high"
+        chains.append(
+            {
+                "player_key": f"T{team}#{num}",
+                "team": team,
+                "jersey_number": num,
+                "role": modal_role(roles) or "outfield",
+                "confidence": confidence,
+                "member_fragment_ids": sorted(f["entity_id"] for f in cluster),
+                "strong_fragment_ids": sorted(strong_ids),
+                "first_s": round(min(f["first_s"] for f in cluster), 2),
+                "last_s": round(max(f["last_s"] for f in cluster), 2),
+                "visible_s_total": round(sum(f["visible_s"] for f in cluster), 2),
+            }
+        )
+        for f in rejected:
+            conflicts.append(
+                {
+                    "fragment_id": f["entity_id"],
+                    "team": team,
+                    "jersey_number": num,
+                    "flag": "span overlap with chain (duplicate number, misread, or team error)",
+                }
+            )
+    return chains, conflicts
+
+
+# --------------------------------------------------------------------------- persistence
+
+
+def persist_artifacts(match: VideoMatch, artifacts: dict) -> dict:
+    """Turn worker artifacts into VideoTracklet rows and flip the match to
+    needs_tagging. Re-runs replace prior pipeline rows but keep human work:
+    a row whose tag_source='human' (or dismissed) survives by pipeline_key.
+
+    artifacts: {fragments: [...], votes: {entities: [{entity_id, ...vote}]},
+                chains: [...]?, thumbnails: {pipeline_key: [blob paths]}?}
+    Chains are rebuilt here when absent so the worker may ship votes only.
+    """
+    fragments = artifacts.get("fragments") or []
+    vote_rows = (artifacts.get("votes") or {}).get("entities") or []
+    vote_by_fragment: dict[int, dict] = {}
+    for v in vote_rows:
+        fid = v.get("entity_id")
+        if fid is None:
+            continue
+        if "anchored" in v:  # already-voted row (spike schema)
+            v.setdefault("weak_number", None)
+            if v.get("weak_number") is None and not v["anchored"] and not v.get("contaminated"):
+                votes = v.get("number_votes") or {}
+                if sum(votes.values()) == 1:
+                    v["weak_number"] = int(next(iter(votes)))
+            vote_by_fragment[fid] = v
+        else:  # raw reads → vote here
+            vote_by_fragment[fid] = vote_fragment(v.get("reads") or [])
+
+    chains = artifacts.get("chains")
+    if chains is None:
+        chains, _conflicts = build_chains(vote_by_fragment, fragments)
+    thumbnails = artifacts.get("thumbnails") or {}
+
+    # preserve human decisions across pipeline re-runs
+    prior = {
+        t.pipeline_key: t
+        for t in db.session.query(VideoTracklet).filter(VideoTracklet.video_match_id == match.id)
+        if t.tag_source == "human" or t.dismissed
+    }
+    db.session.query(VideoTracklet).filter(
+        VideoTracklet.video_match_id == match.id,
+        VideoTracklet.id.notin_([t.id for t in prior.values()] or [0]),
+    ).delete(synchronize_session=False)
+
+    frag_by_id = {f["entity_id"]: f for f in fragments}
+    chained_fragment_ids: set[int] = set()
+    created = 0
+    for ch in chains:
+        chained_fragment_ids.update(ch["member_fragment_ids"])
+        if ch["player_key"] in prior:
+            continue
+        db.session.add(
+            VideoTracklet(
+                video_match_id=match.id,
+                kind="chain",
+                pipeline_key=ch["player_key"],
+                team_cluster=ch["team"],
+                suggested_number=ch["jersey_number"],
+                suggested_role=ch.get("role"),
+                confidence=ch.get("confidence"),
+                first_s=ch.get("first_s"),
+                last_s=ch.get("last_s"),
+                visible_s=ch.get("visible_s_total"),
+                thumbnail_paths=thumbnails.get(ch["player_key"]),
+                evidence={
+                    "member_fragment_ids": ch["member_fragment_ids"],
+                    "strong_fragment_ids": ch.get("strong_fragment_ids", []),
+                    "votes": {
+                        str(fid): vote_by_fragment.get(fid, {}).get("number_votes")
+                        for fid in ch["member_fragment_ids"]
+                        if fid in vote_by_fragment
+                    },
+                },
+            )
+        )
+        created += 1
+
+    leftovers = [
+        f
+        for f in fragments
+        if f["entity_id"] not in chained_fragment_ids
+        and (f.get("visible_s") or 0) >= MIN_FRAGMENT_VISIBLE_S
+        and vote_by_fragment.get(f["entity_id"], {}).get("role") not in GREY_ROLES
+    ]
+    leftovers.sort(key=lambda f: -(f.get("visible_s") or 0))
+    for f in leftovers[:MAX_FRAGMENT_ROWS]:
+        key = f"E{f['entity_id']}"
+        if key in prior:
+            continue
+        v = vote_by_fragment.get(f["entity_id"], {})
+        db.session.add(
+            VideoTracklet(
+                video_match_id=match.id,
+                kind="fragment",
+                pipeline_key=key,
+                team_cluster=f.get("team"),
+                suggested_number=v.get("jersey_number") or v.get("weak_number"),
+                suggested_role=v.get("role"),
+                confidence=v.get("confidence"),
+                contaminated=bool(v.get("contaminated")),
+                first_s=f.get("first_s"),
+                last_s=f.get("last_s"),
+                visible_s=f.get("visible_s"),
+                thumbnail_paths=thumbnails.get(key),
+                evidence={"number_votes": v.get("number_votes")} if v else None,
+            )
+        )
+        created += 1
+
+    match.status = "needs_tagging"
+    db.session.commit()
+
+    bound = auto_bind(match) if match.our_team_cluster is not None else 0
+    logger.info(
+        "video match %s: persisted %d tracklet rows (%d chains), auto-bound %d",
+        match.id,
+        created,
+        len(chains),
+        bound,
+    )
+    return {"tracklets": created, "chains": len(chains), "auto_bound": bound}
+
+
+def auto_bind(match: VideoMatch) -> int:
+    """Default-accept high-confidence bindings: an our-side chain whose
+    suggested number matches exactly one roster entry binds automatically
+    (tag_source='auto'); the review UI shows these as accepted-by-default.
+    Requires match.our_team_cluster (human confirms which side is ours)."""
+    if match.our_team_cluster not in (0, 1):
+        return 0
+    roster_by_number: dict[int, VideoRosterEntry] = {r.jersey_number: r for r in match.roster_entries}
+    bound = 0
+    rows = (
+        db.session.query(VideoTracklet)
+        .filter(
+            VideoTracklet.video_match_id == match.id,
+            VideoTracklet.kind == "chain",
+            VideoTracklet.confidence == "high",
+            VideoTracklet.team_cluster == match.our_team_cluster,
+            VideoTracklet.roster_entry_id.is_(None),
+            VideoTracklet.dismissed.is_(False),
+        )
+        .all()
+    )
+    for t in rows:
+        entry = roster_by_number.get(t.suggested_number)
+        if entry is None or t.suggested_role in GREY_ROLES:
+            continue
+        t.roster_entry_id = entry.id
+        t.tag_source = "auto"
+        bound += 1
+    db.session.commit()
+    return bound
+
+
+def complete_job_with_artifacts(job_id: str, artifacts: dict, gpu_seconds: float | None = None) -> dict:
+    """Worker entry point: mark the job succeeded and persist its artifacts."""
+    from src.models.video import VideoAnalysisJob  # local import avoids cycles
+
+    job = db.session.get(VideoAnalysisJob, job_id)
+    if job is None:
+        raise ValueError(f"job {job_id} not found")
+    match = db.session.get(VideoMatch, job.video_match_id)
+    result = persist_artifacts(match, artifacts)
+    job.status = "succeeded"
+    job.stage = "persist"
+    job.progress = 100
+    job.gpu_seconds = gpu_seconds
+    job.completed_at = datetime.now(UTC)
+    db.session.commit()
+    return result

--- a/academy-watch-backend/src/services/video_queue.py
+++ b/academy-watch-backend/src/services/video_queue.py
@@ -1,0 +1,116 @@
+"""
+Job dispatch + claim for video analysis (Phase A).
+
+The DATABASE is the source of truth for job state; the queue is only a wake-up
+signal. Workers claim work with a conditional UPDATE (queued -> running), so a
+duplicate or replayed message is a harmless no-op, and a worker polling the DB
+directly (no Service Bus configured — concierge mode) behaves identically.
+
+Service Bus (when VIDEO_SERVICE_BUS_CONNECTION is set) gives us peek-lock
+delivery + DLQ for production scale; its absence must never block a job, which
+is also the outbox property: any 'queued' row with no message gets picked up by
+the next DB poll.
+"""
+
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+
+from src.models.league import db
+from src.models.video import VideoAnalysisJob
+
+logger = logging.getLogger(__name__)
+
+QUEUE_NAME = os.getenv("VIDEO_JOBS_QUEUE", "video-jobs")
+STALE_RUNNING_HOURS = 6  # reaper: running with no heartbeat for this long => failed
+MAX_ATTEMPTS = 3
+
+
+def enqueue(job_id: str) -> str:
+    """Signal that a queued job exists. Returns the dispatch mode used.
+    DB row must already be committed (status='queued') BEFORE calling this —
+    a lost signal then degrades to DB polling instead of losing the job."""
+    conn = os.getenv("VIDEO_SERVICE_BUS_CONNECTION")
+    if not conn:
+        return "db-poll"
+    try:
+        from azure.servicebus import ServiceBusClient, ServiceBusMessage
+
+        with ServiceBusClient.from_connection_string(conn) as client:
+            with client.get_queue_sender(QUEUE_NAME) as sender:
+                sender.send_messages(ServiceBusMessage(job_id))
+        return "service-bus"
+    except Exception as e:
+        logger.warning("service bus enqueue failed for job %s (DB poll covers it): %s", job_id, e)
+        return "db-poll"
+
+
+def claim_job(job_id: str, worker_id: str) -> bool:
+    """Atomically claim a specific job. False means someone else owns it."""
+    claimed = (
+        db.session.query(VideoAnalysisJob)
+        .filter(VideoAnalysisJob.id == job_id, VideoAnalysisJob.status == "queued")
+        .update(
+            {
+                "status": "running",
+                "worker_id": worker_id,
+                "started_at": datetime.now(UTC),
+                "heartbeat_at": datetime.now(UTC),
+            },
+            synchronize_session=False,
+        )
+    )
+    db.session.commit()
+    return bool(claimed)
+
+
+def claim_next_job(worker_id: str) -> "VideoAnalysisJob | None":
+    """DB-poll path: claim the oldest queued job. Safe under concurrency via
+    row-level locking (skip_locked keeps idle workers from queueing on the row)."""
+    job = (
+        db.session.query(VideoAnalysisJob)
+        .filter(VideoAnalysisJob.status == "queued")
+        .order_by(VideoAnalysisJob.created_at)
+        .with_for_update(skip_locked=True)
+        .first()
+    )
+    if job is None:
+        db.session.commit()
+        return None
+    job.status = "running"
+    job.worker_id = worker_id
+    job.started_at = datetime.now(UTC)
+    job.heartbeat_at = datetime.now(UTC)
+    db.session.commit()
+    return job
+
+
+def heartbeat(job_id: str, stage: str | None = None, progress: int | None = None) -> None:
+    values: dict = {"heartbeat_at": datetime.now(UTC)}
+    if stage is not None:
+        values["stage"] = stage
+    if progress is not None:
+        values["progress"] = progress
+    db.session.query(VideoAnalysisJob).filter(VideoAnalysisJob.id == job_id).update(values, synchronize_session=False)
+    db.session.commit()
+
+
+def reap_stale_jobs() -> int:
+    """Mark heartbeat-dead running jobs failed. Returns count. Callers decide
+    refund policy (admin/auto) — this only flips state so retries can happen."""
+    cutoff = datetime.now(UTC) - timedelta(hours=STALE_RUNNING_HOURS)
+    stale = (
+        db.session.query(VideoAnalysisJob)
+        .filter(
+            VideoAnalysisJob.status == "running",
+            VideoAnalysisJob.heartbeat_at < cutoff,
+        )
+        .update(
+            {"status": "failed", "error": f"no heartbeat for {STALE_RUNNING_HOURS}h (stale-fail)"},
+            synchronize_session=False,
+        )
+    )
+    db.session.commit()
+    if stale:
+        logger.warning("stale-failed %d video job(s)", stale)
+    return int(stale)

--- a/academy-watch-backend/src/services/video_storage.py
+++ b/academy-watch-backend/src/services/video_storage.py
@@ -1,0 +1,105 @@
+"""
+Blob storage for match-video uploads (Phase A).
+
+Browser uploads go DIRECTLY to Azure Blob via short-lived write SAS — video
+never transits the Flask app. The app only mints SAS tokens, verifies the blob
+after upload-complete (size cap + ETag capture for the job-start TOCTOU check),
+and mints read SAS for the worker and for report assets.
+
+Env:
+  AZURE_STORAGE_CONNECTION_STRING   account with the video container
+  VIDEO_BLOB_CONTAINER              default "video-matches"
+  VIDEO_MAX_UPLOAD_GB               server-side size cap, default 12
+"""
+
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+
+logger = logging.getLogger(__name__)
+
+try:
+    from azure.storage.blob import (
+        BlobSasPermissions,
+        BlobServiceClient,
+        generate_blob_sas,
+    )
+
+    _AZURE_AVAILABLE = True
+except ImportError:  # keep the app importable without the optional dependency
+    _AZURE_AVAILABLE = False
+
+UPLOAD_SAS_MINUTES = 60  # re-mint endpoint exists because 6GB at club uplink speeds outlives this
+READ_SAS_HOURS = 6
+
+
+def _container() -> str:
+    return os.getenv("VIDEO_BLOB_CONTAINER", "video-matches")
+
+
+def _max_upload_bytes() -> int:
+    return int(float(os.getenv("VIDEO_MAX_UPLOAD_GB", "12")) * 1024**3)
+
+
+def is_configured() -> bool:
+    return _AZURE_AVAILABLE and bool(os.getenv("AZURE_STORAGE_CONNECTION_STRING"))
+
+
+def _service_client() -> "BlobServiceClient":
+    if not _AZURE_AVAILABLE:
+        raise RuntimeError("azure-storage-blob is not installed")
+    conn = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
+    if not conn:
+        raise RuntimeError("AZURE_STORAGE_CONNECTION_STRING is not configured")
+    return BlobServiceClient.from_connection_string(conn)
+
+
+def _mint_sas(blob_path: str, permission: "BlobSasPermissions", expiry: datetime) -> str:
+    client = _service_client()
+    return generate_blob_sas(
+        account_name=client.account_name,
+        container_name=_container(),
+        blob_name=blob_path,
+        account_key=client.credential.account_key,
+        permission=permission,
+        expiry=expiry,
+    )
+
+
+def mint_upload_sas(blob_path: str) -> dict:
+    """Write-only SAS for the browser's direct-to-blob upload."""
+    expiry = datetime.now(UTC) + timedelta(minutes=UPLOAD_SAS_MINUTES)
+    sas = _mint_sas(blob_path, BlobSasPermissions(write=True, create=True), expiry)
+    client = _service_client()
+    return {
+        "upload_url": f"{client.url}{_container()}/{blob_path}?{sas}",
+        "blob_path": blob_path,
+        "expires_at": expiry.isoformat(),
+        "max_bytes": _max_upload_bytes(),
+    }
+
+
+def mint_read_sas(blob_path: str, hours: int = READ_SAS_HOURS) -> str:
+    """Read-only SAS URL (worker footage pull, report thumbnails)."""
+    expiry = datetime.now(UTC) + timedelta(hours=hours)
+    sas = _mint_sas(blob_path, BlobSasPermissions(read=True), expiry)
+    client = _service_client()
+    return f"{client.url}{_container()}/{blob_path}?{sas}"
+
+
+def verify_uploaded_blob(blob_path: str) -> dict:
+    """Post-upload verification: blob exists and is within the size cap.
+    Returns {ok, size_bytes, etag} or {ok: False, error}."""
+    try:
+        blob = _service_client().get_blob_client(_container(), blob_path)
+        props = blob.get_blob_properties()
+    except Exception as e:  # missing blob, auth, network — all mean "not verified"
+        logger.warning("video blob verify failed for %s: %s", blob_path, e)
+        return {"ok": False, "error": "blob not found or unreadable"}
+    if props.size > _max_upload_bytes():
+        return {
+            "ok": False,
+            "error": f"file exceeds {_max_upload_bytes() // 1024**3}GB cap",
+            "size_bytes": props.size,
+        }
+    return {"ok": True, "size_bytes": props.size, "etag": props.etag}

--- a/academy-watch-backend/src/workers/vision_worker.py
+++ b/academy-watch-backend/src/workers/vision_worker.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Vision worker: claims queued video jobs and runs the GPU pipeline.
+
+Runs inside the academy-watch-vision image (GPU deps live THERE, not in this
+repo — RF-DETR, BoT-SORT, supervision, the jersey reader). The contract between
+this orchestrator and the CV code is a subprocess command plus an artifacts
+directory, which keeps the Flask codebase importable without CUDA and matches
+the chunk-and-merge architecture the ~33-min serverless-GPU eviction window
+forces anyway:
+
+  $VIDEO_PIPELINE_CMD --video <local mp4> --out <artifacts dir> \
+      [--kickoff-s N] [--halftime-s N]
+
+must produce fragments.json + votes.json (+ optional chains.json,
+thumbnails.json) in <artifacts dir> — the schema validated in the Phase 0 spike
+(invert_identity.py outputs). The worker then persists via
+video_identity.complete_job_with_artifacts().
+
+Modes:
+  one-shot (VIDEO_JOB_ID set)  process exactly that job, exit — ACA Jobs path
+  loop (default)               poll-claim queued jobs until idle-timeout
+
+Job state is DB-authoritative: claims are conditional UPDATEs, heartbeats let
+the stale-reaper recover from evictions, and a re-delivered queue message
+no-ops against an already-claimed job.
+"""
+
+import logging
+import os
+import shlex
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("vision_worker")
+
+IDLE_POLL_SECONDS = 30
+IDLE_EXIT_AFTER_POLLS = 10  # loop mode: exit after ~5 idle minutes (KEDA rescales)
+
+
+def _download_footage(blob_path: str, dest: Path) -> None:
+    from src.services.video_storage import mint_read_sas
+
+    url = mint_read_sas(blob_path)
+    log.info("downloading footage to %s", dest)
+    subprocess.run(
+        ["curl", "-fsSL", "--retry", "3", "-o", str(dest), url],
+        check=True,
+        timeout=3600,
+    )
+
+
+def _run_pipeline(video_path: Path, out_dir: Path, match) -> None:
+    cmd_template = os.getenv("VIDEO_PIPELINE_CMD")
+    if not cmd_template:
+        raise RuntimeError("VIDEO_PIPELINE_CMD is not set (vision image misconfigured)")
+    cmd = shlex.split(cmd_template) + ["--video", str(video_path), "--out", str(out_dir)]
+    if match.kickoff_s is not None:
+        cmd += ["--kickoff-s", str(match.kickoff_s)]
+    if match.halftime_s is not None:
+        cmd += ["--halftime-s", str(match.halftime_s)]
+    log.info("running pipeline: %s", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def process_job(app, job_id: str) -> bool:
+    """Run one claimed job to completion. Returns True on success."""
+    import json
+
+    from src.models.league import db
+    from src.models.video import VideoAnalysisJob, VideoMatch
+    from src.services.video_identity import complete_job_with_artifacts
+    from src.services.video_queue import heartbeat
+    from src.services.video_storage import verify_uploaded_blob
+
+    job = db.session.get(VideoAnalysisJob, job_id)
+    match = db.session.get(VideoMatch, job.video_match_id)
+    t0 = time.monotonic()
+    try:
+        # content-swap TOCTOU check: blob must still match the upload-complete ETag
+        heartbeat(job_id, stage="decode", progress=0)
+        check = verify_uploaded_blob(match.blob_path)
+        if not check["ok"]:
+            raise RuntimeError(f"footage blob failed verification: {check.get('error')}")
+        if match.blob_etag and check.get("etag") != match.blob_etag:
+            raise RuntimeError("footage blob changed since upload-complete (ETag mismatch)")
+
+        with tempfile.TemporaryDirectory(prefix="vision-job-") as tmp:
+            tmp_path = Path(tmp)
+            video_path = tmp_path / "match.mp4"
+            _download_footage(match.blob_path, video_path)
+
+            heartbeat(job_id, stage="detect", progress=5)
+            out_dir = tmp_path / "artifacts"
+            out_dir.mkdir()
+            _run_pipeline(video_path, out_dir, match)
+
+            heartbeat(job_id, stage="persist", progress=90)
+            artifacts = {
+                "fragments": json.loads((out_dir / "fragments.json").read_text()),
+                "votes": json.loads((out_dir / "votes.json").read_text()),
+            }
+            for opt in ("chains", "thumbnails"):
+                p = out_dir / f"{opt}.json"
+                if p.exists():
+                    artifacts[opt] = json.loads(p.read_text())
+            complete_job_with_artifacts(job_id, artifacts, gpu_seconds=round(time.monotonic() - t0, 1))
+        log.info("job %s succeeded", job_id)
+        return True
+    except Exception as e:
+        log.exception("job %s failed", job_id)
+        db.session.rollback()
+        job = db.session.get(VideoAnalysisJob, job_id)
+        job.status = "failed"
+        job.error = str(e)[:2000]
+        job.gpu_seconds = round(time.monotonic() - t0, 1)
+        job.completed_at = datetime.now(UTC)
+        match = db.session.get(VideoMatch, job.video_match_id)
+        match.status = "failed"
+        db.session.commit()
+        return False
+
+
+def main() -> None:
+    from src.main import app
+
+    worker_id = os.getenv("CONTAINER_APP_REPLICA_NAME") or socket.gethostname()
+    with app.app_context():
+        from src.services.video_queue import claim_job, claim_next_job
+
+        pinned = os.getenv("VIDEO_JOB_ID")
+        if pinned:
+            if not claim_job(pinned, worker_id):
+                log.info("job %s already claimed elsewhere — exiting (duplicate delivery)", pinned)
+                return
+            ok = process_job(app, pinned)
+            sys.exit(0 if ok else 1)
+
+        idle = 0
+        while idle < IDLE_EXIT_AFTER_POLLS:
+            job = claim_next_job(worker_id)
+            if job is None:
+                idle += 1
+                time.sleep(IDLE_POLL_SECONDS)
+                continue
+            idle = 0
+            process_job(app, job.id)
+        log.info("idle for %ds — exiting", IDLE_POLL_SECONDS * IDLE_EXIT_AFTER_POLLS)
+
+
+if __name__ == "__main__":
+    main()

--- a/academy-watch-backend/tests/test_video_identity.py
+++ b/academy-watch-backend/tests/test_video_identity.py
@@ -1,0 +1,214 @@
+"""Tests for the video identity service (vote/chain rules proven in the Phase 0
+spike) and the worker-artifact persistence + credit ledger flows."""
+
+import pytest
+from flask import Flask
+from src.models.league import Team, db
+from src.models.video import (
+    VideoCreditLedger,
+    VideoMatch,
+    VideoRosterEntry,
+    VideoTracklet,
+)
+from src.services.video_identity import (
+    auto_bind,
+    build_chains,
+    persist_artifacts,
+    vote_fragment,
+)
+
+# --------------------------------------------------------------------------- voting
+
+
+class TestVoteFragment:
+    def test_two_agreeing_reads_anchor(self):
+        v = vote_fragment([{"jersey_number": 10}, {"jersey_number": 10}])
+        assert v["anchored"] and v["jersey_number"] == 10 and v["confidence"] == "high"
+
+    def test_single_read_is_weak_never_anchored(self):
+        v = vote_fragment([{"jersey_number": 7}])
+        assert not v["anchored"] and v["weak_number"] == 7
+
+    def test_digit_doubling_supports_top_number(self):
+        # OCR artifact: "44" on a #4 shirt must not rival 4
+        v = vote_fragment([{"jersey_number": 4}, {"jersey_number": 4}, {"jersey_number": 44}])
+        assert v["anchored"] and v["jersey_number"] == 4 and v["confidence"] == "high"
+
+    def test_two_multiply_attested_numbers_refused_as_splice(self):
+        reads = [{"jersey_number": n} for n in (10, 10, 14, 14, 14)]
+        v = vote_fragment(reads)
+        assert v["contaminated"] and not v["anchored"] and v["jersey_number"] is None
+
+    def test_outvoted_rival_lowers_confidence(self):
+        v = vote_fragment([{"jersey_number": 12}, {"jersey_number": 12}, {"jersey_number": 15}])
+        assert v["anchored"] and v["jersey_number"] == 12 and v["confidence"] == "low"
+
+    def test_role_votes_collected(self):
+        v = vote_fragment([{"role": "not_a_player"}, {"role": "not_a_player"}, {"role": "outfield"}])
+        assert v["role"] == "not_a_player" and not v["anchored"]
+
+    def test_garbage_numbers_ignored(self):
+        v = vote_fragment([{"jersey_number": 0}, {"jersey_number": 100}, {"jersey_number": True}])
+        assert v["number_votes"] == {} and not v["anchored"]
+
+
+# --------------------------------------------------------------------------- chains
+
+
+def _frag(fid, team, first, last, visible):
+    return {"entity_id": fid, "team": team, "first_s": first, "last_s": last, "visible_s": visible}
+
+
+def _strong(number, confidence="high"):
+    return vote_fragment([{"jersey_number": number}] * 2) | {"confidence": confidence}
+
+
+class TestBuildChains:
+    def test_disjoint_fragments_chain_by_number(self):
+        frags = [_frag(1, 0, 0, 100, 90), _frag(2, 0, 200, 300, 80)]
+        votes = {1: _strong(9), 2: _strong(9)}
+        chains, conflicts = build_chains(votes, frags)
+        assert len(chains) == 1
+        assert chains[0]["player_key"] == "T0#9"
+        assert chains[0]["member_fragment_ids"] == [1, 2]
+        assert not conflicts
+
+    def test_overlapping_same_number_is_conflict_not_merge(self):
+        # one person cannot be in two places: physics check refuses the merge
+        frags = [_frag(1, 0, 0, 100, 90), _frag(2, 0, 50, 150, 70)]
+        votes = {1: _strong(9), 2: _strong(9)}
+        chains, conflicts = build_chains(votes, frags)
+        assert len(chains) == 1 and chains[0]["member_fragment_ids"] == [1]
+        assert len(conflicts) == 1 and conflicts[0]["fragment_id"] == 2
+
+    def test_same_number_different_teams_are_distinct_players(self):
+        frags = [_frag(1, 0, 0, 100, 90), _frag(2, 1, 0, 100, 90)]
+        votes = {1: _strong(10), 2: _strong(10)}
+        chains, _ = build_chains(votes, frags)
+        assert {c["player_key"] for c in chains} == {"T0#10", "T1#10"}
+
+    def test_weak_fragment_joins_strong_chain(self):
+        frags = [_frag(1, 0, 0, 100, 90), _frag(2, 0, 200, 250, 40)]
+        votes = {1: _strong(4), 2: vote_fragment([{"jersey_number": 4}])}
+        chains, _ = build_chains(votes, frags)
+        assert chains[0]["member_fragment_ids"] == [1, 2]
+        assert chains[0]["strong_fragment_ids"] == [1]
+
+    def test_single_weak_read_never_names_a_player(self):
+        frags = [_frag(1, 0, 0, 50, 40)]
+        votes = {1: vote_fragment([{"jersey_number": 8}])}
+        chains, _ = build_chains(votes, frags)
+        assert chains == []
+
+    def test_two_independent_weak_reads_may_seed_a_chain(self):
+        frags = [_frag(1, 0, 0, 50, 40), _frag(2, 0, 100, 150, 40)]
+        votes = {
+            1: vote_fragment([{"jersey_number": 8}]),
+            2: vote_fragment([{"jersey_number": 8}]),
+        }
+        chains, _ = build_chains(votes, frags)
+        assert len(chains) == 1 and chains[0]["confidence"] == "low"
+
+    def test_unlabeled_team_fragments_ignored(self):
+        frags = [_frag(1, -1, 0, 100, 90)]
+        votes = {1: _strong(5)}
+        chains, _ = build_chains(votes, frags)
+        assert chains == []
+
+
+# --------------------------------------------------------------------------- persistence
+
+
+@pytest.fixture
+def video_app():
+    app = Flask(__name__)
+    app.config.update(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def match(video_app):
+    team = Team(team_id=1, name="Test FC", country="England", season=2026)
+    db.session.add(team)
+    db.session.flush()
+    m = VideoMatch(team_id=team.id, status="processing", our_kit_color="red")
+    db.session.add(m)
+    db.session.add(VideoRosterEntry(video_match_id=1, player_name="John Smith", jersey_number=10))
+    db.session.commit()
+    return m
+
+
+def _artifacts():
+    return {
+        "fragments": [
+            _frag(1, 0, 0, 100, 90),
+            _frag(2, 0, 200, 300, 80),
+            _frag(3, 1, 0, 400, 200),
+            _frag(4, 0, 500, 540, 35),  # leftover, no reads
+            _frag(5, 0, 600, 610, 5),  # below MIN_FRAGMENT_VISIBLE_S — dropped
+        ],
+        "votes": {
+            "entities": [
+                {"entity_id": 1, **vote_fragment([{"jersey_number": 10}] * 3)},
+                {"entity_id": 2, **vote_fragment([{"jersey_number": 10}] * 2)},
+                {"entity_id": 3, **vote_fragment([{"jersey_number": 7}] * 2)},
+            ]
+        },
+    }
+
+
+class TestPersistArtifacts:
+    def test_creates_chains_and_leftovers_and_flips_status(self, match):
+        result = persist_artifacts(match, _artifacts())
+        assert match.status == "needs_tagging"
+        rows = db.session.query(VideoTracklet).all()
+        kinds = {(t.pipeline_key, t.kind) for t in rows}
+        assert ("T0#10", "chain") in kinds and ("T1#7", "chain") in kinds
+        assert ("E4", "fragment") in kinds
+        assert ("E5", "fragment") not in kinds  # too short for human time
+        assert result["chains"] == 2
+
+    def test_auto_bind_after_side_confirmation(self, match):
+        persist_artifacts(match, _artifacts())
+        match.our_team_cluster = 0
+        db.session.commit()
+        bound = auto_bind(match)
+        assert bound == 1
+        t = db.session.query(VideoTracklet).filter_by(pipeline_key="T0#10").one()
+        entry = db.session.query(VideoRosterEntry).filter_by(jersey_number=10).one()
+        assert t.roster_entry_id == entry.id and t.tag_source == "auto"
+        # opposition #7 chain must NOT bind to our roster
+        t7 = db.session.query(VideoTracklet).filter_by(pipeline_key="T1#7").one()
+        assert t7.roster_entry_id is None
+
+    def test_rerun_preserves_human_tags(self, match):
+        persist_artifacts(match, _artifacts())
+        entry = db.session.query(VideoRosterEntry).one()
+        t = db.session.query(VideoTracklet).filter_by(pipeline_key="T0#10").one()
+        t.roster_entry_id = entry.id
+        t.tag_source = "human"
+        db.session.commit()
+        persist_artifacts(match, _artifacts())  # pipeline re-run
+        t2 = db.session.query(VideoTracklet).filter_by(pipeline_key="T0#10").one()
+        assert t2.id == t.id and t2.tag_source == "human"
+
+
+class TestCreditLedger:
+    def test_balance_sums_deltas(self, video_app):
+        team = Team(team_id=2, name="Ledger FC", country="England", season=2026)
+        db.session.add(team)
+        db.session.flush()
+        for delta, reason in ((5, "purchase"), (-1, "debit"), (1, "refund")):
+            db.session.add(VideoCreditLedger(team_id=team.id, delta=delta, reason=reason))
+        db.session.commit()
+        assert VideoCreditLedger.balance(team.id) == 5
+        assert VideoCreditLedger.balance(9999) == 0

--- a/academy-watch-frontend/src/App.jsx
+++ b/academy-watch-frontend/src/App.jsx
@@ -94,6 +94,8 @@ import { AdminCuration } from '@/pages/admin/AdminCuration'
 import { AdminFlags } from '@/pages/admin/AdminFlags'
 import { AdminAcademy } from '@/pages/admin/AdminAcademy'
 import { AdminCohorts } from '@/pages/admin/AdminCohorts'
+import { AdminVideo } from '@/pages/admin/AdminVideo'
+import { AdminVideoMatch } from '@/pages/admin/AdminVideoMatch'
 import { AdminTools } from '@/pages/admin/AdminTools'
 import { AdminSandbox } from '@/pages/admin/AdminSandbox'
 import { AdminFormation } from '@/pages/admin/AdminFormation'
@@ -10509,6 +10511,8 @@ function AppRoutes() {
         <Route path="flags" element={<AdminFlags />} />
         <Route path="academy" element={<AdminAcademy />} />
         <Route path="cohorts" element={<AdminCohorts />} />
+        <Route path="video" element={<AdminVideo />} />
+        <Route path="video/:matchId" element={<AdminVideoMatch />} />
         <Route path="settings" element={<AdminSettings />} />
         <Route path="tools" element={<AdminTools />} />
         <Route path="sandbox" element={<AdminSandbox />} />

--- a/academy-watch-frontend/src/components/admin/AdminSidebar.jsx
+++ b/academy-watch-frontend/src/components/admin/AdminSidebar.jsx
@@ -16,6 +16,7 @@ import {
     FlaskConical,
     ChevronDown,
     Flag,
+    Video,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible'
@@ -38,6 +39,7 @@ const sidebarGroups = [
             { icon: Shield, label: 'Teams', href: '/admin/teams' },
             { icon: GraduationCap, label: 'Academy', href: '/admin/academy' },
             { icon: Users, label: 'Cohorts', href: '/admin/cohorts' },
+            { icon: Video, label: 'Video Analysis', href: '/admin/video' },
         ],
     },
     {

--- a/academy-watch-frontend/src/lib/api.js
+++ b/academy-watch-frontend/src/lib/api.js
@@ -1909,4 +1909,136 @@ export class APIService {
         const query = new URLSearchParams(params).toString()
         return this.request(`/teams/${teamApiId}/academy-network${query ? '?' + query : ''}`)
     }
+
+    // ==========================================================================
+    // Video Analysis (admin, Phase A concierge)
+    // ==========================================================================
+
+    static async createVideoMatch(payload) {
+        return this.request('/admin/video/matches', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        }, { admin: true })
+    }
+
+    static async getVideoMatch(matchId) {
+        return this.request(`/admin/video/matches/${matchId}`, {}, { admin: true })
+    }
+
+    static async updateVideoMatch(matchId, payload) {
+        return this.request(`/admin/video/matches/${matchId}`, {
+            method: 'PATCH',
+            body: JSON.stringify(payload),
+        }, { admin: true })
+    }
+
+    static async remintVideoUploadSas(matchId) {
+        return this.request(`/admin/video/matches/${matchId}/sas`, { method: 'POST' }, { admin: true })
+    }
+
+    static async videoUploadComplete(matchId, payload = {}) {
+        return this.request(`/admin/video/matches/${matchId}/upload-complete`, {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        }, { admin: true })
+    }
+
+    static async upsertVideoRoster(matchId, entries) {
+        return this.request(`/admin/video/matches/${matchId}/roster`, {
+            method: 'PUT',
+            body: JSON.stringify({ entries }),
+        }, { admin: true })
+    }
+
+    static async processVideoMatch(matchId) {
+        return this.request(`/admin/video/matches/${matchId}/process`, { method: 'POST' }, { admin: true })
+    }
+
+    static async requeueVideoMatch(matchId) {
+        return this.request(`/admin/video/matches/${matchId}/requeue`, { method: 'POST' }, { admin: true })
+    }
+
+    static async getVideoTracklets(matchId, params = {}) {
+        const query = new URLSearchParams(params).toString()
+        return this.request(`/admin/video/matches/${matchId}/tracklets${query ? '?' + query : ''}`, {}, { admin: true })
+    }
+
+    static async bindVideoTags(matchId, tags) {
+        return this.request(`/admin/video/matches/${matchId}/tags`, {
+            method: 'POST',
+            body: JSON.stringify({ tags }),
+        }, { admin: true })
+    }
+
+    static async finalizeVideoMatch(matchId) {
+        return this.request(`/admin/video/matches/${matchId}/finalize`, { method: 'POST' }, { admin: true })
+    }
+
+    static async getVideoReport(matchId) {
+        return this.request(`/admin/video/matches/${matchId}/report`, {}, { admin: true })
+    }
+
+    static async getTeamVideoMatches(teamId) {
+        return this.request(`/admin/video/teams/${teamId}/matches`, {}, { admin: true })
+    }
+
+    static async getTeamVideoCredits(teamId) {
+        return this.request(`/admin/video/teams/${teamId}/credits`, {}, { admin: true })
+    }
+
+    static async grantVideoCredits(teamId, payload) {
+        return this.request(`/admin/video/teams/${teamId}/credits/grant`, {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        }, { admin: true })
+    }
+
+    static async refundVideoMatch(matchId, note) {
+        return this.request(`/admin/video/matches/${matchId}/refund`, {
+            method: 'POST',
+            body: JSON.stringify({ note }),
+        }, { admin: true })
+    }
+
+    /**
+     * Direct-to-blob upload via the SAS URL using Azure block upload
+     * (Put Block + Put Block List), so multi-GB match files work and we can
+     * report progress. No Azure SDK needed.
+     */
+    static async uploadVideoToBlob(uploadUrl, file, onProgress) {
+        const BLOCK_SIZE = 32 * 1024 * 1024 // 32MB
+        const total = file.size
+        const blockIds = []
+        let sent = 0
+        for (let offset = 0, index = 0; offset < total; offset += BLOCK_SIZE, index += 1) {
+            const chunk = file.slice(offset, Math.min(offset + BLOCK_SIZE, total))
+            // fixed-width id, base64-encoded, identical length for every block
+            const rawId = `block-${String(index).padStart(8, '0')}`
+            const blockId = btoa(rawId)
+            blockIds.push(blockId)
+            const res = await fetch(`${uploadUrl}&comp=block&blockid=${encodeURIComponent(blockId)}`, {
+                method: 'PUT',
+                body: chunk,
+            })
+            if (!res.ok) {
+                const err = new Error(`block upload failed at ${Math.round((offset / total) * 100)}% (HTTP ${res.status})`)
+                err.status = res.status
+                throw err
+            }
+            sent += chunk.size
+            if (onProgress) onProgress(Math.round((sent / total) * 100))
+        }
+        const manifest = `<?xml version="1.0" encoding="utf-8"?><BlockList>${blockIds.map((id) => `<Latest>${id}</Latest>`).join('')}</BlockList>`
+        const commit = await fetch(`${uploadUrl}&comp=blocklist`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/xml', 'x-ms-blob-content-type': file.type || 'video/mp4' },
+            body: manifest,
+        })
+        if (!commit.ok) {
+            const err = new Error(`block list commit failed (HTTP ${commit.status})`)
+            err.status = commit.status
+            throw err
+        }
+        if (onProgress) onProgress(100)
+    }
 }

--- a/academy-watch-frontend/src/lib/video-utils.js
+++ b/academy-watch-frontend/src/lib/video-utils.js
@@ -1,0 +1,33 @@
+/** Helpers for the video-analysis admin pages. */
+
+/** Accept "47:30", "1:02:15" or plain seconds; return seconds, null for empty,
+ * undefined for unparseable. */
+export function parseTimeInput(value) {
+    const text = String(value ?? '').trim()
+    if (!text) return null
+    if (/^\d+(\.\d+)?$/.test(text)) return Number(text)
+    const parts = text.split(':').map((p) => p.trim())
+    if (parts.length < 2 || parts.length > 3 || parts.some((p) => !/^\d+$/.test(p))) return undefined
+    return parts.reduce((acc, p) => acc * 60 + Number(p), 0)
+}
+
+export function formatSeconds(s) {
+    if (s === null || s === undefined) return ''
+    const total = Math.round(s)
+    const h = Math.floor(total / 3600)
+    const m = Math.floor((total % 3600) / 60)
+    const sec = total % 60
+    const mm = String(m).padStart(h ? 2 : 1, '0')
+    const ss = String(sec).padStart(2, '0')
+    return h ? `${h}:${mm}:${ss}` : `${mm}:${ss}`
+}
+
+/** Parse pasted roster lines like "10 John Smith" / "10, John Smith". */
+export function parseRosterText(text) {
+    const entries = []
+    for (const line of String(text || '').split('\n')) {
+        const m = line.trim().match(/^(\d{1,2})[\s,.-]+(.+)$/)
+        if (m) entries.push({ jersey_number: Number(m[1]), player_name: m[2].trim() })
+    }
+    return entries
+}

--- a/academy-watch-frontend/src/pages/admin/AdminVideo.jsx
+++ b/academy-watch-frontend/src/pages/admin/AdminVideo.jsx
@@ -1,0 +1,266 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog'
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select'
+import { Coins, Loader2, Plus, Video } from 'lucide-react'
+import { APIService } from '@/lib/api'
+
+const STATUS_VARIANTS = {
+    created: 'outline',
+    uploaded: 'secondary',
+    preflight: 'secondary',
+    queued: 'secondary',
+    processing: 'default',
+    needs_tagging: 'default',
+    finalized: 'default',
+    failed: 'destructive',
+    expired: 'outline',
+}
+
+export function VideoStatusBadge({ status }) {
+    return <Badge variant={STATUS_VARIANTS[status] || 'outline'}>{(status || '').replace(/_/g, ' ')}</Badge>
+}
+
+export function AdminVideo() {
+    const navigate = useNavigate()
+    const [teams, setTeams] = useState([])
+    const [teamId, setTeamId] = useState('')
+    const [matches, setMatches] = useState([])
+    const [balance, setBalance] = useState(null)
+    const [loading, setLoading] = useState(false)
+    const [error, setError] = useState(null)
+
+    const [createOpen, setCreateOpen] = useState(false)
+    const [creating, setCreating] = useState(false)
+    const [form, setForm] = useState({ opponent_name: '', match_date: '', competition: '', our_kit_color: '', opponent_kit_color: '' })
+
+    const [grantOpen, setGrantOpen] = useState(false)
+    const [grantDelta, setGrantDelta] = useState(1)
+    const [grantNote, setGrantNote] = useState('')
+    const [granting, setGranting] = useState(false)
+
+    useEffect(() => {
+        APIService.getTeams()
+            .then((res) => setTeams(res?.teams || (Array.isArray(res) ? res : [])))
+            .catch((err) => setError(err.message))
+    }, [])
+
+    const loadMatches = useCallback(async (tid) => {
+        if (!tid) return
+        setLoading(true)
+        setError(null)
+        try {
+            const res = await APIService.getTeamVideoMatches(tid)
+            setMatches(res.matches || [])
+            setBalance(res.credit_balance)
+        } catch (err) {
+            setError(err.message)
+        } finally {
+            setLoading(false)
+        }
+    }, [])
+
+    useEffect(() => {
+        if (teamId) loadMatches(teamId)
+    }, [teamId, loadMatches])
+
+    const handleCreate = async () => {
+        setCreating(true)
+        setError(null)
+        try {
+            const payload = { team_id: Number(teamId) }
+            for (const [key, value] of Object.entries(form)) {
+                if (value) payload[key] = value
+            }
+            const match = await APIService.createVideoMatch(payload)
+            setCreateOpen(false)
+            navigate(`/admin/video/${match.id}`)
+        } catch (err) {
+            setError(err.message)
+        } finally {
+            setCreating(false)
+        }
+    }
+
+    const handleGrant = async () => {
+        setGranting(true)
+        setError(null)
+        try {
+            const res = await APIService.grantVideoCredits(Number(teamId), { delta: Number(grantDelta), note: grantNote || undefined })
+            setBalance(res.balance)
+            setGrantOpen(false)
+            setGrantNote('')
+        } catch (err) {
+            setError(err.message)
+        } finally {
+            setGranting(false)
+        }
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                    <h1 className="text-2xl font-bold flex items-center gap-2"><Video className="h-6 w-6" /> Video Analysis</h1>
+                    <p className="text-sm text-muted-foreground">Match uploads, processing and tag review (concierge)</p>
+                </div>
+                <div className="flex items-center gap-2">
+                    {balance !== null && (
+                        <Badge variant="secondary" className="text-sm">
+                            <Coins className="h-3.5 w-3.5 mr-1" /> {balance} credit{balance === 1 ? '' : 's'}
+                        </Badge>
+                    )}
+                    <Button variant="outline" size="sm" disabled={!teamId} onClick={() => setGrantOpen(true)}>Grant credits</Button>
+                    <Button size="sm" disabled={!teamId} onClick={() => setCreateOpen(true)}>
+                        <Plus className="h-4 w-4 mr-1" /> New match
+                    </Button>
+                </div>
+            </div>
+
+            {error && <p className="text-sm text-destructive">{error}</p>}
+
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-base">Team</CardTitle>
+                    <CardDescription>Video matches belong to the paying club</CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <Select value={teamId} onValueChange={setTeamId}>
+                        <SelectTrigger className="w-full sm:w-96">
+                            <SelectValue placeholder="Select a team…" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {teams.map((t) => (
+                                <SelectItem key={t.id} value={String(t.id)}>{t.name}</SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </CardContent>
+            </Card>
+
+            {teamId && (
+                <Card>
+                    <CardHeader>
+                        <CardTitle className="text-base">Matches</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        {loading ? (
+                            <div className="flex items-center gap-2 text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" /> Loading…</div>
+                        ) : matches.length === 0 ? (
+                            <p className="text-sm text-muted-foreground">No video matches yet — create one to start.</p>
+                        ) : (
+                            <div className="space-y-2">
+                                {matches.map((m) => (
+                                    <button
+                                        key={m.id}
+                                        type="button"
+                                        onClick={() => navigate(`/admin/video/${m.id}`)}
+                                        className="w-full flex flex-wrap items-center justify-between gap-2 rounded-lg border p-3 text-left hover:bg-accent"
+                                    >
+                                        <div className="min-w-0">
+                                            <div className="font-medium truncate">
+                                                vs {m.opponent_name || 'Unknown opponent'}
+                                                {m.match_date ? <span className="text-muted-foreground font-normal"> · {m.match_date}</span> : null}
+                                            </div>
+                                            <div className="text-xs text-muted-foreground">
+                                                #{m.id}{m.competition ? ` · ${m.competition}` : ''}
+                                                {m.job?.stage && m.status === 'processing' ? ` · ${m.job.stage}` : ''}
+                                            </div>
+                                        </div>
+                                        <VideoStatusBadge status={m.status} />
+                                    </button>
+                                ))}
+                            </div>
+                        )}
+                    </CardContent>
+                </Card>
+            )}
+
+            <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>New video match</DialogTitle>
+                        <DialogDescription>Creates the match shell and an upload link.</DialogDescription>
+                    </DialogHeader>
+                    <div className="space-y-3">
+                        <div>
+                            <Label htmlFor="vm-opponent">Opponent</Label>
+                            <Input id="vm-opponent" value={form.opponent_name} onChange={(e) => setForm({ ...form, opponent_name: e.target.value })} placeholder="AFC Wyke" />
+                        </div>
+                        <div className="grid grid-cols-2 gap-3">
+                            <div>
+                                <Label htmlFor="vm-date">Match date</Label>
+                                <Input id="vm-date" type="date" value={form.match_date} onChange={(e) => setForm({ ...form, match_date: e.target.value })} />
+                            </div>
+                            <div>
+                                <Label htmlFor="vm-comp">Competition</Label>
+                                <Input id="vm-comp" value={form.competition} onChange={(e) => setForm({ ...form, competition: e.target.value })} placeholder="League / friendly" />
+                            </div>
+                        </div>
+                        <div className="grid grid-cols-2 gap-3">
+                            <div>
+                                <Label htmlFor="vm-kit">Our kit color</Label>
+                                <Input id="vm-kit" value={form.our_kit_color} onChange={(e) => setForm({ ...form, our_kit_color: e.target.value })} placeholder="red" />
+                            </div>
+                            <div>
+                                <Label htmlFor="vm-okit">Opponent kit color</Label>
+                                <Input id="vm-okit" value={form.opponent_kit_color} onChange={(e) => setForm({ ...form, opponent_kit_color: e.target.value })} placeholder="blue" />
+                            </div>
+                        </div>
+                    </div>
+                    <DialogFooter>
+                        <Button variant="outline" onClick={() => setCreateOpen(false)}>Cancel</Button>
+                        <Button onClick={handleCreate} disabled={creating}>
+                            {creating && <Loader2 className="h-4 w-4 mr-1 animate-spin" />} Create
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            <Dialog open={grantOpen} onOpenChange={setGrantOpen}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Grant credits</DialogTitle>
+                        <DialogDescription>Concierge credit movement (Stripe checkout arrives in Phase B). Negative values remove credits.</DialogDescription>
+                    </DialogHeader>
+                    <div className="space-y-3">
+                        <div>
+                            <Label htmlFor="vm-grant-delta">Credits</Label>
+                            <Input id="vm-grant-delta" type="number" value={grantDelta} onChange={(e) => setGrantDelta(e.target.value)} />
+                        </div>
+                        <div>
+                            <Label htmlFor="vm-grant-note">Note</Label>
+                            <Input id="vm-grant-note" value={grantNote} onChange={(e) => setGrantNote(e.target.value)} placeholder="paid via invoice #…" />
+                        </div>
+                    </div>
+                    <DialogFooter>
+                        <Button variant="outline" onClick={() => setGrantOpen(false)}>Cancel</Button>
+                        <Button onClick={handleGrant} disabled={granting || !Number(grantDelta)}>
+                            {granting && <Loader2 className="h-4 w-4 mr-1 animate-spin" />} Apply
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </div>
+    )
+}
+
+export default AdminVideo

--- a/academy-watch-frontend/src/pages/admin/AdminVideoMatch.jsx
+++ b/academy-watch-frontend/src/pages/admin/AdminVideoMatch.jsx
@@ -1,0 +1,545 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Progress } from '@/components/ui/progress'
+import { Textarea } from '@/components/ui/textarea'
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select'
+import {
+    AlertTriangle,
+    CheckCircle2,
+    Coins,
+    Loader2,
+    Play,
+    RefreshCw,
+    Upload,
+    UserX,
+} from 'lucide-react'
+import { APIService } from '@/lib/api'
+import { formatSeconds, parseRosterText, parseTimeInput } from '@/lib/video-utils'
+import { VideoStatusBadge } from './AdminVideo'
+
+const POLL_STATUSES = new Set(['queued', 'processing', 'preflight'])
+
+export function AdminVideoMatch() {
+    const { matchId } = useParams()
+    const [match, setMatch] = useState(null)
+    const [error, setError] = useState(null)
+    const [notice, setNotice] = useState(null)
+
+    const [uploadState, setUploadState] = useState({ phase: 'idle', progress: 0 })
+    const [markers, setMarkers] = useState({ kickoff: '', halftime: '', secondHalf: '' })
+    const fileRef = useRef(null)
+    const uploadInfoRef = useRef(null)
+
+    const [rosterText, setRosterText] = useState('')
+    const [rosterSaving, setRosterSaving] = useState(false)
+
+    const [processing, setProcessing] = useState(false)
+
+    const [tracklets, setTracklets] = useState([])
+    const [pendingTags, setPendingTags] = useState({})
+    const [tagsSaving, setTagsSaving] = useState(false)
+    const [report, setReport] = useState(null)
+
+    const load = useCallback(async () => {
+        try {
+            const data = await APIService.getVideoMatch(matchId)
+            setMatch(data)
+            if (data.status === 'needs_tagging' || data.status === 'finalized') {
+                const t = await APIService.getVideoTracklets(matchId)
+                setTracklets(t.tracklets || [])
+            }
+            if (data.status === 'finalized') {
+                const r = await APIService.getVideoReport(matchId)
+                setReport(r)
+            }
+            return data
+        } catch (err) {
+            setError(err.message)
+            return null
+        }
+    }, [matchId])
+
+    useEffect(() => { load() }, [load])
+
+    // poll while the pipeline owns the match
+    useEffect(() => {
+        if (!match || !POLL_STATUSES.has(match.status)) return undefined
+        const id = setInterval(load, 5000)
+        return () => clearInterval(id)
+    }, [match, load])
+
+    useEffect(() => {
+        if (match) {
+            setMarkers({
+                kickoff: match.kickoff_s != null ? formatSeconds(match.kickoff_s) : '',
+                halftime: match.halftime_s != null ? formatSeconds(match.halftime_s) : '',
+                secondHalf: match.second_half_kickoff_s != null ? formatSeconds(match.second_half_kickoff_s) : '',
+            })
+            if (!rosterText && match.roster?.length) {
+                setRosterText(match.roster.map((r) => `${r.jersey_number} ${r.player_name}`).join('\n'))
+            }
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [match?.id, match?.status])
+
+    const rosterByEntryId = useMemo(() => {
+        const map = {}
+        for (const r of match?.roster || []) map[r.id] = r
+        return map
+    }, [match])
+
+    const handleUpload = async () => {
+        const file = fileRef.current?.files?.[0]
+        if (!file) { setError('Choose a video file first'); return }
+        setError(null)
+        setUploadState({ phase: 'uploading', progress: 0 })
+        try {
+            if (!uploadInfoRef.current) {
+                uploadInfoRef.current = await APIService.remintVideoUploadSas(matchId)
+            }
+            try {
+                await APIService.uploadVideoToBlob(uploadInfoRef.current.upload_url, file, (p) => setUploadState({ phase: 'uploading', progress: p }))
+            } catch (err) {
+                if (err.status === 403) { // SAS expired mid-upload — re-mint once and retry
+                    uploadInfoRef.current = await APIService.remintVideoUploadSas(matchId)
+                    await APIService.uploadVideoToBlob(uploadInfoRef.current.upload_url, file, (p) => setUploadState({ phase: 'uploading', progress: p }))
+                } else {
+                    throw err
+                }
+            }
+            setUploadState({ phase: 'uploaded', progress: 100 })
+            setNotice('Upload complete — mark kickoff below, then confirm.')
+        } catch (err) {
+            setError(err.message)
+            setUploadState({ phase: 'idle', progress: 0 })
+        }
+    }
+
+    const handleConfirmUpload = async () => {
+        const kickoff = parseTimeInput(markers.kickoff)
+        if (kickoff === undefined || kickoff === null) {
+            setError('Kickoff time is required (mm:ss into the video)')
+            return
+        }
+        const halftime = parseTimeInput(markers.halftime)
+        const secondHalf = parseTimeInput(markers.secondHalf)
+        if (halftime === undefined || secondHalf === undefined) {
+            setError('Times must be mm:ss or seconds')
+            return
+        }
+        setError(null)
+        try {
+            await APIService.videoUploadComplete(matchId, {
+                kickoff_s: kickoff,
+                halftime_s: halftime,
+                second_half_kickoff_s: secondHalf,
+            })
+            setNotice('Footage verified.')
+            await load()
+        } catch (err) {
+            setError(err.message)
+        }
+    }
+
+    const handleSaveMarkers = async () => {
+        const kickoff = parseTimeInput(markers.kickoff)
+        const halftime = parseTimeInput(markers.halftime)
+        const secondHalf = parseTimeInput(markers.secondHalf)
+        if ([kickoff, halftime, secondHalf].includes(undefined)) {
+            setError('Times must be mm:ss or seconds')
+            return
+        }
+        setError(null)
+        try {
+            await APIService.updateVideoMatch(matchId, {
+                kickoff_s: kickoff,
+                halftime_s: halftime,
+                second_half_kickoff_s: secondHalf,
+            })
+            setNotice('Markers saved.')
+            await load()
+        } catch (err) {
+            setError(err.message)
+        }
+    }
+
+    const handleSaveRoster = async () => {
+        const entries = parseRosterText(rosterText)
+        if (!entries.length) { setError('Roster needs lines like "10 John Smith"'); return }
+        setRosterSaving(true)
+        setError(null)
+        try {
+            await APIService.upsertVideoRoster(matchId, entries)
+            setNotice(`Roster saved (${entries.length} players).`)
+            await load()
+        } catch (err) {
+            setError(err.message)
+        } finally {
+            setRosterSaving(false)
+        }
+    }
+
+    const handleProcess = async () => {
+        setProcessing(true)
+        setError(null)
+        try {
+            await APIService.processVideoMatch(matchId)
+            setNotice('Queued for processing — this page polls automatically.')
+            await load()
+        } catch (err) {
+            setError(err.status === 402 ? 'No credits — grant credits from the Video Analysis page first.' : err.message)
+        } finally {
+            setProcessing(false)
+        }
+    }
+
+    const handlePickSide = async (cluster) => {
+        setError(null)
+        try {
+            const res = await APIService.updateVideoMatch(matchId, { our_team_cluster: cluster })
+            setNotice(res.auto_bound ? `Side confirmed — ${res.auto_bound} high-confidence players auto-tagged.` : 'Side confirmed.')
+            await load()
+        } catch (err) {
+            setError(err.message)
+        }
+    }
+
+    const stageTag = (trackletId, change) => {
+        setPendingTags((prev) => ({ ...prev, [trackletId]: { ...prev[trackletId], ...change } }))
+    }
+
+    const handleSaveTags = async () => {
+        const tags = Object.entries(pendingTags).map(([trackletId, change]) => ({
+            tracklet_id: Number(trackletId),
+            ...change,
+        }))
+        if (!tags.length) return
+        setTagsSaving(true)
+        setError(null)
+        try {
+            await APIService.bindVideoTags(matchId, tags)
+            setPendingTags({})
+            setNotice(`${tags.length} tag change${tags.length === 1 ? '' : 's'} saved.`)
+            await load()
+        } catch (err) {
+            setError(err.message)
+        } finally {
+            setTagsSaving(false)
+        }
+    }
+
+    const handleFinalize = async () => {
+        setError(null)
+        try {
+            const res = await APIService.finalizeVideoMatch(matchId)
+            setNotice(`Finalized — ${res.reports} player report${res.reports === 1 ? '' : 's'}.`)
+            await load()
+        } catch (err) {
+            setError(err.message)
+        }
+    }
+
+    if (!match) {
+        return error
+            ? <p className="text-sm text-destructive">{error}</p>
+            : <div className="flex items-center gap-2 text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" /> Loading…</div>
+    }
+
+    const job = match.job
+    const trackletValue = (t, field, fallback) => {
+        const pending = pendingTags[t.id]
+        return pending && field in pending ? pending[field] : fallback
+    }
+
+    return (
+        <div className="space-y-6 max-w-4xl">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                    <h1 className="text-2xl font-bold">vs {match.opponent_name || 'Unknown opponent'}</h1>
+                    <p className="text-sm text-muted-foreground">
+                        Match #{match.id}{match.match_date ? ` · ${match.match_date}` : ''}{match.competition ? ` · ${match.competition}` : ''}
+                    </p>
+                </div>
+                <div className="flex items-center gap-2">
+                    <Badge variant="secondary"><Coins className="h-3.5 w-3.5 mr-1" />{match.credit_balance}</Badge>
+                    <VideoStatusBadge status={match.status} />
+                    <Button variant="ghost" size="icon" onClick={load} aria-label="Refresh"><RefreshCw className="h-4 w-4" /></Button>
+                </div>
+            </div>
+
+            {error && <p className="text-sm text-destructive">{error}</p>}
+            {notice && <p className="text-sm text-emerald-600">{notice}</p>}
+
+            {match.status === 'created' && (
+                <Card>
+                    <CardHeader>
+                        <CardTitle className="text-base flex items-center gap-2"><Upload className="h-4 w-4" /> Upload footage</CardTitle>
+                        <CardDescription>
+                            Goes directly to storage — keep this tab open. Mark kickoff when the upload finishes:
+                            ten seconds of your time beats any auto-detection.
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                        <Input ref={fileRef} type="file" accept="video/mp4,video/*" disabled={uploadState.phase === 'uploading'} />
+                        {uploadState.phase === 'uploading' && (
+                            <div className="space-y-1">
+                                <Progress value={uploadState.progress} />
+                                <p className="text-xs text-muted-foreground">{uploadState.progress}% uploaded</p>
+                            </div>
+                        )}
+                        {uploadState.phase !== 'uploaded' ? (
+                            <Button onClick={handleUpload} disabled={uploadState.phase === 'uploading'}>
+                                {uploadState.phase === 'uploading' ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : <Upload className="h-4 w-4 mr-1" />}
+                                Upload
+                            </Button>
+                        ) : (
+                            <div className="space-y-3 rounded-lg border p-3">
+                                <p className="text-sm font-medium">Mark the match timeline (mm:ss into the video)</p>
+                                <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                                    <div>
+                                        <Label htmlFor="vm-kick">Kickoff *</Label>
+                                        <Input id="vm-kick" placeholder="15:00" value={markers.kickoff} onChange={(e) => setMarkers({ ...markers, kickoff: e.target.value })} />
+                                    </div>
+                                    <div>
+                                        <Label htmlFor="vm-half">Halftime whistle</Label>
+                                        <Input id="vm-half" placeholder="62:30" value={markers.halftime} onChange={(e) => setMarkers({ ...markers, halftime: e.target.value })} />
+                                    </div>
+                                    <div>
+                                        <Label htmlFor="vm-second">2nd-half kickoff</Label>
+                                        <Input id="vm-second" placeholder="78:00" value={markers.secondHalf} onChange={(e) => setMarkers({ ...markers, secondHalf: e.target.value })} />
+                                    </div>
+                                </div>
+                                <Button onClick={handleConfirmUpload}><CheckCircle2 className="h-4 w-4 mr-1" /> Confirm upload</Button>
+                            </div>
+                        )}
+                    </CardContent>
+                </Card>
+            )}
+
+            {match.status !== 'finalized' && match.status !== 'created' && (
+                <Card>
+                    <CardHeader>
+                        <CardTitle className="text-base">Timeline markers</CardTitle>
+                        <CardDescription>Kickoff is required before processing.</CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                            <div>
+                                <Label htmlFor="vm-kick2">Kickoff *</Label>
+                                <Input id="vm-kick2" placeholder="15:00" value={markers.kickoff} onChange={(e) => setMarkers({ ...markers, kickoff: e.target.value })} />
+                            </div>
+                            <div>
+                                <Label htmlFor="vm-half2">Halftime whistle</Label>
+                                <Input id="vm-half2" placeholder="62:30" value={markers.halftime} onChange={(e) => setMarkers({ ...markers, halftime: e.target.value })} />
+                            </div>
+                            <div>
+                                <Label htmlFor="vm-second2">2nd-half kickoff</Label>
+                                <Input id="vm-second2" placeholder="78:00" value={markers.secondHalf} onChange={(e) => setMarkers({ ...markers, secondHalf: e.target.value })} />
+                            </div>
+                        </div>
+                        <Button variant="outline" size="sm" onClick={handleSaveMarkers}>Save markers</Button>
+                    </CardContent>
+                </Card>
+            )}
+
+            {match.status !== 'finalized' && (
+                <Card>
+                    <CardHeader>
+                        <CardTitle className="text-base">Squad list ({match.roster?.length || 0})</CardTitle>
+                        <CardDescription>One player per line: number then name — e.g. “10 John Smith”. Your team only; opposition stays numbers-only.</CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                        <Textarea rows={6} value={rosterText} onChange={(e) => setRosterText(e.target.value)} placeholder={'1 Sam Keeper\n10 John Smith\n…'} />
+                        <Button variant="outline" size="sm" onClick={handleSaveRoster} disabled={rosterSaving}>
+                            {rosterSaving && <Loader2 className="h-4 w-4 mr-1 animate-spin" />} Save squad
+                        </Button>
+                    </CardContent>
+                </Card>
+            )}
+
+            {match.status === 'uploaded' && (
+                <Card>
+                    <CardHeader>
+                        <CardTitle className="text-base">Process</CardTitle>
+                        <CardDescription>Debits 1 credit and queues the analysis. Most matches finish within a few hours.</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <Button onClick={handleProcess} disabled={processing || !match.roster?.length || match.kickoff_s == null}>
+                            {processing ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : <Play className="h-4 w-4 mr-1" />}
+                            Process match (1 credit)
+                        </Button>
+                        {(!match.roster?.length || match.kickoff_s == null) && (
+                            <p className="text-xs text-muted-foreground mt-2">
+                                Needs {!match.roster?.length ? 'a squad list' : ''}{!match.roster?.length && match.kickoff_s == null ? ' and ' : ''}{match.kickoff_s == null ? 'a kickoff marker' : ''}.
+                            </p>
+                        )}
+                    </CardContent>
+                </Card>
+            )}
+
+            {POLL_STATUSES.has(match.status) && job && (
+                <Card>
+                    <CardHeader>
+                        <CardTitle className="text-base flex items-center gap-2"><Loader2 className="h-4 w-4 animate-spin" /> Processing</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-2">
+                        <Progress value={job.progress || 0} />
+                        <p className="text-sm text-muted-foreground">
+                            {job.status === 'queued' ? 'Waiting for a worker…' : `Stage: ${job.stage || '—'} (attempt ${job.attempt})`}
+                        </p>
+                    </CardContent>
+                </Card>
+            )}
+
+            {match.status === 'failed' && (
+                <Card>
+                    <CardHeader>
+                        <CardTitle className="text-base flex items-center gap-2 text-destructive"><AlertTriangle className="h-4 w-4" /> Processing failed</CardTitle>
+                        <CardDescription className="break-words">{job?.error || 'Unknown error'}</CardDescription>
+                    </CardHeader>
+                    <CardContent className="flex gap-2">
+                        <Button variant="outline" size="sm" onClick={async () => { await APIService.requeueVideoMatch(matchId); load() }}>Requeue (no charge)</Button>
+                        <Button variant="outline" size="sm" onClick={async () => { await APIService.refundVideoMatch(matchId); setNotice('Refunded.'); load() }}>Refund credit</Button>
+                    </CardContent>
+                </Card>
+            )}
+
+            {(match.status === 'needs_tagging' || match.status === 'finalized') && (
+                <Card>
+                    <CardHeader>
+                        <CardTitle className="text-base">Tag review</CardTitle>
+                        <CardDescription>
+                            Confirm who is who. High-confidence suggestions are accepted automatically once you pick your side;
+                            review the rest — usually a few minutes, not a re-watch.
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                        {match.our_team_cluster == null && (
+                            <div className="rounded-lg border p-3 space-y-2">
+                                <p className="text-sm font-medium">Which side is your team?</p>
+                                <div className="flex gap-2">
+                                    <Button variant="outline" onClick={() => handlePickSide(0)}>
+                                        Team A{match.our_kit_color ? ` (${match.our_kit_color}?)` : ''}
+                                    </Button>
+                                    <Button variant="outline" onClick={() => handlePickSide(1)}>Team B</Button>
+                                </div>
+                                <p className="text-xs text-muted-foreground">Check a few suggested numbers below against your squad to tell the sides apart.</p>
+                            </div>
+                        )}
+
+                        <div className="space-y-2">
+                            {tracklets.map((t) => {
+                                const boundTo = trackletValue(t, 'roster_entry_id', t.roster_entry_id)
+                                const dismissed = trackletValue(t, 'dismissed', t.dismissed)
+                                const entry = boundTo ? rosterByEntryId[boundTo] : null
+                                return (
+                                    <div key={t.id} className={`rounded-lg border p-3 flex flex-wrap items-center gap-3 ${dismissed ? 'opacity-50' : ''}`}>
+                                        <div className="min-w-0 flex-1">
+                                            <div className="flex items-center gap-2 flex-wrap">
+                                                <span className="font-medium">
+                                                    {t.kind === 'chain' && t.suggested_number != null ? `#${t.suggested_number}` : t.pipeline_key}
+                                                </span>
+                                                {t.kind === 'chain' && (
+                                                    <Badge variant={t.confidence === 'high' ? 'default' : 'secondary'}>
+                                                        {t.confidence === 'high' ? 'confident' : 'uncertain'}
+                                                    </Badge>
+                                                )}
+                                                {t.team_cluster != null && t.team_cluster >= 0 && (
+                                                    <Badge variant="outline">{match.our_team_cluster == null ? `side ${t.team_cluster === 0 ? 'A' : 'B'}` : (t.team_cluster === match.our_team_cluster ? 'us' : 'opposition')}</Badge>
+                                                )}
+                                                {t.contaminated && (
+                                                    <Badge variant="destructive"><AlertTriangle className="h-3 w-3 mr-1" />mixed identity</Badge>
+                                                )}
+                                                {t.tag_source === 'auto' && !pendingTags[t.id] && <Badge variant="secondary">auto</Badge>}
+                                            </div>
+                                            <p className="text-xs text-muted-foreground">
+                                                visible {Math.round((t.visible_s || 0) / 60)}m · {formatSeconds(t.first_s)}–{formatSeconds(t.last_s)}
+                                            </p>
+                                        </div>
+                                        <div className="flex items-center gap-2">
+                                            <Select
+                                                value={boundTo ? String(boundTo) : 'none'}
+                                                onValueChange={(v) => stageTag(t.id, { roster_entry_id: v === 'none' ? null : Number(v), dismissed: false })}
+                                                disabled={dismissed}
+                                            >
+                                                <SelectTrigger className="w-44">
+                                                    <SelectValue placeholder="Assign player…">
+                                                        {entry ? `#${entry.jersey_number} ${entry.player_name}` : 'Unassigned'}
+                                                    </SelectValue>
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                    <SelectItem value="none">Unassigned</SelectItem>
+                                                    {(match.roster || []).map((r) => (
+                                                        <SelectItem key={r.id} value={String(r.id)}>#{r.jersey_number} {r.player_name}</SelectItem>
+                                                    ))}
+                                                </SelectContent>
+                                            </Select>
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                aria-label="Not a player"
+                                                title="Not a player (spectator/staff)"
+                                                onClick={() => stageTag(t.id, { dismissed: !dismissed })}
+                                            >
+                                                <UserX className={`h-4 w-4 ${dismissed ? 'text-destructive' : ''}`} />
+                                            </Button>
+                                        </div>
+                                    </div>
+                                )
+                            })}
+                            {tracklets.length === 0 && <p className="text-sm text-muted-foreground">No tracklets yet.</p>}
+                        </div>
+
+                        <div className="flex flex-wrap gap-2">
+                            <Button onClick={handleSaveTags} disabled={tagsSaving || Object.keys(pendingTags).length === 0}>
+                                {tagsSaving && <Loader2 className="h-4 w-4 mr-1 animate-spin" />}
+                                Save tags ({Object.keys(pendingTags).length})
+                            </Button>
+                            <Button variant="outline" onClick={handleFinalize}>
+                                <CheckCircle2 className="h-4 w-4 mr-1" /> {match.status === 'finalized' ? 'Re-finalize' : 'Finalize match'}
+                            </Button>
+                        </div>
+                    </CardContent>
+                </Card>
+            )}
+
+            {match.status === 'finalized' && report && (
+                <Card>
+                    <CardHeader>
+                        <CardTitle className="text-base">Player reports</CardTitle>
+                        <CardDescription>
+                            On-camera minutes from a single panning camera — players out of frame aren’t counted, so
+                            these are visibility numbers, not full-match totals.
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <div className="space-y-1">
+                            {(report.reports || []).map((r) => (
+                                <div key={r.id} className="flex items-center justify-between rounded border px-3 py-2">
+                                    <span className="font-medium">#{r.jersey_number} {r.player_name}</span>
+                                    <span className="text-sm text-muted-foreground">{r.minutes_visible ?? '—'} min on camera</span>
+                                </div>
+                            ))}
+                            {(report.reports || []).length === 0 && (
+                                <p className="text-sm text-muted-foreground">No reports — bind tracklets to players, then re-finalize.</p>
+                            )}
+                        </div>
+                    </CardContent>
+                </Card>
+            )}
+        </div>
+    )
+}
+
+export default AdminVideoMatch


### PR DESCRIPTION
## Summary

Product backbone for the video-analysis feature (teams upload match footage → GPU pipeline → human tag review → per-player reports), built to the spec in `ledgers/CONTINUITY_video-analysis.md` and the algorithms validated in the Phase 0 spike on real VEO footage.

### Backend
- **Data model + migration `vid01`** (guarded DDL): `VideoMatch` (status lifecycle `created → uploaded → queued → processing → needs_tagging → finalized`), `VideoAnalysisJob` (heartbeats + `gpu_seconds` COGS telemetry), `VideoRosterEntry` (own-side names only — opposition stays numbers-only), `VideoTracklet` (what tags bind to), `VideoPlayerReport` (carries `model_version`), `VideoCreditLedger` (append-only; unique Stripe session id = webhook idempotency).
- **API (`/api/admin/video/*`, admin-key gated for concierge Phase A)**: create match + direct-to-blob SAS upload with re-mint, upload-complete blob verification + ETag capture (content-swap check at job start), uploader-marked kickoff/halftime (10s of human input beats fragile inference — spike lesson), roster upsert, process with atomic debit+enqueue (402 without credits), tag review endpoints, finalize via CPU re-aggregation (tag fixes never re-run the GPU), refund/requeue/reaper admin ops.
- **Identity service**: the spike-proven rules — ≥2 agreeing reads to anchor a number, two multiply-attested numbers = splice → refused, digit-doubling tolerance, number-driven chain merging with span-overlap physics (measured read purity 0.847 → 0.927). Re-runs preserve human tags; high-confidence chains auto-bind to the roster once the club confirms which side is theirs.
- **Worker contract**: `vision_worker.py` (one-shot ACA Jobs mode + DB-poll loop, conditional-UPDATE claims so duplicate deliveries no-op, Service Bus optional by design) and `load_video_artifacts.py` to load chunked-GPU-run artifacts in concierge mode.

### Frontend
- `/admin/video` — team matches list, create-match wizard, credit grants.
- `/admin/video/:id` — multi-GB chunked direct-to-blob upload with progress + automatic SAS re-mint, kickoff/halftime marking, paste-a-list squad entry, live processing status, mobile-first tag review (side confirmation → auto-tags, uncertainty badges, mixed-identity warnings, not-a-player dismissal), finalize + on-camera minutes report (visibility-honest copy).

## Test plan
- [x] 18 new backend tests (vote rules incl. doubling/contamination, chain building incl. overlap conflicts and weak-read rules, artifact persistence, auto-bind scoping, human-tag preservation across re-runs, ledger balance) — all green
- [x] Backend suite: no new failures (24 pre-existing failures + 12 stale `LoanedPlayer` import errors reproduced unchanged on origin/main)
- [x] `pnpm lint` 0 errors, `pnpm build` passes
- [x] ruff lint + format clean on all new files
- [ ] End-to-end with real footage artifacts via `load_video_artifacts.py` (next: load the spike's v8 inverted outputs against a staging match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)