### PR TITLE
fix: coerce SQLALCHEMY_DATABASE_URI scheme to psycopg v3 (prod outage recovery)

### DIFF
--- a/academy-watch-backend/src/main.py
+++ b/academy-watch-backend/src/main.py
@@ -157,6 +157,22 @@ def _env_value(key: str, *, allow_inline_comment: bool = False) -> str | None:
     return value or None
 
 
+def _coerce_psycopg_driver(uri: str) -> str:
+    """Force a Postgres URI onto the psycopg (v3) driver.
+
+    The image ships psycopg v3 only (no psycopg2), so a bare `postgresql://`
+    or `postgres://` scheme — exactly what Supabase/Heroku hand you — routes
+    SQLAlchemy to psycopg2 and crashes the app at engine creation. Rewrite the
+    driver to `postgresql+psycopg` while leaving host/credentials/query intact.
+    Already-qualified schemes (e.g. `postgresql+psycopg`) pass through. Raises
+    on an unparseable URI so the caller can fall back to DB_* components.
+    """
+    url = make_url(uri)
+    if url.drivername in ("postgresql", "postgres"):
+        url = url.set(drivername="postgresql+psycopg")
+    return url.render_as_string(hide_password=False)
+
+
 def _build_db_uri_from_components() -> str:
     """Assemble a Postgres SQLAlchemy URI from DB_* environment variables."""
     port_raw = _env_value("DB_PORT", allow_inline_comment=True) or ""
@@ -184,9 +200,10 @@ if is_prod and os.getenv("SQLALCHEMY_DATABASE_URI"):
     # Sanitize accidental quotes/whitespace
     candidate = raw_uri.strip().strip('"').strip("'")
     try:
-        # Validate it parses; raises on bad format
-        make_url(candidate)
-        db_uri = candidate
+        # Validate + coerce the scheme to psycopg v3 (raises on bad format).
+        # A bare `postgresql://` (Supabase/Heroku default) would otherwise
+        # route to psycopg2, which is not installed, and crash the app.
+        db_uri = _coerce_psycopg_driver(candidate)
         logger.info("🗄️ Using SQLALCHEMY_DATABASE_URI from environment (production)")
     except Exception:
         logger.warning("⚠️ SQLALCHEMY_DATABASE_URI is invalid; falling back to DB_* components")

--- a/academy-watch-backend/tests/test_db_uri_scheme.py
+++ b/academy-watch-backend/tests/test_db_uri_scheme.py
@@ -1,0 +1,40 @@
+"""Coercion of the SQLALCHEMY_DATABASE_URI scheme to psycopg v3."""
+
+import pytest
+from src.main import _coerce_psycopg_driver
+
+
+@pytest.mark.parametrize(
+    "raw, expect_driver",
+    [
+        ("postgresql://u:p@h:5432/db", "postgresql+psycopg"),
+        ("postgres://u:p@h:5432/db", "postgresql+psycopg"),
+        ("postgresql+psycopg://u:p@h:5432/db", "postgresql+psycopg"),
+        ("postgresql+psycopg2://u:p@h:5432/db", "postgresql+psycopg2"),
+    ],
+)
+def test_driver_coerced_to_psycopg(raw, expect_driver):
+    from sqlalchemy.engine.url import make_url
+
+    out = _coerce_psycopg_driver(raw)
+    assert make_url(out).drivername == expect_driver
+
+
+def test_supabase_pooler_string_preserves_everything():
+    raw = "postgresql://postgres.abcd:s3cr3t@aws-0-x.pooler.supabase.com:6543/postgres?sslmode=require"
+    out = _coerce_psycopg_driver(raw)
+    from sqlalchemy.engine.url import make_url
+
+    u = make_url(out)
+    assert u.drivername == "postgresql+psycopg"
+    assert u.username == "postgres.abcd"
+    assert u.password == "s3cr3t"
+    assert u.host == "aws-0-x.pooler.supabase.com"
+    assert u.port == 6543
+    assert u.database == "postgres"
+    assert u.query.get("sslmode") == "require"
+
+
+def test_invalid_uri_raises():
+    with pytest.raises(Exception):
+        _coerce_psycopg_driver("not a uri at all ::::")


### PR DESCRIPTION
## Incident
Prod is **down** after a DB password rotation. The new `SQLALCHEMY_DATABASE_URI` was correct but used the default `postgresql://` scheme (what Supabase hands you). The image ships **psycopg v3 only** (`psycopg==3.3.4`, no psycopg2), so SQLAlchemy routed `postgresql://` to psycopg2 → `ModuleNotFoundError: No module named 'psycopg2'` at engine creation → app crashes on boot (gunicorn `--preload`) → revision `ActivationFailed`, DB endpoints 500.

Rollback isn't possible: the previous revision holds the *old* (now-rotated, dead) password.

## Fix
`_coerce_psycopg_driver()` rewrites a bare `postgresql://` / `postgres://` driver to `postgresql+psycopg`, leaving host/credentials/query intact and passing through already-qualified schemes. The `DB_*` component path already did this; this brings the `SQLALCHEMY_DATABASE_URI` path to parity. The app now self-heals from a default Supabase/Heroku connection string with no manual scheme editing — recovering prod using the (correct, new-password) URI already set in the container env.

## Testing
6 tests: scheme coercion for `postgresql://`/`postgres://`/`+psycopg`/`+psycopg2`, a full Supabase pooler string preserving user/host/port/db/sslmode, and invalid-URI raising. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)