### PR TITLE
fix(player): headline status shows actual current situation (on loan), not academy-relative

### DIFF
--- a/academy-watch-backend/src/routes/players.py
+++ b/academy-watch-backend/src/routes/players.py
@@ -299,6 +299,57 @@ def get_public_player_profile(player_id: int):
                 result["parent_team_id"] = tp.team.team_id
                 result["primary_team_db_id"] = tp.team_id
 
+        # ── Actual current status (overrides the academy-relative status) ──
+        # tp.status is the player's status RELATIVE TO his tracked academy: a
+        # player who left his academy reads 'left'/'sold' there even though his
+        # real, current situation is an active loan from a DIFFERENT club the
+        # platform doesn't track as his academy (e.g. Julian Rijkhoff — a
+        # Borussia Dortmund academy product, on loan at Almere City FROM AJAX;
+        # Ajax isn't tracked because his pre-2021 Ajax youth isn't in the feed).
+        # The journey knows the truth: its current-club entry is typed 'loan'.
+        # Surface that as the player-page headline so the badge matches reality,
+        # without touching the per-academy rows that drive team/academy views.
+        from src.models.journey import PlayerJourney, PlayerJourneyEntry
+
+        journey = PlayerJourney.query.filter_by(player_api_id=player_id).first()
+        if journey and journey.current_club_api_id:
+            on_loan_now = (
+                PlayerJourneyEntry.query.filter_by(
+                    journey_id=journey.id,
+                    club_api_id=journey.current_club_api_id,
+                    entry_type="loan",
+                ).first()
+                is not None
+            )
+            if on_loan_now:
+                result["status"] = "on_loan"
+                # Owner = the club the player is on loan FROM: the most recent
+                # senior (first-team, non-international) club that isn't the
+                # loan club, resolved to its senior org (Jong Ajax -> Ajax).
+                from src.models.league import Team
+                from src.utils.affiliates import resolve_senior_id
+
+                owner_entry = (
+                    PlayerJourneyEntry.query.filter(
+                        PlayerJourneyEntry.journey_id == journey.id,
+                        PlayerJourneyEntry.entry_type == "first_team",
+                        PlayerJourneyEntry.is_international.is_(False),
+                        PlayerJourneyEntry.club_api_id != journey.current_club_api_id,
+                    )
+                    .order_by(PlayerJourneyEntry.season.desc())
+                    .first()
+                )
+                if owner_entry:
+                    owner_id = resolve_senior_id(owner_entry.club_api_id, owner_entry.club_name)
+                    owner_team = (
+                        Team.query.filter_by(team_id=owner_id, is_active=True)
+                        .order_by(Team.season.desc())
+                        .first()
+                    )
+                    result["owner_team_id"] = owner_id
+                    result["owner_team_name"] = owner_team.name if owner_team else owner_entry.club_name
+                    result["owner_team_logo"] = owner_team.logo if owner_team else None
+
         if not result["position"]:
             POS_MAP = {"G": "Goalkeeper", "D": "Defender", "M": "Midfielder", "F": "Attacker"}
             recent_stats = (

--- a/academy-watch-backend/src/routes/players.py
+++ b/academy-watch-backend/src/routes/players.py
@@ -342,9 +342,7 @@ def get_public_player_profile(player_id: int):
                 if owner_entry:
                     owner_id = resolve_senior_id(owner_entry.club_api_id, owner_entry.club_name)
                     owner_team = (
-                        Team.query.filter_by(team_id=owner_id, is_active=True)
-                        .order_by(Team.season.desc())
-                        .first()
+                        Team.query.filter_by(team_id=owner_id, is_active=True).order_by(Team.season.desc()).first()
                     )
                     result["owner_team_id"] = owner_id
                     result["owner_team_name"] = owner_team.name if owner_team else owner_entry.club_name

--- a/academy-watch-frontend/src/pages/PlayerPage.jsx
+++ b/academy-watch-frontend/src/pages/PlayerPage.jsx
@@ -622,7 +622,7 @@ export function PlayerPage() {
                                     )}
                                     {profile?.status && (
                                         <Badge className={STATUS_BADGE_CLASSES[profile.status] || 'bg-secondary text-muted-foreground'}>
-                                            {profile.status.replace('_', ' ')}{profile.sale_fee ? ` · ${profile.sale_fee}` : ''}
+                                            {profile.status.replace('_', ' ')}{profile.status === 'on_loan' && profile.owner_team_name ? ` · from ${profile.owner_team_name}` : ''}{profile.sale_fee ? ` · ${profile.sale_fee}` : ''}
                                         </Badge>
                                     )}
                                     {academyStats?.appearances > 0 && stats.length > 0 && (


### PR DESCRIPTION
## Problem
The player page showed Julian Rijkhoff as **sold** when he is actually **on loan at Almere City from Ajax**. The profile endpoint set the headline from the *academy* tracked row (`tp.status`), which is **relative to his tracked academy** (Dortmund → he left → `sold`/`left`). His real owner **Ajax** isn't tracked because the platform is missing his 2013–2021 Ajax youth (API‑Football gap), so the academy-relative status contradicted reality.

**120 players** are in this state — actually on loan (their journey's current-club entry is typed `loan`) but shown `sold` (64), `left` (49), `released` (4), or `first_team` (3).

## Fix — display layer only, no data mutation, no re-sync
The journey already knows the truth. `/players/<id>/profile` now:
- If the journey's **current-club entry is typed `loan`** → headline `status = "on_loan"`.
- Resolves the **owning club** (most recent senior, non-international club ≠ loan club, affiliate-resolved e.g. Jong Ajax → Ajax) into `owner_team_name`.
- Frontend badge renders **"on loan · from Ajax"**.

The per-academy tracked rows are **untouched**, so team/academy views keep their relative status (Dortmund still correctly shows him as departed). This cleanly separates the two axes: *academy origin* vs *current situation*.

## Risk
Minimal — one read endpoint + one badge string. No DB writes, no journey re-sync (notably **not** repeating the earlier recompute regression).

## Verification
Will confirm on prod that Rijkhoff's profile returns `status: on_loan`, `owner_team_name: Ajax`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)