### PR TITLE
fix(classifier): evidence-based status model + new 'left' status + tenure gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,9 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    ignore:
+      # numpy >= 2.5 requires Python >= 3.12; the backend image is
+      # python:3.11-slim, so 2.5.x breaks the ACR build. Pin to 2.4.x until
+      # the base image is bumped to 3.12. (Re-bumped repeatedly by Dependabot.)
+      - dependency-name: "numpy"
+        versions: [">=2.5.0"]

--- a/academy-watch-backend/requirements.txt
+++ b/academy-watch-backend/requirements.txt
@@ -46,7 +46,7 @@ MarkupSafe==3.0.3
 matplotlib==3.11.0
 mcp==1.28.0
 mdurl==0.1.2
-numpy==2.5.0
+numpy==2.4.6
 pandas==3.0.3
 openai==2.43.0
 openai-agents==0.17.6

--- a/academy-watch-backend/src/agents/weekly_newsletter_agent.py
+++ b/academy-watch-backend/src/agents/weekly_newsletter_agent.py
@@ -1821,7 +1821,7 @@ def _sync_team_fixtures_for_week(
     tracked = TrackedPlayer.query.filter(
         TrackedPlayer.team_id == team_db_id,
         TrackedPlayer.is_active.is_(True),
-        TrackedPlayer.status.notin_(["released", "sold"]),
+        TrackedPlayer.status.notin_(["released", "sold", "left"]),
     ).all()
 
     if not tracked:
@@ -2036,7 +2036,7 @@ def fetch_pipeline_report_tool(
     tracked = TrackedPlayer.query.filter(
         TrackedPlayer.team_id == parent_team_db_id,
         TrackedPlayer.is_active.is_(True),
-        TrackedPlayer.status.notin_(["released", "sold"]),
+        TrackedPlayer.status.notin_(["released", "sold", "left"]),
     ).all()
 
     # Pre-flight: warn loudly about any player whose linked PlayerJourney

--- a/academy-watch-backend/src/jobs/run_weekly_newsletters_mcp.py
+++ b/academy-watch-backend/src/jobs/run_weekly_newsletters_mcp.py
@@ -12,7 +12,7 @@ def teams_with_active_tracked_players() -> list[int]:
         db.session.query(TrackedPlayer.team_id)
         .filter(
             TrackedPlayer.is_active.is_(True),
-            TrackedPlayer.status.notin_(["released", "sold"]),
+            TrackedPlayer.status.notin_(["released", "sold", "left"]),
         )
         .distinct()
     )

--- a/academy-watch-backend/src/models/tracked_player.py
+++ b/academy-watch-backend/src/models/tracked_player.py
@@ -28,7 +28,10 @@ class TrackedPlayer(db.Model):
 
     # Current pathway status
     status = db.Column(db.String(20), nullable=False, default="academy")
-    #   'academy' | 'on_loan' | 'first_team' | 'released' | 'sold'
+    #   'academy' | 'on_loan' | 'first_team' | 'released' | 'sold' | 'left'
+    #   'left' = academy product who departed this club for another club with
+    #            no recorded senior transfer (distinct from 'sold' = permanent
+    #            transfer with a destination, and 'released' = free agent / dropped).
     current_level = db.Column(db.String(20))
     #   'U18' | 'U21' | 'U23' | 'Reserve' | 'Senior'
 

--- a/academy-watch-backend/src/routes/api.py
+++ b/academy-watch-backend/src/routes/api.py
@@ -5310,7 +5310,7 @@ def _run_batch_fixture_sync(data: dict, job_id: str = None) -> dict:
 
     sold_released = TrackedPlayer.query.filter(
         TrackedPlayer.is_active.is_(True),
-        TrackedPlayer.status.in_(["sold", "released"]),
+        TrackedPlayer.status.in_(["sold", "released", "left"]),
     ).all()
 
     discovery_count = 0

--- a/academy-watch-backend/src/routes/journalist.py
+++ b/academy-watch-backend/src/routes/journalist.py
@@ -1107,7 +1107,7 @@ def get_chart_data():
                 .order_by(TrackedPlayer.updated_at.desc())
                 .first()
             )
-            if tp_for_scope and tp_for_scope.current_club_api_id and tp_for_scope.status in ("on_loan", "sold"):
+            if tp_for_scope and tp_for_scope.current_club_api_id and tp_for_scope.status in ("on_loan", "sold", "left"):
                 current_club_api_id = tp_for_scope.current_club_api_id
         except Exception:
             pass
@@ -1855,7 +1855,7 @@ def _fetch_chart_data_for_rendering(
                 .order_by(TrackedPlayer.updated_at.desc())
                 .first()
             )
-            if tp and tp.current_club_api_id and tp.status in ("on_loan", "sold"):
+            if tp and tp.current_club_api_id and tp.status in ("on_loan", "sold", "left"):
                 current_club_api_id = tp.current_club_api_id
         except Exception:
             pass

--- a/academy-watch-backend/src/routes/journey.py
+++ b/academy-watch-backend/src/routes/journey.py
@@ -733,7 +733,7 @@ def _build_legacy_journey(player_id: int, primary_team_id: int = None) -> dict:
         if stint["country"]:
             country_counts[stint["country"]] += 1
 
-    moved_on = tp.status in ("released", "sold")
+    moved_on = tp.status in ("released", "sold", "left")
 
     countries = [{"name": name, "stint_count": count} for name, count in sorted(country_counts.items())]
 

--- a/academy-watch-backend/src/routes/scout.py
+++ b/academy-watch-backend/src/routes/scout.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 scout_bp = Blueprint("scout", __name__)
 
 VALID_POSITIONS = {"Goalkeeper", "Defender", "Midfielder", "Attacker"}
-VALID_STATUSES = {"academy", "on_loan", "first_team", "released", "sold"}
+VALID_STATUSES = {"academy", "on_loan", "first_team", "released", "sold", "left"}
 PER90_MIN_MINUTES = 270  # floor for per-90 rankings so 10-minute cameos don't top the boards
 MAX_PER_PAGE = 100
 MAX_COMPARE_PLAYERS = 4

--- a/academy-watch-backend/src/services/cohort_service.py
+++ b/academy-watch-backend/src/services/cohort_service.py
@@ -318,7 +318,7 @@ class CohortService:
         cohort.players_first_team = sum(1 for m in members if m.current_status == "first_team")
         cohort.players_on_loan = sum(1 for m in members if m.current_status == "on_loan")
         cohort.players_still_academy = sum(1 for m in members if m.current_status == "academy")
-        cohort.players_released = sum(1 for m in members if m.current_status in ("released", "sold"))
+        cohort.players_released = sum(1 for m in members if m.current_status in ("released", "sold", "left"))
 
         db.session.commit()
         logger.info(f"Refreshed stats for cohort {cohort_id}: {cohort.total_players} players")

--- a/academy-watch-backend/src/services/gol_service.py
+++ b/academy-watch-backend/src/services/gol_service.py
@@ -49,7 +49,7 @@ Columns: player_api_id (int), player_name (str), position (str: Goalkeeper/Defen
 nationality (str), age (int), team_id (int, FK to teams.id), \
 parent_club (str, club that currently owns/controls the player), \
 academy_club (str or null, original academy the player came through), \
-status (str: academy/on_loan/first_team/released/sold), \
+status (str: academy/on_loan/first_team/released/sold/left), \
 current_level (str), current_club_name (str or null), data_source (str), is_active (bool), \
 updated_at (datetime)
 **For loan players:** filter `tracked[tracked['status'] == 'on_loan']`. \
@@ -159,7 +159,7 @@ prefer the helper functions or `tracked` DataFrame — these use live journey-de
 `cohorts.players_first_team` is only accurate for cohorts with `sync_status = 'complete'`. \
 `cohort_members` contains only journey-synced members with validated career data.
 - **Active vs. historical academy queries:** For "how is academy X doing?" or current-state \
-questions, use `active_academy_pipeline()` — it excludes released/sold players and focuses on \
+questions, use `active_academy_pipeline()` — it excludes released/sold/left players and focuses on \
 the live pathway (academy, on_loan, first_team). For "what has academy X produced?" or full \
 historical breakdowns, use `academy_comparison()` or `player_status_breakdown()` which include \
 all statuses.
@@ -269,7 +269,7 @@ result = ft.groupby('name').agg(graduates=('player_api_id', 'count'), apps=('tot
 
 ## Helper Functions (pre-loaded, call directly in run_analysis code)
 - `academy_comparison()` → Big 6 academy status breakdown (first_team/on_loan/academy/released per club). Includes ALL statuses. Returns a DataFrame.
-- `active_academy_pipeline(team_name=None)` → Players currently in an active pathway (academy/on_loan/first_team only — excludes released/sold). Optional team filter (partial match); defaults to Big 6. Best for "how is academy X doing?" questions. Returns a DataFrame.
+- `active_academy_pipeline(team_name=None)` → Players currently in an active pathway (academy/on_loan/first_team only — excludes released/sold/left). Optional team filter (partial match); defaults to Big 6. Best for "how is academy X doing?" questions. Returns a DataFrame.
 - `first_team_graduates(team_name=None)` → Players who reached first team, optionally filtered by club name (partial match). Returns a DataFrame.
 - `player_status_breakdown(team_name)` → Status distribution for one team's tracked players. Includes all statuses. Returns a DataFrame.
 

--- a/academy-watch-backend/src/services/journey_sync.py
+++ b/academy-watch-backend/src/services/journey_sync.py
@@ -1278,18 +1278,45 @@ class JourneySyncService:
             self._upsert_tracked_players(journey, set(), transfers=transfers)
             return
 
-        # ── Minimum youth appearances threshold ──
-        # Clubs below threshold are excluded to filter noise / data errors.
-        MIN_ACADEMY_APPEARANCES = 1
-        club_youth_apps = {}
+        # ── Academy tenure gate ──
+        # A single youth appearance (the old MIN_ACADEMY_APPEARANCES=1) tagged a
+        # club as an academy origin, manufacturing phantom rows from trial /
+        # cup cameos (e.g. a 1-app U18 spell at a club the player merely passed
+        # through). Require real tenure: total youth apps >= 3 OR appearances
+        # across >= 2 distinct youth seasons. ALWAYS exempt the player's single
+        # best (rank-1) base so no one loses their sole / primary academy to
+        # thin early-career API coverage. Seasons count only the already-filtered
+        # youth_entries (academy/development), so an 'integration' U21 rehab game
+        # can't inflate a season count.
+        MIN_ACADEMY_APPEARANCES = 3
+        MIN_ACADEMY_SEASONS = 2
+        club_youth_apps: dict[str, int] = {}
+        club_youth_seasons: dict[str, set] = {}
         for e in youth_entries:
             base = self._strip_youth_suffix(e.club_name)
             club_youth_apps[base] = club_youth_apps.get(base, 0) + (e.appearances or 0)
+            if e.season is not None:
+                club_youth_seasons.setdefault(base, set()).add(e.season)
+
+        def _passes_tenure_gate(base: str) -> bool:
+            return (
+                club_youth_apps.get(base, 0) >= MIN_ACADEMY_APPEARANCES
+                or len(club_youth_seasons.get(base, ())) >= MIN_ACADEMY_SEASONS
+            )
+
+        # Rank-1 base by (apps DESC, distinct seasons DESC) — always kept.
+        ranked_bases = sorted(
+            club_youth_apps.keys(),
+            key=lambda b: (club_youth_apps.get(b, 0), len(club_youth_seasons.get(b, ()))),
+            reverse=True,
+        )
+        top_base = ranked_bases[0] if ranked_bases else None
 
         youth_entries = [
             e
             for e in youth_entries
-            if club_youth_apps.get(self._strip_youth_suffix(e.club_name), 0) >= MIN_ACADEMY_APPEARANCES
+            if _passes_tenure_gate(self._strip_youth_suffix(e.club_name))
+            or self._strip_youth_suffix(e.club_name) == top_base
         ]
         if not youth_entries:
             journey.academy_club_ids = []

--- a/academy-watch-backend/src/services/team_verify.py
+++ b/academy-watch-backend/src/services/team_verify.py
@@ -119,7 +119,7 @@ def audit_team_consistency(team_db_id: int) -> dict[str, Any]:
         if tp.status == "first_team" and tp.current_club_api_id is None:
             suspect_first_team_null_current_club.append(row_summary)
 
-        if tp.status in ("on_loan", "sold", "released") and tp.current_club_api_id is None:
+        if tp.status in ("on_loan", "sold", "released", "left") and tp.current_club_api_id is None:
             suspect_loanee_null_current_club.append(row_summary)
 
         if tp.current_club_api_id is not None and tp.current_club_db_id is None:

--- a/academy-watch-backend/src/utils/academy_classifier.py
+++ b/academy-watch-backend/src/utils/academy_classifier.py
@@ -369,7 +369,19 @@ def derive_player_status(
     if is_same_club(current_club_name or "", parent_club_name):
         return (_base_status(current_level), None, None)
 
-    # 4. Genuinely at a different club → on loan (will be refined by transfer check)
+    # 3b. Parent's OWN reserve / youth / B side (Jong Ajax for Ajax, Atalanta
+    # U20 for Atalanta, Birmingham U21 for Birmingham). Catches the cases
+    # is_same_club misses — a "Jong " prefix, a U-number like U20, or an id
+    # whose team name isn't loaded — so the player reads as still at the
+    # parent, not as having left.
+    from src.utils.affiliates import is_affiliate
+
+    if is_affiliate(current_club_api_id, current_club_name, parent_api_id, parent_club_name):
+        return (_base_status(current_level), None, None)
+
+    # 4. Genuinely at a different club → tentatively on_loan; the transfer
+    # check in classify_tracked_player Step 2 decides the real status
+    # (on_loan only with a parent loan record; sold / released / left otherwise).
     return ("on_loan", current_club_api_id, current_club_name)
 
 
@@ -461,12 +473,26 @@ def derive_player_status_with_reasoning(
     if same_name:
         return _base_status(current_level), None, None, reasoning
 
+    from src.utils.affiliates import is_affiliate
+
+    affiliate = is_affiliate(current_club_api_id, current_club_name, parent_api_id, parent_club_name)
+    reasoning.append(
+        {
+            "rule": "affiliate_b_team",
+            "result": "match" if affiliate else "pass",
+            "check": f'is_affiliate("{current_club_name}", parent "{parent_club_name}")',
+            "detail": f'"{current_club_name}" {"is" if affiliate else "is not"} the parent\'s own reserve/youth side',
+        }
+    )
+    if affiliate:
+        return _base_status(current_level), None, None, reasoning
+
     reasoning.append(
         {
             "rule": "different_club",
             "result": "match",
-            "check": "No rules matched — different club",
-            "detail": f"Classified as on_loan at {current_club_name}",
+            "check": "No rules matched — different club (transfer check decides on_loan/sold/released/left)",
+            "detail": f"Tentatively on_loan at {current_club_name}",
         }
     )
     return "on_loan", current_club_api_id, current_club_name, reasoning
@@ -477,50 +503,82 @@ def upgrade_status_from_transfers(
     transfers: list,
     parent_api_id: int,
     current_club_api_id: int | None = None,
+    parent_club_name: str | None = None,
 ) -> str:
-    """Upgrade 'on_loan' → 'sold'/'released' when latest departure was permanent
-    or when the current club has no loan transfer record."""
+    """Decide the real status of a player who is at a club other than the
+    parent academy, from transfer evidence. Resolves the tentative 'on_loan'
+    from derive_player_status into one of on_loan / sold / released / left.
+
+    The key inversion: 'on_loan' must be EARNED by a parent loan record; it is
+    no longer the fallback. Rules (relative to parent P), in order:
+
+      • current club is a P loan destination (a P→current loan transfer) → on_loan
+      • no departure from P at all, but player is elsewhere            → left
+      • latest P departure is a loan but current ∉ P loan dests
+        (loaned then moved on)                                         → left
+      • latest P departure is permanent with a real, non-parent,
+        non-national destination                                       → sold
+      • latest P departure is permanent with no resolvable destination → released
+
+    Loan destinations and departures are matched against P OR P's own
+    reserve/youth/B side (e.g. Valencia and Valencia II both count as a Valencia
+    loan), and ignore null destination ids and loan-RETURN types.
+    """
     if status != "on_loan" or not transfers:
         return status
 
     from src.api_football_client import is_new_loan_transfer
+    from src.utils.affiliates import is_affiliate
 
-    departures = [t for t in transfers if (t.get("teams", {}).get("out", {}).get("id") == parent_api_id)]
+    def _out_is_parent(t: dict) -> bool:
+        o = t.get("teams", {}).get("out", {}) or {}
+        oid = o.get("id")
+        return oid == parent_api_id or is_affiliate(oid, o.get("name"), parent_api_id, parent_club_name)
+
+    # Loan destinations the PARENT (or its B-team) loaned the player to.
+    # Exclude null in.id; is_new_loan_transfer already excludes loan-returns.
+    loan_destinations = {
+        (t.get("teams", {}).get("in", {}) or {}).get("id")
+        for t in transfers
+        if is_new_loan_transfer((t.get("type") or "").strip().lower()) and _out_is_parent(t)
+    }
+    loan_destinations.discard(None)
+
+    # Genuine current loan FROM the parent — transfer-driven, not entry-type
+    # driven (a brand-new loan has no synced fixtures yet so its journey entry
+    # is not typed 'loan', but the loan transfer is already present).
+    if current_club_api_id and current_club_api_id in loan_destinations:
+        return "on_loan"
+
+    # The 'left' outcomes require a KNOWN current club (the player is
+    # demonstrably elsewhere). When current_club_api_id is unknown we cannot
+    # assert they left, so we keep the tentative on_loan (callers that classify
+    # without a current club rely on this conservative behaviour).
+    departures = [t for t in transfers if _out_is_parent(t)]
     if not departures:
-        return status
+        # The player is at a different club but there is NO recorded departure
+        # from the parent (typical of academy-to-academy youth moves). They
+        # left the academy without a recorded senior transfer.
+        return "left" if current_club_api_id else status
 
     departures.sort(key=lambda t: t.get("date", ""), reverse=True)
     dep_type = (departures[0].get("type") or "").strip().lower()
 
     if not dep_type or is_new_loan_transfer(dep_type):
-        # Latest departure looks like a loan — but verify the current club
-        # actually matches a loan destination. If not, the player moved
-        # permanently to a club with no transfer record (common in lower leagues).
-        if current_club_api_id:
-            loan_destinations = {
-                t.get("teams", {}).get("in", {}).get("id")
-                for t in transfers
-                if is_new_loan_transfer((t.get("type") or "").strip().lower())
-            }
-            if current_club_api_id not in loan_destinations:
-                return "sold"  # at a club with no loan record → permanent move
-        return status  # confirmed loan destination
+        # Latest parent departure is a loan. We already returned on_loan above
+        # if the current club is one of the parent's loan destinations, so a
+        # known current club here means loaned-out-then-moved-on → left.
+        return "left" if current_club_api_id else status
 
     # Permanent (non-loan) departure. The transfer TYPE alone cannot tell a
     # free-agency exit from a permanent move to a new club: API-Football
-    # populates teams.in for virtually every departure, and an
-    # undisclosed-fee sale is typed "N/A" (not a release). Decide on the
-    # departure's recorded destination, not the fee string — a real,
-    # non-parent, non-national club ⇒ 'sold'; no recorded destination ⇒
-    # 'released' (a genuine free-agency exit; the Step-3 inactivity check is
-    # the other path that yields 'released'). We read only the departure's
-    # teams.in here, deliberately NOT the journey's current club: an empty
-    # teams.in is the free-agency signal, and folding in a stale last-club
-    # would manufacture a false 'sold'.
-    # NB: "N/A" is treated as ambiguous elsewhere (journey_sync's
-    # current-club override deliberately skips it); lumping it with free
-    # agents here is what mislabelled permanent movers (e.g. Rijkhoff,
-    # Dortmund→Ajax typed "N/A") as 'released' instead of 'sold'.
+    # populates teams.in for virtually every departure, and an undisclosed-fee
+    # sale is typed "N/A" (not a release). Decide on the departure's recorded
+    # destination — a real, non-parent, non-national club ⇒ 'sold'; no recorded
+    # destination ⇒ 'released' (a genuine free-agency exit; Step-3 inactivity
+    # is the other path to 'released'). Read only the departure's teams.in,
+    # NOT the journey's current club: an empty teams.in is the free-agency
+    # signal, and folding in a stale last-club would manufacture a false 'sold'.
     dest = departures[0].get("teams", {}).get("in", {}) or {}
     dest_id = dest.get("id")
     if dest_id and dest_id != parent_api_id and not is_national_team(dest.get("name")):
@@ -733,6 +791,7 @@ def classify_tracked_player(
                 effective_transfers,
                 parent_api_id,
                 current_club_api_id=current_club_api_id,
+                parent_club_name=parent_club_name,
             )
             if upgraded != status:
                 if with_reasoning:
@@ -747,7 +806,24 @@ def classify_tracked_player(
                 status = upgraded
                 # Keep current_club info — loan_id/loan_name are reused as
                 # current_club_api_id/current_club_name in the return value.
-                # For sold/released players, this is their destination club.
+                # For sold/released/left players, this is their destination/current club.
+        elif effective_transfers is not None:
+            # We have transfer data (an empty list) and the player is at a
+            # different club, but there is NO transfer record at all → they
+            # left the academy without a recorded senior transfer. Only treat
+            # an explicit empty list this way; None means transfers were not
+            # fetched, so keep the conservative on_loan default for callers
+            # that classify without transfer data.
+            status = "left"
+            if with_reasoning:
+                reasoning.append(
+                    {
+                        "rule": "no_transfers_left",
+                        "result": "match",
+                        "check": "at a different club with no transfer records",
+                        "detail": "Left the academy (no recorded departure) → left",
+                    }
+                )
 
     # ── Step 2.5: squad cross-reference ────────────────────────────────
     # Skip squad check if transfers confirm a loan — transfer data is more
@@ -809,7 +885,7 @@ def classify_tracked_player(
 
     # ── Step 3: inactivity-based release ──────────────────────────────
     inactivity_years = config.get("inactivity_release_years")
-    if inactivity_years and latest_season is not None and status in ("academy", "on_loan"):
+    if inactivity_years and latest_season is not None and status in ("academy", "on_loan", "left"):
         current_year = datetime.now().year
         if latest_season < current_year - inactivity_years:
             if with_reasoning:

--- a/academy-watch-backend/src/utils/affiliates.py
+++ b/academy-watch-backend/src/utils/affiliates.py
@@ -1,0 +1,111 @@
+"""Resolve a club's reserve / youth / B side to its senior parent organisation.
+
+Used by the player-status classifier so a player at their parent academy's OWN
+B / reserve / youth team (e.g. Jong Ajax for Ajax, Atalanta U20 for Atalanta,
+Birmingham City U21 for Birmingham) is treated as STILL at the parent — not as
+having "left". Without this guard, those players have no departure transfer and
+fall through to the "left" default (the configuration the model otherwise gets
+right).
+
+Two layers, by design (the user chose data-driven + hardcoded fallback):
+  1. DATA-DRIVEN name normalisation — strip a leading "Jong " and trailing
+     reserve / youth suffixes (incl. any U-number, III, C, Castilla), then
+     compare base names. Works whenever the club name is available, and (unlike
+     academy_classifier.strip_youth_suffix) catches U20/U16/Jong/III.
+  2. HARDCODED api_id -> senior api_id fallback for ids whose name is not
+     loaded (the teams row is absent so the name is NULL) or does not normalise
+     to the parent's name (e.g. "RSC Anderlecht II" vs parent "Anderlecht").
+
+This module is intentionally dependency-free (no import from academy_classifier)
+to avoid a circular import — academy_classifier imports THIS module.
+"""
+
+import re
+
+# ── data-driven name normalisation ─────────────────────────────────────
+_JONG_PREFIX = re.compile(r"^jong\s+", re.IGNORECASE)
+_RESERVE_SUFFIX = re.compile(
+    r"\s+(?:U\d{1,2}|Under[\s-]?\d+|Sub[\s-]?\d+|II|III|IV|B|C|Castilla|Youth|Academy|Reserves?|Development|Bis)\b\.?$",
+    re.IGNORECASE,
+)
+
+
+def senior_base_name(name: str | None) -> str:
+    """Strip a 'Jong ' prefix and any trailing reserve/youth suffixes to get
+    the senior club's base name.
+
+    >>> senior_base_name('Jong Ajax')
+    'Ajax'
+    >>> senior_base_name('Atalanta U20')
+    'Atalanta'
+    >>> senior_base_name('Real Madrid Castilla')
+    'Real Madrid'
+    >>> senior_base_name('Manchester United U18')
+    'Manchester United'
+    """
+    if not name:
+        return ""
+    n = _JONG_PREFIX.sub("", name.strip())
+    prev = None
+    # Loop so multi-token tails (rare) fully strip; idempotent for clean names.
+    while prev != n:
+        prev = n
+        n = _RESERVE_SUFFIX.sub("", n).strip()
+    return n
+
+
+# ── hardcoded fallback: reserve/youth api_id -> senior api_id ───────────
+# Seeded with pairs verified during the status-model audit (2026-06). The
+# data-driven layer covers the common case; this catches ids whose team name
+# is unavailable or does not normalise to the parent name. Expand as the
+# `left`-log surfaces unmapped affiliates (see classifier logging).
+B_TEAM_TO_SENIOR: dict[int, int] = {
+    425: 194,  # Jong Ajax -> Ajax
+    427: 194,  # (Ajax youth alt) -> Ajax
+    9260: 81,  # Olympique Marseille II -> Marseille
+    24725: 499,  # Atalanta U20 -> Atalanta
+    20078: 54,  # Birmingham City U21 -> Birmingham
+    19046: 554,  # RSC Anderlecht II -> Anderlecht
+    17426: 65,  # Nottingham Forest U18 -> Nottingham Forest
+    19746: 65,  # Nottingham Forest U21 -> Nottingham Forest
+    9594: 532,  # Valencia Mestalla / II -> Valencia
+    9575: 541,  # Real Madrid Castilla / II -> Real Madrid
+    726: 541,  # Real Madrid C -> Real Madrid
+    9783: 798,  # Mallorca II -> Mallorca
+    9367: 165,  # Borussia Dortmund II -> Borussia Dortmund
+    7890: 165,  # Borussia Dortmund U19 -> Borussia Dortmund
+}
+
+
+def resolve_senior_id(club_api_id: int | None, club_name: str | None = None) -> int | None:
+    """Best-effort senior org api_id for a club id (hardcoded map only — the
+    data-driven layer needs a name->id lookup we don't have here). Returns the
+    id unchanged when no mapping is known."""
+    if club_api_id is None:
+        return None
+    return B_TEAM_TO_SENIOR.get(club_api_id, club_api_id)
+
+
+def is_affiliate(
+    club_api_id: int | None,
+    club_name: str | None,
+    parent_api_id: int | None,
+    parent_club_name: str | None,
+) -> bool:
+    """Return True if *club* is *parent*'s own reserve / youth / B side.
+
+    Hardcoded id map first (covers NULL-name ids), then data-driven base-name
+    equality (covers Jong/U-number/III that the youth-suffix stripper misses).
+    """
+    if club_api_id is None or parent_api_id is None:
+        return False
+    if club_api_id == parent_api_id:
+        return True
+    if B_TEAM_TO_SENIOR.get(club_api_id) == parent_api_id:
+        return True
+    if club_name and parent_club_name:
+        base = senior_base_name(club_name).lower()
+        pbase = senior_base_name(parent_club_name).lower()
+        if base and base == pbase:
+            return True
+    return False

--- a/academy-watch-backend/src/utils/job_utils.py
+++ b/academy-watch-backend/src/utils/job_utils.py
@@ -10,7 +10,7 @@ def teams_with_active_tracked_players() -> list[int]:
         db.session.query(TrackedPlayer.team_id)
         .filter(
             TrackedPlayer.is_active.is_(True),
-            TrackedPlayer.status.notin_(["released", "sold"]),
+            TrackedPlayer.status.notin_(["released", "sold", "left"]),
         )
         .distinct()
     )

--- a/academy-watch-backend/tests/test_released_classification.py
+++ b/academy-watch-backend/tests/test_released_classification.py
@@ -26,6 +26,7 @@ from src.utils.academy_classifier import (
     classify_tracked_player,
     upgrade_status_from_transfers,
 )
+from src.utils.affiliates import is_affiliate, senior_base_name
 
 DORTMUND = 165
 
@@ -89,11 +90,22 @@ class TestUpgradeStatusFromTransfers:
         transfers = [_t("2025-07-01", 700, "Loan Club", DORTMUND, "Borussia Dortmund", "Loan")]
         assert upgrade_status_from_transfers("on_loan", transfers, DORTMUND, 700) == "on_loan"
 
-    def test_loan_typed_but_current_club_not_a_loan_destination_is_sold(self):
-        # Existing safety behaviour preserved: loan-typed departure but the
-        # player is at a club with no loan record -> permanent move.
+    def test_loan_typed_but_current_club_not_a_loan_destination_is_left(self):
+        # Loan-typed departure to 700, but the player's current club is 999 (not
+        # a parent loan destination) -> loaned out then moved on -> left.
         transfers = [_t("2025-07-01", 700, "Loan Club", DORTMUND, "Borussia Dortmund", "Loan")]
-        assert upgrade_status_from_transfers("on_loan", transfers, DORTMUND, 999) == "sold"
+        assert upgrade_status_from_transfers("on_loan", transfers, DORTMUND, 999) == "left"
+
+    def test_no_parent_departure_with_current_club_is_left(self):
+        # Berry@Man United: player is at another club (Al Kholood 10509) but has
+        # NO recorded departure from the parent -> left, not on_loan.
+        transfers = [_t("2026-01-25", 10509, "Al Kholood", 65, "Nottingham Forest", "Transfer")]
+        assert upgrade_status_from_transfers("on_loan", transfers, DORTMUND, 10509) == "left"
+
+    def test_no_parent_departure_without_current_club_stays_on_loan(self):
+        # Conservative: with no known current club we cannot assert departure.
+        transfers = [_t("2026-01-25", 10509, "Al Kholood", 65, "Nottingham Forest", "Transfer")]
+        assert upgrade_status_from_transfers("on_loan", transfers, DORTMUND, None) == "on_loan"
 
     def test_non_on_loan_status_unchanged(self):
         assert upgrade_status_from_transfers("academy", RIJKHOFF_TRANSFERS, DORTMUND, 419) == "academy"
@@ -194,3 +206,72 @@ class TestGetLatestSeason:
     def test_international_only_history_falls_back_to_latest(self, app):
         jid = self._make_journey([(2024, 10, "Netherlands U19", True)])
         assert _get_latest_season(jid, parent_api_id=DORTMUND, parent_club_name="Borussia Dortmund") == 2024
+
+
+class TestAffiliateResolver:
+    """Affiliate / B-team -> senior org resolution (data-driven + hardcoded)."""
+
+    def test_senior_base_name_strips_jong_prefix(self):
+        assert senior_base_name("Jong Ajax") == "Ajax"
+
+    def test_senior_base_name_strips_u_number(self):
+        assert senior_base_name("Atalanta U20") == "Atalanta"
+
+    def test_senior_base_name_strips_castilla_and_reserve(self):
+        assert senior_base_name("Real Madrid Castilla") == "Real Madrid"
+        assert senior_base_name("Manchester United U18") == "Manchester United"
+
+    def test_is_affiliate_via_name(self):
+        # "Jong Ajax" normalises to "Ajax" == parent "Ajax"
+        assert is_affiliate(99999, "Jong Ajax", 194, "Ajax") is True
+
+    def test_is_affiliate_via_hardcoded_id_when_name_missing(self):
+        # 425 (Jong Ajax) -> 194, even with no name loaded
+        assert is_affiliate(425, None, 194, "Ajax") is True
+
+    def test_not_affiliate_of_different_club(self):
+        assert is_affiliate(15382, "Manchester United U18", 50, "Manchester City") is False
+
+
+class TestClassifyEvidenceBasedModel:
+    """End-to-end: on_loan is earned; departure-without-record -> 'left'."""
+
+    CONFIG = {"inactivity_release_years": 2, "use_squad_check": False}
+
+    def _classify(self, current_id, current_name, level, parent_id, parent_name, transfers, latest_season):
+        return classify_tracked_player(
+            current_club_api_id=current_id,
+            current_club_name=current_name,
+            current_level=level,
+            parent_api_id=parent_id,
+            parent_club_name=parent_name,
+            transfers=transfers,
+            latest_season=latest_season,
+            config=self.CONFIG,
+        )
+
+    def test_berry_under_man_united_is_left(self):
+        # No Man United departure transfer; player is at Al Kholood -> left.
+        transfers = [
+            _t("2024-04-20", 19746, "Nottingham Forest U21", 17426, "Nottingham Forest U18", "N/A"),
+            _t("2026-01-25", 10509, "Al Kholood", 65, "Nottingham Forest", "Transfer"),
+        ]
+        status, _, _ = self._classify(10509, "Al Kholood", "First Team", 33, "Manchester United", transfers, 2026)
+        assert status == "left"
+
+    def test_berry_under_forest_is_sold(self):
+        # Forest -> Al Kholood is a recorded permanent transfer with destination.
+        transfers = [_t("2026-01-25", 10509, "Al Kholood", 65, "Nottingham Forest", "Transfer")]
+        status, _, _ = self._classify(10509, "Al Kholood", "First Team", 65, "Nottingham Forest", transfers, 2026)
+        assert status == "sold"
+
+    def test_player_at_parent_b_team_is_not_left(self):
+        # Jong Ajax (425) is Ajax's own reserve -> still in the org, not left.
+        status, _, _ = self._classify(425, "Jong Ajax", "First Team", 194, "Ajax", [], 2025)
+        assert status == "first_team"
+
+    def test_genuine_current_loan_stays_on_loan(self):
+        # Parent loaned the player to 430 and that IS the current club.
+        transfers = [_t("2026-01-13", 430, "Bourg", 111, "Le Havre", "Loan")]
+        status, _, _ = self._classify(430, "Bourg", "First Team", 111, "Le Havre", transfers, 2026)
+        assert status == "on_loan"

--- a/academy-watch-frontend/src/components/constellation/constellation-utils.js
+++ b/academy-watch-frontend/src/components/constellation/constellation-utils.js
@@ -15,6 +15,7 @@ export const STATUS_LABELS = {
     academy: 'Academy',
     released: 'Released',
     sold: 'Sold',
+    left: 'Left',
 }
 
 /**

--- a/academy-watch-frontend/src/components/newsletter/PlayerCardDrawer.jsx
+++ b/academy-watch-frontend/src/components/newsletter/PlayerCardDrawer.jsx
@@ -78,6 +78,7 @@ function StatusPill({ status, level, loanTeam }) {
     academy: level || 'Academy',
     released: 'Released',
     sold: 'Sold',
+    left: 'Left',
   }
   const label = labelMap[status] || (loanTeam ? 'On Loan' : null)
   if (!label) return null

--- a/academy-watch-frontend/src/components/newsletter/PlayerCommentaryCard.jsx
+++ b/academy-watch-frontend/src/components/newsletter/PlayerCommentaryCard.jsx
@@ -78,6 +78,7 @@ function StatusPill({ status, level, loanTeam }) {
     academy: level || 'Academy',
     released: 'Released',
     sold: 'Sold',
+    left: 'Left',
   }
   const label = labelMap[status] || (loanTeam ? 'On Loan' : null)
   if (!label) return null

--- a/academy-watch-frontend/src/lib/theme-constants.js
+++ b/academy-watch-frontend/src/lib/theme-constants.js
@@ -16,6 +16,7 @@ export const STATUS_BADGE_CLASSES = {
   academy:          'bg-orange-50 text-orange-800 border-orange-200',
   released:         'bg-stone-100 text-stone-700 border-stone-200',
   sold:             'bg-rose-50 text-rose-800 border-rose-200',
+  left:             'bg-slate-100 text-slate-700 border-slate-300',
 }
 
 /* ------------------------------------------------------------------ */
@@ -69,6 +70,7 @@ export const CONSTELLATION_STATUS_COLORS = {
   academy:          '#ea580c', // orange-600
   released:         '#78716c', // stone-500
   sold:             '#e11d48', // rose-600
+  left:             '#475569', // slate-600
 }
 
 /* ------------------------------------------------------------------ */

--- a/academy-watch-frontend/src/pages/ScoutPage.jsx
+++ b/academy-watch-frontend/src/pages/ScoutPage.jsx
@@ -603,6 +603,7 @@ export function ScoutPage() {
                 <SelectItem value="first_team">First team</SelectItem>
                 <SelectItem value="sold">Sold</SelectItem>
                 <SelectItem value="released">Released</SelectItem>
+                <SelectItem value="left">Left</SelectItem>
               </SelectContent>
             </Select>
             <Select value={sort} onValueChange={(value) => { setSort(value); setOrder(value === 'name' || value === 'age' ? 'asc' : 'desc') }}>

--- a/academy-watch-frontend/src/pages/TeamDetailPage.jsx
+++ b/academy-watch-frontend/src/pages/TeamDetailPage.jsx
@@ -9,7 +9,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
-import { Loader2, ArrowLeft, ChevronRight, User, TrendingUp, Share2, Users, FileText, Search, X, Star, ArrowRightLeft, GraduationCap, UserMinus, BadgeDollarSign, Globe, Bell, Check } from 'lucide-react'
+import { Loader2, ArrowLeft, ChevronRight, User, TrendingUp, Share2, Users, FileText, Search, X, Star, ArrowRightLeft, GraduationCap, UserMinus, BadgeDollarSign, Globe, Bell, Check, LogOut } from 'lucide-react'
 import { motion, AnimatePresence } from 'framer-motion' // eslint-disable-line no-unused-vars
 import { APIService } from '@/lib/api'
 import { AcademyConstellation } from '@/components/constellation/AcademyConstellation'
@@ -27,6 +27,7 @@ const STATUS_ICONS = {
     academy: GraduationCap,
     released: UserMinus,
     sold: BadgeDollarSign,
+    left: LogOut,
 }
 
 function StatusIndicator({ status, teamName, saleFee }) {

--- a/academy-watch-frontend/src/pages/admin/AdminPlayers.jsx
+++ b/academy-watch-frontend/src/pages/admin/AdminPlayers.jsx
@@ -21,6 +21,7 @@ const STATUS_OPTIONS = [
     { value: 'first_team', label: 'First Team' },
     { value: 'released', label: 'Released' },
     { value: 'sold', label: 'Sold' },
+    { value: 'left', label: 'Left' },
 ]
 
 const LEVEL_OPTIONS = [


### PR DESCRIPTION
## Why
The status pipeline defaulted any *"current club ≠ parent"* to `on_loan`, only correcting it when a transfer **from the parent** existed. Academy-to-academy youth moves are almost never recorded as transfers, so academy products who **left** a club were stuck as `on_loan`. On prod, **1,404 of 1,603 `on_loan` rows had no loan evidence** — e.g. A. Berry shown "on loan" under Man United despite leaving years ago (→ Forest → Al Kholood). Same root cause as the earlier `released` inflation; we'd been patching the *correction* layer, never the wrong *default*.

## The model (relative to academy P) — `on_loan` must now be *earned*
| Evidence | Status |
|---|---|
| current club is a recorded **parent loan destination** (transfer-driven) | `on_loan` |
| permanent transfer P→X with a real destination | `sold` *(keeps the N/A→sold fix)* |
| free-agent / no-destination departure | `released` |
| **at another club, no recorded parent departure** | **`left`** *(new)* |
| no domestic activity anywhere for 2 yrs | `released` (inactivity, now also catches `left`) |
| at P / P's own reserve-youth-B side | `academy` / `first_team` (affiliate guard) |

## Pieces
- **`left` status** (new) — academy product who moved on without a recorded senior transfer. No DB migration (status is a free string).
- **Affiliate resolver** (`src/utils/affiliates.py`, data-driven + hardcoded fallback) — Jong Ajax / Atalanta U20 / Birmingham U21 read as still-at-parent, not `left`. Catches `Jong`/U-number/`III` that `strip_youth_suffix` misses, plus an id→senior map for ids whose team name isn't loaded.
- **Tenure gate** (`_compute_academy_club_ids`) — `apps≥3 OR seasons≥2`, always exempting the player's #1 academy, so 1-app cameos (Berry@Brighton/Burnley) stop creating phantom rows while no one loses their sole academy.
- **`left` propagated** to ~16 consumers (scout filters, journey moved-on, journalist scope, newsletter player- *and* team-selection gates, GOL docs, frontend badge/color/icon/label/filter maps).
- **numpy re-pinned to 2.4.6 + Dependabot ignore** for `numpy>=2.5` (2.5.0 needs Python ≥3.12 vs the 3.11 image — Dependabot kept re-bumping and breaking all deploys).

## Validation
- New evidence-based model + affiliate guard + attribution threshold were **calibrated and adversarially attacked against real prod data** in a prior workflow (3/4 buckets held; this diff implements the validated fixes for the rest). A second workflow reviewed *this diff* — both reviewers ship-clear after the two team-selection gates were fixed.
- 29 tests in `test_released_classification.py` pass: Rijkhoff→`sold`, genuine-loan→`on_loan`, no-current-club→`on_loan`, Berry@ManU→`left`, Berry@Forest→`sold`, B-team→not-`left`, affiliate resolver, tenure-gate logic. No new failures in `test_journey.py` (the 10 there are pre-existing app-context debt on `main`).

## Predicted effect after re-sync
`on_loan` ~1,603 → ~230 (evidence-backed only); the rest become **`left`** (~1,100–1,250) + some `released`. `left` becomes the largest status, which is correct — most academy players move on.

## Repair (follow-up after merge+deploy)
Batched journey re-sync (`force_full=false`) off a scaled-up container to re-derive statuses with the new model + deactivate cameo rows via `recompute-academy`, then verify the distribution and scale back. Same proven path as the prior repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)