### PR TITLE
fix(journey): walk transfer chain + reject phantom transfers (no Ashington AFC)

### DIFF
--- a/academy-watch-backend/src/services/journey_sync.py
+++ b/academy-watch-backend/src/services/journey_sync.py
@@ -697,6 +697,32 @@ class JourneySyncService:
         if not permanent_moves:
             return
 
+        # Clubs the player has independent evidence for (journey entries are
+        # derived from the statistics feed). Used to reject bogus transfers:
+        # API-Football occasionally returns a duplicate transfer into the real
+        # destination from an unrelated lower-league club it invented — e.g.
+        # "Newcastle ⟸ Ashington AFC" alongside the genuine "Newcastle ⟸
+        # Nottingham Forest". Correcting a season to that phantom source
+        # manufactures a club the player never played for.
+        evidence_club_ids = {e.club_api_id for e in entries if not e.is_international}
+
+        moves_by_in: dict[int, list] = {}
+        for move in permanent_moves:
+            moves_by_in.setdefault(move["in_id"], []).append(move)
+
+        def _source_move(in_id, season_end):
+            """The transfer that explains being at ``in_id`` for a season that
+            ended before it: the earliest permanent move INTO ``in_id`` after the
+            season. When several moves share that destination (a contradictory
+            feed), prefer one whose source club the player actually has evidence
+            for, which discards the invented lower-league transfer."""
+            candidates = [m for m in moves_by_in.get(in_id, []) if m["date"] > season_end]
+            if not candidates:
+                return None
+            corroborated = [m for m in candidates if m["out_id"] in evidence_club_ids]
+            pool = corroborated or candidates
+            return min(pool, key=lambda m: m["date"])
+
         corrected = 0
         for entry in entries:
             if entry.is_international:
@@ -705,21 +731,32 @@ class JourneySyncService:
             # Season runs Aug to Jun: entry.season=2024 → Aug 2024 to Jun 2025
             season_end = f"{entry.season + 1}-06-30"
 
-            for move in permanent_moves:
-                # If this entry's club matches the transfer destination,
-                # and the transfer happened AFTER the season ended,
-                # then the entry was actually at the source club
-                if move["in_id"] == entry.club_api_id and move["date"] > season_end:
-                    logger.info(
-                        f"Correcting entry: {entry.club_name} (season {entry.season}) "
-                        f"→ {move['out_name']} (transfer to {move['in_name']} "
-                        f"on {move['date']} is after season end {season_end})"
-                    )
-                    entry.club_api_id = move["out_id"]
-                    entry.club_name = move["out_name"]
-                    entry.club_logo = move["out_logo"]
-                    corrected += 1
+            # Walk the transfer chain back until the club is no longer the
+            # destination of a post-season transfer. A single hop only repairs the
+            # season directly before the latest move; older seasons need the full
+            # chain (e.g. Newcastle → Forest → Man Utd), otherwise they collapse
+            # onto the wrong club. ``visited`` guards against cyclic feed data.
+            club_id = entry.club_api_id
+            final_move = None
+            visited: set[int] = set()
+            while club_id not in visited:
+                visited.add(club_id)
+                move = _source_move(club_id, season_end)
+                if move is None or move["out_id"] == club_id:
                     break
+                club_id = move["out_id"]
+                final_move = move
+
+            if final_move is not None and club_id != entry.club_api_id:
+                logger.info(
+                    f"Correcting entry: {entry.club_name} (season {entry.season}) "
+                    f"→ {final_move['out_name']} (walked transfer chain back to the "
+                    f"club active before season end {season_end})"
+                )
+                entry.club_api_id = final_move["out_id"]
+                entry.club_name = final_move["out_name"]
+                entry.club_logo = final_move["out_logo"]
+                corrected += 1
 
         if corrected:
             logger.info(f"Corrected {corrected} entries with wrong club from post-transfer API data")

--- a/academy-watch-backend/tests/test_journey_transfer_correction.py
+++ b/academy-watch-backend/tests/test_journey_transfer_correction.py
@@ -1,0 +1,101 @@
+"""Regression tests for JourneySyncService._correct_club_ids_from_transfers.
+
+API-Football retroactively returns a player's CURRENT club for historical
+seasons after a permanent transfer. The correction walks the transfer history to
+restore the real club. Two failure modes this guards against:
+
+1. Multi-hop history. A single-hop correction only fixes the season directly
+   before the latest move; older seasons collapse onto the wrong club
+   (e.g. a 2022 Man Utd season becoming Nottingham Forest).
+2. Contradictory feed data. API-Football sometimes returns a duplicate transfer
+   into the real destination from an invented lower-league club
+   ("Newcastle ⟸ Ashington AFC" alongside "Newcastle ⟸ Nottingham Forest").
+   Correcting to that phantom source manufactures a club the player never
+   played for — the visible "Ashington AFC" bug on A. Elanga's journey.
+"""
+
+from src.services.journey_sync import JourneySyncService
+
+
+class _Entry:
+    def __init__(self, season, club_api_id, club_name, *, is_international=False, appearances=1):
+        self.season = season
+        self.club_api_id = club_api_id
+        self.club_name = club_name
+        self.club_logo = ""
+        self.is_international = is_international
+        self.appearances = appearances
+
+
+def _transfer(date, in_id, in_name, out_id, out_name):
+    return {
+        "date": date,
+        "type": "Transfer",
+        "teams": {
+            "in": {"id": in_id, "name": in_name, "logo": ""},
+            "out": {"id": out_id, "name": out_name, "logo": ""},
+        },
+    }
+
+
+def _svc():
+    # Bypass __init__ (which builds an API client / handshake); the method under
+    # test only uses its arguments and the module logger.
+    return JourneySyncService.__new__(JourneySyncService)
+
+
+def test_elanga_chain_walk_and_phantom_rejection():
+    """The exact A. Elanga scenario: Man Utd → Forest → Newcastle, with a bogus
+    duplicate 'Newcastle ⟸ Ashington AFC' transfer in the feed."""
+    # Order the invented transfer FIRST so a naive "first matching move" picks
+    # the phantom — the worst case the corroboration guard must reject.
+    transfers = [
+        _transfer("2025-07-11", 34, "Newcastle", 8686, "Ashington AFC"),  # invented
+        _transfer("2025-07-11", 34, "Newcastle", 65, "Nottingham Forest"),
+        _transfer("2023-07-25", 65, "Nottingham Forest", 33, "Manchester United"),
+    ]
+    # API mis-attributed 2022-2024 to the current club (Newcastle), plus the real
+    # entries the player actually has (the evidence that discards Ashington).
+    misattributed = [
+        _Entry(2022, 34, "Newcastle"),
+        _Entry(2023, 34, "Newcastle"),
+        _Entry(2024, 34, "Newcastle"),
+    ]
+    real = [
+        _Entry(2022, 33, "Manchester United"),
+        _Entry(2023, 65, "Nottingham Forest"),
+        _Entry(2025, 34, "Newcastle"),  # genuine current club — must stay
+    ]
+    entries = misattributed + real
+
+    _svc()._correct_club_ids_from_transfers(entries, transfers)
+
+    # Phantom never appears.
+    assert all(e.club_api_id != 8686 for e in entries)
+    assert all("Ashington" not in (e.club_name or "") for e in entries)
+    # Multi-hop chain restores the right club per season.
+    assert misattributed[0].club_api_id == 33, "2022 should walk back to Man Utd"
+    assert misattributed[1].club_api_id == 65, "2023 should be Nottingham Forest"
+    assert misattributed[2].club_api_id == 65, "2024 should be Nottingham Forest"
+    # The genuine current-club season is untouched.
+    assert real[2].club_api_id == 34
+
+
+def test_single_hop_correction_still_applies():
+    """The common case — one permanent transfer — keeps working."""
+    transfers = [_transfer("2024-07-01", 50, "New Club", 40, "Old Club")]
+    entries = [_Entry(2023, 50, "New Club")]  # mis-attributed to the new club
+
+    _svc()._correct_club_ids_from_transfers(entries, transfers)
+
+    assert entries[0].club_api_id == 40
+    assert entries[0].club_name == "Old Club"
+
+
+def test_international_entries_are_never_rewritten():
+    transfers = [_transfer("2025-07-11", 34, "Newcastle", 65, "Nottingham Forest")]
+    natl = _Entry(2022, 34, "Sweden", is_international=True)
+
+    _svc()._correct_club_ids_from_transfers([natl], transfers)
+
+    assert natl.club_api_id == 34 and natl.club_name == "Sweden"


### PR DESCRIPTION
## Problem

Player journeys were "all off" — e.g. **A. Elanga** showing repeated **Ashington AFC** stints (a non-league club he never played for) wedged between his real clubs, with nonsensical app counts.

## Root cause

After a permanent transfer, API-Football retroactively returns the player's **current** club for **historical** seasons. `_correct_club_ids_from_transfers` (added 2026-04-01, `f0697a2`) detects this from the transfer history, but had two flaws:

1. **Single-hop only.** It reassigned a mis-attributed season to the *immediate* transfer source. For seasons two or more moves in the past, that's still the wrong club (Elanga's 2022 Man Utd season became Forest).
2. **Trusts contradictory feed data.** API-Football returned a **duplicate** transfer into the real destination from an invented lower-league club:
   ```
   2025-07-11  Newcastle <- Nottingham Forest   (real)
   2025-07-11  Newcastle <- Ashington AFC        (phantom)
   ```
   The "first matching move" logic could pick the phantom source, manufacturing an Ashington AFC stint.

This was dormant because local/older data was synced before April 1; it materialized when journeys were **re-synced** (the recent loan→sold repair). Reproduced deterministically by re-syncing Elanga.

## Fix

- **Walk the full transfer chain** back to the club active during each season (Newcastle → Forest → Man Utd), instead of a single hop.
- When several transfers share a destination, **prefer the one whose source club the player actually has journey evidence for** — discarding the invented lower-league transfer.

Verified against live Elanga data — journey now reads **Man Utd → Forest → Newcastle**, no phantom:
```
2017–2022  Manchester United (academy → first team)
2023       Man Utd → Nottingham Forest
2024       Nottingham Forest
2025       Newcastle
```

## ⚠️ Follow-up (operational)

Prod journeys **already corrupted** by this need a **re-sync after this deploys**. Re-syncing journeys *before* it lands re-creates the phantom — so the previously-planned loan→sold journey re-sync must wait for this.

## Test

`tests/test_journey_transfer_correction.py` — multi-hop chain, phantom rejection (bogus transfer ordered first), single-hop, and international-entry cases. Verified red→green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)