### PR TITLE
fix(names): decode HTML entities in player names (no more N. O&apos;Reilly)

### DIFF
--- a/academy-watch-backend/src/models/tracked_player.py
+++ b/academy-watch-backend/src/models/tracked_player.py
@@ -9,6 +9,7 @@ Replaces the old AcademyPlayer model for the Academy Watch redesign.
 from datetime import UTC, datetime
 
 from src.models.league import db
+from src.utils.player_names import clean_name
 
 
 class TrackedPlayer(db.Model):
@@ -160,7 +161,7 @@ class TrackedPlayer(db.Model):
         return {
             "id": self.id,
             "player_api_id": self.player_api_id,
-            "player_name": self.player_name,
+            "player_name": clean_name(self.player_name),
             "photo_url": self.photo_url,
             "position": self.position,
             "nationality": self.nationality,
@@ -194,7 +195,7 @@ class TrackedPlayer(db.Model):
         return {
             "id": self.id,
             "player_id": self.player_api_id,
-            "player_name": self.player_name,
+            "player_name": clean_name(self.player_name),
             "player_photo": self.photo_url,
             "position": self.position,
             "age": self.effective_age,

--- a/academy-watch-backend/src/scripts/decode_name_entities.py
+++ b/academy-watch-backend/src/scripts/decode_name_entities.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""One-time repair: decode HTML entities in stored player names.
+
+API-Football occasionally returns names with HTML entities (e.g.
+``N. O&apos;Reilly``). Those were stored verbatim and then rendered literally
+by the React frontend (which escapes, never decodes), leaking the raw entity
+into the UI — visible on the Scout Desk leaderboards.
+
+The ingestion paths now run names through ``clean_name`` (see
+``src.utils.player_names``), so this script only repairs rows written before
+that fix. It is idempotent — a clean name decodes to itself — and safe to
+re-run.
+
+Usage:
+    cd academy-watch-backend
+    python -m src.scripts.decode_name_entities            # dry-run (default)
+    python -m src.scripts.decode_name_entities --apply    # commit changes
+
+Postgres-only (uses the ``~`` regex operator). Safe to run against production.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+log = logging.getLogger(__name__)
+
+# (table, column) pairs holding feed-sourced player names.
+NAME_COLUMNS = [
+    ("tracked_players", "player_name"),
+    ("player_journeys", "player_name"),
+    ("academy_player_season_stats", "player_name"),
+    ("cohort_members", "player_name"),
+    ("academy_appearances", "player_name"),
+    ("players", "name"),
+]
+
+# Matches named (&apos;), decimal (&#39;) and hex (&#x27;) HTML entities.
+ENTITY_REGEX = r"&[a-zA-Z][a-zA-Z0-9]*;|&#[0-9]+;|&#x[0-9a-fA-F]+;"
+
+
+def get_app():
+    from src.main import app
+
+    return app
+
+
+def repair(apply: bool) -> int:
+    """Decode entity-bearing names in place. Returns total rows updated."""
+    import html
+
+    from sqlalchemy import text
+    from src.models.league import db
+
+    total_rows = 0
+    for table, column in NAME_COLUMNS:
+        # Distinct encoded values → one UPDATE per value (no PK needed, and
+        # the same encoded string always decodes to the same clean name).
+        rows = db.session.execute(
+            text(f"SELECT DISTINCT {column} AS val FROM {table} WHERE {column} ~ :rx"),  # noqa: S608
+            {"rx": ENTITY_REGEX},
+        ).all()
+
+        table_rows = 0
+        for (encoded,) in rows:
+            decoded = html.unescape(encoded).strip()
+            if decoded == encoded:
+                continue  # entity-looking substring that is already correct
+            log.info("  %s.%s: %r -> %r", table, column, encoded, decoded)
+            if apply:
+                result = db.session.execute(
+                    text(f"UPDATE {table} SET {column} = :new WHERE {column} = :old"),  # noqa: S608
+                    {"new": decoded, "old": encoded},
+                )
+                table_rows += result.rowcount or 0
+            else:
+                table_rows += 1
+
+        if table_rows:
+            log.info("[%s] %s rows %s", table, table_rows, "updated" if apply else "would update")
+        total_rows += table_rows
+
+    if apply:
+        db.session.commit()
+    return total_rows
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Decode HTML entities in stored player names")
+    parser.add_argument("--apply", action="store_true", help="Commit changes (default: dry-run)")
+    args = parser.parse_args()
+
+    with get_app().app_context():
+        mode = "APPLY" if args.apply else "DRY-RUN"
+        log.info("Decoding HTML entities in player names (%s)", mode)
+        total = repair(apply=args.apply)
+        log.info("Done. %s rows %s.", total, "updated" if args.apply else "would be updated")
+        if not args.apply and total:
+            log.info("Re-run with --apply to commit.")
+
+
+if __name__ == "__main__":
+    main()

--- a/academy-watch-backend/src/services/academy_sync_service.py
+++ b/academy-watch-backend/src/services/academy_sync_service.py
@@ -12,6 +12,7 @@ from src.api_football_client import APIFootballClient
 from src.models.league import AcademyAppearance, AcademyLeague, AcademyPlayerSeasonStats, db
 from src.models.tracked_player import TrackedPlayer
 from src.services.big6_seeding_service import RateLimiter
+from src.utils.player_names import clean_name
 
 logger = logging.getLogger(__name__)
 
@@ -285,7 +286,7 @@ class AcademySyncService:
                 # Create new appearance
                 appearance = AcademyAppearance(
                     player_id=player_id,
-                    player_name=player_info.get("name", f"Player {player_id}"),
+                    player_name=clean_name(player_info.get("name")) or f"Player {player_id}",
                     fixture_id=fixture_id,
                     fixture_date=fixture_date,
                     home_team=home_team,
@@ -524,7 +525,7 @@ class AcademySyncService:
                     player_data = players_data[0]
                     stats_list = player_data.get("statistics", [])
                     p_info = player_data.get("player", {})
-                    display_name = p_info.get("name") or player_name
+                    display_name = clean_name(p_info.get("name")) or player_name
 
                     for stat in stats_list:
                         league_info = stat.get("league", {})

--- a/academy-watch-backend/src/services/cohort_service.py
+++ b/academy-watch-backend/src/services/cohort_service.py
@@ -15,6 +15,7 @@ from src.models.journey import PlayerJourney, PlayerJourneyEntry
 from src.models.league import db
 from src.services.journey_sync import JourneySyncService
 from src.utils.academy_classifier import classify_tracked_player, strip_youth_suffix
+from src.utils.player_names import clean_name
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +148,7 @@ class CohortService:
                     member = CohortMember(
                         cohort_id=cohort.id,
                         player_api_id=player_api_id,
-                        player_name=player.get("name"),
+                        player_name=clean_name(player.get("name")),
                         player_photo=player.get("photo"),
                         nationality=player.get("nationality"),
                         birth_date=player.get("birth", {}).get("date"),

--- a/academy-watch-backend/src/services/journey_sync.py
+++ b/academy-watch-backend/src/services/journey_sync.py
@@ -25,7 +25,7 @@ from src.utils.academy_classifier import (
     strip_youth_suffix,
 )
 from src.utils.geocoding import get_team_coordinates
-from src.utils.player_names import is_placeholder_name, resolve_player_name
+from src.utils.player_names import clean_name, is_placeholder_name, resolve_player_name
 
 logger = logging.getLogger(__name__)
 
@@ -253,7 +253,7 @@ class JourneySyncService:
 
             # Update player info
             if player_info:
-                incoming_name = (player_info.get("name") or "").strip() or None
+                incoming_name = clean_name(player_info.get("name")) or None
                 # Never overwrite a real name with a placeholder
                 if incoming_name and (not journey.player_name or not is_placeholder_name(incoming_name)):
                     journey.player_name = incoming_name

--- a/academy-watch-backend/src/utils/player_names.py
+++ b/academy-watch-backend/src/utils/player_names.py
@@ -10,9 +10,26 @@ Models are imported lazily inside the lookup so this module stays free of
 circular imports.
 """
 
+import html
 import re
 
 PLACEHOLDER_NAME_RE = re.compile(r"^Player \d+$")
+
+
+def clean_name(value):
+    """Normalise a feed-sourced name for storage and display.
+
+    API-Football occasionally returns names with HTML entities (e.g.
+    ``N. O&apos;Reilly``). Those are stored verbatim and then rendered
+    literally by the React frontend (which escapes, never decodes), so the
+    raw entity leaks into the UI. Decode entities and trim whitespace.
+
+    ``None`` passes through unchanged so callers can keep their own
+    placeholder fallbacks.
+    """
+    if value is None:
+        return None
+    return html.unescape(str(value)).strip()
 
 
 def is_placeholder_name(name) -> bool:
@@ -63,10 +80,10 @@ def resolve_player_name(player_api_id, *candidates) -> str:
     """
     for candidate in candidates:
         if not is_placeholder_name(candidate):
-            return str(candidate).strip()
+            return clean_name(candidate)
     for name, _photo, _nationality in _iter_local_profiles(player_api_id):
         if not is_placeholder_name(name):
-            return str(name).strip()
+            return clean_name(name)
     return f"Player {player_api_id}"
 
 
@@ -81,7 +98,7 @@ def resolve_player_profile(player_api_id) -> dict:
         if is_placeholder_name(src_name):
             continue
         if name is None:
-            name = str(src_name).strip()
+            name = clean_name(src_name)
         if photo is None and src_photo:
             photo = src_photo
         if nationality is None and src_nationality:

--- a/academy-watch-backend/tests/test_player_name_backfill.py
+++ b/academy-watch-backend/tests/test_player_name_backfill.py
@@ -15,7 +15,7 @@ from src.models.journey import PlayerJourney
 from src.models.league import AcademyPlayerSeasonStats, League, Player, Team, db
 from src.models.tracked_player import TrackedPlayer
 from src.models.weekly import Fixture, FixturePlayerStats
-from src.utils.player_names import is_placeholder_name, resolve_player_name
+from src.utils.player_names import clean_name, is_placeholder_name, resolve_player_name
 
 ADMIN_KEY = "test-admin-key"
 
@@ -152,6 +152,34 @@ class TestResolvePriorityOrder:
 
     def test_last_resort_placeholder(self, app):
         assert resolve_player_name(604) == "Player 604"
+
+
+class TestCleanName:
+    """HTML entities from the API feed must never reach the UI verbatim."""
+
+    def test_decodes_named_entity(self):
+        assert clean_name("N. O&apos;Reilly") == "N. O'Reilly"
+        assert clean_name("M&apos;Bala Nzola") == "M'Bala Nzola"
+
+    def test_decodes_numeric_and_amp(self):
+        assert clean_name("A. N&#39;Diaye") == "A. N'Diaye"
+        assert clean_name("Brighton &amp; Hove") == "Brighton & Hove"
+
+    def test_idempotent_and_trims(self):
+        # A clean name decodes to itself (script/serializer can re-run safely).
+        assert clean_name("  Lamine Yamal  ") == "Lamine Yamal"
+        assert clean_name(clean_name("N. O&apos;Reilly")) == "N. O'Reilly"
+
+    def test_none_passes_through(self):
+        assert clean_name(None) is None
+
+    def test_resolve_decodes_candidate(self, app):
+        assert resolve_player_name(610, "N. O&apos;Reilly") == "N. O'Reilly"
+
+    def test_resolve_decodes_local_source(self, app):
+        db.session.add(PlayerJourney(player_api_id=611, player_name="S. Oulad M&apos;Hand"))
+        db.session.flush()
+        assert resolve_player_name(611) == "S. Oulad M'Hand"
 
 
 class TestBackfillNamesEndpoint:


### PR DESCRIPTION
## Problem

API-Football occasionally returns player names with HTML entities (e.g. `N. O&apos;Reilly`, `S. Oulad M&apos;Hand`, `A. N&apos;Diaye`). These were stored verbatim and then rendered **literally** by the React frontend (which HTML-escapes output but never decodes entities), so the raw `&apos;` leaked into the UI — visible on the **Scout Desk** leaderboards ("Most Minutes" → `N. O&apos;Reilly`).

Confirmed in the data: encoded names exist in `tracked_players`, `player_journeys`, `academy_player_season_stats`, `cohort_members`, and `players`.

## Fix (three layers)

1. **Ingestion** — new `clean_name()` (`html.unescape` + strip) in `utils/player_names.py`, applied in `resolve_player_name` / `resolve_player_profile` and at every feed-write path (`journey_sync`, `academy_sync_service`, `cohort_service`). New and re-synced rows stay clean.
2. **Display guarantee** — `TrackedPlayer.to_dict` / `to_public_dict` decode `player_name`, so the Scout Desk (and every consumer of these dicts) renders clean **on code deploy alone**, regardless of stored value.
3. **Data repair** — `src/scripts/decode_name_entities.py`, idempotent, covering `tracked_players`, `player_journeys`, `academy_player_season_stats`, `cohort_members`, `academy_appearances`, `players`. Already applied to local (32 rows; verified clean + idempotent).

Tests added for `clean_name` and entity-decoding resolution.

## ⚠️ Post-deploy step (production)

The display-layer decode makes the **Scout Desk clean immediately on deploy**. To also clean *stored* data (so search, CSV export, and player pages are correct — otherwise these self-heal only on the next journey/academy sync), run the repair in the prod container after merge/deploy:

```sh
az containerapp exec --name ca-loan-army-backend --resource-group rg-loan-army-westus2 --command /bin/sh
# inside the container:
python -m src.scripts.decode_name_entities            # dry-run preview
python -m src.scripts.decode_name_entities --apply    # commit
```

Idempotent and safe to re-run (a clean name decodes to itself).

## Notes
- Branched from `main`, isolated from the in-progress video work in the tree.
- The 10 `test_journey.py` failures in this repo are **pre-existing** (an app-context fixture issue) — they fail identically on clean `main` without these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)