### PR TITLE
style: ruff format test_video_report.py (green Backend Lint)

### DIFF
--- a/academy-watch-backend/tests/test_video_report.py
+++ b/academy-watch-backend/tests/test_video_report.py
@@ -236,7 +236,9 @@ class TestOrmBridge:
 class TestWindowCount:
     def test_chain_expands_to_member_fragments(self):
         r = build_player_report(
-            jersey_number=10, team_cluster=0, our_team_cluster=0,
+            jersey_number=10,
+            team_cluster=0,
+            our_team_cluster=0,
             bound=[_bound(windows=35), _bound(windows=8)],
             match_duration_s=2700,
         )
@@ -244,7 +246,9 @@ class TestWindowCount:
 
     def test_missing_windows_defaults_to_one(self):
         r = build_player_report(
-            jersey_number=10, team_cluster=0, our_team_cluster=0,
+            jersey_number=10,
+            team_cluster=0,
+            our_team_cluster=0,
             bound=[_bound(), _bound()],  # no 'windows' key
             match_duration_s=2700,
         )


### PR DESCRIPTION
Quick fix: #447 added test code that passed `ruff check` but not `ruff format --check` (what CI's Backend Lint runs), so Backend Lint is red on main. This reformats the file. No logic change; 18 tests pass; `ruff format --check academy-watch-backend` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)