### PR TITLE
fix(deps): pin numpy to 2.4.6 for Python 3.11 compatibility

### DIFF
--- a/academy-watch-backend/requirements.txt
+++ b/academy-watch-backend/requirements.txt
@@ -46,7 +46,7 @@ MarkupSafe==3.0.3
 matplotlib==3.11.0
 mcp==1.28.0
 mdurl==0.1.2
-numpy==2.5.0
+numpy==2.4.6
 pandas==3.0.3
 openai==2.43.0
 openai-agents==0.17.5


### PR DESCRIPTION
## Problem
The backend ACR build (Deploy workflow) fails with:
```
ERROR: Could not find a version that satisfies the requirement numpy==2.5.0
ERROR: No matching distribution found for numpy==2.5.0
```
`numpy==2.5.0` requires **Python >=3.12**, but `Dockerfile` uses `python:3.11-slim`. This blocks **all** backend deploys (surfaced by the deploy of #508).

## Fix
Pin `numpy==2.4.6` — the highest release compatible with Python 3.11. `pandas==3.0.3` also supports 3.11 and is satisfied by numpy 2.4.6. Minimal, low-risk; avoids a base-image bump. Likely an over-eager Dependabot bump (the local feature branch already had 2.4.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)