### PR TITLE
fix(classifier): permanent moves with a destination are 'sold', not 'released'

### DIFF
--- a/academy-watch-backend/src/utils/academy_classifier.py
+++ b/academy-watch-backend/src/utils/academy_classifier.py
@@ -506,10 +506,26 @@ def upgrade_status_from_transfers(
                 return "sold"  # at a club with no loan record → permanent move
         return status  # confirmed loan destination
 
-    # Permanent departure: free agent → 'released', else → 'sold'
-    if dep_type in ("free agent", "free", "n/a"):
-        return "released"
-    return "sold"
+    # Permanent (non-loan) departure. The transfer TYPE alone cannot tell a
+    # free-agency exit from a permanent move to a new club: API-Football
+    # populates teams.in for virtually every departure, and an
+    # undisclosed-fee sale is typed "N/A" (not a release). Decide on the
+    # departure's recorded destination, not the fee string — a real,
+    # non-parent, non-national club ⇒ 'sold'; no recorded destination ⇒
+    # 'released' (a genuine free-agency exit; the Step-3 inactivity check is
+    # the other path that yields 'released'). We read only the departure's
+    # teams.in here, deliberately NOT the journey's current club: an empty
+    # teams.in is the free-agency signal, and folding in a stale last-club
+    # would manufacture a false 'sold'.
+    # NB: "N/A" is treated as ambiguous elsewhere (journey_sync's
+    # current-club override deliberately skips it); lumping it with free
+    # agents here is what mislabelled permanent movers (e.g. Rijkhoff,
+    # Dortmund→Ajax typed "N/A") as 'released' instead of 'sold'.
+    dest = departures[0].get("teams", {}).get("in", {}) or {}
+    dest_id = dest.get("id")
+    if dest_id and dest_id != parent_api_id and not is_national_team(dest.get("name")):
+        return "sold"
+    return "released"
 
 
 # ─── unified classification entry point ───────────────────────────────
@@ -588,36 +604,34 @@ def _get_latest_season(
     parent_api_id: int | None = None,
     parent_club_name: str | None = None,
 ) -> int | None:
-    """Get the most recent season from a player's journey entries.
+    """Get the player's most recent season of CLUB activity, for the
+    inactivity-release check.
 
-    When *parent_api_id* (and optionally *parent_club_name*) are provided,
-    entries at the parent club are preferred.  If no parent-club entries
-    exist (common because API-Football records loan *destinations*, not
-    the parent club itself), we fall back to the latest season at any club.
-    Active loans will have recent entries that pass the inactivity
-    threshold; truly inactive players will have old entries that trigger
-    release.
+    "Latest activity" must mean "played for any club recently", NOT "last
+    seen at the parent club". A player sold or loaned away keeps appearing
+    for other clubs, while their newest *parent-named* entry is often a
+    stale youth season (e.g. "<Parent> U19"). Returning that stale season
+    wrongly trips the Step-3 inactivity rule → 'released' even though the
+    player is actively playing elsewhere. So return the latest *domestic*
+    season at ANY club. International caps are not club activity and are
+    excluded (a recent youth-international appearance must not keep an
+    otherwise-inactive player active).
+
+    *parent_api_id* / *parent_club_name* are accepted for signature
+    compatibility with callers but no longer bias the result toward the
+    parent.
     """
     from src.models.journey import PlayerJourneyEntry
 
-    query = PlayerJourneyEntry.query.filter_by(journey_id=journey_id)
-
-    if parent_api_id is not None:
-        entries = query.order_by(PlayerJourneyEntry.season.desc()).all()
-        for entry in entries:
-            if entry.club_api_id == parent_api_id:
-                return entry.season
-            if parent_club_name and is_same_club(entry.club_name or "", parent_club_name):
-                return entry.season
-        # No entries at parent club — fall back to latest season at any club.
-        # Active loans have recent entries (2025) that pass the threshold.
-        # Truly inactive players have old entries that trigger release.
-        if entries:
-            return entries[0].season
+    entries = PlayerJourneyEntry.query.filter_by(journey_id=journey_id).order_by(PlayerJourneyEntry.season.desc()).all()
+    if not entries:
         return None
 
-    entry = query.order_by(PlayerJourneyEntry.season.desc()).first()
-    return entry.season if entry else None
+    domestic = [e for e in entries if not e.is_international]
+    if domestic:
+        return domestic[0].season
+    # Only international entries exist — fall back to the latest of those.
+    return entries[0].season
 
 
 def classify_tracked_player(

--- a/academy-watch-backend/tests/test_journey.py
+++ b/academy-watch-backend/tests/test_journey.py
@@ -1042,8 +1042,12 @@ class TestUpgradeStatusFromTransfers:
         ]
         assert upgrade_status_from_transfers("on_loan", transfers, 33) == "sold"
 
-    def test_free_agent_becomes_released(self):
-        """Free agent departure upgrades to released"""
+    def test_free_agent_with_destination_becomes_sold(self):
+        """A permanent departure to a concrete new club is 'sold', even when
+        typed 'Free Agent'/'Free'/'N/A'. API-Football populates teams.in for
+        virtually every departure, so the fee string cannot mark a release —
+        a real onward club means the player left permanently (sold), not into
+        free agency. Only the absence of an onward club is a release."""
         from src.utils.academy_classifier import upgrade_status_from_transfers
 
         transfers = [
@@ -1053,10 +1057,11 @@ class TestUpgradeStatusFromTransfers:
                 "teams": {"out": {"id": 33}, "in": {"id": 200}},
             }
         ]
-        assert upgrade_status_from_transfers("on_loan", transfers, 33) == "released"
+        assert upgrade_status_from_transfers("on_loan", transfers, 33, 200) == "sold"
 
-    def test_free_lowercase_becomes_released(self):
-        """'free' departure type also upgrades to released"""
+    def test_free_lowercase_with_destination_becomes_sold(self):
+        """'free' permanent move to a real club is 'sold' (e.g. C. Scott
+        Bayern->Antwerp was typed 'Free' and wrongly read 'released')."""
         from src.utils.academy_classifier import upgrade_status_from_transfers
 
         transfers = [
@@ -1066,10 +1071,11 @@ class TestUpgradeStatusFromTransfers:
                 "teams": {"out": {"id": 33}, "in": {"id": 200}},
             }
         ]
-        assert upgrade_status_from_transfers("on_loan", transfers, 33) == "released"
+        assert upgrade_status_from_transfers("on_loan", transfers, 33, 200) == "sold"
 
-    def test_na_becomes_released(self):
-        """N/A departure type upgrades to released"""
+    def test_na_with_destination_becomes_sold(self):
+        """'N/A' = undisclosed-fee permanent transfer, NOT a free agent. With
+        a concrete destination it is 'sold' (the Rijkhoff Dortmund->Ajax bug)."""
         from src.utils.academy_classifier import upgrade_status_from_transfers
 
         transfers = [
@@ -1079,7 +1085,21 @@ class TestUpgradeStatusFromTransfers:
                 "teams": {"out": {"id": 33}, "in": {"id": 200}},
             }
         ]
-        assert upgrade_status_from_transfers("on_loan", transfers, 33) == "released"
+        assert upgrade_status_from_transfers("on_loan", transfers, 33, 200) == "sold"
+
+    def test_permanent_departure_without_destination_becomes_released(self):
+        """Only a permanent departure with no resolvable onward club (no
+        teams.in id and no current club) is a genuine release."""
+        from src.utils.academy_classifier import upgrade_status_from_transfers
+
+        transfers = [
+            {
+                "type": "Free Agent",
+                "date": "2026-01-14",
+                "teams": {"out": {"id": 33}, "in": {}},
+            }
+        ]
+        assert upgrade_status_from_transfers("on_loan", transfers, 33, None) == "released"
 
     def test_latest_departure_wins(self):
         """When multiple departures exist, the latest one determines status"""
@@ -1092,12 +1112,12 @@ class TestUpgradeStatusFromTransfers:
                 "teams": {"out": {"id": 33}, "in": {"id": 62}},
             },
             {
-                "type": "Free Agent",
+                "type": "Transfer",
                 "date": "2026-01-14",
                 "teams": {"out": {"id": 33}, "in": {"id": 200}},
             },
         ]
-        assert upgrade_status_from_transfers("on_loan", transfers, 33) == "released"
+        assert upgrade_status_from_transfers("on_loan", transfers, 33, 200) == "sold"
 
     def test_no_departures_from_parent_unchanged(self):
         """Transfers from other clubs don't affect status"""

--- a/academy-watch-backend/tests/test_released_classification.py
+++ b/academy-watch-backend/tests/test_released_classification.py
@@ -1,0 +1,196 @@
+"""Regression tests for the 'released' over-classification bug.
+
+Two independent defects in src/utils/academy_classifier.py used to mark
+actively-playing academy products as 'released' (relative to their parent
+academy club):
+
+HEAD 1 — upgrade_status_from_transfers() mapped a permanent parent departure
+typed "N/A"/"Free" to 'released'. API-Football types undisclosed-fee sales as
+"N/A" and populates teams.in for virtually every departure, so the fee string
+cannot distinguish a free-agency exit from a permanent move to a new club. The
+fix keys off a concrete onward destination: a real, non-parent, non-national
+club ⇒ 'sold'; only the absence of one ⇒ 'released'. Canonical case: Julian
+Rijkhoff (Dortmund→Jong Ajax typed "N/A", now on loan at Almere) read
+'released' under Dortmund; he should be 'sold'.
+
+HEAD 2 — _get_latest_season() returned the latest *parent-named* season
+(often a stale youth entry like "<Parent> U19") instead of the player's latest
+activity anywhere, tripping the Step-3 inactivity rule for players active
+elsewhere. The fix returns the latest *domestic* season at ANY club.
+"""
+
+from src.models.journey import PlayerJourney, PlayerJourneyEntry
+from src.models.league import db
+from src.utils.academy_classifier import (
+    _get_latest_season,
+    classify_tracked_player,
+    upgrade_status_from_transfers,
+)
+
+DORTMUND = 165
+
+
+def _t(date, in_id, in_name, out_id, out_name, ttype):
+    return {
+        "date": date,
+        "type": ttype,
+        "teams": {
+            "in": {"id": in_id, "name": in_name},
+            "out": {"id": out_id, "name": out_name},
+        },
+    }
+
+
+# Rijkhoff's real flattened transfer history (verified via API-Football).
+RIJKHOFF_TRANSFERS = [
+    _t("2024-02-01", 425, "Jong Ajax", DORTMUND, "Borussia Dortmund", "N/A"),
+    _t("2025-06-23", 419, "Almere City FC", 194, "Ajax", "Loan"),
+    _t("2025-06-30", 419, "Almere City FC", 194, "Ajax", "Loan"),
+]
+
+
+class TestUpgradeStatusFromTransfers:
+    """HEAD 1 — permanent departures resolve to sold/released by destination."""
+
+    def test_na_departure_with_destination_is_sold(self):
+        # Rijkhoff: only Dortmund departure is type "N/A" -> Jong Ajax (425).
+        assert upgrade_status_from_transfers("on_loan", RIJKHOFF_TRANSFERS, DORTMUND, 419) == "sold"
+
+    def test_free_departure_with_destination_is_sold(self):
+        transfers = [_t("2022-07-01", 740, "Antwerp", DORTMUND, "Borussia Dortmund", "Free")]
+        assert upgrade_status_from_transfers("on_loan", transfers, DORTMUND, 740) == "sold"
+
+    def test_fee_departure_is_sold(self):
+        transfers = [_t("2023-08-01", 50, "Man City", DORTMUND, "Borussia Dortmund", "€ 20M")]
+        assert upgrade_status_from_transfers("on_loan", transfers, DORTMUND, 50) == "sold"
+
+    def test_permanent_departure_with_no_destination_is_released(self):
+        # Genuine free agent: no onward club recorded on the departure.
+        transfers = [{"date": "2023-06-30", "type": "Free agent", "teams": {"in": {}, "out": {"id": DORTMUND}}}]
+        assert upgrade_status_from_transfers("on_loan", transfers, DORTMUND, None) == "released"
+
+    def test_no_departure_destination_stays_released_even_with_current_club(self):
+        # The departure's empty teams.in is the free-agency signal. The
+        # journey's current club (passed as current_club_api_id) is a separate
+        # signal and must NOT be folded in to manufacture a 'sold'.
+        transfers = [{"date": "2023-06-30", "type": "Free agent", "teams": {"in": {}, "out": {"id": DORTMUND}}}]
+        assert upgrade_status_from_transfers("on_loan", transfers, DORTMUND, 999) == "released"
+
+    def test_destination_equal_to_parent_is_released(self):
+        # A departure whose "in" is the parent itself is not a sale away.
+        transfers = [_t("2023-06-30", DORTMUND, "Borussia Dortmund", DORTMUND, "Borussia Dortmund", "N/A")]
+        assert upgrade_status_from_transfers("on_loan", transfers, DORTMUND, None) == "released"
+
+    def test_national_team_destination_is_not_sold(self):
+        transfers = [_t("2023-06-30", 10, "England", DORTMUND, "Borussia Dortmund", "N/A")]
+        assert upgrade_status_from_transfers("on_loan", transfers, DORTMUND, None) == "released"
+
+    def test_genuine_loan_to_loan_destination_stays_on_loan(self):
+        transfers = [_t("2025-07-01", 700, "Loan Club", DORTMUND, "Borussia Dortmund", "Loan")]
+        assert upgrade_status_from_transfers("on_loan", transfers, DORTMUND, 700) == "on_loan"
+
+    def test_loan_typed_but_current_club_not_a_loan_destination_is_sold(self):
+        # Existing safety behaviour preserved: loan-typed departure but the
+        # player is at a club with no loan record -> permanent move.
+        transfers = [_t("2025-07-01", 700, "Loan Club", DORTMUND, "Borussia Dortmund", "Loan")]
+        assert upgrade_status_from_transfers("on_loan", transfers, DORTMUND, 999) == "sold"
+
+    def test_non_on_loan_status_unchanged(self):
+        assert upgrade_status_from_transfers("academy", RIJKHOFF_TRANSFERS, DORTMUND, 419) == "academy"
+
+    def test_no_transfers_unchanged(self):
+        assert upgrade_status_from_transfers("on_loan", [], DORTMUND, 419) == "on_loan"
+
+
+class TestClassifyTrackedPlayerEndToEnd:
+    """Full classify pipeline (pure: config + transfers + latest_season passed)."""
+
+    CONFIG = {"inactivity_release_years": 2, "use_squad_check": False}
+
+    def test_rijkhoff_classifies_as_sold(self):
+        status, club_id, club_name = classify_tracked_player(
+            current_club_api_id=419,
+            current_club_name="Almere City FC",
+            current_level="First Team",
+            parent_api_id=DORTMUND,
+            parent_club_name="Borussia Dortmund",
+            transfers=RIJKHOFF_TRANSFERS,
+            latest_season=2025,
+            config=self.CONFIG,
+        )
+        assert status == "sold"
+        assert club_id == 419  # destination retained for display
+
+    def test_player_active_elsewhere_recently_is_not_released(self):
+        # academy base status, no permanent departure transfer, recent activity.
+        status, _, _ = classify_tracked_player(
+            current_club_api_id=None,
+            current_club_name=None,
+            current_level="U21",
+            parent_api_id=100,
+            parent_club_name="Some FC",
+            transfers=[],
+            latest_season=2025,
+            config=self.CONFIG,
+        )
+        assert status == "academy"
+
+    def test_genuinely_inactive_player_is_released(self):
+        # No activity anywhere for years -> the inactivity rule still releases.
+        status, _, _ = classify_tracked_player(
+            current_club_api_id=None,
+            current_club_name=None,
+            current_level="U21",
+            parent_api_id=100,
+            parent_club_name="Some FC",
+            transfers=[],
+            latest_season=2020,
+            config=self.CONFIG,
+        )
+        assert status == "released"
+
+
+class TestGetLatestSeason:
+    """HEAD 2 — latest *domestic* activity anywhere, not the stale parent season."""
+
+    def _make_journey(self, entries):
+        journey = PlayerJourney(player_api_id=999999)
+        db.session.add(journey)
+        db.session.flush()
+        for season, club_api_id, club_name, is_intl in entries:
+            db.session.add(
+                PlayerJourneyEntry(
+                    journey_id=journey.id,
+                    season=season,
+                    club_api_id=club_api_id,
+                    club_name=club_name,
+                    is_international=is_intl,
+                    appearances=1,
+                )
+            )
+        db.session.flush()
+        return journey.id
+
+    def test_returns_latest_domestic_anywhere_not_stale_parent_youth(self, app):
+        # Parent youth season 2023 is stale; player active at Almere in 2025.
+        jid = self._make_journey(
+            [
+                (2023, 7890, "Borussia Dortmund U19", False),
+                (2025, 419, "Almere City FC", False),
+            ]
+        )
+        assert _get_latest_season(jid, parent_api_id=DORTMUND, parent_club_name="Borussia Dortmund") == 2025
+
+    def test_ignores_international_only_recent_entries(self, app):
+        # Recent activity is only an international cap; latest club season is 2022.
+        jid = self._make_journey(
+            [
+                (2022, 419, "Almere City FC", False),
+                (2025, 10, "Netherlands U21", True),
+            ]
+        )
+        assert _get_latest_season(jid, parent_api_id=DORTMUND, parent_club_name="Borussia Dortmund") == 2022
+
+    def test_international_only_history_falls_back_to_latest(self, app):
+        jid = self._make_journey([(2024, 10, "Netherlands U19", True)])
+        assert _get_latest_season(jid, parent_api_id=DORTMUND, parent_club_name="Borussia Dortmund") == 2024


### PR DESCRIPTION
## Problem

\"released\" is the single largest active player status on prod — **1,480 / 3,454 active `TrackedPlayer` rows (43%)** vs only 243 `sold` — and **93% of \"released\" players still have 2024+ activity**. They didn't retire; they moved on. Reported via Julian Rijkhoff, shown `released` under Borussia Dortmund despite being an active 20-year-old on loan at Almere City.

Two independent defects in `academy_classifier.py`, both judging a player *relative to their parent academy*:

### HEAD 1 — `N/A`/free permanent moves → `released`
`upgrade_status_from_transfers` mapped any permanent parent departure typed `"N/A"`/`"Free"`/`"free agent"` to `released`. API-Football types **undisclosed-fee sales as `"N/A"`** and populates `teams.in` for virtually every departure, so the fee string can't tell a free-agency exit from a permanent move to a new club. Rijkhoff's only Dortmund departure is `2024-02-01 type="N/A" → Jong Ajax` → wrongly `released`; should be `sold`. (Note: `journey_sync._update_journey_aggregates` already treats `"N/A"` as *too ambiguous to act on* — the classifier was the outlier.)

**Fix:** decide on the departure's recorded destination — a real, non-parent, non-national club ⇒ `sold`; no recorded destination ⇒ `released`.

### HEAD 2 — inactivity rule over-fires
`_get_latest_season` returned the latest *parent-named* season (often a stale youth entry like `"<Parent> U19"`) instead of latest activity anywhere, tripping the Step-3 inactivity release for players active elsewhere (sold/loaned away).

**Fix:** return the latest **domestic** season at ANY club; international caps don't count as club activity.

## Scope of the bug (verified, read-only, on prod)
- ~227 `released` rows have a concrete destination (HEAD 1 cohort) — sampled 20, **all** active permanent movers (Cîrjan→Dinamo, Targhalline→Feyenoord, Price→West Brom, Scott→Antwerp).
- ~1,148 `released` rows are active elsewhere but stale at parent (HEAD 2 cohort).
- ~110 are genuine releases (no recent domestic activity) — **preserved** by both fixes.

## Tests
- New `tests/test_released_classification.py` (17): HEAD 1 destination cases (sold/released/parent/national/loan), end-to-end Rijkhoff → `sold`, inactivity preserved, HEAD 2 domestic-season logic.
- Updated the now-stale `TestUpgradeStatusFromTransfers` cases (they encoded the old buggy behavior).
- No new regressions; the 10 pre-existing `test_journey.py` failures are app-context/test-isolation debt on `main` (confirmed by stashing this diff).

## Data repair (follow-up, not in this PR)
The code only fixes *future* classification. Existing rows are repaired by **re-syncing journeys** (`recompute-academy` does not re-derive status):
1. `POST /api/admin/journey/335335/sync` → flips Rijkhoff to `sold` (immediate verification).
2. Batched `POST /api/admin/journey/bulk-sync` (≤50/call) over the ~1,375-row cohort, **off-container** (prod is 0.5 CPU / 1 Gi — journey re-syncs flap health).

No row de-duplication is needed: the 267 multi-active-row players are all legitimate dual-academy cases (0 owning-club / manual-unpinned / orphan rows); the status fix resolves the apparent duplication without deleting anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)