### PR TITLE
feat(journey): stored player-level current_status (actual situation, not academy-relative)

### DIFF
--- a/academy-watch-backend/migrations/versions/cs01_journey_current_status.py
+++ b/academy-watch-backend/migrations/versions/cs01_journey_current_status.py
@@ -1,0 +1,40 @@
+"""Player-level current_status on player_journeys.
+
+The player's ACTUAL current situation (on loan / etc.), independent of any
+tracked academy. TrackedPlayer.status is RELATIVE to a parent academy, so a
+departed academy product reads 'left'/'sold' there even while he is really on
+loan from a club the platform doesn't track as his academy (e.g. Rijkhoff:
+Dortmund academy product, on loan from Ajax). current_status overrides the
+academy-relative status for player-facing surfaces; NULL defers to it.
+
+- player_journeys.current_status: e.g. 'on_loan' (NULL = defer to academy row).
+- player_journeys.current_owner_api_id / current_owner_name: the club the player
+  is on loan FROM (for "on loan from <owner>").
+
+Idempotent (add_column_safe) — prod columns are also added out-of-band, so a
+re-run is a no-op.
+
+Revision ID: cs01
+Revises: aw18
+"""
+
+import sqlalchemy as sa
+from migrations._migration_helpers import add_column_safe, column_exists
+from alembic import op
+
+revision = "cs01"
+down_revision = "aw18"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    add_column_safe("player_journeys", sa.Column("current_status", sa.String(length=20), nullable=True))
+    add_column_safe("player_journeys", sa.Column("current_owner_api_id", sa.Integer(), nullable=True))
+    add_column_safe("player_journeys", sa.Column("current_owner_name", sa.String(length=200), nullable=True))
+
+
+def downgrade():
+    for col in ("current_status", "current_owner_api_id", "current_owner_name"):
+        if column_exists("player_journeys", col):
+            op.drop_column("player_journeys", col)

--- a/academy-watch-backend/migrations/versions/cs01_journey_current_status.py
+++ b/academy-watch-backend/migrations/versions/cs01_journey_current_status.py
@@ -19,8 +19,8 @@ Revises: aw18
 """
 
 import sqlalchemy as sa
-from migrations._migration_helpers import add_column_safe, column_exists
 from alembic import op
+from migrations._migration_helpers import add_column_safe, column_exists
 
 revision = "cs01"
 down_revision = "aw18"

--- a/academy-watch-backend/src/models/journey.py
+++ b/academy-watch-backend/src/models/journey.py
@@ -36,6 +36,19 @@ class PlayerJourney(db.Model):
     current_club_name = db.Column(db.String(200))
     current_level = db.Column(db.String(30))  # 'U18', 'U21', 'First Team', 'On Loan'
 
+    # Player-level CURRENT status — the player's ACTUAL current situation,
+    # independent of any tracked academy. TrackedPlayer.status is RELATIVE to a
+    # parent academy (a departed academy product reads 'left'/'sold' there even
+    # while he is, in reality, on loan from a club the platform doesn't track as
+    # his academy — e.g. Rijkhoff: Dortmund academy product, on loan from Ajax).
+    # current_status overrides the academy-relative status for player-facing
+    # surfaces; NULL means "defer to the academy-relative status". Currently set
+    # to 'on_loan' (+ owner) when the current club is a loan. Computed from
+    # STORED journey entries during sync — no extra API call.
+    current_status = db.Column(db.String(20))
+    current_owner_api_id = db.Column(db.Integer)
+    current_owner_name = db.Column(db.String(200))
+
     # First team debut milestone
     first_team_debut_season = db.Column(db.Integer)  # e.g., 2021
     first_team_debut_club_id = db.Column(db.Integer)
@@ -93,6 +106,9 @@ class PlayerJourney(db.Model):
                 "club_id": self.current_club_api_id,
                 "club_name": self.current_club_name,
                 "level": self.current_level,
+                "status": self.current_status,
+                "owner_id": self.current_owner_api_id,
+                "owner_name": self.current_owner_name,
             }
             if self.current_club_api_id
             else None,

--- a/academy-watch-backend/src/routes/journey.py
+++ b/academy-watch-backend/src/routes/journey.py
@@ -318,9 +318,7 @@ def admin_backfill_current_status():
         return jsonify({"error": "cursor must be a non-negative integer"}), 400
 
     service = JourneySyncService()
-    journeys = (
-        PlayerJourney.query.filter(PlayerJourney.id > cursor).order_by(PlayerJourney.id).limit(limit).all()
-    )
+    journeys = PlayerJourney.query.filter(PlayerJourney.id > cursor).order_by(PlayerJourney.id).limit(limit).all()
 
     processed = 0
     on_loan_set = 0

--- a/academy-watch-backend/src/routes/journey.py
+++ b/academy-watch-backend/src/routes/journey.py
@@ -291,6 +291,69 @@ def admin_recompute_academy():
     return jsonify(response)
 
 
+@journey_bp.route("/admin/journeys/backfill-current-status", methods=["POST"])
+@require_api_key
+def admin_backfill_current_status():
+    """Backfill player_journeys.current_status / current_owner_* from STORED
+    journey entries (no API calls, no journey re-sync). Computes the player's
+    actual current situation (on_loan + owner) exactly as a sync would, so the
+    player-facing 'actual status' is correct without a full re-sync.
+
+    Writes ONLY the new current_status / current_owner_* journey columns — it
+    never touches TrackedPlayer.status, so it cannot clobber the per-academy
+    statuses. Paged via cursor; one small transaction per journey.
+
+    Body: {"dry_run": bool=true, "limit": int=200, "cursor": int=0}
+    """
+    from src.services.journey_sync import JourneySyncService
+
+    data = request.get_json(silent=True) or {}
+    dry_run = bool(data.get("dry_run", True))
+    limit = data.get("limit", 200)
+    if not isinstance(limit, int) or isinstance(limit, bool) or limit < 1:
+        limit = 200
+    limit = min(limit, 500)
+    cursor = data.get("cursor", 0)
+    if not isinstance(cursor, int) or isinstance(cursor, bool) or cursor < 0:
+        return jsonify({"error": "cursor must be a non-negative integer"}), 400
+
+    service = JourneySyncService()
+    journeys = (
+        PlayerJourney.query.filter(PlayerJourney.id > cursor).order_by(PlayerJourney.id).limit(limit).all()
+    )
+
+    processed = 0
+    on_loan_set = 0
+    errors = 0
+    last_processed = cursor
+    for journey in journeys:
+        try:
+            entries = PlayerJourneyEntry.query.filter_by(journey_id=journey.id).all()
+            service._set_current_status(journey, entries)
+            if journey.current_status == "on_loan":
+                on_loan_set += 1
+            processed += 1
+            if dry_run:
+                db.session.rollback()
+            else:
+                db.session.commit()
+        except Exception as exc:
+            errors += 1
+            logger.warning("backfill-current-status failed for journey %s: %s", journey.id, exc)
+            db.session.rollback()
+        last_processed = journey.id
+
+    return jsonify(
+        {
+            "dry_run": dry_run,
+            "journeys_processed": processed,
+            "on_loan_set": on_loan_set,
+            "errors": errors,
+            "next_cursor": last_processed if len(journeys) == limit else None,
+        }
+    )
+
+
 # Maps FixturePlayerStats.position codes to TrackedPlayer.position conventions
 _PROFILE_POSITION_MAP = {"G": "Goalkeeper", "D": "Defender", "M": "Midfielder", "F": "Attacker"}
 

--- a/academy-watch-backend/src/routes/players.py
+++ b/academy-watch-backend/src/routes/players.py
@@ -304,49 +304,26 @@ def get_public_player_profile(player_id: int):
         # player who left his academy reads 'left'/'sold' there even though his
         # real, current situation is an active loan from a DIFFERENT club the
         # platform doesn't track as his academy (e.g. Julian Rijkhoff — a
-        # Borussia Dortmund academy product, on loan at Almere City FROM AJAX;
-        # Ajax isn't tracked because his pre-2021 Ajax youth isn't in the feed).
-        # The journey knows the truth: its current-club entry is typed 'loan'.
-        # Surface that as the player-page headline so the badge matches reality,
-        # without touching the per-academy rows that drive team/academy views.
-        from src.models.journey import PlayerJourney, PlayerJourneyEntry
+        # Borussia Dortmund academy product, on loan at Almere City FROM AJAX).
+        # journey.current_status holds that player-level truth (computed + stored
+        # during sync); NULL means defer to the academy-relative tp.status. This
+        # reads the stored field so every surface stays consistent.
+        from src.models.journey import PlayerJourney
 
         journey = PlayerJourney.query.filter_by(player_api_id=player_id).first()
-        if journey and journey.current_club_api_id:
-            on_loan_now = (
-                PlayerJourneyEntry.query.filter_by(
-                    journey_id=journey.id,
-                    club_api_id=journey.current_club_api_id,
-                    entry_type="loan",
-                ).first()
-                is not None
-            )
-            if on_loan_now:
-                result["status"] = "on_loan"
-                # Owner = the club the player is on loan FROM: the most recent
-                # senior (first-team, non-international) club that isn't the
-                # loan club, resolved to its senior org (Jong Ajax -> Ajax).
+        if journey and journey.current_status:
+            result["status"] = journey.current_status
+            if journey.current_owner_api_id:
                 from src.models.league import Team
-                from src.utils.affiliates import resolve_senior_id
 
-                owner_entry = (
-                    PlayerJourneyEntry.query.filter(
-                        PlayerJourneyEntry.journey_id == journey.id,
-                        PlayerJourneyEntry.entry_type == "first_team",
-                        PlayerJourneyEntry.is_international.is_(False),
-                        PlayerJourneyEntry.club_api_id != journey.current_club_api_id,
-                    )
-                    .order_by(PlayerJourneyEntry.season.desc())
+                owner_team = (
+                    Team.query.filter_by(team_id=journey.current_owner_api_id, is_active=True)
+                    .order_by(Team.season.desc())
                     .first()
                 )
-                if owner_entry:
-                    owner_id = resolve_senior_id(owner_entry.club_api_id, owner_entry.club_name)
-                    owner_team = (
-                        Team.query.filter_by(team_id=owner_id, is_active=True).order_by(Team.season.desc()).first()
-                    )
-                    result["owner_team_id"] = owner_id
-                    result["owner_team_name"] = owner_team.name if owner_team else owner_entry.club_name
-                    result["owner_team_logo"] = owner_team.logo if owner_team else None
+                result["owner_team_id"] = journey.current_owner_api_id
+                result["owner_team_name"] = journey.current_owner_name
+                result["owner_team_logo"] = owner_team.logo if owner_team else None
 
         if not result["position"]:
             POS_MAP = {"G": "Goalkeeper", "D": "Defender", "M": "Midfielder", "F": "Attacker"}

--- a/academy-watch-backend/src/services/journey_sync.py
+++ b/academy-watch-backend/src/services/journey_sync.py
@@ -1149,6 +1149,60 @@ class JourneySyncService:
         # Compute academy connections from youth entries
         self._compute_academy_club_ids(journey, entries, transfers=transfers)
 
+        # Player-level current status (actual situation, not academy-relative)
+        self._set_current_status(journey, entries)
+
+    def _set_current_status(self, journey: PlayerJourney, entries: list) -> None:
+        """Set journey.current_status / current_owner_* from STORED entries only
+        (no API). The player's ACTUAL current situation, independent of any
+        tracked academy: when the current-club entry is a loan, mark 'on_loan'
+        and resolve the owning club (the club he is on loan FROM). Otherwise
+        leave NULL so player-facing surfaces fall back to the academy-relative
+        TrackedPlayer.status. Idempotent — safe to call from sync or backfill.
+        """
+        from src.utils.affiliates import resolve_senior_id
+
+        cur_id = journey.current_club_api_id
+        if not cur_id:
+            journey.current_status = None
+            journey.current_owner_api_id = None
+            journey.current_owner_name = None
+            return
+
+        on_loan_now = any(e.club_api_id == cur_id and e.entry_type == "loan" for e in entries)
+        if not on_loan_now:
+            journey.current_status = None
+            journey.current_owner_api_id = None
+            journey.current_owner_name = None
+            return
+
+        journey.current_status = "on_loan"
+        # Owner = the club he is on loan FROM: most recent senior (first_team,
+        # non-international) club that isn't the loan club, resolved to its
+        # senior org (Jong Ajax -> Ajax).
+        owner_entry = max(
+            (
+                e
+                for e in entries
+                if e.entry_type == "first_team"
+                and not e.is_international
+                and e.club_api_id
+                and e.club_api_id != cur_id
+            ),
+            key=lambda e: (e.season or 0),
+            default=None,
+        )
+        if owner_entry:
+            owner_id = resolve_senior_id(owner_entry.club_api_id, owner_entry.club_name)
+            owner_team = (
+                Team.query.filter_by(team_id=owner_id, is_active=True).order_by(Team.season.desc()).first()
+            )
+            journey.current_owner_api_id = owner_id
+            journey.current_owner_name = owner_team.name if owner_team else owner_entry.club_name
+        else:
+            journey.current_owner_api_id = None
+            journey.current_owner_name = None
+
     def _strip_youth_suffix(self, club_name: str) -> str:
         """Strip youth team suffix to get parent club base name."""
         return strip_youth_suffix(club_name)

--- a/academy-watch-backend/src/services/journey_sync.py
+++ b/academy-watch-backend/src/services/journey_sync.py
@@ -1184,19 +1184,14 @@ class JourneySyncService:
             (
                 e
                 for e in entries
-                if e.entry_type == "first_team"
-                and not e.is_international
-                and e.club_api_id
-                and e.club_api_id != cur_id
+                if e.entry_type == "first_team" and not e.is_international and e.club_api_id and e.club_api_id != cur_id
             ),
-            key=lambda e: (e.season or 0),
+            key=lambda e: e.season or 0,
             default=None,
         )
         if owner_entry:
             owner_id = resolve_senior_id(owner_entry.club_api_id, owner_entry.club_name)
-            owner_team = (
-                Team.query.filter_by(team_id=owner_id, is_active=True).order_by(Team.season.desc()).first()
-            )
+            owner_team = Team.query.filter_by(team_id=owner_id, is_active=True).order_by(Team.season.desc()).first()
             journey.current_owner_api_id = owner_id
             journey.current_owner_name = owner_team.name if owner_team else owner_entry.club_name
         else:

--- a/academy-watch-backend/tests/test_released_classification.py
+++ b/academy-watch-backend/tests/test_released_classification.py
@@ -298,3 +298,72 @@ class TestClassifyEvidenceBasedModel:
         # A genuine sync that fetched transfers and found NONE -> departed.
         status, _, _ = self._classify(999, "Some Club", "First Team", 100, "Parent FC", [], 2026)
         assert status == "left"
+
+
+class TestJourneyCurrentStatus:
+    """PlayerJourney.current_status is the player's ACTUAL current situation
+    (on_loan + owner), computed from stored entries — independent of academy."""
+
+    def _journey(self, current_club_api_id, entries):
+        from src.models.journey import PlayerJourney, PlayerJourneyEntry
+
+        j = PlayerJourney(player_api_id=424242, current_club_api_id=current_club_api_id)
+        db.session.add(j)
+        db.session.flush()
+        objs = []
+        for season, club_api_id, club_name, entry_type, is_intl in entries:
+            e = PlayerJourneyEntry(
+                journey_id=j.id,
+                season=season,
+                club_api_id=club_api_id,
+                club_name=club_name,
+                entry_type=entry_type,
+                is_international=is_intl,
+                appearances=1,
+            )
+            db.session.add(e)
+            objs.append(e)
+        db.session.flush()
+        return j, objs
+
+    def _svc(self):
+        from src.services.journey_sync import JourneySyncService
+
+        return JourneySyncService()
+
+    def test_on_loan_sets_status_and_owner(self, app):
+        # Rijkhoff-shaped: current club Almere (419) is a loan; owner = Ajax (194).
+        j, entries = self._journey(
+            419,
+            [
+                (2025, 419, "Almere City FC", "loan", False),
+                (2024, 194, "Ajax", "first_team", False),
+            ],
+        )
+        self._svc()._set_current_status(j, entries)
+        assert j.current_status == "on_loan"
+        assert j.current_owner_api_id == 194
+        assert j.current_owner_name == "Ajax"
+
+    def test_owner_resolves_b_team_to_senior(self, app):
+        # Owner recorded as Jong Ajax (425) resolves to Ajax (194).
+        j, entries = self._journey(
+            419,
+            [
+                (2025, 419, "Almere City FC", "loan", False),
+                (2024, 425, "Jong Ajax", "first_team", False),
+            ],
+        )
+        self._svc()._set_current_status(j, entries)
+        assert j.current_status == "on_loan"
+        assert j.current_owner_api_id == 194  # Jong Ajax -> Ajax via affiliate map
+
+    def test_not_on_loan_leaves_status_null(self, app):
+        # Current club entry is first_team (not a loan) -> defer to academy status.
+        j, entries = self._journey(
+            10509,
+            [(2026, 10509, "Al Kholood", "first_team", False)],
+        )
+        self._svc()._set_current_status(j, entries)
+        assert j.current_status is None
+        assert j.current_owner_api_id is None


### PR DESCRIPTION
## Why
Hardens the player-page "actual current status" fix (PR #513) from a **single-endpoint derivation** into a **first-class, stored, tested field** so it's consistent across surfaces and can't silently degrade.

The two axes:
- `TrackedPlayer.status` — RELATIVE to a tracked academy (a departed academy product reads `left`/`sold`). Drives team/academy views. Unchanged.
- `PlayerJourney.current_status` (new) — the player's REAL current situation, independent of academy. Rijkhoff: Dortmund academy product → **on loan from Ajax**.

## What
- **Model + migration** (`cs01`, guarded/idempotent): `current_status`, `current_owner_api_id`, `current_owner_name` on `player_journeys`. Prod columns also added out-of-band (additive, safe).
- **Computed in sync** (`_set_current_status` in `_update_journey_aggregates`) from **stored journey entries only** — current-club entry typed `loan` → `on_loan` + owner (latest senior non-intl club ≠ loan club, affiliate-resolved Jong Ajax → Ajax). No extra API call.
- **Consumed** by the profile endpoint reading `journey.current_status` (replaces PR #513's ad-hoc query) — cheap and consistent. `NULL` defers to the academy-relative status.
- **Backfill** endpoint `POST /admin/journeys/backfill-current-status` recomputes from stored entries — **no API, no journey re-sync, never writes `TrackedPlayer.status`** (zero clobber risk, unlike the earlier recompute incident).

## Tests
- `TestJourneyCurrentStatus`: on-loan sets status+owner; Jong Ajax owner resolves to Ajax; non-loan leaves NULL. 34 pass; no new regressions in `test_journey.py`.

## Rollout
Columns already added to prod. After merge+deploy: run the backfill endpoint (paged, no API), then verify Rijkhoff's profile returns `status: on_loan, owner: Ajax` **from the stored field**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)