### PR TITLE
fix(scout): reflect actual current club/status, not academy-relative

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -153,9 +153,11 @@ CONTINUITY.md
 | CONTINUITY_cohort-dynamic-resolution.md | in-progress | codex | pending live Full Rebuild validation |
 | CONTINUITY_video-analysis.md | design complete | — | Phase 0 blocked on footage acquisition (0.1) + MJ decisions (pricing, footage source) |
 | CONTINUITY_global-talent-platform.md | implementation complete | claude | awaiting PR review/merge |
+| CONTINUITY_admin-interface.md | shipped (PR #432, prod 2026-06-14) | claude | manual click-through QA recommended |
 
 ## Trivial Log
 
+- 2026-06-25: Scout page now reflects a player's ACTUAL current situation (matches PlayerPage). `scout.py._base_scout_query` outer-joins `player_journeys` (on unique `player_api_id`, ≤1 row) and exposes `effective_status = coalesce(journey.current_status, tracked_player.status)`; the status filter uses it so it never disagrees with the displayed badge. `_row_to_dict` + `scout_compare` override `status` and add `owner_team_id`/`owner_team_name` when `current_status` is set. `ScoutPage.jsx` CLUB column "from X" now prefers `owner_team_name` (e.g. Rijkhoff → "from Ajax", not "from Borussia Dortmund"). Tests: `TestCurrentSituationOverride` in `test_scout_blueprint.py` (38 pass).
 - 2026-04-08: Added admin-only newsletter PDF download (WeasyPrint) — endpoint `GET /newsletters/<id>/download.pdf`, reuses existing `newsletter_email.html` template with injected print CSS (`@page`, `break-inside: avoid` on `.item`/`.highlights`/`.toc`/`.matches-section`, `break-before: page` on section `<h2>`s). Dockerfile gains libpango/libcairo/libgdk-pixbuf/shared-mime-info (~80MB). Download buttons in `AdminNewsletters.jsx` row actions and `NewsletterPreviewDialog.jsx` control panel. Plan file at `.claude/plans/staged-wibbling-cocoa.md`.
 - 2026-02-12: Academy data audit — all Big 6 teams show 0% conversion due to journey sync never completing
 - 2026-02-12: Fixed Full Rebuild journey sync: added RateLimiter, quota-exceeded break, non-fatal Stage 3, empty-journey bug fix

--- a/academy-watch-backend/src/routes/scout.py
+++ b/academy-watch-backend/src/routes/scout.py
@@ -33,6 +33,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import aliased, joinedload
 from src.auth import _ensure_user_account, _safe_error_payload, require_api_key, require_user_auth
 from src.extensions import limiter
+from src.models.journey import PlayerJourney
 from src.models.league import PlayerStatsCache, UserAccount, db
 from src.models.scout_watchlist import ScoutWatchlistEntry
 from src.models.tracked_player import TrackedPlayer
@@ -252,8 +253,31 @@ def _base_scout_query():
     appearances = func.coalesce(fps.c.appearances, cache.c.appearances, 0).label("appearances")
     avg_rating = fps.c.avg_rating.label("avg_rating")
 
+    # Player-level CURRENT situation overrides the academy-relative
+    # TrackedPlayer.status on player-facing surfaces. A Dortmund academy product
+    # on loan from Ajax reads 'sold' relative to Dortmund but is really
+    # 'on_loan · from Ajax'. journey.current_status (computed + stored during
+    # sync) holds that truth; NULL defers to the academy-relative status.
+    # player_journeys.player_api_id is unique, so this outerjoin yields ≤1 row
+    # per player (no duplication) and never drops rows lacking a journey.
+    journey_status = PlayerJourney.current_status.label("journey_status")
+    journey_owner_id = PlayerJourney.current_owner_api_id.label("journey_owner_id")
+    journey_owner_name = PlayerJourney.current_owner_name.label("journey_owner_name")
+    effective_status = func.coalesce(PlayerJourney.current_status, TrackedPlayer.status).label("effective_status")
+
     query = (
-        db.session.query(TrackedPlayer, goals, assists, minutes, appearances, avg_rating)
+        db.session.query(
+            TrackedPlayer,
+            goals,
+            assists,
+            minutes,
+            appearances,
+            avg_rating,
+            journey_status,
+            journey_owner_id,
+            journey_owner_name,
+        )
+        .outerjoin(PlayerJourney, PlayerJourney.player_api_id == TrackedPlayer.player_api_id)
         .outerjoin(
             fps,
             and_(
@@ -283,6 +307,9 @@ def _base_scout_query():
         "minutes_played": minutes,
         "appearances": appearances,
         "avg_rating": avg_rating,
+        # status filter matches what the row displays (current situation,
+        # falling back to academy-relative status).
+        "effective_status": effective_status,
     }
     return query, columns
 
@@ -300,7 +327,7 @@ def _apply_filters(query, columns):
         invalid = [s for s in statuses if s not in VALID_STATUSES]
         if invalid:
             return query, (jsonify({"error": f"Invalid status {invalid}. One of: {sorted(VALID_STATUSES)}"}), 400)
-        query = query.filter(TrackedPlayer.status.in_(statuses))
+        query = query.filter(columns["effective_status"].in_(statuses))
 
     min_age = request.args.get("min_age", type=int)
     max_age = request.args.get("max_age", type=int)
@@ -338,6 +365,13 @@ def _row_to_dict(row):
     contributions = payload["goals"] + payload["assists"]
     payload["goal_contributions"] = contributions
     payload["contributions_per90"] = round(contributions * 90.0 / minutes, 2) if minutes else None
+    # Surface the player's actual current situation (mirrors the player profile
+    # endpoint): when stored, it overrides the academy-relative status and adds
+    # the owning club so the CLUB column reads "from <owner>", not "from <academy>".
+    if row.journey_status:
+        payload["status"] = row.journey_status
+        payload["owner_team_id"] = row.journey_owner_id
+        payload["owner_team_name"] = row.journey_owner_name
     return payload
 
 
@@ -600,9 +634,16 @@ def scout_compare():
                 except Exception as availability_error:
                     logger.warning(f"Availability lookup failed for player {player_id}: {availability_error}")
 
+            profile = tracked_player.to_public_dict()
+            # Same current-situation override as the list/profile surfaces.
+            if journey and journey.current_status:
+                profile["status"] = journey.current_status
+                profile["owner_team_id"] = journey.current_owner_api_id
+                profile["owner_team_name"] = journey.current_owner_name
+
             players.append(
                 {
-                    "profile": tracked_player.to_public_dict(),
+                    "profile": profile,
                     "totals": totals,
                     "per90": per90,
                     "career": career,

--- a/academy-watch-backend/tests/test_scout_blueprint.py
+++ b/academy-watch-backend/tests/test_scout_blueprint.py
@@ -469,6 +469,85 @@ class TestPlayerAvailabilityEndpoint:
         assert data["summary"]["last_absence"] is None
 
 
+@pytest.fixture
+def current_situation_seeded(scout_app):
+    """A Rijkhoff-like player: a Borussia Dortmund academy product, 'sold'
+    relative to Dortmund, but ACTUALLY on loan at Almere City FROM Ajax.
+    journey.current_status holds that player-level truth."""
+    with scout_app.app_context():
+        league = League(league_id=78, name="Bundesliga", country="Germany", season=2025)
+        db.session.add(league)
+        db.session.flush()
+        dortmund = Team(
+            team_id=165, name="Borussia Dortmund", country="Germany", season=2025, league_id=league.id, is_active=True
+        )
+        almere = Team(
+            team_id=910, name="Almere City FC", country="Netherlands", season=2025, league_id=league.id, is_active=True
+        )
+        db.session.add_all([dortmund, almere])
+        db.session.flush()
+
+        journey = PlayerJourney(
+            player_api_id=2001,
+            player_name="Julian Rijkhoff",
+            current_club_api_id=910,
+            current_club_name="Almere City FC",
+            current_status="on_loan",
+            current_owner_api_id=194,
+            current_owner_name="Ajax",
+        )
+        db.session.add(journey)
+        db.session.flush()
+
+        rijkhoff = TrackedPlayer(
+            player_api_id=2001,
+            player_name="Julian Rijkhoff",
+            position="Midfielder",
+            nationality="Netherlands",
+            age=20,
+            team_id=dortmund.id,
+            status="sold",  # academy-relative: Dortmund sold him
+            current_club_api_id=910,
+            current_club_name="Almere City FC",
+            current_club_db_id=almere.id,
+            data_depth="full_stats",
+            journey_id=journey.id,
+            is_active=True,
+        )
+        db.session.add(rijkhoff)
+        db.session.commit()
+
+
+class TestCurrentSituationOverride:
+    def test_browse_reflects_actual_current_situation(self, scout_client, current_situation_seeded):
+        resp = scout_client.get("/api/scout/players?search=Rijkhoff")
+        data = resp.get_json()
+        assert len(data["players"]) == 1
+        player = data["players"][0]
+        # Academy-relative status was 'sold'; actual situation is an active loan
+        assert player["status"] == "on_loan"
+        # CLUB column reads current club + OWNING club (Ajax), not academy
+        assert player["loan_team_name"] == "Almere City FC"
+        assert player["primary_team_name"] == "Borussia Dortmund"
+        assert player["owner_team_name"] == "Ajax"
+        assert player["owner_team_id"] == 194
+
+    def test_status_filter_tracks_current_situation(self, scout_client, current_situation_seeded):
+        # Filtering by the actual current status surfaces him…
+        on_loan = scout_client.get("/api/scout/players?status=on_loan").get_json()
+        assert [p["player_id"] for p in on_loan["players"]] == [2001]
+        # …and the academy-relative 'sold' does not, so the filter never
+        # disagrees with the status the row displays.
+        sold = scout_client.get("/api/scout/players?status=sold").get_json()
+        assert sold["total"] == 0
+
+    def test_compare_reflects_actual_current_situation(self, scout_client, current_situation_seeded):
+        resp = scout_client.get("/api/scout/compare?ids=2001")
+        profile = resp.get_json()["players"][0]["profile"]
+        assert profile["status"] == "on_loan"
+        assert profile["owner_team_name"] == "Ajax"
+
+
 class TestSupportedLeaguesConfig:
     def test_default_supported_leagues_global(self):
         from src.utils.supported_leagues import get_supported_leagues

--- a/academy-watch-frontend/src/pages/ScoutPage.jsx
+++ b/academy-watch-frontend/src/pages/ScoutPage.jsx
@@ -681,8 +681,8 @@ export function ScoutPage() {
                         <td className="px-3 py-2.5"><StatusBadge status={player.status} /></td>
                         <td className="px-3 py-2.5 max-w-44">
                           <span className="block truncate text-sm text-foreground/90">{player.loan_team_name || player.primary_team_name || '—'}</span>
-                          {player.loan_team_name && player.primary_team_name && (
-                            <span className="block truncate text-xs text-muted-foreground">from {player.primary_team_name}</span>
+                          {player.loan_team_name && (player.owner_team_name || player.primary_team_name) && (
+                            <span className="block truncate text-xs text-muted-foreground">from {player.owner_team_name || player.primary_team_name}</span>
                           )}
                         </td>
                         <td className="px-3 py-2.5">

--- a/academy-watch-frontend/src/pages/WatchlistPage.jsx
+++ b/academy-watch-frontend/src/pages/WatchlistPage.jsx
@@ -293,8 +293,8 @@ export function WatchlistPage() {
                               <td className="px-3 py-2.5"><StatusBadge status={player.status} /></td>
                               <td className="px-3 py-2.5 max-w-44">
                                 <span className="block truncate text-sm text-foreground/90">{player.loan_team_name || player.primary_team_name || '—'}</span>
-                                {player.loan_team_name && player.primary_team_name && (
-                                  <span className="block truncate text-xs text-muted-foreground">from {player.primary_team_name}</span>
+                                {player.loan_team_name && (player.owner_team_name || player.primary_team_name) && (
+                                  <span className="block truncate text-xs text-muted-foreground">from {player.owner_team_name || player.primary_team_name}</span>
                                 )}
                                 {entry.note && (
                                   <span className="block max-w-44 truncate text-xs italic text-primary/80" title={entry.note}>


### PR DESCRIPTION
## Problem

On the **Scout Desk** (and the Watchlist view of it), a player's row showed the **academy-relative** status and origin club, while the player profile page already shows the **actual current situation** (the recent `current_status` work, #513/#514).

Example — Julian Dean Rijkhoff (a Borussia Dortmund academy product, sold to Ajax, now on loan at Almere City **from Ajax**):

| | Scout (before) | Profile (correct) |
|---|---|---|
| STATUS | `Sold` | `on loan · from Ajax` |
| CLUB | Almere City FC / **from Borussia Dortmund** | from Ajax |

## Fix

Reuses the exact pattern the profile endpoint already uses (`players.py` → `journey.current_status` + `owner_team_*`), applied at the Scout layer — and at **SQL level** so the status *filter* never disagrees with the displayed badge.

**Backend (`scout.py`)**
- `_base_scout_query()` outer-joins `player_journeys` on the **unique** `player_api_id` (≤1 row, no duplication, never drops journey-less rows) and exposes `effective_status = COALESCE(journey.current_status, tracked_player.status)`.
- Status filter uses `effective_status` — filtering "On Loan" surfaces Rijkhoff, "Sold" doesn't.
- `_row_to_dict()` + `scout_compare()` override `status` and add `owner_team_id` / `owner_team_name` when `current_status` is set.

**Frontend (`ScoutPage.jsx`, `WatchlistPage.jsx`)**
- CLUB "from X" prefers `owner_team_name` ("from Ajax"), falling back to the academy. STATUS badge needs no change — `player.status` now arrives already overridden.

## No backfill needed
The profile already renders "on loan · from Ajax" for Rijkhoff, proving `journey.current_status` / `current_owner_name` are populated in prod. The Scout page reads the same rows.

## Tests
- `test_scout_blueprint.py`: 38 passed (incl. new `TestCurrentSituationOverride`); `test_scout_watchlist.py`: 31 passed.
- `ruff check` / `ruff format` clean; ESLint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)