### PR TITLE
chore(db): recurring api_cache purge via pg_cron (prod-applied)

### DIFF
--- a/academy-watch-backend/migrations/maintenance/api_cache_purge_cron.sql
+++ b/academy-watch-backend/migrations/maintenance/api_cache_purge_cron.sql
@@ -31,8 +31,12 @@ select cron.schedule(
   $$delete from public.api_cache where expires_at < now()$$
 );
 
--- One-time disk reclaim (NOT run automatically): the daily DELETE bounds growth,
--- but to shrink the already-allocated ~200 MB back to disk, run a one-off during
--- a maintenance window (briefly ACCESS EXCLUSIVE locks api_cache — safe because
--- it is only read on API-Football cache lookups, not on normal page loads):
+-- ONE-TIME disk reclaim (NOT recurring, NOT in the cron): the daily DELETE +
+-- autovacuum bound growth, but DELETE only frees space for reuse — it does not
+-- return it to the OS. To shrink already-allocated bloat back to disk, run this
+-- ONCE during a quiet window. It briefly ACCESS EXCLUSIVE locks api_cache, which
+-- is safe because the table is only read on API-Football cache lookups, not on
+-- normal page loads. Do NOT schedule it — VACUUM FULL on a timer is a Postgres
+-- anti-pattern; autovacuum + the daily purge keep the table at steady state.
 --     vacuum (full, analyze) public.api_cache;
+-- Applied once on 2026-06-23: api_cache 200 MB -> 90 MB, total DB 399 MB -> 289 MB.

--- a/academy-watch-backend/migrations/maintenance/api_cache_purge_cron.sql
+++ b/academy-watch-backend/migrations/maintenance/api_cache_purge_cron.sql
@@ -1,0 +1,38 @@
+-- =============================================================================
+-- Recurring purge of expired API-Football cache (api_cache) via pg_cron
+-- =============================================================================
+-- Applied to PROD (Supabase project snqwamzutbcbjgusubsa) on 2026-06-22.
+--
+-- WHY: api_cache is a DB-backed TTL cache for API-Football responses. Nothing
+-- was ever deleting expired rows, so it grew to ~200 MB (92.5k rows, ~65% of
+-- them already expired) — the single biggest table in the DB and ~half of total
+-- DB size. This schedules a daily purge so the cache stays at a bounded
+-- steady-state instead of growing forever. Mirrors APICache.cleanup_expired()
+-- in src/models/api_cache.py.
+--
+-- This is OUT-OF-BAND maintenance, intentionally NOT an Alembic migration:
+--   * pg_cron setup needs the postgres superuser; running CREATE EXTENSION over
+--     the app's deploy connection risks breaking `flask db upgrade`.
+--   * It is infra/scheduling, not application schema.
+-- It is idempotent and re-runnable. If the database is ever rebuilt/migrated to
+-- a new project, re-run this file (psql / Supabase SQL editor) to restore the job.
+--
+-- Verify:    select jobid, jobname, schedule, active, command from cron.job;
+-- Run log:   select * from cron.job_run_details order by start_time desc limit 10;
+-- Unschedule: select cron.unschedule('purge-expired-api-cache');
+-- =============================================================================
+
+create extension if not exists pg_cron;
+
+-- Named job => cron.schedule upserts by name, so re-running this is safe.
+select cron.schedule(
+  'purge-expired-api-cache',
+  '30 3 * * *',                                            -- daily, 03:30 UTC (off-peak)
+  $$delete from public.api_cache where expires_at < now()$$
+);
+
+-- One-time disk reclaim (NOT run automatically): the daily DELETE bounds growth,
+-- but to shrink the already-allocated ~200 MB back to disk, run a one-off during
+-- a maintenance window (briefly ACCESS EXCLUSIVE locks api_cache — safe because
+-- it is only read on API-Football cache lookups, not on normal page loads):
+--     vacuum (full, analyze) public.api_cache;


### PR DESCRIPTION
## What

Documents the **recurring purge of expired `api_cache` rows** that's now **live on the prod Supabase DB** via `pg_cron`.

## Why

`api_cache` (DB-backed API-Football TTL cache) had **no purge job** — it had grown to **~200 MB / 92.5k rows, ~65% of them already expired**. It was the single largest table and roughly **half of total DB size** (399 MB).

## What was done (on prod, verified)

- Enabled `pg_cron` (was available, not enabled).
- Scheduled `purge-expired-api-cache` — daily 03:30 UTC — running `delete from public.api_cache where expires_at < now()` (mirrors `APICache.cleanup_expired()`).
- **Verified the pg_cron worker fires end-to-end** (1-minute self-test succeeded, then removed).
- Ran the initial purge: **60,350 expired rows cleared** (92,570 → 32,220 live).

This caps the cache at a bounded steady state instead of unbounded growth.

## This file

An **idempotent, re-runnable** record of the out-of-band setup. Intentionally **not** an Alembic migration — `pg_cron` setup needs the postgres superuser and shouldn't run over the deploy connection (deploy-risk). Re-run it (psql / Supabase SQL editor) if the DB is ever rebuilt.

## Not included (follow-ups)

- **One-time disk reclaim:** `DELETE` frees space for reuse but doesn't shrink the file; a one-off `vacuum (full, analyze) public.api_cache` in a maintenance window reclaims ~200 MB → ~30 MB (briefly locks the table — low risk, only read on API cache lookups).
- **Newsletter bloat:** 20 newsletters hold ~94 MB of base64-embedded images (~5 MB each, real data — will grow). Fix is to externalize images to Azure Blob; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)