### PR TITLE
Video: structured confidence-per-field player report

### DIFF
--- a/academy-watch-backend/migrations/versions/vid02_structured_player_report.py
+++ b/academy-watch-backend/migrations/versions/vid02_structured_player_report.py
@@ -1,0 +1,43 @@
+"""Add structured confidence-per-field columns to video_player_reports
+
+Revision ID: vid02
+Revises: vid01
+Create Date: 2026-06-16
+
+Per-player video reports become a structured, confidence-per-data-point object:
+identity is the gate (a stat is only as trustworthy as the identity it hangs on),
+coverage tells the coach how much of the player we actually saw, and every metric
+carries its own confidence + a `kind` (point / lower_bound / partial_observed /
+beta / suppressed) so a biased partial is never shown as a full-match total.
+
+All DDL is guarded — production has had columns added out-of-band.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from migrations._migration_helpers import add_column_safe, column_exists
+
+revision = "vid02"
+down_revision = "vid01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # identity gate
+    add_column_safe("video_player_reports", sa.Column("identity_confidence", sa.String(20), nullable=True))
+    add_column_safe("video_player_reports", sa.Column("identity_evidence", sa.JSON(), nullable=True))
+    # how much of the player we confidently observed
+    add_column_safe("video_player_reports", sa.Column("coverage", sa.JSON(), nullable=True))
+    # per-metric list: [{key, value, unit, confidence, kind, note, suppressed}]
+    add_column_safe("video_player_reports", sa.Column("metrics", sa.JSON(), nullable=True))
+    # confidence-flagged partial outputs (confirmed sprints, shots, sequences)
+    add_column_safe("video_player_reports", sa.Column("events", sa.JSON(), nullable=True))
+
+
+def downgrade():
+    # Guard each drop on existence rather than swallowing errors — a real failure
+    # (lock, permission) should surface, not be masked by a bare except.
+    for col in ("identity_confidence", "identity_evidence", "coverage", "metrics", "events"):
+        if column_exists("video_player_reports", col):
+            op.drop_column("video_player_reports", col)

--- a/academy-watch-backend/src/models/video.py
+++ b/academy-watch-backend/src/models/video.py
@@ -51,6 +51,17 @@ VIDEO_JOB_STAGES = (
 
 CREDIT_REASONS = ("purchase", "debit", "refund", "grant")
 
+# Per-player report identity gate. A stat is only as trustworthy as this.
+IDENTITY_CONFIDENCE = ("human_confirmed", "high", "low", "unverified")
+
+# What KIND of number a metric is — so a biased partial is never shown as a full total.
+#   point           direct, trustworthy measurement (minutes on camera, fastest sustained speed)
+#   lower_bound     only confident windows seen, so counts are floors ("at least N")
+#   partial_observed aggregate over a biased (near-side) sample — never a full-match total
+#   beta            experimental; suppressed below a quality threshold
+#   suppressed      cannot be measured reliably yet → value null, never fabricated
+METRIC_KINDS = ("point", "lower_bound", "partial_observed", "beta", "suppressed")
+
 
 def _utcnow() -> datetime:
     return datetime.now(UTC)
@@ -279,6 +290,14 @@ class VideoPlayerReport(db.Model):
     touches = db.Column(db.Integer)
     touches_is_beta = db.Column(db.Boolean, nullable=False, default=True)
 
+    # Structured confidence-per-field report (the contract; see services/video_report.py).
+    # identity is the GATE — every metric below is only as true as the identity it hangs on.
+    identity_confidence = db.Column(db.String(20))  # one of IDENTITY_CONFIDENCE
+    identity_evidence = db.Column(db.JSON)  # {source, votes, splice_risk, human_reviewed}
+    coverage = db.Column(db.JSON)  # {on_camera_min, confident_windows, pct_of_match, span_s, near_side_pct, sampling}
+    metrics = db.Column(db.JSON)  # [{key, value, unit, confidence, kind, note, suppressed}]
+    events = db.Column(db.JSON)  # [{type, t, confidence, clip}]
+
     model_version = db.Column(db.String(40), nullable=False)
     created_at = db.Column(db.DateTime, default=_utcnow)
 
@@ -299,6 +318,11 @@ class VideoPlayerReport(db.Model):
             "heatmap_path": self.heatmap_path,
             "touches": self.touches,
             "touches_is_beta": self.touches_is_beta,
+            "identity_confidence": self.identity_confidence,
+            "identity_evidence": self.identity_evidence,
+            "coverage": self.coverage,
+            "metrics": self.metrics,
+            "events": self.events,
             "model_version": self.model_version,
         }
 

--- a/academy-watch-backend/src/routes/video.py
+++ b/academy-watch-backend/src/routes/video.py
@@ -31,6 +31,7 @@ from src.models.video import (
 )
 from src.routes.api import require_api_key
 from src.services import video_queue, video_storage
+from src.services.video_report import build_player_report, tracklet_to_bound
 
 video_bp = Blueprint("video", __name__)
 logger = logging.getLogger(__name__)
@@ -420,17 +421,37 @@ def finalize_match(match_id: int):
             )
             .all()
         )
-        if not bound:
-            continue
-        visible = sum(t.visible_s or 0.0 for t in bound)
-        # Phase A v1: identity + visibility metrics. Distance/speed/heatmaps land
-        # with the homography stage; columns stay NULL rather than fabricating.
+        # A roster player with no confident tracklets still gets a report — an
+        # "unverified / 0 on-camera" row is more honest than silent omission (the
+        # coach can tell "we saw nothing of them" from "not in the squad").
+        # Build the structured confidence-per-field report. Phase A v1: identity +
+        # coverage + on-camera minutes are real; distance/speed/heatmaps are emitted
+        # as `suppressed` (value null) until the homography stage — never fabricated.
+        team_cluster = next((t.team_cluster for t in bound if t.team_cluster in (0, 1)), None)
+        structured = build_player_report(
+            jersey_number=entry.jersey_number,
+            team_cluster=team_cluster,
+            our_team_cluster=match.our_team_cluster,
+            bound=[tracklet_to_bound(t) for t in bound],
+            match_duration_s=match.duration_s,
+        )
+        identity = structured["identity"]
         report = VideoPlayerReport(
             video_match_id=match.id,
             roster_entry_id=entry.id,
             tracked_player_id=entry.tracked_player_id,
-            minutes_visible=round(visible / 60.0, 1),
+            minutes_visible=structured["coverage"]["on_camera_min"],
             touches_is_beta=True,
+            identity_confidence=identity["confidence"],
+            identity_evidence={
+                "source": identity["source"],
+                "votes": identity["votes"],
+                "splice_risk": identity["splice_risk"],
+                "human_reviewed": identity["human_reviewed"],
+            },
+            coverage=structured["coverage"],
+            metrics=structured["metrics"],
+            events=structured["events"],
             model_version=model_version,
         )
         db.session.add(report)

--- a/academy-watch-backend/src/services/video_report.py
+++ b/academy-watch-backend/src/services/video_report.py
@@ -1,0 +1,196 @@
+"""
+Structured confidence-per-field player report (Phase A).
+
+A per-player video report is NOT a flat row of stats — it is a structured object
+where every data point carries its own confidence, gated by identity:
+
+  identity  → the gate. A stat is only as trustworthy as the identity it hangs on.
+  coverage  → how much of this player we actually, confidently observed.
+  metrics   → each tagged with a `kind` (point / lower_bound / partial_observed /
+              beta / suppressed) so a biased partial is never shown as a full total.
+  events    → confidence-flagged partial outputs (confirmed sprints/shots/sequences).
+
+This module is the contract builder. It is deliberately HONEST about Phase A
+capability: only identity, coverage, and on-camera minutes are real today;
+distance/speed/heatmap/touches are emitted as `suppressed` (value null) until the
+homography stage lands — present in the structure, never fabricated.
+
+`build_player_report` is a pure function over plain dicts so it can be unit-tested
+without a database; `tracklet_to_bound` bridges a VideoTracklet ORM row into it.
+"""
+
+from collections import Counter
+
+# Metrics that need pitch calibration (homography) before they can be trusted.
+# Listed here so the contract is stable now and fields fill in as capability arrives.
+_PENDING_HOMOGRAPHY_NOTE = "awaits pitch calibration (homography stage)"
+
+
+def tracklet_number_votes(evidence) -> Counter:
+    """Pull jersey-number vote tallies out of a tracklet's evidence JSON.
+
+    Handles both shapes persist_artifacts writes:
+      chain    {"votes": {"<frag_id>": {"10": 4, ...}}, ...}
+      fragment {"number_votes": {"10": 1, ...}}
+    """
+    c: Counter = Counter()
+    if not isinstance(evidence, dict):
+        return c
+    nv = evidence.get("number_votes")
+    if isinstance(nv, dict):
+        for k, v in nv.items():
+            try:
+                c[str(k)] += int(v)
+            except (TypeError, ValueError):
+                continue
+    votes = evidence.get("votes")
+    if isinstance(votes, dict):
+        for per_frag in votes.values():
+            if isinstance(per_frag, dict):
+                for k, v in per_frag.items():
+                    try:
+                        c[str(k)] += int(v)
+                    except (TypeError, ValueError):
+                        continue
+    return c
+
+
+def tracklet_to_bound(t) -> dict:
+    """VideoTracklet ORM row -> the plain dict build_player_report consumes."""
+    return {
+        "confidence": t.confidence,
+        "visible_s": float(t.visible_s or 0.0),
+        "first_s": float(t.first_s) if t.first_s is not None else None,
+        "last_s": float(t.last_s) if t.last_s is not None else None,
+        "tag_source": t.tag_source,
+        "contaminated": bool(t.contaminated),
+        "number_votes": dict(tracklet_number_votes(t.evidence)),
+    }
+
+
+def _metric(key, value, *, kind, confidence, unit=None, note=None):
+    return {
+        "key": key,
+        "value": value,
+        "unit": unit,
+        "confidence": confidence,
+        "kind": kind,
+        "note": note,
+        "suppressed": value is None,
+    }
+
+
+def build_player_report(
+    *,
+    jersey_number: int,
+    team_cluster: int | None,
+    our_team_cluster: int | None,
+    bound: list[dict],
+    match_duration_s: float | None,
+) -> dict:
+    """Build the structured confidence-per-field report for one player.
+
+    `bound` is the list of (non-dismissed) tracklets tagged to this roster entry,
+    each: {confidence, visible_s, first_s, last_s, tag_source, contaminated, number_votes}.
+    Returns {identity, coverage, metrics, events} — the report contract.
+    """
+    if not bound:
+        # No confident attribution — identity unverified, nothing to report.
+        return {
+            "identity": {
+                "confidence": "unverified",
+                "source": "unresolved",
+                "votes": {},
+                "splice_risk": False,
+                "human_reviewed": False,
+                "jersey_number": jersey_number,
+                "team": _team_label(team_cluster, our_team_cluster),
+            },
+            "coverage": {
+                "on_camera_min": 0.0,
+                "confident_windows": 0,
+                "pct_of_match": None,
+                "span_s": None,
+                "near_side_pct": None,
+                "sampling": "no confident windows",
+            },
+            "metrics": _metrics(0.0),
+            "events": [],
+        }
+
+    any_human = any(b.get("tag_source") == "human" for b in bound)
+    any_high = any(b.get("confidence") == "high" for b in bound)
+    any_contaminated = any(b.get("contaminated") for b in bound)
+
+    if any_human:
+        identity_conf = "human_confirmed"
+    elif any_high and not any_contaminated:
+        identity_conf = "high"
+    else:
+        identity_conf = "low"
+
+    votes: Counter = Counter()
+    for b in bound:
+        for k, v in (b.get("number_votes") or {}).items():
+            try:  # same defensive coercion as tracklet_number_votes
+                votes[str(k)] += int(v)
+            except (TypeError, ValueError):
+                continue
+
+    attributed_s = sum(float(b.get("visible_s") or 0.0) for b in bound)
+    firsts = [b["first_s"] for b in bound if b.get("first_s") is not None]
+    lasts = [b["last_s"] for b in bound if b.get("last_s") is not None]
+    on_camera_min = round(attributed_s / 60.0, 1)
+    pct_of_match = round(attributed_s / match_duration_s, 3) if match_duration_s and match_duration_s > 0 else None
+
+    coverage = {
+        "on_camera_min": on_camera_min,
+        "confident_windows": len(bound),
+        "pct_of_match": pct_of_match,
+        "span_s": [round(min(firsts), 1), round(max(lasts), 1)] if firsts and lasts else None,
+        # near/far split needs per-frame positions (not in the DB yet) — forward-compatible,
+        # never guessed. The sampling note keeps the bias caveat visible meanwhile.
+        "near_side_pct": None,
+        "sampling": "confident windows only; near/far split not yet measured",
+    }
+
+    return {
+        "identity": {
+            "confidence": identity_conf,
+            "source": "human" if any_human else "auto",
+            "votes": {k: votes[k] for k in sorted(votes, key=lambda x: -votes[x])},
+            "splice_risk": any_contaminated,
+            "human_reviewed": any_human,
+            "jersey_number": jersey_number,
+            "team": _team_label(team_cluster, our_team_cluster),
+        },
+        "coverage": coverage,
+        "metrics": _metrics(on_camera_min),
+        "events": [],  # event detection not in Phase A; structure ready for it
+    }
+
+
+def _team_label(team_cluster: int | None, our_team_cluster: int | None) -> str | None:
+    if our_team_cluster is None or team_cluster not in (0, 1):
+        return None
+    return "ours" if team_cluster == our_team_cluster else "opposition"
+
+
+def _metrics(on_camera_min: float) -> list[dict]:
+    """The metric list. Today only minutes-on-camera is real; the rest are
+    structurally present but suppressed until pitch calibration — never faked."""
+    return [
+        _metric("minutes_on_camera", on_camera_min, kind="point", confidence="high", unit="min"),
+        _metric("distance_m", None, kind="suppressed", confidence=None, unit="m", note=_PENDING_HOMOGRAPHY_NOTE),
+        _metric(
+            "fastest_sustained_kmh",
+            None,
+            kind="suppressed",
+            confidence=None,
+            unit="km/h",
+            note=_PENDING_HOMOGRAPHY_NOTE,
+        ),
+        _metric("sprint_count", None, kind="suppressed", confidence=None, note=_PENDING_HOMOGRAPHY_NOTE),
+        _metric("touches", None, kind="beta", confidence=None, note="experimental; needs ball association"),
+        _metric("heatmap", None, kind="suppressed", confidence=None, note=_PENDING_HOMOGRAPHY_NOTE),
+    ]

--- a/academy-watch-backend/tests/test_video_report.py
+++ b/academy-watch-backend/tests/test_video_report.py
@@ -1,0 +1,231 @@
+"""Tests for the structured confidence-per-field player-report builder."""
+
+import pytest
+from flask import Flask
+from src.models.league import db
+from src.models.video import VideoTracklet
+from src.services.video_report import (
+    build_player_report,
+    tracklet_number_votes,
+    tracklet_to_bound,
+)
+
+
+@pytest.fixture
+def report_app():
+    app = Flask(__name__)
+    app.config.update(TESTING=True, SQLALCHEMY_DATABASE_URI="sqlite:///:memory:", SQLALCHEMY_TRACK_MODIFICATIONS=False)
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+def _bound(**kw):
+    base = {
+        "confidence": "high",
+        "visible_s": 60.0,
+        "first_s": 100.0,
+        "last_s": 200.0,
+        "tag_source": "auto",
+        "contaminated": False,
+        "number_votes": {"10": 3},
+    }
+    base.update(kw)
+    return base
+
+
+class TestIdentityGate:
+    def test_human_tag_is_strongest(self):
+        r = build_player_report(
+            jersey_number=10,
+            team_cluster=0,
+            our_team_cluster=0,
+            bound=[_bound(tag_source="human", confidence="low")],
+            match_duration_s=2700,
+        )
+        assert r["identity"]["confidence"] == "human_confirmed"
+        assert r["identity"]["source"] == "human"
+        assert r["identity"]["human_reviewed"] is True
+
+    def test_auto_high_clean_is_high(self):
+        r = build_player_report(
+            jersey_number=10,
+            team_cluster=0,
+            our_team_cluster=0,
+            bound=[_bound(confidence="high", contaminated=False)],
+            match_duration_s=2700,
+        )
+        assert r["identity"]["confidence"] == "high"
+
+    def test_auto_low_is_low(self):
+        r = build_player_report(
+            jersey_number=10,
+            team_cluster=0,
+            our_team_cluster=0,
+            bound=[_bound(confidence="low")],
+            match_duration_s=2700,
+        )
+        assert r["identity"]["confidence"] == "low"
+
+    def test_contamination_blocks_high_and_flags_splice(self):
+        r = build_player_report(
+            jersey_number=4,
+            team_cluster=0,
+            our_team_cluster=0,
+            bound=[_bound(confidence="high", contaminated=True, number_votes={"4": 3, "10": 3})],
+            match_duration_s=2700,
+        )
+        assert r["identity"]["confidence"] == "low"  # high blocked by contamination
+        assert r["identity"]["splice_risk"] is True
+
+    def test_human_overrides_even_with_contamination(self):
+        r = build_player_report(
+            jersey_number=4,
+            team_cluster=0,
+            our_team_cluster=0,
+            bound=[_bound(tag_source="human", contaminated=True)],
+            match_duration_s=2700,
+        )
+        assert r["identity"]["confidence"] == "human_confirmed"
+        assert r["identity"]["splice_risk"] is True  # still surfaced
+
+    def test_empty_bound_is_unverified(self):
+        r = build_player_report(
+            jersey_number=9,
+            team_cluster=None,
+            our_team_cluster=None,
+            bound=[],
+            match_duration_s=None,
+        )
+        assert r["identity"]["confidence"] == "unverified"
+        assert r["coverage"]["confident_windows"] == 0
+        assert r["coverage"]["pct_of_match"] is None
+
+
+class TestCoverage:
+    def test_minutes_windows_and_pct(self):
+        r = build_player_report(
+            jersey_number=10,
+            team_cluster=0,
+            our_team_cluster=0,
+            bound=[_bound(visible_s=120, first_s=100, last_s=400), _bound(visible_s=60, first_s=800, last_s=900)],
+            match_duration_s=2700,
+        )
+        cov = r["coverage"]
+        assert cov["on_camera_min"] == 3.0
+        assert cov["confident_windows"] == 2
+        assert cov["pct_of_match"] == round(180 / 2700, 3)
+        assert cov["span_s"] == [100.0, 900.0]
+
+    def test_no_duration_means_no_pct(self):
+        r = build_player_report(
+            jersey_number=10,
+            team_cluster=0,
+            our_team_cluster=0,
+            bound=[_bound()],
+            match_duration_s=None,
+        )
+        assert r["coverage"]["pct_of_match"] is None
+
+
+class TestTeamLabel:
+    def test_ours_vs_opposition(self):
+        ours = build_player_report(
+            jersey_number=1, team_cluster=0, our_team_cluster=0, bound=[_bound()], match_duration_s=None
+        )
+        opp = build_player_report(
+            jersey_number=1, team_cluster=1, our_team_cluster=0, bound=[_bound()], match_duration_s=None
+        )
+        assert ours["identity"]["team"] == "ours"
+        assert opp["identity"]["team"] == "opposition"
+
+    def test_unknown_side_is_none(self):
+        r = build_player_report(
+            jersey_number=1, team_cluster=None, our_team_cluster=None, bound=[_bound()], match_duration_s=None
+        )
+        assert r["identity"]["team"] is None
+
+
+class TestMetrics:
+    def test_minutes_is_real_rest_suppressed(self):
+        r = build_player_report(
+            jersey_number=10,
+            team_cluster=0,
+            our_team_cluster=0,
+            bound=[_bound(visible_s=90)],
+            match_duration_s=2700,
+        )
+        by_key = {m["key"]: m for m in r["metrics"]}
+        assert by_key["minutes_on_camera"]["kind"] == "point"
+        assert by_key["minutes_on_camera"]["confidence"] == "high"
+        assert by_key["minutes_on_camera"]["value"] == 1.5
+        # everything needing homography is structurally present but suppressed (never faked)
+        for k in ("distance_m", "fastest_sustained_kmh", "sprint_count", "heatmap"):
+            assert by_key[k]["suppressed"] is True
+            assert by_key[k]["value"] is None
+        assert by_key["touches"]["kind"] == "beta"
+
+    def test_votes_aggregated_and_sorted(self):
+        r = build_player_report(
+            jersey_number=10,
+            team_cluster=0,
+            our_team_cluster=0,
+            bound=[_bound(number_votes={"10": 4}), _bound(number_votes={"10": 2, "12": 1})],
+            match_duration_s=2700,
+        )
+        votes = r["identity"]["votes"]
+        assert votes["10"] == 6 and votes["12"] == 1
+        assert list(votes.keys())[0] == "10"  # most-voted first
+
+
+class TestVoteExtraction:
+    def test_fragment_shape(self):
+        assert dict(tracklet_number_votes({"number_votes": {"10": 2}})) == {"10": 2}
+
+    def test_chain_shape(self):
+        got = dict(tracklet_number_votes({"votes": {"1": {"10": 3}, "2": {"10": 1, "12": 1}}}))
+        assert got == {"10": 4, "12": 1}
+
+    def test_garbage_evidence_is_safe(self):
+        assert dict(tracklet_number_votes(None)) == {}
+        assert dict(tracklet_number_votes({"votes": "nope"})) == {}
+        assert dict(tracklet_number_votes({"number_votes": {"x": "y"}})) == {}
+
+
+class TestOrmBridge:
+    """tracklet_to_bound must read real VideoTracklet rows (chain evidence shape)."""
+
+    def test_chain_tracklet_round_trips_into_report(self, report_app):
+        t = VideoTracklet(
+            video_match_id=1,
+            kind="chain",
+            pipeline_key="T0#10",
+            team_cluster=0,
+            suggested_number=10,
+            confidence="high",
+            contaminated=False,
+            first_s=120.0,
+            last_s=480.0,
+            visible_s=150.0,
+            tag_source="auto",
+            evidence={"member_fragment_ids": [1, 2], "votes": {"1": {"10": 4}, "2": {"10": 2, "12": 1}}},
+        )
+        db.session.add(t)
+        db.session.commit()
+        bound = tracklet_to_bound(t)
+        assert bound["confidence"] == "high"
+        assert bound["visible_s"] == 150.0
+        assert bound["number_votes"] == {"10": 6, "12": 1}
+        r = build_player_report(
+            jersey_number=10,
+            team_cluster=0,
+            our_team_cluster=0,
+            bound=[bound],
+            match_duration_s=2700,
+        )
+        assert r["identity"]["confidence"] == "high"
+        assert r["identity"]["votes"]["10"] == 6
+        assert r["coverage"]["on_camera_min"] == 2.5

--- a/academy-watch-frontend/src/pages/admin/AdminVideoMatch.jsx
+++ b/academy-watch-frontend/src/pages/admin/AdminVideoMatch.jsx
@@ -30,6 +30,36 @@ import { VideoStatusBadge } from './AdminVideo'
 
 const POLL_STATUSES = new Set(['queued', 'processing', 'preflight'])
 
+const IDENTITY_BADGE = {
+    human_confirmed: { label: 'confirmed', variant: 'default' },
+    high: { label: 'high confidence', variant: 'default' },
+    low: { label: 'low confidence', variant: 'secondary' },
+    unverified: { label: 'unverified', variant: 'outline' },
+}
+
+const METRIC_LABELS = {
+    minutes_on_camera: 'Minutes on camera',
+    distance_m: 'Distance',
+    fastest_sustained_kmh: 'Top sustained speed',
+    sprint_count: 'Sprints',
+    touches: 'Touches',
+    heatmap: 'Heatmap',
+}
+
+function metricDisplay(m) {
+    if (m.value === null || m.value === undefined) {
+        return m.kind === 'beta' ? 'beta — coming soon' : 'pending calibration'
+    }
+    const v = `${m.value}${m.unit ? ' ' + m.unit : ''}`
+    return m.kind === 'lower_bound' ? `≥ ${v}` : v
+}
+
+function votesSummary(votes) {
+    if (!votes || typeof votes !== 'object') return null
+    const parts = Object.entries(votes).map(([n, c]) => `${n}×${c}`)
+    return parts.length ? parts.join(' · ') : null
+}
+
 export function AdminVideoMatch() {
     const { matchId } = useParams()
     const [match, setMatch] = useState(null)
@@ -519,18 +549,48 @@ export function AdminVideoMatch() {
                     <CardHeader>
                         <CardTitle className="text-base">Player reports</CardTitle>
                         <CardDescription>
-                            On-camera minutes from a single panning camera — players out of frame aren’t counted, so
-                            these are visibility numbers, not full-match totals.
+                            Every figure carries its own confidence, gated by identity — a stat is only as
+                            trustworthy as the player it’s attributed to. Coverage shows how much of each player we
+                            actually saw; metrics that need pitch calibration are shown as pending, never guessed.
                         </CardDescription>
                     </CardHeader>
                     <CardContent>
-                        <div className="space-y-1">
-                            {(report.reports || []).map((r) => (
-                                <div key={r.id} className="flex items-center justify-between rounded border px-3 py-2">
-                                    <span className="font-medium">#{r.jersey_number} {r.player_name}</span>
-                                    <span className="text-sm text-muted-foreground">{r.minutes_visible ?? '—'} min on camera</span>
-                                </div>
-                            ))}
+                        <div className="space-y-3">
+                            {(report.reports || []).map((r) => {
+                                const idconf = r.identity_confidence || 'unverified'
+                                const idb = IDENTITY_BADGE[idconf] || IDENTITY_BADGE.unverified
+                                const cov = r.coverage || {}
+                                const votes = votesSummary(r.identity_evidence?.votes)
+                                return (
+                                    <div key={r.id} className="rounded-lg border p-3 space-y-2">
+                                        <div className="flex flex-wrap items-center gap-2">
+                                            <span className="font-medium">#{r.jersey_number} {r.player_name}</span>
+                                            <Badge variant={idb.variant}>{idb.label}</Badge>
+                                            {r.identity_evidence?.splice_risk && (
+                                                <Badge variant="destructive"><AlertTriangle className="h-3 w-3 mr-1" />mixed identity?</Badge>
+                                            )}
+                                            {r.identity_evidence?.source === 'human' && <Badge variant="outline">you confirmed</Badge>}
+                                        </div>
+                                        <p className="text-xs text-muted-foreground">
+                                            {cov.on_camera_min ?? r.minutes_visible ?? '—'} min on camera
+                                            {cov.confident_windows != null ? ` · ${cov.confident_windows} window${cov.confident_windows === 1 ? '' : 's'}` : ''}
+                                            {cov.pct_of_match != null ? ` · ${Math.round(cov.pct_of_match * 100)}% of match` : ''}
+                                            {votes ? ` · reads ${votes}` : ''}
+                                        </p>
+                                        <div className="grid grid-cols-2 sm:grid-cols-3 gap-x-4 gap-y-1">
+                                            {(r.metrics || []).filter((m) => m && m.key).map((m) => (
+                                                <div key={m.key} className="flex items-baseline justify-between gap-2 text-sm">
+                                                    <span className="text-muted-foreground">{METRIC_LABELS[m.key] || m.key}</span>
+                                                    <span className={m.suppressed ? 'text-muted-foreground/60 italic text-xs' : 'font-medium'}>
+                                                        {metricDisplay(m)}
+                                                        {!m.suppressed && m.confidence ? <span className="text-muted-foreground font-normal text-xs"> ({m.confidence})</span> : null}
+                                                    </span>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                )
+                            })}
                             {(report.reports || []).length === 0 && (
                                 <p className="text-sm text-muted-foreground">No reports — bind tracklets to players, then re-finalize.</p>
                             )}


### PR DESCRIPTION
## Summary
Per-player video reports become a **structured object where every data point carries its own confidence, gated by identity** — a stat is only as trustworthy as the player it's attributed to. This is the report contract for the video-analysis product (discussed with MJ); it ships honest partial reports now and fills fields in as capability arrives, without ever changing the contract or faking a number.

## What's in it
- **migration `vid02`** — adds `identity_confidence`, `identity_evidence`, `coverage`, `metrics`, `events` JSON columns to `video_player_reports` (guarded/idempotent; existence-checked downgrade). Chains off `vid01`.
- **`services/video_report.py`** — `build_player_report` (pure, unit-tested):
  - **identity gate**: `human_confirmed` > `high` > `low` > `unverified`; contamination blocks "high" and surfaces `splice_risk`.
  - **coverage**: on-camera minutes, confident windows, % of match, span.
  - **metrics** tagged by `kind`: `point` / `lower_bound` / `partial_observed` / `beta` / `suppressed`. Only minutes-on-camera is real today; distance/speed/heatmap/touches emit as `suppressed` (value `null`) until the homography stage — structurally present, never fabricated.
- **`finalize_match`** builds + stores the structured report; untracked roster players now get an honest "unverified / 0 on-camera" row instead of being silently omitted.
- **report API** emits the structured shape; **Film Room report view** renders identity badges, coverage, vote tallies, and per-metric confidence with pending-calibration states.

## Test plan
- [x] 16 builder unit tests (identity gate incl. contamination/human-override, coverage math, `kind` taxonomy, vote extraction from both evidence shapes, ORM bridge) — all green; full video suite 34 pass
- [x] `ruff` clean on changed files; `pnpm lint` 0 errors; `pnpm build` passes
- [x] Adversarially reviewed (3-dimension workflow + verify pass); 3 confirmed findings fixed: vote int-coercion guard in the aggregation, existence-checked migration downgrade (no bare except), and emitting unverified rows for untracked roster players
- [ ] Post-merge: deploy → `flask db upgrade vid02` → load the already-processed AFC Yorkies game and view a populated confidence-per-field report end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)