### PR TITLE
fix: cursor paging for backfill-names fetch_missing

### DIFF
--- a/academy-watch-backend/src/routes/journey.py
+++ b/academy-watch-backend/src/routes/journey.py
@@ -470,21 +470,38 @@ def admin_backfill_player_names():
     # opt-in and capped — profile calls spend API-Football quota (DB-cached
     # 24h), so the operator controls the spend per invocation.
     api_fetched = 0
+    next_fetch_cursor = None
     payload = request.get_json(silent=True) or {}
     if payload.get("fetch_missing") is True and not dry_run:
         fetch_limit = payload.get("fetch_limit", 50)
         if not isinstance(fetch_limit, int) or isinstance(fetch_limit, bool) or fetch_limit < 1:
             fetch_limit = 50
         fetch_limit = min(fetch_limit, 200)
+        # Cursor (last tracked_player id processed) makes this driveable in
+        # small, independent HTTPS batches: each row is attempted at most once
+        # because the cursor advances past unfillable rows (no front-blocking),
+        # and every call stays well under the gunicorn/ingress timeout. Loop
+        # from the caller until next_fetch_cursor is null.
+        fetch_cursor = payload.get("fetch_cursor", 0)
+        if not isinstance(fetch_cursor, int) or isinstance(fetch_cursor, bool) or fetch_cursor < 0:
+            fetch_cursor = 0
         from src.routes.api import api_client
 
         still_missing = (
-            TrackedPlayer.query.filter(db.or_(TrackedPlayer.position.is_(None), TrackedPlayer.birth_date.is_(None)))
-            .filter(TrackedPlayer.is_active.is_(True))
+            TrackedPlayer.query.filter(
+                db.or_(
+                    TrackedPlayer.position.is_(None),
+                    TrackedPlayer.birth_date.is_(None),
+                    TrackedPlayer.nationality.is_(None),
+                )
+            )
+            .filter(TrackedPlayer.is_active.is_(True), TrackedPlayer.id > fetch_cursor)
             .order_by(TrackedPlayer.id)
             .limit(fetch_limit)
             .all()
         )
+        if len(still_missing) == fetch_limit:
+            next_fetch_cursor = still_missing[-1].id
         for tp in still_missing:
             try:
                 profile = api_client.get_player_profile(tp.player_api_id) or {}
@@ -521,6 +538,7 @@ def admin_backfill_player_names():
         "ages_refreshed": ages_refreshed,
         "nationality_filled": nationality_filled,
         "api_fetched": api_fetched,
+        "next_fetch_cursor": next_fetch_cursor,
         "unresolved": unresolved,
         "examples": examples,
         "dry_run": dry_run,

--- a/academy-watch-backend/tests/test_player_name_backfill.py
+++ b/academy-watch-backend/tests/test_player_name_backfill.py
@@ -496,3 +496,73 @@ class TestAgesRefreshed:
 
             refreshed = db.session.get(TP, target_id)
             assert refreshed.age == 20  # Jan-1 birthday in `year - 20` → exactly 20 today
+
+
+class TestFetchCursor:
+    """fetch_missing cursor paging — driveable in small HTTPS batches,
+    each row attempted at most once (no front-blocking)."""
+
+    def test_cursor_pages_and_attempts_each_row_once(self, app, client, admin_headers, monkeypatch):
+        team = _seed_team()
+        ids = []
+        for pid in (910, 911, 912, 913, 914):
+            ids.append(_seed_tracked(team, pid, f"NoPos {pid}", position=None, birth_date=None).id)
+        db.session.commit()
+
+        calls = []
+
+        class _FakeClient:
+            def get_player_profile(self, player_api_id):
+                calls.append(player_api_id)
+                # Only odd api-ids have a position in the API → others are
+                # irreducibly unfillable but must not block the cursor.
+                if player_api_id % 2 == 1:
+                    return {"player": {"position": "Midfielder", "nationality": "Spain"}}
+                return {"player": {}}
+
+        import src.routes.api as api_mod
+
+        monkeypatch.setattr(api_mod, "api_client", _FakeClient())
+
+        cursor = 0
+        guard = 0
+        total_pos = 0
+        while True:
+            guard += 1
+            assert guard < 20
+            r = client.post(
+                "/api/admin/players/backfill-names",
+                json={"dry_run": False, "fetch_missing": True, "fetch_limit": 2, "fetch_cursor": cursor},
+                headers=admin_headers,
+            )
+            d = r.get_json()
+            total_pos += d["position_filled"]
+            if d["next_fetch_cursor"] is None:
+                break
+            cursor = d["next_fetch_cursor"]
+
+        # Every player fetched exactly once despite the unfillable evens.
+        assert sorted(calls) == [910, 911, 912, 913, 914]
+        assert len(calls) == 5
+        # Odd api-ids (911, 913) got positions.
+        assert total_pos == 2
+
+    def test_invalid_cursor_defaults_to_zero(self, app, client, admin_headers, monkeypatch):
+        team = _seed_team()
+        _seed_tracked(team, 920, "X", position=None, birth_date=None)
+        db.session.commit()
+
+        class _FakeClient:
+            def get_player_profile(self, player_api_id):
+                return {"player": {"position": "Defender"}}
+
+        import src.routes.api as api_mod
+
+        monkeypatch.setattr(api_mod, "api_client", _FakeClient())
+        r = client.post(
+            "/api/admin/players/backfill-names",
+            json={"dry_run": False, "fetch_missing": True, "fetch_cursor": -5},
+            headers=admin_headers,
+        )
+        assert r.status_code == 200
+        assert r.get_json()["position_filled"] == 1


### PR DESCRIPTION
## Problem
The opt-in `fetch_missing` profile backfill fetched up to `fetch_limit` API-Football profiles in one synchronous request, ordered by id from the front. At production scale this fails two ways:
1. A 200-cold-profile fetch exceeds gunicorn's 120s worker timeout → **504** (observed on prod).
2. Irreducibly unfillable rows (the API has no position for some youth/obscure players) cluster at low ids and **block** small front-anchored batches — a "stop when nothing filled" driver halts before reaching fillable rows further back.

## Fix
Add `fetch_cursor` (last tracked_player id processed) and return `next_fetch_cursor`. Each row is attempted **at most once** because the cursor advances past unfillable rows. The fill is now driveable in small, independent HTTPS batches that each stay well under the timeout and are immune to pod recycles from concurrent deploys — converging to the API's true data floor. Gap filter also widened to include `nationality`.

## Operator usage
```
POST /api/admin/players/backfill-names {"dry_run": false, "fetch_missing": true, "fetch_limit": 40, "fetch_cursor": <previous next_fetch_cursor>}
```
Loop until `next_fetch_cursor` is null. NULL-only fills; never overwrites; concurrent-safe.

## Testing
2 new tests (cursor pages to completion attempting each row exactly once despite unfillable rows; invalid cursor → 0); 23 green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)