### PR TITLE
fix(classifier): always run loan→sold/released upgrade, ignore config kill-switch

### DIFF
--- a/academy-watch-backend/src/utils/academy_classifier.py
+++ b/academy-watch-backend/src/utils/academy_classifier.py
@@ -525,7 +525,10 @@ def _get_active_classification_config() -> dict[str, Any]:
     """Load classification rules from the active RebuildConfig.
 
     Returns a dict with keys:
-        use_transfers_for_status (bool, default True)
+        use_transfers_for_status (bool, default True) — retained for
+            backward compatibility only; the loan→sold/released upgrade now
+            always runs regardless of this flag (see classify_tracked_player
+            Step 2). It no longer suppresses sold-detection.
         inactivity_release_years (int | None, default None)
 
     Uses a module-level cache with 5-minute TTL to avoid a DB query on
@@ -637,7 +640,8 @@ def classify_tracked_player(
     Applies these rules in order:
     1. Base status derivation (academy / first_team / on_loan)
     2. Transfer-based upgrade (on_loan → sold / released)
-       — controlled by ``config['use_transfers_for_status']``
+       — always runs when transfer data is available (core correctness;
+         a permanent departure must never read as a loan)
     2.5. Squad cross-reference (on_loan players only)
        — if player absent from loan club squad, check parent squad;
          returned to parent → academy/first_team, absent from both → released
@@ -652,8 +656,8 @@ def classify_tracked_player(
         parent_api_id: Parent / academy club API-Football ID.
         parent_club_name: Parent / academy club name.
         transfers: Pre-fetched *flat* transfer list (already flattened).
-            When ``None`` and ``use_transfers_for_status`` is True the
-            function will attempt to fetch via *api_client*.
+            When ``None`` the function will attempt to fetch via
+            *api_client* (if *player_api_id* is also supplied).
         player_api_id: Required when transfers must be fetched on demand.
         api_client: ``APIFootballClient`` instance for on-demand fetch.
         config: Classification config dict.  When ``None`` the active
@@ -690,7 +694,16 @@ def classify_tracked_player(
         reasoning: list[dict] = []
 
     # ── Step 2: transfer-based upgrade ────────────────────────────────
-    if status == "on_loan" and config.get("use_transfers_for_status", True):
+    # The loan→sold/released upgrade is core correctness, not a tunable: a
+    # permanent departure (sale or free transfer) must never read as a loan.
+    # This step therefore always runs when transfer data is available and is
+    # NOT gated by config['use_transfers_for_status']. That flag used to
+    # suppress this entire step; with the active config storing it False,
+    # sold-detection silently died platform-wide — every permanently
+    # transferred player (e.g. Garnacho sold to Chelsea) was stuck at
+    # on_loan. The upgrade itself is conservative (only promotes when the
+    # latest parent departure is non-loan), so genuine loans stay on_loan.
+    if status == "on_loan":
         effective_transfers = transfers
         if effective_transfers is None and player_api_id and api_client:
             try:

--- a/academy-watch-backend/tests/test_journey.py
+++ b/academy-watch-backend/tests/test_journey.py
@@ -1126,6 +1126,73 @@ class TestUpgradeStatusFromTransfers:
         assert upgrade_status_from_transfers("on_loan", transfers, 33) == "on_loan"
 
 
+class TestTransferUpgradeIgnoresConfigFlag:
+    """The loan→sold/released upgrade must run even when the active config
+    has use_transfers_for_status disabled.
+
+    Regression: the 'Big 6 Standard' RebuildConfig stored
+    use_transfers_for_status=False, which silently disabled sold-detection
+    platform-wide — a permanently-transferred player (Garnacho sold to
+    Chelsea) stayed classified on_loan instead of sold.
+    """
+
+    GARNACHO_TRANSFERS = [
+        {
+            "type": "Transfer",
+            "date": "2025-08-30",
+            "teams": {"out": {"id": 33}, "in": {"id": 49}},
+        }
+    ]
+
+    def _classify(self, flag):
+        from src.utils.academy_classifier import classify_tracked_player
+
+        return classify_tracked_player(
+            current_club_api_id=49,  # Chelsea (buying club)
+            current_club_name="Chelsea",
+            current_level="First Team",
+            parent_api_id=33,  # Manchester United (academy)
+            parent_club_name="Manchester United",
+            transfers=self.GARNACHO_TRANSFERS,
+            config={"use_transfers_for_status": flag, "use_squad_check": False},
+        )
+
+    def test_sold_when_flag_disabled(self):
+        """Permanent sale → 'sold' even with use_transfers_for_status=False."""
+        status, club_id, club_name = self._classify(flag=False)
+        assert status == "sold"
+        assert club_id == 49
+        assert club_name == "Chelsea"
+
+    def test_sold_when_flag_enabled(self):
+        """Same result with the flag enabled — behaviour is now flag-agnostic."""
+        status, club_id, club_name = self._classify(flag=True)
+        assert status == "sold"
+        assert club_id == 49
+        assert club_name == "Chelsea"
+
+    def test_genuine_loan_still_on_loan_with_flag_disabled(self):
+        """A real loan departure must NOT be promoted to sold."""
+        from src.utils.academy_classifier import classify_tracked_player
+
+        status, _club_id, _club_name = classify_tracked_player(
+            current_club_api_id=62,  # loan destination
+            current_club_name="Some Club",
+            current_level="First Team",
+            parent_api_id=33,
+            parent_club_name="Manchester United",
+            transfers=[
+                {
+                    "type": "Loan",
+                    "date": "2025-08-01",
+                    "teams": {"out": {"id": 33}, "in": {"id": 62}},
+                }
+            ],
+            config={"use_transfers_for_status": False, "use_squad_check": False},
+        )
+        assert status == "on_loan"
+
+
 class TestComputeAcademyClubIdsExcludesIntegration:
     """Test that _compute_academy_club_ids excludes integration entries"""
 


### PR DESCRIPTION
## Problem

Alejandro Garnacho showed as **on loan to Chelsea** when Chelsea **bought** him. Not a one-off — it was systemic.

**Root cause:** the transfer-based status upgrade in `classify_tracked_player` was gated by `config['use_transfers_for_status']`. The active **"Big 6 Standard"** `RebuildConfig` stored that flag as `false` (the code default is `true` — config drift). That single flag disabled the entire `on_loan → sold/released` upgrade across the whole journey-sync pipeline.

The API data and the upgrade logic were both fine — `upgrade_status_from_transfers(...)` returns `sold` for Garnacho's `type='Transfer'` Man Utd→Chelsea move. It just never ran.

**Blast radius (local snapshot):** journey-sync `sold` = **2** rows vs `on_loan` = **108**; 17 players had a direct contradiction (an `on_loan` row *and* a `sold/released` row elsewhere), Garnacho included. `released` was unaffected because it also comes from the squad-check / inactivity paths, which the flag doesn't gate.

## Fix

A permanent departure must never read as a loan, so the `loan → sold/released` upgrade is core correctness, not a tunable. It now **always runs** when transfer data is present, regardless of `use_transfers_for_status`. The upgrade stays conservative (only promotes when the latest parent departure is non-loan), so **genuine loans stay `on_loan`**. The flag is retained for backward compatibility but no longer suppresses sold-detection.

## Tests

`TestTransferUpgradeIgnoresConfigFlag`:
- permanent sale → `sold` with the flag **off**
- permanent sale → `sold` with the flag **on**
- genuine loan → stays `on_loan` with the flag off

Full `test_journey.py` suite otherwise unchanged (pre-existing app-context failures are unrelated, confirmed against baseline). Ruff lint + format clean.

**Verified end-to-end on a local DB:** re-syncing Garnacho flipped his journey-sync row `on_loan → Chelsea` ⟶ `sold → Chelsea` (destination preserved).

## Note on repairing existing rows

This corrects classification going forward. Existing mis-as-loan rows need the **transfers** to re-classify, so a **journey re-sync** of affected players repairs them — `recompute-academy` runs transfer-free and will *not* flip them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)