### PR TITLE
fix(players): show match data for sold/released players (current-club filter)

### DIFF
--- a/academy-watch-backend/src/routes/players.py
+++ b/academy-watch-backend/src/routes/players.py
@@ -95,25 +95,40 @@ def get_public_player_stats(player_id: int):
                 .all()
             )
 
-        # Build a map of team_api_id -> team info
-        # For on_loan: use current_club (loan destination)
-        # For first_team/academy: use parent club (team)
+        # Build a map of team_api_id -> team info for every club the player is
+        # tracked at. We include BOTH the club where they currently play
+        # (current_club_api_id — loan destination OR the club that bought them)
+        # AND their parent/academy club. Previously the current club was added
+        # only for status == "on_loan"; once moved players were reclassified
+        # "sold"/"released" they fell through to the parent-only branch, so this
+        # query filtered out every fixture at their real club and the page showed
+        # "No match data available" even though the rows exist in
+        # FixturePlayerStats (season-stats builds its club list straight from
+        # FixturePlayerStats and was therefore unaffected).
         loan_teams_info = {}
         for tp in tracked:
-            if tp.status == "on_loan" and tp.current_club_api_id:
-                loan_teams_info[tp.current_club_api_id] = {
-                    "name": tp.current_club_name or (tp.current_club.name if tp.current_club else "Unknown"),
-                    "logo": tp.current_club.logo if tp.current_club else None,
-                    "window_type": "Summer",
-                    "is_active": tp.is_active,
-                }
-            elif tp.team:
-                loan_teams_info[tp.team.team_id] = {
-                    "name": tp.team.name,
-                    "logo": tp.team.logo,
-                    "window_type": "Summer",
-                    "is_active": tp.is_active,
-                }
+            # The club where the player actually plays now (loan dest or buyer).
+            if tp.current_club_api_id:
+                loan_teams_info.setdefault(
+                    tp.current_club_api_id,
+                    {
+                        "name": tp.current_club_name or (tp.current_club.name if tp.current_club else "Unknown"),
+                        "logo": tp.current_club.logo if tp.current_club else None,
+                        "window_type": "Summer",
+                        "is_active": tp.is_active,
+                    },
+                )
+            # The parent/academy club (academy + first-team-at-origin appearances).
+            if tp.team:
+                loan_teams_info.setdefault(
+                    tp.team.team_id,
+                    {
+                        "name": tp.team.name,
+                        "logo": tp.team.logo,
+                        "window_type": "Summer",
+                        "is_active": tp.is_active,
+                    },
+                )
 
         loan_team_api_ids = list(loan_teams_info.keys())
 

--- a/academy-watch-backend/tests/test_player_stats_current_club.py
+++ b/academy-watch-backend/tests/test_player_stats_current_club.py
@@ -1,0 +1,112 @@
+"""Regression: GET /players/<id>/stats must include per-match rows at the club
+where a player CURRENTLY plays (loan destination OR the club that bought them),
+not only the parent academy club.
+
+Bug history: the team filter in get_public_player_stats added the current club to
+the query only when status == "on_loan". Once moved players were reclassified
+"sold"/"released" they fell through to the parent-only branch, so the query
+filtered out every fixture at their real club and the player page rendered
+"No match data available for this player yet." — even though the rows exist in
+FixturePlayerStats (the aggregate season-stats endpoint, which derives its club
+list straight from FixturePlayerStats, kept showing the appearances).
+"""
+
+import os
+from datetime import UTC, datetime
+
+import pytest
+from flask import Flask
+from src.models.league import Team, db
+from src.models.tracked_player import TrackedPlayer
+from src.models.weekly import Fixture, FixturePlayerStats
+
+
+class _StubAPIClient:
+    """No-network stand-in. Returns a non-empty dict so api_totals_failed is
+    False, and games_played=0 so the freshness-sync branch never fires."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def _fetch_player_team_season_totals_api(self, *args, **kwargs):
+        return {"games_played": 0}
+
+
+@pytest.fixture
+def app(monkeypatch):
+    os.environ.setdefault("SKIP_API_HANDSHAKE", "1")
+    os.environ.setdefault("API_USE_STUB_DATA", "true")
+
+    import src.api_football_client as apifc
+
+    monkeypatch.setattr(apifc, "APIFootballClient", _StubAPIClient)
+
+    from src.routes.players import players_bp
+
+    application = Flask(__name__)
+    application.config.update(
+        TESTING=True,
+        SECRET_KEY="test",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        RATELIMIT_ENABLED=False,
+    )
+    db.init_app(application)
+    application.register_blueprint(players_bp, url_prefix="/api")
+    with application.app_context():
+        db.create_all()
+        yield application
+        db.session.remove()
+        db.drop_all()
+
+
+def _seed(status, *, parent_api=33, buyer_api=50, player_api=999001):
+    """Seed a tracked player at a parent club who now plays for buyer_api, with a
+    single FixturePlayerStats row recorded against buyer_api."""
+    parent = Team(team_id=parent_api, name="Parent FC", country="England", season=2025, logo="p.png")
+    buyer = Team(team_id=buyer_api, name="Buyer FC", country="England", season=2025, logo="b.png")
+    db.session.add_all([parent, buyer])
+    db.session.commit()
+
+    tp = TrackedPlayer(
+        player_api_id=player_api,
+        player_name="Moved Player",
+        team_id=parent.id,
+        status=status,
+        current_club_api_id=buyer_api,
+        current_club_name="Buyer FC",
+        current_club_db_id=buyer.id,
+        is_active=True,
+    )
+    db.session.add(tp)
+    fx = Fixture(
+        fixture_id_api=910001,
+        season=2025,
+        date_utc=datetime(2025, 9, 1, tzinfo=UTC),
+        competition_name="Championship",
+        home_team_api_id=buyer_api,
+        away_team_api_id=77,
+        home_goals=1,
+        away_goals=0,
+    )
+    db.session.add(fx)
+    db.session.commit()
+    db.session.add(FixturePlayerStats(fixture_id=fx.id, player_api_id=player_api, team_api_id=buyer_api))
+    db.session.commit()
+    return player_api
+
+
+@pytest.mark.parametrize("status", ["sold", "released", "first_team", "on_loan"])
+def test_stats_includes_current_club_regardless_of_status(app, status):
+    """Match data for the player's CURRENT club is returned for every status —
+    not just on_loan (the original behaviour, which dropped sold/released)."""
+    with app.app_context():
+        player_api = _seed(status)
+
+    res = app.test_client().get(f"/api/players/{player_api}/stats")
+    assert res.status_code == 200
+    data = res.get_json()
+    assert isinstance(data, list)
+    assert len(data) == 1, f"status={status}: expected the buyer-club fixture, got {data}"
+    assert data[0]["loan_team_name"] == "Buyer FC"
+    assert data[0]["competition"] == "Championship"


### PR DESCRIPTION
## Problem

Player pages were showing **"No match data available for this player yet."** for a large cohort of players — anyone who was **sold** or **released** to a new club (e.g. A. Elanga, A. Garnacho, and ~1,740 active players across the platform). The per-match table was empty even though the player clearly had appearances.

## Root cause

`GET /players/<id>/stats` builds a team-id allow-list, then filters `FixturePlayerStats.team_api_id.in_(...)`. That list only added the player's **current** club (`current_club_api_id`) when `status == "on_loan"`; every other status fell through to the **parent academy club**.

Once #431 started reclassifying moved players `on_loan → sold/released`, those players landed on the parent-only branch, so the query filtered out **every fixture at the club where they actually play**. The data was never lost — the aggregate `/season-stats` endpoint (which derives its club list straight from `FixturePlayerStats`) kept showing the right totals. Concretely, on prod:

| Player | status | now at | `/stats` rows (before) | `season-stats` apps |
|---|---|---|---|---|
| A. Elanga | sold | Newcastle | **0** | 53 |
| A. Garnacho | sold | Chelsea | **1** (Man Utd only) | 50 |
| C. McNeill | released | Sheffield Wed | **0** | 48 |
| C. Savage | released | Reading | **0** | 47 |

## Fix

Include **both** the current club (loan destination *or* the club that bought them) **and** the parent academy club in the allow-list, for **every** status. This is a **filter-only** change — the rows already exist in `FixturePlayerStats`, so **no re-sync is required**; affected pages populate on next load.

## Test

`tests/test_player_stats_current_club.py` — parametrized over `sold / released / first_team / on_loan`. Verified red→green: without the fix the three non-`on_loan` cases return 0 rows; with it all four return the current-club fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)