### PR TITLE
fix: pin pydantic_core to 2.46.4 to match pydantic 2.13.4

### DIFF
--- a/academy-watch-backend/requirements.txt
+++ b/academy-watch-backend/requirements.txt
@@ -58,7 +58,7 @@ psycopg==3.3.4
 psycopg-binary==3.3.4
 pydantic==2.13.4
 pydantic-settings==2.14.1
-pydantic_core==2.47.0
+pydantic_core==2.46.4
 pydyf==0.12.1
 Pygments==2.20.0
 pyparsing==3.3.2


### PR DESCRIPTION
pydantic 2.13.4 requires pydantic-core==2.46.4 exactly (verified via PyPI metadata). The existing 2.47.0 pin made pip resolution impossible, failing the backend ACR image build on the Deploy workflow (first run since April, triggered by #421). One-line pin correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)