### PR TITLE
fix(video): confident_windows counts underlying fragments, not rows

### DIFF
--- a/academy-watch-backend/src/services/video_report.py
+++ b/academy-watch-backend/src/services/video_report.py
@@ -55,6 +55,18 @@ def tracklet_number_votes(evidence) -> Counter:
     return c
 
 
+def _member_window_count(evidence) -> int:
+    """How many underlying confident windows this tracklet represents. A chain
+    bundles many short fragments into one row, so the meaningful window count is
+    its member-fragment count — not 1. (Matches MJ's 'confident windows, combined'
+    framing.) A leftover fragment is a single window."""
+    if isinstance(evidence, dict):
+        members = evidence.get("member_fragment_ids")
+        if isinstance(members, list) and members:
+            return len(members)
+    return 1
+
+
 def tracklet_to_bound(t) -> dict:
     """VideoTracklet ORM row -> the plain dict build_player_report consumes."""
     return {
@@ -65,6 +77,7 @@ def tracklet_to_bound(t) -> dict:
         "tag_source": t.tag_source,
         "contaminated": bool(t.contaminated),
         "number_votes": dict(tracklet_number_votes(t.evidence)),
+        "windows": _member_window_count(t.evidence),
     }
 
 
@@ -145,7 +158,8 @@ def build_player_report(
 
     coverage = {
         "on_camera_min": on_camera_min,
-        "confident_windows": len(bound),
+        # underlying confident windows (chains expand to their member-fragment count)
+        "confident_windows": sum(int(b.get("windows", 1)) for b in bound),
         "pct_of_match": pct_of_match,
         "span_s": [round(min(firsts), 1), round(max(lasts), 1)] if firsts and lasts else None,
         # near/far split needs per-frame positions (not in the DB yet) — forward-compatible,

--- a/academy-watch-backend/tests/test_video_report.py
+++ b/academy-watch-backend/tests/test_video_report.py
@@ -219,6 +219,7 @@ class TestOrmBridge:
         assert bound["confidence"] == "high"
         assert bound["visible_s"] == 150.0
         assert bound["number_votes"] == {"10": 6, "12": 1}
+        assert bound["windows"] == 2  # chain expands to its member-fragment count
         r = build_player_report(
             jersey_number=10,
             team_cluster=0,
@@ -229,3 +230,22 @@ class TestOrmBridge:
         assert r["identity"]["confidence"] == "high"
         assert r["identity"]["votes"]["10"] == 6
         assert r["coverage"]["on_camera_min"] == 2.5
+        assert r["coverage"]["confident_windows"] == 2  # not 1 (the row count)
+
+
+class TestWindowCount:
+    def test_chain_expands_to_member_fragments(self):
+        r = build_player_report(
+            jersey_number=10, team_cluster=0, our_team_cluster=0,
+            bound=[_bound(windows=35), _bound(windows=8)],
+            match_duration_s=2700,
+        )
+        assert r["coverage"]["confident_windows"] == 43
+
+    def test_missing_windows_defaults_to_one(self):
+        r = build_player_report(
+            jersey_number=10, team_cluster=0, our_team_cluster=0,
+            bound=[_bound(), _bound()],  # no 'windows' key
+            match_duration_s=2700,
+        )
+        assert r["coverage"]["confident_windows"] == 2


### PR DESCRIPTION
Follow-up to #446. `coverage.confident_windows` summed bound `VideoTracklet` rows, so a number-anchored **chain** (which combines many short fragments into one row) read as "1 window" for what is really dozens of confident observations — contradicting the "confident windows, combined" mental model the report is built around.

Now `tracklet_to_bound` carries a `windows` count (a chain expands to `len(evidence.member_fragment_ids)`; a leftover fragment stays 1), and `build_player_report` sums it. On the real v8 AFC Yorkies game, #17 now reads **35 windows / 14.8 min** instead of 1.

Backend-only, no schema change. 18 report tests pass (2 new: chain expansion + default-to-1), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)