### PR TITLE
chore(deps): batch backend dependency bumps (pytest, azure-storage-blob, flask-cors, idna)

### DIFF
--- a/academy-watch-backend/requirements.txt
+++ b/academy-watch-backend/requirements.txt
@@ -4,7 +4,7 @@ anyio==4.13.0
 attrs==26.1.0
 azure-identity==1.25.3
 azure-keyvault-secrets==4.11.0
-azure-storage-blob==12.27.1
+azure-storage-blob==12.30.0
 bleach==6.4.0
 blinker==1.9.0
 certifi==2026.5.20
@@ -16,7 +16,7 @@ cycler==0.12.1
 Deprecated==1.3.1
 distro==1.9.0
 Flask==3.1.3
-flask-cors==6.0.2
+flask-cors==6.0.5
 Flask-Limiter==4.1.1
 Flask-Migrate==4.1.0
 Flask-SQLAlchemy==3.1.1
@@ -30,7 +30,7 @@ h11==0.16.0
 httpcore==1.0.9
 httpx==0.28.1
 httpx-sse==0.4.3
-idna==3.15
+idna==3.18
 iniconfig==2.3.0
 itsdangerous==2.2.0
 Jinja2==3.1.6
@@ -62,7 +62,7 @@ pydantic_core==2.46.4
 pydyf==0.12.1
 Pygments==2.20.0
 pyparsing==3.3.2
-pytest==9.0.3
+pytest==9.1.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
 python-multipart==0.0.32


### PR DESCRIPTION
Combines four independent Dependabot **backend** bumps into one `requirements.txt` change so they share a single CI run + deploy instead of a 5-way rebase cascade (all five touched the same file):

| package | from | to | supersedes |
|---|---|---|---|
| pytest | 9.0.3 | 9.1.0 | #437 |
| azure-storage-blob | 12.27.1 | 12.30.0 | #427 |
| flask-cors | 6.0.2 | 6.0.5 | #403 |
| idna | 3.15 | 3.18 | #361 |

**Excludes** the `pydantic_core` → 2.47.0 bump (#424): `pydantic==2.13.4` pins `pydantic-core==2.46.4` *exactly* (confirmed via PyPI), so bumping core alone would fail the deploy's `pip install`. That one needs a coordinated `pydantic` upgrade.

Validated with `pip install --dry-run --ignore-installed -r requirements.txt` — the full pinned set (incl. these four bumps) resolves with no conflicts.

Closes #437, #427, #403, #361.

🤖 Generated with [Claude Code](https://claude.com/claude-code)