### PR TITLE
fix(classifier): recompute-academy must not re-derive status without transfers

### DIFF
--- a/academy-watch-backend/src/services/journey_sync.py
+++ b/academy-watch-backend/src/services/journey_sync.py
@@ -1456,6 +1456,15 @@ class JourneySyncService:
 
         last_seasons = last_seasons or {}
 
+        # Status (on_loan/sold/released/left) is transfer-driven, so it can only
+        # be derived when transfers were actually fetched. Callers that pass
+        # transfers=None (e.g. the recompute-academy attribution sweep) must NOT
+        # re-derive status — without transfers every "current club != parent"
+        # player would collapse to the tentative on_loan / 'left' default and
+        # clobber the real status. transfers=[] (a fetched-but-empty list, as in
+        # a full journey sync) is a legitimate signal and DOES update status.
+        update_status = transfers is not None
+
         # Owning club is still computed for current-club classification
         # context, but it no longer keeps TrackedPlayer rows alive.
         owning_api_id = self._determine_owning_club_id(journey, transfers, academy_ids)
@@ -1535,7 +1544,7 @@ class JourneySyncService:
                 current_level=journey.current_level,
                 parent_api_id=academy_api_id,
                 parent_club_name=team.name,
-                transfers=transfers or [],
+                transfers=transfers,
                 latest_season=_get_latest_season(journey.id, parent_api_id=academy_api_id, parent_club_name=team.name),
             )
 
@@ -1576,9 +1585,13 @@ class JourneySyncService:
                         f"Reactivated TrackedPlayer {existing.id} for player "
                         f"{journey.player_api_id} at {team.name} (academy origin inside tracking window)"
                     )
-                existing.status = status
-                existing.current_club_api_id = current_club_api_id
-                existing.current_club_name = current_club_name
+                # Only re-derive status when transfers were available (a real
+                # journey sync). The recompute-academy attribution sweep passes
+                # transfers=None and must leave the existing status untouched.
+                if update_status:
+                    existing.status = status
+                    existing.current_club_api_id = current_club_api_id
+                    existing.current_club_name = current_club_name
 
     def _determine_owning_club_id(self, journey, transfers, academy_ids):
         """Find the club that currently owns the player (last permanent transfer dest).

--- a/academy-watch-backend/tests/test_released_classification.py
+++ b/academy-watch-backend/tests/test_released_classification.py
@@ -275,3 +275,26 @@ class TestClassifyEvidenceBasedModel:
         transfers = [_t("2026-01-13", 430, "Bourg", 111, "Le Havre", "Loan")]
         status, _, _ = self._classify(430, "Bourg", "First Team", 111, "Le Havre", transfers, 2026)
         assert status == "on_loan"
+
+    def test_transfers_none_does_not_become_left(self):
+        # REGRESSION: the recompute-academy sweep classifies with transfers=None
+        # (not fetched). It must NOT collapse a different-club player to 'left'
+        # — it stays the tentative on_loan; the caller (recompute) then leaves
+        # the real stored status untouched via its update_status guard. This is
+        # the guard that prevents recompute from clobbering on_loan/sold to left.
+        status, _, _ = classify_tracked_player(
+            current_club_api_id=999,
+            current_club_name="Some Club",
+            current_level="First Team",
+            parent_api_id=100,
+            parent_club_name="Parent FC",
+            transfers=None,
+            latest_season=2026,
+            config=self.CONFIG,
+        )
+        assert status == "on_loan"
+
+    def test_transfers_empty_list_means_departed_left(self):
+        # A genuine sync that fetched transfers and found NONE -> departed.
+        status, _, _ = self._classify(999, "Some Club", "First Team", 100, "Parent FC", [], 2026)
+        assert status == "left"


### PR DESCRIPTION
## Regression
After the evidence-based status model (#511), running `recompute-academy` collapsed **on_loan and sold to 0** platform-wide — every "current club ≠ parent" row became `left`.

**Root cause:** `_upsert_tracked_players` passed `transfers or []` to the classifier. The `recompute-academy` attribution sweep calls with `transfers=None`, so the classifier received an empty list → the new "empty list = departed → `left`" rule fired → and the unconditional `existing.status = status` overwrote every such row.

## Fix
Status is **transfer-driven**, so only re-derive it when transfers were actually fetched:
- `update_status = transfers is not None` gates the existing-row status/current-club write. `recompute-academy` (transfers=None) now leaves status untouched (its job is attribution only); a real journey sync (transfers=`[]` or a list) still updates.
- Pass `transfers` through as-is (not `or []`) so `None` can't masquerade as a fetched-empty list.

## Tests
- `test_transfers_none_does_not_become_left` — transfers=None → stays `on_loan` (not `left`).
- `test_transfers_empty_list_means_departed_left` — a real sync that fetched none → `left`.
- 31 pass; lint clean.

Data will be restored by re-syncing journeys (transfers fetched → correct statuses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)