### PR TITLE
feat(showcase): player showcase profiles — claims, curated reels, club-verified footage

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -125,6 +125,32 @@ The Academy Watch — Football academy tracking platform with AI-powered newslet
     that was failing ALL frontend CI; react-hooks v7 rules pinned to warn
   - Branch `feature/global-scout-discovery`
   - **See `ledgers/CONTINUITY_global-talent-platform.md`**
+- Talent Showcase — two-sided vision slice SHIPPED to branch (2026-07-02, /goal)
+  - Vision: players worldwide get showcase profile pages (YouTube highlights,
+    commentary, verified stats) for discoverability; clubs upload footage and
+    get per-player stats (Film Room). Roadmap: P0→F0→P1→X sequencing.
+  - This slice: P0 (Showcase section on PlayerPage: highlight reel from
+    PlayerLink + newsletter yt merge) + P1 (claim & curate: user claims,
+    admin approves, owner curates reel/bio — ALL owner content pre-moderated,
+    self-reported vs verified hard-separated) + X (Film Room finalized
+    reports → "Club-verified" appearance evidence on profiles; roster→player
+    linking admin UI; only human_confirmed identities surface)
+  - Migration aw19 (merge cs01+vid02 → single head restored; claims +
+    showcase-profile tables + player_links.sort_order). aw19 upgrade verified
+    on real Postgres clone; downgrade across merges needs explicit target.
+  - Security: shared https-only URL validator; pre-existing
+    submit_player_link javascript:-URL hole closed; newsletter yt merge
+    filtered server-side.
+  - Built multi-agent (Fable 5 orchestrator + Opus 4.8 builders), 6-surface
+    recon, adversarial review (23 agents: 8 confirmed findings ALL fixed,
+    1 refuted), 40 backend tests, live-verified end-to-end incl. UI screenshot
+    (demo: player 403064 H. Amass — reel + profile + verified appearance).
+  - Branch `feature/talent-showcase` (worktree) — PR opened, awaiting MJ
+  - PROD OPERATOR STEPS after merge: flask db upgrade (aw19); vid03 (still
+    uncommitted in the video branch) must rebase onto aw19 before it lands
+  - Known pre-existing (NOT this slice): full migration chain cannot replay
+    on an EMPTY DB (old unguarded supplemental_loans migration)
+  - **See `ledgers/ROADMAP_talent-showcase-vision.md` + `docs/showcase.md`**
 
 ### Next
 - Run migration: `flask db upgrade`

--- a/academy-watch-backend/migrations/versions/aw19_talent_showcase.py
+++ b/academy-watch-backend/migrations/versions/aw19_talent_showcase.py
@@ -1,0 +1,96 @@
+"""Talent Showcase — profile claims, showcase profiles, reel ordering.
+
+Merges the two open heads (cs01 journey current_status + vid02 structured
+player report) back to a single head and adds the Talent Showcase surface:
+
+- ``player_profile_claims``   — a user claims a player's profile (admin-reviewed)
+- ``player_showcase_profiles`` — self-reported profile card (pre-moderated)
+- ``player_links.sort_order``  — curated highlight-reel ordering
+
+Idempotent (guards + helpers) — production has had objects added out-of-band,
+so every DDL op is safe to re-run in both directions.
+
+Revision ID: aw19
+Revises: cs01, vid02
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from migrations._migration_helpers import (
+    add_column_safe,
+    column_exists,
+    create_index_safe,
+    index_exists,
+    table_exists,
+)
+
+revision = "aw19"
+down_revision = ("cs01", "vid02")
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if not table_exists("player_profile_claims"):
+        op.create_table(
+            "player_profile_claims",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("player_api_id", sa.Integer(), nullable=False),
+            sa.Column(
+                "user_account_id",
+                sa.Integer(),
+                sa.ForeignKey("user_accounts.id"),
+                nullable=False,
+            ),
+            sa.Column("relationship_type", sa.String(length=20), nullable=False),
+            sa.Column("status", sa.String(length=20), nullable=False, server_default="pending"),
+            sa.Column("message", sa.Text(), nullable=True),
+            sa.Column("reviewed_by", sa.String(length=200), nullable=True),
+            sa.Column("reviewed_at", sa.DateTime(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.UniqueConstraint("player_api_id", "user_account_id", name="uq_profile_claim_player_user"),
+        )
+    create_index_safe("ix_profile_claims_player", "player_profile_claims", ["player_api_id"])
+    create_index_safe("ix_profile_claims_user", "player_profile_claims", ["user_account_id"])
+
+    if not table_exists("player_showcase_profiles"):
+        op.create_table(
+            "player_showcase_profiles",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("player_api_id", sa.Integer(), nullable=False),
+            sa.Column("bio", sa.Text(), nullable=True),
+            sa.Column("positions", sa.String(length=100), nullable=True),
+            sa.Column("preferred_foot", sa.String(length=10), nullable=True),
+            sa.Column("height_cm", sa.Integer(), nullable=True),
+            sa.Column("status", sa.String(length=20), nullable=False, server_default="pending"),
+            sa.Column(
+                "updated_by_user_id",
+                sa.Integer(),
+                sa.ForeignKey("user_accounts.id"),
+                nullable=True,
+            ),
+            sa.Column("reviewed_by", sa.String(length=200), nullable=True),
+            sa.Column("reviewed_at", sa.DateTime(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+        )
+    create_index_safe("ix_showcase_profiles_player", "player_showcase_profiles", ["player_api_id"], unique=True)
+
+    add_column_safe("player_links", sa.Column("sort_order", sa.Integer(), nullable=True, server_default="0"))
+
+
+def downgrade():
+    if column_exists("player_links", "sort_order"):
+        op.drop_column("player_links", "sort_order")
+
+    if index_exists("ix_showcase_profiles_player"):
+        op.drop_index("ix_showcase_profiles_player", table_name="player_showcase_profiles")
+    if table_exists("player_showcase_profiles"):
+        op.drop_table("player_showcase_profiles")
+
+    if index_exists("ix_profile_claims_user"):
+        op.drop_index("ix_profile_claims_user", table_name="player_profile_claims")
+    if index_exists("ix_profile_claims_player"):
+        op.drop_index("ix_profile_claims_player", table_name="player_profile_claims")
+    if table_exists("player_profile_claims"):
+        op.drop_table("player_profile_claims")

--- a/academy-watch-backend/src/main.py
+++ b/academy-watch-backend/src/main.py
@@ -31,6 +31,7 @@ from src.routes.newsletter_deadline import newsletter_deadline_bp
 from src.routes.ops import ops_bp
 from src.routes.players import players_bp
 from src.routes.scout import scout_bp
+from src.routes.showcase import showcase_bp
 from src.routes.teams import teams_bp
 from src.routes.video import video_bp
 
@@ -92,6 +93,9 @@ for name in ("mcp", "agents.mcp", "mcp.shared.session", "mcp.client"):
 app.register_blueprint(journey_bp, url_prefix="/api")
 app.register_blueprint(players_bp, url_prefix="/api")
 app.register_blueprint(scout_bp, url_prefix="/api")
+# Registered BEFORE api_bp (mirroring players_bp) so /players/<id>/showcase*
+# routes take priority over any api_bp /players/<id>/* catch-alls.
+app.register_blueprint(showcase_bp, url_prefix="/api")
 app.register_blueprint(api_bp, url_prefix="/api")
 app.register_blueprint(auth_bp, url_prefix="/api")
 app.register_blueprint(journalist_bp, url_prefix="/api")

--- a/academy-watch-backend/src/models/league.py
+++ b/academy-watch-backend/src/models/league.py
@@ -1828,6 +1828,9 @@ class PlayerLink(db.Model):
     link_type = db.Column(db.String(30), default="article")  # article | highlight | social | stats | other
     status = db.Column(db.String(20), default="pending")  # pending | approved | rejected
     upvotes = db.Column(db.Integer, default=0)
+    # Curated ordering for Talent Showcase highlight reels (link_type='highlight').
+    # Added in migration aw19; non-highlight links leave it at the default 0.
+    sort_order = db.Column(db.Integer, default=0, server_default="0")
     created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
 
     user = db.relationship("UserAccount", backref="player_links")

--- a/academy-watch-backend/src/models/showcase.py
+++ b/academy-watch-backend/src/models/showcase.py
@@ -1,0 +1,95 @@
+"""Talent Showcase models — player-claimed profiles + curated highlight reel.
+
+A player (or their agent/guardian/club official) claims their public profile;
+an admin approves the claim, after which the owner can curate a self-reported
+profile card and a YouTube highlight reel. All owner-submitted content is
+pre-moderated (safeguarding — many players are minors), so anything an owner
+edits reverts to ``pending`` and is hidden from the public until re-approved.
+
+- ``PlayerProfileClaim`` — one row per (player, user). Multiple *approved* claims
+  per player are allowed (a player and their agent can both own it). A player's
+  api-football id is used directly (no FK) to mirror ``PlayerLink``.
+- ``PlayerShowcaseProfile`` — at most one self-reported card per player.
+
+Reel storage reuses the existing ``PlayerLink`` model (``link_type='highlight'``)
+plus the ``sort_order`` column added in migration ``aw19``.
+"""
+
+from datetime import UTC, datetime
+
+from src.models.league import db
+
+
+class PlayerProfileClaim(db.Model):
+    """A user's claim to own a player's public profile (admin-reviewed)."""
+
+    __tablename__ = "player_profile_claims"
+    __table_args__ = (
+        db.UniqueConstraint("player_api_id", "user_account_id", name="uq_profile_claim_player_user"),
+        db.Index("ix_profile_claims_player", "player_api_id"),
+        db.Index("ix_profile_claims_user", "user_account_id"),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    player_api_id = db.Column(db.Integer, nullable=False)  # API-Football player id
+    user_account_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"), nullable=False)
+    relationship_type = db.Column(db.String(20), nullable=False)  # player | agent | guardian | club_official
+    status = db.Column(db.String(20), nullable=False, default="pending")  # pending | approved | rejected | revoked
+    message = db.Column(db.Text)  # claimant note to the admin reviewer
+    reviewed_by = db.Column(db.String(200))  # admin email
+    reviewed_at = db.Column(db.DateTime)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
+
+    user = db.relationship("UserAccount", backref=db.backref("player_profile_claims", lazy="dynamic"))
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "player_api_id": self.player_api_id,
+            "user_account_id": self.user_account_id,
+            "relationship_type": self.relationship_type,
+            "status": self.status,
+            "message": self.message,
+            "reviewed_by": self.reviewed_by,
+            "reviewed_at": self.reviewed_at.isoformat() if self.reviewed_at else None,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+        }
+
+
+class PlayerShowcaseProfile(db.Model):
+    """A player's self-reported profile card — pre-moderated before it goes public."""
+
+    __tablename__ = "player_showcase_profiles"
+    __table_args__ = (db.Index("ix_showcase_profiles_player", "player_api_id", unique=True),)
+
+    id = db.Column(db.Integer, primary_key=True)
+    player_api_id = db.Column(db.Integer, nullable=False)  # API-Football player id (unique)
+    bio = db.Column(db.Text)
+    positions = db.Column(db.String(100))
+    preferred_foot = db.Column(db.String(10))  # left | right | both
+    height_cm = db.Column(db.Integer)
+    status = db.Column(db.String(20), nullable=False, default="pending")  # pending | approved
+    updated_by_user_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"), nullable=True)
+    reviewed_by = db.Column(db.String(200))  # admin email
+    reviewed_at = db.Column(db.DateTime)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
+    updated_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+
+    def public_dict(self):
+        """Fields exposed on the public player page (self-reported badge)."""
+        return {
+            "player_api_id": self.player_api_id,
+            "bio": self.bio,
+            "positions": self.positions,
+            "preferred_foot": self.preferred_foot,
+            "height_cm": self.height_cm,
+            "self_reported": True,
+        }
+
+    def owner_dict(self):
+        """Public fields plus moderation state — for owner + admin views."""
+        payload = self.public_dict()
+        payload["id"] = self.id
+        payload["status"] = self.status
+        payload["updated_at"] = self.updated_at.isoformat() if self.updated_at else None
+        return payload

--- a/academy-watch-backend/src/routes/api.py
+++ b/academy-watch-backend/src/routes/api.py
@@ -98,7 +98,12 @@ from src.utils.background_jobs import (
 )
 from src.utils.newsletter_slug import compose_newsletter_public_slug
 from src.utils.player_names import resolve_player_name
-from src.utils.sanitize import sanitize_comment_body, sanitize_commentary_html, sanitize_plain_text
+from src.utils.sanitize import (
+    is_safe_https_url,
+    sanitize_comment_body,
+    sanitize_commentary_html,
+    sanitize_plain_text,
+)
 from src.utils.slug import resolve_team_by_identifier
 from werkzeug.exceptions import HTTPException
 
@@ -1860,6 +1865,10 @@ def submit_player_link(player_id: int):
             return jsonify({"error": "url is required"}), 400
         if len(raw_url) > 500:
             return jsonify({"error": "url is too long"}), 400
+        # Reject javascript:/data:/non-https URLs — React does not neutralize
+        # javascript: hrefs, so an unchecked URL is a stored-XSS-on-click vector.
+        if not is_safe_https_url(raw_url):
+            return jsonify({"error": "url must be a valid https URL"}), 400
         raw_title = (payload.get("title") or "").strip()
         title = sanitize_plain_text(raw_title)[:200] if raw_title else None
         link_type = (payload.get("link_type") or "article").strip()

--- a/academy-watch-backend/src/routes/showcase.py
+++ b/academy-watch-backend/src/routes/showcase.py
@@ -1,0 +1,866 @@
+"""Talent Showcase blueprint — player-owned profiles, highlight reels, and
+club-verified footage evidence.
+
+Product slice:
+- Public: a player's showcase (curated YouTube reel + self-reported card +
+  club-verified appearance evidence from Film Room).
+- Users claim a player's profile; an admin approves; approved owners curate the
+  reel and profile. All owner-submitted content is pre-moderated (many players
+  are minors) — an edit reverts to ``pending`` and is hidden until re-approved.
+
+Reuse decisions (see the build contract):
+- Reel storage is the existing ``PlayerLink`` (``link_type='highlight'``); the
+  public reel merges newsletter YouTube links as synthetic read-only entries.
+- Link moderation reuses the existing ``/admin/player-links`` pipeline — no new
+  link-moderation endpoints here.
+- Auth mirrors ``routes/scout.py``: ``require_user_auth`` may leave ``g.user``
+  unset, so the account is resolved lazily; per-user rate limits key off the
+  authenticated email (the ingress proxy collapses per-IP buckets).
+"""
+
+import logging
+import re
+from datetime import UTC, datetime
+from urllib.parse import parse_qs, urlparse
+
+from flask import Blueprint, g, jsonify, request
+from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
+from src.auth import (
+    _ensure_user_account,
+    _safe_error_payload,
+    _user_serializer,
+    require_api_key,
+    require_user_auth,
+)
+from src.extensions import limiter
+from src.models.league import NewsletterPlayerYoutubeLink, PlayerLink, UserAccount, db
+from src.models.showcase import PlayerProfileClaim, PlayerShowcaseProfile
+from src.models.tracked_player import TrackedPlayer
+from src.models.video import VideoMatch, VideoPlayerReport, VideoRosterEntry
+from src.utils.sanitize import is_safe_https_url, sanitize_plain_text
+
+logger = logging.getLogger(__name__)
+
+showcase_bp = Blueprint("showcase", __name__)
+
+RELATIONSHIP_TYPES = {"player", "agent", "guardian", "club_official"}
+CLAIM_STATUSES = {"pending", "approved", "rejected", "revoked"}
+PROFILE_STATUSES = {"pending", "approved"}
+PREFERRED_FEET = {"left", "right", "both"}
+
+MAX_BIO_LENGTH = 2000
+MAX_POSITIONS_LENGTH = 100
+MAX_TITLE_LENGTH = 200
+MAX_MESSAGE_LENGTH = 1000
+MAX_URL_LENGTH = 500
+MAX_REEL_ITEMS = 20
+MIN_HEIGHT_CM = 100
+MAX_HEIGHT_CM = 260
+VERIFIED_FOOTAGE_CAP = 10
+PLAYER_SEARCH_CAP = 20
+
+# The only identity gate strong enough for public display (see models/video.py).
+VERIFIED_IDENTITY = "human_confirmed"
+
+
+# ---------------------------------------------------------------------------
+# Auth / account helpers (mirrors routes/scout.py)
+# ---------------------------------------------------------------------------
+
+
+def _user_rate_limit_key() -> str:
+    # remote_addr is the ingress proxy in production, so per-IP buckets collapse
+    # into one shared global bucket — key by the authenticated email.
+    return getattr(g, "user_email", None) or (request.remote_addr or "anon")
+
+
+def _current_user_account():
+    """UserAccount for the authenticated request, created on first use."""
+    user = getattr(g, "user", None)
+    if user is not None:
+        return user
+    email = getattr(g, "user_email", None)
+    if not email:
+        return None
+    user = UserAccount.query.filter_by(email=email).first()
+    if user is None:
+        user = _ensure_user_account(email)
+        db.session.commit()
+    return user
+
+
+def _has_approved_claim(player_api_id: int, user_id: int) -> bool:
+    return (
+        PlayerProfileClaim.query.filter_by(
+            player_api_id=player_api_id, user_account_id=user_id, status="approved"
+        ).first()
+        is not None
+    )
+
+
+def _optional_owner_user(player_api_id: int):
+    """The authenticated approved owner of this player, or None (optional auth).
+
+    Parses the Bearer manually — mirroring ``require_user_auth`` internals — so a
+    missing / expired / malformed token DEGRADES to the public view instead of
+    401. Returns the UserAccount only when the token is valid AND that user holds
+    an approved claim on the player. Any error → None (never raise).
+    """
+    try:
+        auth = request.headers.get("Authorization", "")
+        if not auth.startswith("Bearer "):
+            return None
+        token = auth.split(" ", 1)[1].strip()
+        if not token:
+            return None
+        data = _user_serializer().loads(token, max_age=60 * 60 * 24 * 30)
+        email = (data or {}).get("email")
+        if not email:
+            return None
+        user = UserAccount.query.filter_by(email=email).first()
+        if user is None or not _has_approved_claim(player_api_id, user.id):
+            return None
+        return user
+    except Exception:
+        # Bad/expired/malformed token, or any lookup error → public view.
+        return None
+
+
+def _approved_claim_or_403(player_api_id: int):
+    """Resolve the caller and require an approved claim for the player.
+
+    Returns ``(user, None)`` when the caller owns an approved claim, otherwise
+    ``(None, (response, status))`` for the route to return directly.
+    """
+    user = _current_user_account()
+    if user is None:
+        return None, (jsonify({"error": "auth context missing email"}), 401)
+    if not _has_approved_claim(player_api_id, user.id):
+        return None, (jsonify({"error": "You do not have an approved claim for this player"}), 403)
+    return user, None
+
+
+# ---------------------------------------------------------------------------
+# Text / URL validation
+# ---------------------------------------------------------------------------
+
+
+def _clean_optional_text(value, max_len: int):
+    """Bleach-clean a free-text field; empty/whitespace/non-str → None."""
+    if value is None or not isinstance(value, str):
+        return None
+    cleaned = sanitize_plain_text(value).strip()
+    return cleaned[:max_len] if cleaned else None
+
+
+def _youtube_video_id(url: str) -> str | None:
+    """Extract the YouTube video id from a safe https URL, else None.
+
+    Server-side port of the frontend ``extractYouTubeId`` — recognises
+    watch?v=, youtu.be/<id>, /embed/<id>, /shorts/<id>.
+    """
+    if not is_safe_https_url(url):
+        return None
+    try:
+        parsed = urlparse(url.strip())
+    except (ValueError, TypeError):
+        return None
+    host = (parsed.hostname or "").lower()
+    if host.startswith("www."):
+        host = host[4:]
+    if host == "youtu.be":
+        first = parsed.path.strip("/").split("/")[0]
+        return first or None
+    if host in ("youtube.com", "m.youtube.com"):
+        vid = parse_qs(parsed.query).get("v", [""])[0]
+        if vid:
+            return vid
+        match = re.match(r"^/(?:embed|shorts)/([^/?]+)", parsed.path)
+        return match.group(1) if match else None
+    return None
+
+
+def _is_youtube_url(url: str) -> bool:
+    """Server-side port of the frontend ``isYouTubeUrl`` (safe https + video id)."""
+    return _youtube_video_id(url) is not None
+
+
+# ---------------------------------------------------------------------------
+# Reel composition (shared public + owner)
+# ---------------------------------------------------------------------------
+
+
+def _link_dict(link: PlayerLink) -> dict:
+    """Compose a reel item dict — PlayerLink.to_dict lacks sort_order."""
+    return {
+        "id": link.id,
+        "player_id": link.player_id,
+        "url": link.url,
+        "title": link.title,
+        "link_type": link.link_type,
+        "status": link.status,
+        "upvotes": link.upvotes or 0,
+        "sort_order": link.sort_order if link.sort_order is not None else 0,
+        "source": "user",
+        "created_at": link.created_at.isoformat() if link.created_at else None,
+    }
+
+
+def _highlight_reel(player_api_id: int, *, include_pending: bool) -> list[dict]:
+    """The player's highlight reel: approved (and, for owners, pending) highlight
+    ``PlayerLink`` rows ordered by sort_order, then newsletter YouTube links
+    appended as synthetic read-only entries (dedup by URL; not reorderable)."""
+    statuses = ("approved", "pending") if include_pending else ("approved",)
+    order_col = func.coalesce(PlayerLink.sort_order, 0)
+    links = (
+        PlayerLink.query.filter(
+            PlayerLink.player_id == player_api_id,
+            PlayerLink.link_type == "highlight",
+            PlayerLink.status.in_(statuses),
+        )
+        .order_by(order_col.asc(), PlayerLink.upvotes.desc(), PlayerLink.created_at.desc())
+        .all()
+    )
+    results = [_link_dict(link) for link in links]
+
+    # Dedup by canonical YouTube video id (same video, different URL forms),
+    # falling back to the raw URL for non-YouTube approved highlights.
+    def _dedup_key(url: str) -> str:
+        return _youtube_video_id(url) or url
+
+    seen_urls = {_dedup_key(r["url"]) for r in results}
+    yt_rows = (
+        NewsletterPlayerYoutubeLink.query.filter_by(player_id=player_api_id)
+        .order_by(NewsletterPlayerYoutubeLink.created_at.desc())
+        .all()
+    )
+    for yt in yt_rows:
+        # Newsletter links are admin-entered with no write-side URL validation —
+        # only merge ones that are verifiably YouTube (defense in depth: a stored
+        # non-https URL must never reach the public <a href> sink).
+        if not _is_youtube_url(yt.youtube_link):
+            continue
+        if _dedup_key(yt.youtube_link) in seen_urls:
+            continue
+        seen_urls.add(_dedup_key(yt.youtube_link))
+        results.append(
+            {
+                "id": f"yt-{yt.id}",
+                "player_id": yt.player_id,
+                "url": yt.youtube_link,
+                "title": (yt.player_name + " Highlights") if yt.player_name else "Match Highlights",
+                "link_type": "highlight",
+                "status": "approved",
+                "upvotes": 0,
+                "sort_order": None,
+                "source": "newsletter",
+                "created_at": yt.created_at.isoformat() if yt.created_at else None,
+            }
+        )
+    return results
+
+
+def _resolve_player_name(player_api_id: int):
+    """Best-effort display name from the tracking universe (may be None)."""
+    tracked = TrackedPlayer.query.filter_by(player_api_id=player_api_id).order_by(TrackedPlayer.id).first()
+    return tracked.player_name if tracked and tracked.player_name else None
+
+
+# ---------------------------------------------------------------------------
+# Flywheel X — Film Room → verified footage evidence
+# ---------------------------------------------------------------------------
+
+
+def _verified_footage(player_api_id: int) -> list[dict]:
+    """Club-verified appearance evidence for a player.
+
+    Joins through the authoritative roster entry (not the denormalized report
+    column): a player's TrackedPlayer ids → roster entries linked to them →
+    their reports on finalized matches with ``human_confirmed`` identity. Any
+    exception degrades to ``[]`` — this must never break the showcase payload.
+    """
+    try:
+        tp_ids = [
+            row[0]
+            for row in db.session.query(TrackedPlayer.id).filter(TrackedPlayer.player_api_id == player_api_id).all()
+        ]
+        if not tp_ids:
+            return []
+
+        rows = (
+            db.session.query(VideoPlayerReport, VideoMatch)
+            .join(VideoRosterEntry, VideoRosterEntry.id == VideoPlayerReport.roster_entry_id)
+            .join(VideoMatch, VideoMatch.id == VideoPlayerReport.video_match_id)
+            .filter(VideoRosterEntry.tracked_player_id.in_(tp_ids))
+            .filter(VideoMatch.status == "finalized")
+            .filter(VideoPlayerReport.identity_confidence == VERIFIED_IDENTITY)
+            .order_by(VideoMatch.match_date.desc().nullslast(), VideoMatch.id.desc())
+            .limit(VERIFIED_FOOTAGE_CAP)
+            .all()
+        )
+
+        out = []
+        for report, match in rows:
+            coverage = report.coverage if isinstance(report.coverage, dict) else {}
+            evidence = report.identity_evidence if isinstance(report.identity_evidence, dict) else {}
+            out.append(
+                {
+                    "match_id": match.id,
+                    "match_date": match.match_date.isoformat() if match.match_date else None,
+                    "opponent_name": match.opponent_name,
+                    "team_name": match.team.name if match.team else None,
+                    "minutes_on_camera": report.minutes_visible,
+                    "pct_of_match": coverage.get("pct_of_match"),
+                    "identity_source": evidence.get("source") or VERIFIED_IDENTITY,
+                    "verified": True,
+                }
+            )
+        return out
+    except Exception as exc:
+        logger.warning("verified_footage failed for player %s: %s", player_api_id, exc)
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Public
+# ---------------------------------------------------------------------------
+
+
+@showcase_bp.route("/players/<int:player_api_id>/showcase", methods=["GET"])
+def get_player_showcase(player_api_id: int):
+    """Showcase payload: approved profile + reel + verified footage + claim status.
+
+    Optionally authenticated: an approved owner (valid Bearer) additionally sees
+    their own pending highlight items and a pending profile draft (each carrying
+    a ``status`` for the frontend's "pending review" badge). Anonymous, non-owner,
+    or bad-token callers get the approved-only public view — never a 401.
+    """
+    try:
+        is_owner = _optional_owner_user(player_api_id) is not None
+
+        profile_row = PlayerShowcaseProfile.query.filter_by(player_api_id=player_api_id).first()
+        if profile_row and profile_row.status == "approved":
+            profile = profile_row.public_dict()
+        elif profile_row and is_owner and profile_row.status == "pending":
+            # Owner sees their unpublished draft with its status; public does not.
+            profile = profile_row.owner_dict()
+        else:
+            profile = None
+
+        reel = _highlight_reel(player_api_id, include_pending=is_owner)
+
+        claimed = PlayerProfileClaim.query.filter_by(player_api_id=player_api_id, status="approved").first() is not None
+
+        return jsonify(
+            {
+                "player_api_id": player_api_id,
+                "profile": profile,
+                "reel": reel,
+                "verified_footage": _verified_footage(player_api_id),
+                "claim_status": "claimed" if claimed else "unclaimed",
+            }
+        )
+    except Exception as e:
+        logger.error("Error in get_player_showcase: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to load showcase")), 500
+
+
+# ---------------------------------------------------------------------------
+# User-authed — claims
+# ---------------------------------------------------------------------------
+
+
+@showcase_bp.route("/players/<int:player_api_id>/claim", methods=["POST"])
+@require_user_auth
+@limiter.limit("3 per hour", key_func=_user_rate_limit_key)
+def submit_profile_claim(player_api_id: int):
+    """Submit a pending claim to own a player's profile."""
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+
+        payload = request.get_json(silent=True) or {}
+        relationship_type = (payload.get("relationship_type") or "").strip().lower()
+        if relationship_type not in RELATIONSHIP_TYPES:
+            return jsonify({"error": f"relationship_type must be one of {sorted(RELATIONSHIP_TYPES)}"}), 400
+        message = _clean_optional_text(payload.get("message"), MAX_MESSAGE_LENGTH)
+
+        existing = PlayerProfileClaim.query.filter_by(player_api_id=player_api_id, user_account_id=user.id).first()
+        if existing:
+            if existing.status in ("rejected", "revoked"):
+                # Recovery path: a rejected/revoked claim may be resubmitted —
+                # reset it to pending for a fresh admin review.
+                existing.relationship_type = relationship_type
+                existing.message = message
+                existing.status = "pending"
+                existing.reviewed_by = None
+                existing.reviewed_at = None
+                existing.created_at = datetime.now(UTC)
+                db.session.commit()
+                return jsonify({"claim": existing.to_dict()}), 201
+            return jsonify(
+                {"error": "You have already submitted a claim for this player", "claim": existing.to_dict()}
+            ), 409
+
+        claim = PlayerProfileClaim(
+            player_api_id=player_api_id,
+            user_account_id=user.id,
+            relationship_type=relationship_type,
+            message=message,
+            status="pending",
+        )
+        db.session.add(claim)
+        try:
+            db.session.commit()
+        except IntegrityError:
+            # Lost the unique-constraint race (double submit) — honour idempotency with 409.
+            db.session.rollback()
+            existing = PlayerProfileClaim.query.filter_by(player_api_id=player_api_id, user_account_id=user.id).first()
+            if existing is not None:
+                return jsonify(
+                    {"error": "You have already submitted a claim for this player", "claim": existing.to_dict()}
+                ), 409
+            raise
+        return jsonify({"claim": claim.to_dict()}), 201
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in submit_profile_claim: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to submit claim")), 500
+
+
+@showcase_bp.route("/me/claims", methods=["GET"])
+@require_user_auth
+@limiter.limit("60 per minute", key_func=_user_rate_limit_key)
+def my_claims():
+    """The authenticated user's claims with statuses and best-effort player names."""
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        claims = (
+            PlayerProfileClaim.query.filter_by(user_account_id=user.id)
+            .order_by(PlayerProfileClaim.created_at.desc(), PlayerProfileClaim.id.desc())
+            .all()
+        )
+        out = []
+        for claim in claims:
+            payload = claim.to_dict()
+            payload["player_name"] = _resolve_player_name(claim.player_api_id)
+            out.append(payload)
+        return jsonify({"claims": out})
+    except Exception as e:
+        logger.error("Error in my_claims: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to load claims")), 500
+
+
+# ---------------------------------------------------------------------------
+# Owner-gated — profile + reel curation
+# ---------------------------------------------------------------------------
+
+
+@showcase_bp.route("/players/<int:player_api_id>/showcase/profile", methods=["PUT"])
+@require_user_auth
+@limiter.limit("20 per hour", key_func=_user_rate_limit_key)
+def upsert_showcase_profile(player_api_id: int):
+    """Upsert the self-reported profile card. Any edit reverts to pending
+    (hidden from public until an admin re-approves)."""
+    try:
+        user, error = _approved_claim_or_403(player_api_id)
+        if error:
+            return error
+
+        payload = request.get_json(silent=True) or {}
+        bio = _clean_optional_text(payload.get("bio"), MAX_BIO_LENGTH)
+        positions = _clean_optional_text(payload.get("positions"), MAX_POSITIONS_LENGTH)
+
+        preferred_foot = payload.get("preferred_foot")
+        if preferred_foot is not None:
+            preferred_foot = str(preferred_foot).strip().lower() or None
+            if preferred_foot and preferred_foot not in PREFERRED_FEET:
+                return jsonify({"error": f"preferred_foot must be one of {sorted(PREFERRED_FEET)}"}), 400
+
+        height_cm = payload.get("height_cm")
+        if height_cm is not None:
+            if isinstance(height_cm, bool) or not isinstance(height_cm, int):
+                return jsonify({"error": "height_cm must be an integer"}), 400
+            if height_cm < MIN_HEIGHT_CM or height_cm > MAX_HEIGHT_CM:
+                return jsonify({"error": f"height_cm must be between {MIN_HEIGHT_CM} and {MAX_HEIGHT_CM}"}), 400
+
+        profile = PlayerShowcaseProfile.query.filter_by(player_api_id=player_api_id).first()
+        if profile is None:
+            profile = PlayerShowcaseProfile(player_api_id=player_api_id)
+            db.session.add(profile)
+        profile.bio = bio
+        profile.positions = positions
+        profile.preferred_foot = preferred_foot
+        profile.height_cm = height_cm
+        profile.status = "pending"  # owner edit → pending; hidden until re-approved
+        profile.updated_by_user_id = user.id
+        db.session.commit()
+        return jsonify({"profile": profile.owner_dict()})
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in upsert_showcase_profile: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to save profile")), 500
+
+
+@showcase_bp.route("/players/<int:player_api_id>/showcase/reel", methods=["POST"])
+@require_user_auth
+@limiter.limit("30 per hour", key_func=_user_rate_limit_key)
+def add_reel_item(player_api_id: int):
+    """Add a pending YouTube highlight to the player's reel (goes to moderation)."""
+    try:
+        user, error = _approved_claim_or_403(player_api_id)
+        if error:
+            return error
+
+        payload = request.get_json(silent=True) or {}
+        raw_url = (payload.get("url") or "").strip()
+        if not raw_url:
+            return jsonify({"error": "url is required"}), 400
+        if len(raw_url) > MAX_URL_LENGTH:
+            return jsonify({"error": "url is too long"}), 400
+        if not _is_youtube_url(raw_url):
+            return jsonify({"error": "url must be a valid https YouTube link"}), 400
+        title = _clean_optional_text(payload.get("title"), MAX_TITLE_LENGTH)
+
+        # Cap the whole player's reel (any status) so pending submissions can't grow unbounded.
+        count = PlayerLink.query.filter_by(player_id=player_api_id, link_type="highlight").count()
+        if count >= MAX_REEL_ITEMS:
+            return jsonify({"error": f"reel limit reached ({MAX_REEL_ITEMS})"}), 400
+
+        link = PlayerLink(
+            player_id=player_api_id,
+            user_id=user.id,
+            url=raw_url,
+            title=title,
+            link_type="highlight",
+            status="pending",
+            sort_order=count,
+        )
+        db.session.add(link)
+        db.session.commit()
+        return jsonify({"link": _link_dict(link)}), 201
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in add_reel_item: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to add reel item")), 500
+
+
+@showcase_bp.route("/players/<int:player_api_id>/showcase/reel/order", methods=["PATCH"])
+@require_user_auth
+@limiter.limit("30 per hour", key_func=_user_rate_limit_key)
+def reorder_reel(player_api_id: int):
+    """Set sort_order from an ordered id list. Only integer PlayerLink ids that
+    belong to this player and are highlights apply; foreign and synthetic
+    ``yt-*`` ids are ignored."""
+    try:
+        user, error = _approved_claim_or_403(player_api_id)
+        if error:
+            return error
+
+        payload = request.get_json(silent=True) or {}
+        ordered_ids = payload.get("ordered_ids")
+        if not isinstance(ordered_ids, list):
+            return jsonify({"error": "ordered_ids must be a list"}), 400
+
+        own_links = {
+            link.id: link for link in PlayerLink.query.filter_by(player_id=player_api_id, link_type="highlight").all()
+        }
+        position = 0
+        for link_id in ordered_ids:
+            if isinstance(link_id, bool) or not isinstance(link_id, int):
+                continue  # synthetic "yt-*" (string) / malformed ids are not reorderable
+            link = own_links.get(link_id)
+            if link is None:
+                continue  # foreign id — ignore
+            link.sort_order = position
+            position += 1
+        db.session.commit()
+        return jsonify({"reel": _highlight_reel(player_api_id, include_pending=True)})
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in reorder_reel: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to reorder reel")), 500
+
+
+@showcase_bp.route("/players/<int:player_api_id>/showcase/reel/<int:link_id>", methods=["DELETE"])
+@require_user_auth
+@limiter.limit("30 per hour", key_func=_user_rate_limit_key)
+def delete_reel_item(player_api_id: int, link_id: int):
+    """Delete a reel item — only the submitter or an approved owner of the player.
+    Synthetic ``yt-*`` ids never match this integer route (not deletable)."""
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        link = PlayerLink.query.filter_by(id=link_id, player_id=player_api_id, link_type="highlight").first()
+        if link is None:
+            return jsonify({"error": "reel item not found"}), 404
+        if link.user_id != user.id and not _has_approved_claim(player_api_id, user.id):
+            return jsonify({"error": "You are not permitted to delete this reel item"}), 403
+        db.session.delete(link)
+        db.session.commit()
+        return jsonify({"deleted": True})
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in delete_reel_item: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to delete reel item")), 500
+
+
+# ---------------------------------------------------------------------------
+# Admin — claim + profile review
+# ---------------------------------------------------------------------------
+
+
+@showcase_bp.route("/admin/showcase/claims", methods=["GET"])
+@require_api_key
+def admin_list_claims():
+    """List profile claims, optionally filtered by status."""
+    try:
+        status = (request.args.get("status") or "").strip().lower()
+        query = PlayerProfileClaim.query
+        if status:
+            if status not in CLAIM_STATUSES:
+                return jsonify({"error": f"invalid status; one of {sorted(CLAIM_STATUSES)}"}), 400
+            query = query.filter(PlayerProfileClaim.status == status)
+        claims = query.order_by(PlayerProfileClaim.created_at.desc(), PlayerProfileClaim.id.desc()).all()
+        out = []
+        for claim in claims:
+            payload = claim.to_dict()
+            payload["player_name"] = _resolve_player_name(claim.player_api_id)
+            payload["user_email"] = claim.user.email if claim.user else None
+            out.append(payload)
+        return jsonify({"claims": out})
+    except Exception as e:
+        logger.error("Error in admin_list_claims: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to load claims")), 500
+
+
+@showcase_bp.route("/admin/showcase/claims/<int:claim_id>/review", methods=["POST"])
+@require_api_key
+def admin_review_claim(claim_id: int):
+    """Transition a claim: pending → approved|rejected, approved → revoked.
+    Approving does NOT auto-revoke other approved claims (player + agent may co-own)."""
+    try:
+        claim = db.session.get(PlayerProfileClaim, claim_id)
+        if claim is None:
+            return jsonify({"error": "claim not found"}), 404
+
+        payload = request.get_json(silent=True) or {}
+        action = (payload.get("action") or "").strip().lower()
+        # approve doubles as the recovery path for mistaken rejections/revocations.
+        transitions = {
+            "approve": ({"pending", "rejected", "revoked"}, "approved"),
+            "reject": ({"pending"}, "rejected"),
+            "revoke": ({"approved"}, "revoked"),
+        }
+        if action not in transitions:
+            return jsonify({"error": "action must be approve, reject, or revoke"}), 400
+        allowed_from, target = transitions[action]
+        if claim.status not in allowed_from:
+            return jsonify({"error": f"cannot {action} a {claim.status} claim"}), 409
+
+        claim.status = target
+        claim.reviewed_by = getattr(g, "user_email", None)
+        claim.reviewed_at = datetime.now(UTC)
+        db.session.commit()
+        return jsonify({"claim": claim.to_dict()})
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in admin_review_claim: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to review claim")), 500
+
+
+@showcase_bp.route("/admin/showcase/profiles", methods=["GET"])
+@require_api_key
+def admin_list_profiles():
+    """List showcase profiles (default: pending edits awaiting review)."""
+    try:
+        status = (request.args.get("status") or "pending").strip().lower()
+        query = PlayerShowcaseProfile.query
+        if status and status != "all":
+            if status not in PROFILE_STATUSES:
+                return jsonify({"error": f"invalid status; one of {sorted(PROFILE_STATUSES)}"}), 400
+            query = query.filter(PlayerShowcaseProfile.status == status)
+        profiles = query.order_by(PlayerShowcaseProfile.updated_at.desc().nullslast()).all()
+        out = []
+        for profile in profiles:
+            payload = profile.owner_dict()
+            payload["player_name"] = _resolve_player_name(profile.player_api_id)
+            out.append(payload)
+        return jsonify({"profiles": out})
+    except Exception as e:
+        logger.error("Error in admin_list_profiles: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to load profiles")), 500
+
+
+@showcase_bp.route("/admin/showcase/profiles/<int:player_api_id>/review", methods=["POST"])
+@require_api_key
+def admin_review_profile(player_api_id: int):
+    """Approve (publish) or reject (keep hidden/pending) a showcase profile edit."""
+    try:
+        profile = PlayerShowcaseProfile.query.filter_by(player_api_id=player_api_id).first()
+        if profile is None:
+            return jsonify({"error": "profile not found"}), 404
+        payload = request.get_json(silent=True) or {}
+        action = (payload.get("action") or "").strip().lower()
+        if action not in ("approve", "reject"):
+            return jsonify({"error": "action must be approve or reject"}), 400
+        profile.status = "approved" if action == "approve" else "pending"
+        profile.reviewed_by = getattr(g, "user_email", None)
+        profile.reviewed_at = datetime.now(UTC)
+        db.session.commit()
+        return jsonify({"profile": profile.owner_dict()})
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in admin_review_profile: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to review profile")), 500
+
+
+# ---------------------------------------------------------------------------
+# Admin — Flywheel X (Film Room roster linking)
+# ---------------------------------------------------------------------------
+
+
+@showcase_bp.route("/admin/showcase/video-rosters", methods=["GET"])
+@require_api_key
+def admin_list_video_rosters():
+    """Finalized matches' roster entries with current tracked_player links and
+    each report's identity summary. Filter by match_id or player_api_id."""
+    try:
+        match_id = request.args.get("match_id", type=int)
+        player_api_id = request.args.get("player_api_id", type=int)
+
+        query = (
+            db.session.query(VideoRosterEntry, VideoMatch)
+            .join(VideoMatch, VideoMatch.id == VideoRosterEntry.video_match_id)
+            .filter(VideoMatch.status == "finalized")
+        )
+        if match_id:
+            query = query.filter(VideoMatch.id == match_id)
+        if player_api_id:
+            tp_ids = [
+                row[0]
+                for row in db.session.query(TrackedPlayer.id).filter(TrackedPlayer.player_api_id == player_api_id).all()
+            ]
+            if not tp_ids:
+                return jsonify({"rosters": []})
+            query = query.filter(VideoRosterEntry.tracked_player_id.in_(tp_ids))
+
+        rows = query.order_by(VideoMatch.match_date.desc().nullslast(), VideoRosterEntry.jersey_number).all()
+        out = []
+        for roster, match in rows:
+            report = VideoPlayerReport.query.filter_by(video_match_id=match.id, roster_entry_id=roster.id).first()
+            linked = db.session.get(TrackedPlayer, roster.tracked_player_id) if roster.tracked_player_id else None
+            out.append(
+                {
+                    "roster_id": roster.id,
+                    "match_id": match.id,
+                    "match_date": match.match_date.isoformat() if match.match_date else None,
+                    "opponent_name": match.opponent_name,
+                    "team_id": match.team_id,
+                    "team_name": match.team.name if match.team else None,
+                    "player_name": roster.player_name,
+                    "jersey_number": roster.jersey_number,
+                    "tracked_player_id": roster.tracked_player_id,
+                    "linked_player_api_id": linked.player_api_id if linked else None,
+                    "linked_player_name": linked.player_name if linked else None,
+                    "identity_confidence": report.identity_confidence if report else None,
+                    "has_report": report is not None,
+                }
+            )
+        return jsonify({"rosters": out})
+    except Exception as e:
+        logger.error("Error in admin_list_video_rosters: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to load video rosters")), 500
+
+
+@showcase_bp.route("/admin/showcase/video-rosters/<int:roster_id>/link", methods=["PUT"])
+@require_api_key
+def admin_link_video_roster(roster_id: int):
+    """Link (or clear) a roster entry to a tracked player. Resolves player_api_id
+    to a TrackedPlayer (prefer the match's team, else an active row) and updates
+    BOTH the roster and the denormalized column on its existing reports."""
+    try:
+        roster = db.session.get(VideoRosterEntry, roster_id)
+        if roster is None:
+            return jsonify({"error": "roster entry not found"}), 404
+
+        payload = request.get_json(silent=True) or {}
+        player_api_id = payload.get("player_api_id")
+
+        if player_api_id is None:
+            roster.tracked_player_id = None
+            for report in VideoPlayerReport.query.filter_by(roster_entry_id=roster.id).all():
+                report.tracked_player_id = None
+            db.session.commit()
+            return jsonify({"roster": roster.to_dict()})
+
+        if isinstance(player_api_id, bool) or not isinstance(player_api_id, int):
+            return jsonify({"error": "player_api_id must be an integer or null"}), 400
+
+        candidates = TrackedPlayer.query.filter_by(player_api_id=player_api_id).all()
+        if not candidates:
+            return jsonify({"error": "no tracked player with that id"}), 404
+
+        match = db.session.get(VideoMatch, roster.video_match_id)
+        tracked = None
+        if match is not None:
+            tracked = next(
+                (c for c in candidates if match.team_id in (c.current_club_db_id, c.team_id)),
+                None,
+            )
+        if tracked is None:
+            tracked = next((c for c in candidates if c.is_active), None) or candidates[0]
+
+        roster.tracked_player_id = tracked.id
+        for report in VideoPlayerReport.query.filter_by(roster_entry_id=roster.id).all():
+            report.tracked_player_id = tracked.id
+        db.session.commit()
+        return jsonify({"roster": roster.to_dict(), "tracked_player_id": tracked.id})
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in admin_link_video_roster: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to link roster entry")), 500
+
+
+@showcase_bp.route("/admin/showcase/player-search", methods=["GET"])
+@require_api_key
+def admin_player_search():
+    """Search active tracked players by name for the roster-linking UI (cap 20)."""
+    try:
+        q = (request.args.get("q") or "").strip()
+        if not q:
+            return jsonify({"players": []})
+        rows = (
+            TrackedPlayer.query.filter(
+                TrackedPlayer.player_name.ilike(f"%{q}%"),
+                TrackedPlayer.is_active.is_(True),
+            )
+            .order_by(TrackedPlayer.player_name)
+            .limit(PLAYER_SEARCH_CAP * 3)
+            .all()
+        )
+        seen = set()
+        out = []
+        for tracked in rows:
+            if tracked.player_api_id in seen:
+                continue
+            seen.add(tracked.player_api_id)
+            out.append(
+                {
+                    "player_api_id": tracked.player_api_id,
+                    "player_name": tracked.player_name,
+                    "team_name": tracked.team.name if tracked.team else None,
+                    "status": tracked.status,
+                }
+            )
+            if len(out) >= PLAYER_SEARCH_CAP:
+                break
+        return jsonify({"players": out})
+    except Exception as e:
+        logger.error("Error in admin_player_search: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to search players")), 500

--- a/academy-watch-backend/src/utils/sanitize.py
+++ b/academy-watch-backend/src/utils/sanitize.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from urllib.parse import urlparse
+
 import bleach
 
 # Allow only very basic formatting; expand if richer markup is desired later.
@@ -72,4 +74,27 @@ def sanitize_commentary_html(value: str) -> str:
     return cleaned
 
 
-__all__ = ["sanitize_comment_body", "sanitize_plain_text", "sanitize_commentary_html"]
+def is_safe_https_url(value: str) -> bool:
+    """True only for a well-formed absolute ``https://`` URL.
+
+    Rejects ``javascript:``, ``data:``, ``mailto:`` and every non-https scheme
+    outright. User-submitted URLs are rendered as link ``href``s; React does not
+    neutralise ``javascript:`` hrefs, so an unvalidated URL is a stored
+    XSS-on-click vector. A single shared check keeps player links and showcase
+    reel items on the same allow-list.
+    """
+    if not value or not isinstance(value, str):
+        return False
+    try:
+        parsed = urlparse(value.strip())
+    except (ValueError, TypeError):
+        return False
+    return parsed.scheme == "https" and bool(parsed.netloc)
+
+
+__all__ = [
+    "sanitize_comment_body",
+    "sanitize_plain_text",
+    "sanitize_commentary_html",
+    "is_safe_https_url",
+]

--- a/academy-watch-backend/tests/test_showcase.py
+++ b/academy-watch-backend/tests/test_showcase.py
@@ -1,0 +1,810 @@
+"""Tests for the Talent Showcase blueprint (src/routes/showcase.py).
+
+Covers claims (create / dedupe / review transitions / permissions / revoke),
+owner-gated profile + reel curation (owner gate, validation, moderation
+visibility, reorder), the public payload shape, Flywheel X verified footage +
+roster linking, and the submit_player_link URL hardening in api.py.
+"""
+
+from datetime import date
+
+import pytest
+from flask import Flask
+from src.auth import _ensure_user_account, issue_user_token
+from src.models.league import League, PlayerLink, Team, db
+from src.models.showcase import PlayerProfileClaim, PlayerShowcaseProfile
+from src.models.tracked_player import TrackedPlayer
+from src.models.video import VideoMatch, VideoPlayerReport, VideoRosterEntry
+
+ADMIN_KEY = "test-admin-key"
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("SKIP_API_HANDSHAKE", "1")
+    monkeypatch.setenv("API_USE_STUB_DATA", "true")
+    monkeypatch.setenv("ADMIN_API_KEY", ADMIN_KEY)
+    monkeypatch.setenv("ADMIN_IP_WHITELIST", "")
+
+    from src.routes.api import api_bp
+    from src.routes.showcase import showcase_bp
+
+    flask_app = Flask(__name__)
+    flask_app.config.update(
+        TESTING=True,
+        SECRET_KEY="test-secret-key",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        RATELIMIT_ENABLED=False,
+    )
+
+    db.init_app(flask_app)
+    flask_app.register_blueprint(showcase_bp, url_prefix="/api")
+    flask_app.register_blueprint(api_bp, url_prefix="/api")
+
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _user_headers(email):
+    token = issue_user_token(email)["token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _admin_headers():
+    token = issue_user_token("admin@test.com", role="admin")["token"]
+    return {"Authorization": f"Bearer {token}", "X-API-Key": ADMIN_KEY}
+
+
+def _make_user(email):
+    user = _ensure_user_account(email)
+    db.session.commit()
+    return user
+
+
+def _seed_team(team_id=33, name="Manchester United"):
+    league = League.query.filter_by(league_id=39).first()
+    if league is None:
+        league = League(league_id=39, name="Premier League", country="England", season=2025)
+        db.session.add(league)
+        db.session.flush()
+    team = Team(team_id=team_id, name=name, country="England", season=2025, league_id=league.id, is_active=True)
+    db.session.add(team)
+    db.session.flush()
+    return team
+
+
+def _tracked(team, player_api_id=5001, name="Kobbie Mainoo", **kwargs):
+    tp = TrackedPlayer(
+        player_api_id=player_api_id,
+        player_name=name,
+        team_id=team.id,
+        status=kwargs.pop("status", "academy"),
+        is_active=kwargs.pop("is_active", True),
+        **kwargs,
+    )
+    db.session.add(tp)
+    db.session.flush()
+    return tp
+
+
+def _approved_claim(player_api_id, email):
+    user = _make_user(email)
+    claim = PlayerProfileClaim(
+        player_api_id=player_api_id,
+        user_account_id=user.id,
+        relationship_type="player",
+        status="approved",
+    )
+    db.session.add(claim)
+    db.session.commit()
+    return user, claim
+
+
+def _finalized_match(team, opponent="Rivals FC", status="finalized", match_date=None):
+    match = VideoMatch(
+        team_id=team.id,
+        opponent_name=opponent,
+        status=status,
+        match_date=match_date or date(2025, 9, 1),
+    )
+    db.session.add(match)
+    db.session.flush()
+    return match
+
+
+def _roster(match, tp_id=None, name="Kobbie Mainoo", number=37):
+    entry = VideoRosterEntry(
+        video_match_id=match.id,
+        player_name=name,
+        jersey_number=number,
+        tracked_player_id=tp_id,
+    )
+    db.session.add(entry)
+    db.session.flush()
+    return entry
+
+
+def _report(match, roster, tp_id=None, identity="human_confirmed", minutes=87.0, pct=72):
+    rep = VideoPlayerReport(
+        video_match_id=match.id,
+        roster_entry_id=roster.id,
+        tracked_player_id=tp_id,
+        minutes_visible=minutes,
+        identity_confidence=identity,
+        coverage={"pct_of_match": pct},
+        model_version="v1",
+    )
+    db.session.add(rep)
+    db.session.flush()
+    return rep
+
+
+# --------------------------------------------------------------------------- #
+# Claims
+# --------------------------------------------------------------------------- #
+
+
+class TestClaims:
+    def test_create_claim_returns_pending(self, client):
+        resp = client.post(
+            "/api/players/5001/claim",
+            json={"relationship_type": "player", "message": "This is me"},
+            headers=_user_headers("kobbie@example.com"),
+        )
+        assert resp.status_code == 201
+        claim = resp.get_json()["claim"]
+        assert claim["status"] == "pending"
+        assert claim["relationship_type"] == "player"
+        assert claim["message"] == "This is me"
+
+    def test_duplicate_claim_returns_409(self, client):
+        headers = _user_headers("kobbie@example.com")
+        first = client.post("/api/players/5001/claim", json={"relationship_type": "player"}, headers=headers)
+        assert first.status_code == 201
+        dupe = client.post("/api/players/5001/claim", json={"relationship_type": "agent"}, headers=headers)
+        assert dupe.status_code == 409
+
+    def test_invalid_relationship_type_rejected(self, client):
+        resp = client.post(
+            "/api/players/5001/claim",
+            json={"relationship_type": "manager"},
+            headers=_user_headers("kobbie@example.com"),
+        )
+        assert resp.status_code == 400
+
+    def test_claim_requires_auth(self, client):
+        resp = client.post("/api/players/5001/claim", json={"relationship_type": "player"})
+        assert resp.status_code == 401
+
+    def test_me_claims_lists_own_claims(self, app, client):
+        with app.app_context():
+            team = _seed_team()
+            _tracked(team, player_api_id=5001, name="Kobbie Mainoo")
+            db.session.commit()
+        headers = _user_headers("kobbie@example.com")
+        client.post("/api/players/5001/claim", json={"relationship_type": "player"}, headers=headers)
+        resp = client.get("/api/me/claims", headers=headers)
+        assert resp.status_code == 200
+        claims = resp.get_json()["claims"]
+        assert len(claims) == 1
+        assert claims[0]["player_api_id"] == 5001
+        assert claims[0]["player_name"] == "Kobbie Mainoo"
+
+
+class TestAdminClaimReview:
+    def test_approve_then_public_claim_status_claimed(self, app, client):
+        headers = _user_headers("kobbie@example.com")
+        create = client.post("/api/players/5001/claim", json={"relationship_type": "player"}, headers=headers)
+        claim_id = create.get_json()["claim"]["id"]
+
+        review = client.post(
+            f"/api/admin/showcase/claims/{claim_id}/review",
+            json={"action": "approve"},
+            headers=_admin_headers(),
+        )
+        assert review.status_code == 200
+        assert review.get_json()["claim"]["status"] == "approved"
+        assert review.get_json()["claim"]["reviewed_by"] == "admin@test.com"
+
+        public = client.get("/api/players/5001/showcase")
+        assert public.get_json()["claim_status"] == "claimed"
+
+    def test_reject_pending_claim(self, client):
+        headers = _user_headers("kobbie@example.com")
+        claim_id = client.post(
+            "/api/players/5001/claim", json={"relationship_type": "player"}, headers=headers
+        ).get_json()["claim"]["id"]
+        review = client.post(
+            f"/api/admin/showcase/claims/{claim_id}/review", json={"action": "reject"}, headers=_admin_headers()
+        )
+        assert review.status_code == 200
+        assert review.get_json()["claim"]["status"] == "rejected"
+
+    def test_revoke_requires_approved(self, client):
+        headers = _user_headers("kobbie@example.com")
+        claim_id = client.post(
+            "/api/players/5001/claim", json={"relationship_type": "player"}, headers=headers
+        ).get_json()["claim"]["id"]
+        # pending → revoke is invalid
+        bad = client.post(
+            f"/api/admin/showcase/claims/{claim_id}/review", json={"action": "revoke"}, headers=_admin_headers()
+        )
+        assert bad.status_code == 409
+        # approve, then revoke succeeds
+        client.post(
+            f"/api/admin/showcase/claims/{claim_id}/review", json={"action": "approve"}, headers=_admin_headers()
+        )
+        good = client.post(
+            f"/api/admin/showcase/claims/{claim_id}/review", json={"action": "revoke"}, headers=_admin_headers()
+        )
+        assert good.status_code == 200
+        assert good.get_json()["claim"]["status"] == "revoked"
+
+    def test_approve_does_not_revoke_other_claims(self, app, client):
+        # A player and an agent both claim; approving one leaves the other untouched.
+        client.post(
+            "/api/players/5001/claim", json={"relationship_type": "player"}, headers=_user_headers("player@x.com")
+        )
+        client.post(
+            "/api/players/5001/claim", json={"relationship_type": "agent"}, headers=_user_headers("agent@x.com")
+        )
+        with app.app_context():
+            claims = PlayerProfileClaim.query.filter_by(player_api_id=5001).order_by(PlayerProfileClaim.id).all()
+            first_id = claims[0].id
+        client.post(
+            f"/api/admin/showcase/claims/{first_id}/review", json={"action": "approve"}, headers=_admin_headers()
+        )
+        listing = client.get("/api/admin/showcase/claims", headers=_admin_headers()).get_json()["claims"]
+        statuses = sorted(c["status"] for c in listing)
+        assert statuses == ["approved", "pending"]
+
+    def test_review_requires_admin(self, client):
+        headers = _user_headers("kobbie@example.com")
+        claim_id = client.post(
+            "/api/players/5001/claim", json={"relationship_type": "player"}, headers=headers
+        ).get_json()["claim"]["id"]
+        # A plain user Bearer token (no admin role / X-API-Key) is rejected.
+        resp = client.post(f"/api/admin/showcase/claims/{claim_id}/review", json={"action": "approve"}, headers=headers)
+        assert resp.status_code in (401, 403)
+
+
+# --------------------------------------------------------------------------- #
+# Owner gate + profile
+# --------------------------------------------------------------------------- #
+
+
+class TestProfileOwnerGate:
+    def test_non_owner_cannot_edit_profile(self, client):
+        # No claim at all → 403.
+        resp = client.put(
+            "/api/players/5001/showcase/profile",
+            json={"bio": "hi"},
+            headers=_user_headers("stranger@example.com"),
+        )
+        assert resp.status_code == 403
+
+    def test_pending_claim_is_not_owner(self, client):
+        headers = _user_headers("kobbie@example.com")
+        client.post("/api/players/5001/claim", json={"relationship_type": "player"}, headers=headers)
+        # Claim is pending (unapproved) → still not an owner.
+        resp = client.put("/api/players/5001/showcase/profile", json={"bio": "hi"}, headers=headers)
+        assert resp.status_code == 403
+
+    def test_owner_edit_goes_pending_and_hidden_until_approved(self, app, client):
+        with app.app_context():
+            _approved_claim(5001, "kobbie@example.com")
+        headers = _user_headers("kobbie@example.com")
+
+        put = client.put(
+            "/api/players/5001/showcase/profile",
+            json={"bio": "Academy graduate", "positions": "CM", "preferred_foot": "right", "height_cm": 180},
+            headers=headers,
+        )
+        assert put.status_code == 200
+        assert put.get_json()["profile"]["status"] == "pending"
+
+        # Public payload hides the pending profile.
+        public = client.get("/api/players/5001/showcase").get_json()
+        assert public["profile"] is None
+
+        # Admin approves → now public.
+        approve = client.post(
+            "/api/admin/showcase/profiles/5001/review", json={"action": "approve"}, headers=_admin_headers()
+        )
+        assert approve.status_code == 200
+        public = client.get("/api/players/5001/showcase").get_json()
+        assert public["profile"] is not None
+        assert public["profile"]["bio"] == "Academy graduate"
+        assert public["profile"]["self_reported"] is True
+
+    def test_invalid_preferred_foot_and_height(self, app, client):
+        with app.app_context():
+            _approved_claim(5001, "kobbie@example.com")
+        headers = _user_headers("kobbie@example.com")
+        assert (
+            client.put(
+                "/api/players/5001/showcase/profile", json={"preferred_foot": "sideways"}, headers=headers
+            ).status_code
+            == 400
+        )
+        assert (
+            client.put("/api/players/5001/showcase/profile", json={"height_cm": 5}, headers=headers).status_code == 400
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Reel
+# --------------------------------------------------------------------------- #
+
+
+class TestReel:
+    def _own(self, app):
+        with app.app_context():
+            _approved_claim(5001, "kobbie@example.com")
+
+    def test_add_youtube_item_then_moderation_visibility(self, app, client):
+        self._own(app)
+        headers = _user_headers("kobbie@example.com")
+        resp = client.post(
+            "/api/players/5001/showcase/reel",
+            json={"url": "https://www.youtube.com/watch?v=abc123", "title": "Screamer"},
+            headers=headers,
+        )
+        assert resp.status_code == 201
+        assert resp.get_json()["link"]["status"] == "pending"
+
+        # Pending item is invisible to the public reel.
+        public = client.get("/api/players/5001/showcase").get_json()
+        assert public["reel"] == []
+
+    def test_non_youtube_url_rejected(self, app, client):
+        self._own(app)
+        resp = client.post(
+            "/api/players/5001/showcase/reel",
+            json={"url": "https://vimeo.com/12345"},
+            headers=_user_headers("kobbie@example.com"),
+        )
+        assert resp.status_code == 400
+
+    def test_non_https_url_rejected(self, app, client):
+        self._own(app)
+        headers = _user_headers("kobbie@example.com")
+        for bad in ("javascript:alert(1)", "http://www.youtube.com/watch?v=abc"):
+            resp = client.post("/api/players/5001/showcase/reel", json={"url": bad}, headers=headers)
+            assert resp.status_code == 400, bad
+
+    def test_reel_cap_enforced(self, app, client):
+        with app.app_context():
+            _approved_claim(5001, "kobbie@example.com")
+            for i in range(20):
+                db.session.add(
+                    PlayerLink(
+                        player_id=5001,
+                        url=f"https://youtu.be/vid{i}",
+                        link_type="highlight",
+                        status="approved",
+                    )
+                )
+            db.session.commit()
+        resp = client.post(
+            "/api/players/5001/showcase/reel",
+            json={"url": "https://youtu.be/onemore"},
+            headers=_user_headers("kobbie@example.com"),
+        )
+        assert resp.status_code == 400
+
+    def test_approved_highlight_appears_in_public_reel(self, app, client):
+        with app.app_context():
+            db.session.add(
+                PlayerLink(
+                    player_id=5001,
+                    url="https://youtu.be/approved1",
+                    title="Best bits",
+                    link_type="highlight",
+                    status="approved",
+                    sort_order=0,
+                )
+            )
+            db.session.commit()
+        public = client.get("/api/players/5001/showcase").get_json()
+        assert len(public["reel"]) == 1
+        assert public["reel"][0]["url"] == "https://youtu.be/approved1"
+        assert public["reel"][0]["sort_order"] == 0
+
+    def test_reorder_ignores_foreign_and_synthetic_ids(self, app, client):
+        with app.app_context():
+            _approved_claim(5001, "kobbie@example.com")
+            a = PlayerLink(player_id=5001, url="https://youtu.be/a", link_type="highlight", status="approved")
+            b = PlayerLink(player_id=5001, url="https://youtu.be/b", link_type="highlight", status="approved")
+            # A link belonging to a DIFFERENT player — must be ignored by reorder.
+            foreign = PlayerLink(player_id=9999, url="https://youtu.be/f", link_type="highlight", status="approved")
+            db.session.add_all([a, b, foreign])
+            db.session.commit()
+            a_id, b_id, foreign_id = a.id, b.id, foreign.id
+
+        headers = _user_headers("kobbie@example.com")
+        resp = client.patch(
+            "/api/players/5001/showcase/reel/order",
+            json={"ordered_ids": [b_id, a_id, foreign_id, "yt-1", 999999]},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+
+        with app.app_context():
+            assert db.session.get(PlayerLink, b_id).sort_order == 0
+            assert db.session.get(PlayerLink, a_id).sort_order == 1
+            # Foreign link untouched (still its default).
+            assert db.session.get(PlayerLink, foreign_id).sort_order in (0, None)
+
+        # Public reel now reflects the new order (b before a).
+        public = client.get("/api/players/5001/showcase").get_json()
+        urls = [r["url"] for r in public["reel"]]
+        assert urls == ["https://youtu.be/b", "https://youtu.be/a"]
+
+    def test_delete_permissions(self, app, client):
+        with app.app_context():
+            owner, _ = _approved_claim(5001, "owner@example.com")
+            link = PlayerLink(
+                player_id=5001, url="https://youtu.be/x", link_type="highlight", status="approved", user_id=owner.id
+            )
+            db.session.add(link)
+            db.session.commit()
+            link_id = link.id
+
+        # A stranger with no claim and who did not submit it cannot delete.
+        stranger = client.delete(
+            f"/api/players/5001/showcase/reel/{link_id}", headers=_user_headers("stranger@example.com")
+        )
+        assert stranger.status_code == 403
+        # The approved owner can delete.
+        owner_del = client.delete(
+            f"/api/players/5001/showcase/reel/{link_id}", headers=_user_headers("owner@example.com")
+        )
+        assert owner_del.status_code == 200
+
+    def test_newsletter_youtube_links_merge_into_public_reel(self, app, client):
+        from src.models.league import NewsletterPlayerYoutubeLink
+
+        with app.app_context():
+            # newsletter_id is a dangling ref (SQLite does not enforce FKs by
+            # default); the reel merge only queries these rows by player_id.
+            db.session.add(
+                NewsletterPlayerYoutubeLink(
+                    newsletter_id=1,
+                    player_id=5001,
+                    player_name="Kobbie Mainoo",
+                    youtube_link="https://youtu.be/nl1",
+                )
+            )
+            db.session.commit()
+        public = client.get("/api/players/5001/showcase").get_json()
+        assert any(r["source"] == "newsletter" and str(r["id"]).startswith("yt-") for r in public["reel"])
+
+
+# --------------------------------------------------------------------------- #
+# Public payload
+# --------------------------------------------------------------------------- #
+
+
+class TestPublicPayload:
+    def test_shape_unclaimed_empty(self, client):
+        resp = client.get("/api/players/5001/showcase")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert set(data.keys()) == {"player_api_id", "profile", "reel", "verified_footage", "claim_status"}
+        assert data["profile"] is None
+        assert data["reel"] == []
+        assert data["verified_footage"] == []
+        assert data["claim_status"] == "unclaimed"
+
+
+# --------------------------------------------------------------------------- #
+# Flywheel X — verified footage + roster linking
+# --------------------------------------------------------------------------- #
+
+
+class TestVerifiedFootage:
+    def test_only_human_confirmed_linked_finalized(self, app, client):
+        with app.app_context():
+            team = _seed_team()
+            tp = _tracked(team, player_api_id=5001, name="Kobbie Mainoo")
+
+            # Qualifying: finalized + human_confirmed + linked roster.
+            m1 = _finalized_match(team, opponent="Rivals FC", match_date=date(2025, 9, 10))
+            r1 = _roster(m1, tp_id=tp.id, number=37)
+            _report(m1, r1, tp_id=tp.id, identity="human_confirmed", minutes=88.0, pct=70)
+
+            # Excluded: low-confidence identity.
+            m2 = _finalized_match(team, opponent="Weak Signal FC", match_date=date(2025, 9, 3))
+            r2 = _roster(m2, tp_id=tp.id, number=37)
+            _report(m2, r2, tp_id=tp.id, identity="low", minutes=50.0)
+
+            # Excluded: not finalized.
+            m3 = _finalized_match(team, opponent="Pending FC", status="needs_tagging", match_date=date(2025, 9, 5))
+            r3 = _roster(m3, tp_id=tp.id, number=37)
+            _report(m3, r3, tp_id=tp.id, identity="human_confirmed", minutes=60.0)
+
+            # Excluded: roster not linked to this player.
+            m4 = _finalized_match(team, opponent="Unlinked FC", match_date=date(2025, 9, 7))
+            r4 = _roster(m4, tp_id=None, number=99)
+            _report(m4, r4, tp_id=None, identity="human_confirmed", minutes=90.0)
+            db.session.commit()
+
+        data = client.get("/api/players/5001/showcase").get_json()
+        footage = data["verified_footage"]
+        assert len(footage) == 1
+        entry = footage[0]
+        assert entry["opponent_name"] == "Rivals FC"
+        assert entry["team_name"] == "Manchester United"
+        assert entry["minutes_on_camera"] == 88.0
+        assert entry["pct_of_match"] == 70
+        assert entry["verified"] is True
+
+
+class TestRosterLinking:
+    def test_link_set_and_clear_propagates_denorm(self, app, client):
+        with app.app_context():
+            team = _seed_team()
+            tp = _tracked(team, player_api_id=5001, name="Kobbie Mainoo")
+            match = _finalized_match(team)
+            roster = _roster(match, tp_id=None, number=37)
+            report = _report(match, roster, tp_id=None, identity="human_confirmed")
+            db.session.commit()
+            roster_id, report_id, tp_id = roster.id, report.id, tp.id
+
+        # Link.
+        link = client.put(
+            f"/api/admin/showcase/video-rosters/{roster_id}/link",
+            json={"player_api_id": 5001},
+            headers=_admin_headers(),
+        )
+        assert link.status_code == 200
+        with app.app_context():
+            assert db.session.get(VideoRosterEntry, roster_id).tracked_player_id == tp_id
+            assert db.session.get(VideoPlayerReport, report_id).tracked_player_id == tp_id
+
+        # Clear.
+        clear = client.put(
+            f"/api/admin/showcase/video-rosters/{roster_id}/link",
+            json={"player_api_id": None},
+            headers=_admin_headers(),
+        )
+        assert clear.status_code == 200
+        with app.app_context():
+            assert db.session.get(VideoRosterEntry, roster_id).tracked_player_id is None
+            assert db.session.get(VideoPlayerReport, report_id).tracked_player_id is None
+
+    def test_link_unknown_player_404(self, app, client):
+        with app.app_context():
+            team = _seed_team()
+            match = _finalized_match(team)
+            roster = _roster(match, tp_id=None)
+            db.session.commit()
+            roster_id = roster.id
+        resp = client.put(
+            f"/api/admin/showcase/video-rosters/{roster_id}/link",
+            json={"player_api_id": 999999},
+            headers=_admin_headers(),
+        )
+        assert resp.status_code == 404
+
+    def test_video_rosters_listing_and_player_search(self, app, client):
+        with app.app_context():
+            team = _seed_team()
+            tp = _tracked(team, player_api_id=5001, name="Kobbie Mainoo")
+            match = _finalized_match(team)
+            _roster(match, tp_id=tp.id, number=37)
+            db.session.commit()
+
+        rosters = client.get(
+            "/api/admin/showcase/video-rosters?player_api_id=5001", headers=_admin_headers()
+        ).get_json()["rosters"]
+        assert len(rosters) == 1
+        assert rosters[0]["player_name"] == "Kobbie Mainoo"
+
+        search = client.get("/api/admin/showcase/player-search?q=mainoo", headers=_admin_headers()).get_json()[
+            "players"
+        ]
+        assert search[0]["player_api_id"] == 5001
+
+
+# --------------------------------------------------------------------------- #
+# Optional-auth owner visibility on the public showcase endpoint
+# --------------------------------------------------------------------------- #
+
+
+class TestOptionalOwnerVisibility:
+    def _seed_owner_with_drafts(self, app, owner_email="owner@example.com"):
+        with app.app_context():
+            owner, _ = _approved_claim(5001, owner_email)
+            db.session.add(PlayerShowcaseProfile(player_api_id=5001, bio="Draft bio", status="pending"))
+            db.session.add(
+                PlayerLink(
+                    player_id=5001,
+                    user_id=owner.id,
+                    url="https://youtu.be/pending1",
+                    title="Draft clip",
+                    link_type="highlight",
+                    status="pending",
+                )
+            )
+            db.session.commit()
+
+    def test_owner_sees_pending_reel_and_profile_draft(self, app, client):
+        self._seed_owner_with_drafts(app)
+        data = client.get("/api/players/5001/showcase", headers=_user_headers("owner@example.com")).get_json()
+        # Pending profile draft is visible to the owner, carrying its status.
+        assert data["profile"] is not None
+        assert data["profile"]["status"] == "pending"
+        assert data["profile"]["bio"] == "Draft bio"
+        # Pending reel item is visible to the owner, carrying its status.
+        pending = [r for r in data["reel"] if r["url"] == "https://youtu.be/pending1"]
+        assert len(pending) == 1
+        assert pending[0]["status"] == "pending"
+
+    def test_anonymous_gets_public_view(self, app, client):
+        self._seed_owner_with_drafts(app)
+        data = client.get("/api/players/5001/showcase").get_json()
+        assert data["profile"] is None
+        assert all(r["url"] != "https://youtu.be/pending1" for r in data["reel"])
+
+    def test_non_owner_authed_gets_public_view(self, app, client):
+        self._seed_owner_with_drafts(app)
+        # A valid token for a user with NO approved claim → public view.
+        data = client.get("/api/players/5001/showcase", headers=_user_headers("stranger@example.com")).get_json()
+        assert data["profile"] is None
+        assert all(r["url"] != "https://youtu.be/pending1" for r in data["reel"])
+
+    def test_garbage_token_degrades_to_public_200(self, app, client):
+        self._seed_owner_with_drafts(app)
+        resp = client.get("/api/players/5001/showcase", headers={"Authorization": "Bearer not.a.real.token"})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["profile"] is None
+        assert all(r["url"] != "https://youtu.be/pending1" for r in data["reel"])
+
+
+# --------------------------------------------------------------------------- #
+# submit_player_link URL hardening (api.py)
+# --------------------------------------------------------------------------- #
+
+
+class TestSubmitPlayerLinkHardening:
+    def test_javascript_url_rejected(self, client):
+        resp = client.post(
+            "/api/players/5001/links",
+            json={"url": "javascript:alert(document.cookie)", "link_type": "article"},
+            headers=_user_headers("fan@example.com"),
+        )
+        assert resp.status_code == 400
+
+    def test_https_url_accepted(self, client):
+        resp = client.post(
+            "/api/players/5001/links",
+            json={"url": "https://example.com/article", "link_type": "article"},
+            headers=_user_headers("fan@example.com"),
+        )
+        assert resp.status_code == 201
+
+
+# --------------------------------------------------------------------------- #
+# Review-fix regressions (adversarial review 2026-07-02)
+# --------------------------------------------------------------------------- #
+
+
+class TestClaimRecovery:
+    """A rejected/revoked claim must never be a permanent dead-end."""
+
+    def _claim(self, client, email="kobbie@example.com"):
+        return client.post(
+            "/api/players/5001/claim",
+            json={"relationship_type": "player", "message": "It's me"},
+            headers=_user_headers(email),
+        )
+
+    def _review(self, client, claim_id, action):
+        return client.post(
+            f"/api/admin/showcase/claims/{claim_id}/review",
+            json={"action": action},
+            headers=_admin_headers(),
+        )
+
+    def test_rejected_claim_can_be_resubmitted(self, app, client):
+        claim_id = self._claim(client).get_json()["claim"]["id"]
+        assert self._review(client, claim_id, "reject").status_code == 200
+
+        resub = self._claim(client)
+        assert resub.status_code == 201
+        body = resub.get_json()["claim"]
+        assert body["id"] == claim_id  # same row, reset
+        assert body["status"] == "pending"
+        assert body["reviewed_by"] is None
+
+    def test_revoked_claim_can_be_resubmitted(self, app, client):
+        claim_id = self._claim(client).get_json()["claim"]["id"]
+        assert self._review(client, claim_id, "approve").status_code == 200
+        assert self._review(client, claim_id, "revoke").status_code == 200
+
+        resub = self._claim(client)
+        assert resub.status_code == 201
+        assert resub.get_json()["claim"]["status"] == "pending"
+
+    def test_admin_can_approve_rejected_claim(self, app, client):
+        claim_id = self._claim(client).get_json()["claim"]["id"]
+        assert self._review(client, claim_id, "reject").status_code == 200
+        resp = self._review(client, claim_id, "approve")
+        assert resp.status_code == 200
+        assert resp.get_json()["claim"]["status"] == "approved"
+
+    def test_pending_claim_still_409s_on_resubmit(self, app, client):
+        assert self._claim(client).status_code == 201
+        assert self._claim(client).status_code == 409
+
+    def test_reject_still_requires_pending(self, app, client):
+        claim_id = self._claim(client).get_json()["claim"]["id"]
+        assert self._review(client, claim_id, "approve").status_code == 200
+        assert self._review(client, claim_id, "reject").status_code == 409
+
+
+class TestReelDedupAndSafety:
+    """Newsletter merge: canonical video-id dedup + unsafe-URL filtering."""
+
+    def _newsletter_link(self, url, player_id=5001):
+        from src.models.league import Newsletter, NewsletterPlayerYoutubeLink
+
+        newsletter = Newsletter.query.first()
+        if newsletter is None:
+            team = Team.query.first() or _seed_team()
+            newsletter = Newsletter(team_id=team.id, title="Weekly", content="c", public_slug="weekly-test-slug")
+            db.session.add(newsletter)
+            db.session.flush()
+        db.session.add(
+            NewsletterPlayerYoutubeLink(
+                newsletter_id=newsletter.id,
+                player_id=player_id,
+                player_name="Kobbie Mainoo",
+                youtube_link=url,
+            )
+        )
+        db.session.commit()
+
+    def test_same_video_different_url_forms_dedups(self, app, client):
+        with app.app_context():
+            db.session.add(
+                PlayerLink(
+                    player_id=5001,
+                    url="https://youtu.be/ABC123xyz",
+                    link_type="highlight",
+                    status="approved",
+                )
+            )
+            db.session.commit()
+            self._newsletter_link("https://www.youtube.com/watch?v=ABC123xyz")
+
+        reel = client.get("/api/players/5001/showcase").get_json()["reel"]
+        assert len(reel) == 1
+        assert reel[0]["source"] == "user"
+
+    def test_unsafe_newsletter_urls_never_reach_public_reel(self, app, client):
+        with app.app_context():
+            self._newsletter_link("javascript:alert(document.cookie)")
+            self._newsletter_link("http://www.youtube.com/watch?v=insecure1")
+            self._newsletter_link("https://example.com/not-youtube")
+            self._newsletter_link("https://youtu.be/good1234")
+
+        reel = client.get("/api/players/5001/showcase").get_json()["reel"]
+        assert [r["url"] for r in reel] == ["https://youtu.be/good1234"]

--- a/academy-watch-frontend/src/App.jsx
+++ b/academy-watch-frontend/src/App.jsx
@@ -80,6 +80,7 @@ import { AdminVideoMatch } from '@/pages/admin/AdminVideoMatch'
 import { AdminTools } from '@/pages/admin/AdminTools'
 import { AdminSandbox } from '@/pages/admin/AdminSandbox'
 import { AdminFormation } from '@/pages/admin/AdminFormation'
+import { AdminShowcase } from '@/pages/admin/AdminShowcase'
 import { HomePage } from '@/pages/HomePage'
 import { PublicFormationBuilder } from '@/pages/PublicFormationBuilder'
 import { CohortBrowser } from '@/pages/CohortBrowser'
@@ -4048,6 +4049,7 @@ function AppRoutes() {
         <Route path="cohorts" element={<AdminCohorts />} />
         <Route path="video" element={<AdminVideo />} />
         <Route path="video/:matchId" element={<AdminVideoMatch />} />
+        <Route path="showcase" element={<AdminShowcase />} />
         <Route path="settings" element={<AdminSettings />} />
         <Route path="tools" element={<AdminTools />} />
         <Route path="sandbox" element={<AdminSandbox />} />

--- a/academy-watch-frontend/src/components/PlayerLinksSection.jsx
+++ b/academy-watch-frontend/src/components/PlayerLinksSection.jsx
@@ -12,8 +12,6 @@ import {
 } from '@/components/ui/select'
 import { Link2, Newspaper, Video, Share2, BarChart3, Globe, Plus, Loader2, Check, ExternalLink } from 'lucide-react'
 import { APIService } from '@/lib/api'
-import { isYouTubeUrl } from '@/lib/youtube'
-import { VideoEmbed } from '@/components/VideoEmbed'
 
 const TYPE_META = {
   article:   { label: 'Article',   icon: Newspaper },
@@ -83,20 +81,20 @@ export function PlayerLinksSection({ playerId }) {
     }
   }
 
-  // Group links by type, with highlights first
-  const grouped = links.reduce((acc, link) => {
+  // Highlight links are surfaced in the Showcase section (curated reel), so
+  // they are excluded here to avoid double-rendering. Fans can still submit
+  // them via the form below.
+  const displayLinks = links.filter((link) => (link.link_type || 'other') !== 'highlight')
+
+  // Group the remaining community links by type.
+  const grouped = displayLinks.reduce((acc, link) => {
     const t = link.link_type || 'other'
     if (!acc[t]) acc[t] = []
     acc[t].push(link)
     return acc
   }, {})
 
-  // Sort so highlights appear first
-  const sortedTypes = Object.keys(grouped).sort((a, b) => {
-    if (a === 'highlight') return -1
-    if (b === 'highlight') return 1
-    return 0
-  })
+  const sortedTypes = Object.keys(grouped)
 
   return (
     <Card>
@@ -105,8 +103,8 @@ export function PlayerLinksSection({ playerId }) {
           <CardTitle className="flex items-center gap-2 text-base">
             <Link2 className="h-4 w-4" />
             Links
-            {links.length > 0 && (
-              <span className="text-sm font-normal text-muted-foreground">({links.length})</span>
+            {displayLinks.length > 0 && (
+              <span className="text-sm font-normal text-muted-foreground">({displayLinks.length})</span>
             )}
           </CardTitle>
           {isLoggedIn && !showForm && (
@@ -172,7 +170,7 @@ export function PlayerLinksSection({ playerId }) {
           <div className="flex justify-center py-6">
             <Loader2 className="h-5 w-5 animate-spin text-muted-foreground/70" />
           </div>
-        ) : links.length === 0 && !showForm ? (
+        ) : displayLinks.length === 0 && !showForm ? (
           <p className="text-sm text-muted-foreground text-center py-4">
             No links yet.{isLoggedIn ? ' Share a relevant article or highlight.' : ' Sign in to submit links.'}
           </p>
@@ -190,16 +188,6 @@ export function PlayerLinksSection({ playerId }) {
                   </div>
                   <div className="space-y-1.5">
                     {items.map((link) => {
-                      if (type === 'highlight' && isYouTubeUrl(link.url)) {
-                        return (
-                          <div key={link.id} className="space-y-1.5">
-                            {link.title && (
-                              <p className="text-sm font-medium text-foreground/80 px-1">{link.title}</p>
-                            )}
-                            <VideoEmbed url={link.url} title={link.title} />
-                          </div>
-                        )
-                      }
                       return (
                         <a
                           key={link.id}
@@ -226,7 +214,7 @@ export function PlayerLinksSection({ playerId }) {
         )}
 
         {/* Sign-in prompt */}
-        {!isLoggedIn && links.length > 0 && (
+        {!isLoggedIn && displayLinks.length > 0 && (
           <div className="pt-2 border-t text-center">
             <p className="text-sm text-muted-foreground">Sign in to submit links</p>
           </div>

--- a/academy-watch-frontend/src/components/ShowcaseSection.jsx
+++ b/academy-watch-frontend/src/components/ShowcaseSection.jsx
@@ -1,0 +1,698 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Clapperboard,
+  ShieldCheck,
+  UserSquare,
+  Plus,
+  Pencil,
+  Trash2,
+  ArrowUp,
+  ArrowDown,
+  Loader2,
+  Check,
+  Sparkles,
+} from 'lucide-react'
+import { APIService } from '@/lib/api'
+import { isYouTubeUrl } from '@/lib/youtube'
+import { VideoEmbed } from '@/components/VideoEmbed'
+import { useAuth, useAuthUI } from '@/context/AuthContext'
+
+const RELATIONSHIP_OPTIONS = [
+  { value: 'player', label: 'Player' },
+  { value: 'agent', label: 'Agent' },
+  { value: 'guardian', label: 'Parent / Guardian' },
+  { value: 'club_official', label: 'Club official' },
+]
+
+const FOOT_OPTIONS = [
+  { value: 'left', label: 'Left' },
+  { value: 'right', label: 'Right' },
+  { value: 'both', label: 'Both' },
+]
+
+// Synthetic newsletter-sourced reel items carry string ids like "yt-123" and
+// are not owner-editable (no reorder/delete). Real PlayerLink rows are integers.
+const isSynthetic = (item) =>
+  typeof item?.id === 'string' && item.id.startsWith('yt-')
+
+function formatDate(value) {
+  if (!value) return null
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return null
+  return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
+function SectionHeader({ icon: Icon, eyebrow, title, action }) {
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <div>
+        <p className="mb-1 inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.2em] text-primary">
+          <Icon className="h-3.5 w-3.5" />
+          {eyebrow}
+        </p>
+        {title && <h2 className="text-xl font-bold tracking-tight text-foreground">{title}</h2>}
+      </div>
+      {action}
+    </div>
+  )
+}
+
+export function ShowcaseSection({ playerApiId, playerName }) {
+  const { token } = useAuth()
+  const { openLoginModal } = useAuthUI()
+
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
+  const [showcase, setShowcase] = useState(null)
+  const [myClaims, setMyClaims] = useState([])
+
+  // Claim dialog
+  const [claimOpen, setClaimOpen] = useState(false)
+  const [claimRelationship, setClaimRelationship] = useState('player')
+  const [claimMessage, setClaimMessage] = useState('')
+  const [claimBusy, setClaimBusy] = useState(false)
+  const [claimDone, setClaimDone] = useState(false)
+  const [claimError, setClaimError] = useState(null)
+
+  // Add-video dialog
+  const [videoOpen, setVideoOpen] = useState(false)
+  const [videoUrl, setVideoUrl] = useState('')
+  const [videoTitle, setVideoTitle] = useState('')
+  const [videoBusy, setVideoBusy] = useState(false)
+  const [videoDone, setVideoDone] = useState(false)
+  const [videoError, setVideoError] = useState(null)
+
+  // Edit-profile dialog
+  const [profileOpen, setProfileOpen] = useState(false)
+  const [profileForm, setProfileForm] = useState({ bio: '', positions: '', preferred_foot: '', height_cm: '' })
+  const [profileBusy, setProfileBusy] = useState(false)
+  const [profileDone, setProfileDone] = useState(false)
+  const [profileError, setProfileError] = useState(null)
+
+  // Reel mutation busy state
+  const [reelBusy, setReelBusy] = useState(false)
+
+  const fetchData = useCallback(async () => {
+    const [sc, claims] = await Promise.all([
+      APIService.getPlayerShowcase(playerApiId),
+      token ? APIService.getMyClaims().catch(() => null) : Promise.resolve(null),
+    ])
+    const claimsArr = Array.isArray(claims) ? claims : claims?.claims || []
+    return { sc, claimsArr }
+  }, [playerApiId, token])
+
+  // PlayerPage is reused across /players/:id navigations — track the active
+  // player so an in-flight refresh for the previous player never lands.
+  const activePlayerRef = useRef(playerApiId)
+
+  useEffect(() => {
+    let cancelled = false
+    activePlayerRef.current = playerApiId
+    setLoading(true)
+    setError(false)
+    fetchData()
+      .then(({ sc, claimsArr }) => {
+        if (cancelled) return
+        setShowcase(sc || null)
+        setMyClaims(claimsArr)
+      })
+      .catch(() => {
+        if (!cancelled) setError(true)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => { cancelled = true }
+  }, [fetchData, playerApiId])
+
+  const refresh = useCallback(async () => {
+    const pid = playerApiId
+    try {
+      const { sc, claimsArr } = await fetchData()
+      if (activePlayerRef.current !== pid) return
+      setShowcase(sc || null)
+      setMyClaims(claimsArr)
+    } catch {
+      // best-effort refresh
+    }
+  }, [fetchData, playerApiId])
+
+  if (loading) {
+    return (
+      <Card>
+        <CardContent className="space-y-4 py-6">
+          <Skeleton className="h-4 w-24" />
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <Skeleton className="aspect-video w-full rounded-lg" />
+            <Skeleton className="aspect-video w-full rounded-lg" />
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  // On error render nothing — never break the page.
+  if (error || !showcase) return null
+
+  const reel = Array.isArray(showcase.reel) ? showcase.reel : []
+  const profile = showcase.profile || null
+  const verified = Array.isArray(showcase.verified_footage) ? showcase.verified_footage : []
+  const claimStatus = showcase.claim_status // 'unclaimed' | 'claimed'
+
+  const myClaim = myClaims.find((c) => Number(c.player_api_id) === Number(playerApiId))
+  const isOwner = myClaim?.status === 'approved'
+
+  // Claim strip shows for non-owners who either have a claim (show its status) or
+  // can still claim an unclaimed profile.
+  const showClaimStrip = !isOwner && (myClaim ? true : claimStatus === 'unclaimed')
+
+  const hasContent = reel.length > 0 || profile || verified.length > 0
+  if (!hasContent && !isOwner && !showClaimStrip) return null
+
+  const reorderableIds = reel.filter((i) => !isSynthetic(i)).map((i) => i.id)
+
+  const openClaimDialog = () => {
+    if (!token) {
+      openLoginModal()
+      return
+    }
+    setClaimError(null)
+    setClaimDone(false)
+    setClaimOpen(true)
+  }
+
+  const submitClaim = async () => {
+    if (claimBusy) return
+    setClaimBusy(true)
+    setClaimError(null)
+    try {
+      await APIService.submitProfileClaim(playerApiId, {
+        relationship_type: claimRelationship,
+        message: claimMessage.trim() || undefined,
+      })
+      setClaimDone(true)
+      await refresh()
+      setTimeout(() => setClaimOpen(false), 1600)
+    } catch (err) {
+      setClaimError(err.body?.error || err.message || 'Failed to submit claim')
+    } finally {
+      setClaimBusy(false)
+    }
+  }
+
+  const submitVideo = async () => {
+    const url = videoUrl.trim()
+    if (!url || videoBusy) return
+    if (!isYouTubeUrl(url)) {
+      setVideoError('Please enter a valid YouTube link.')
+      return
+    }
+    setVideoBusy(true)
+    setVideoError(null)
+    try {
+      await APIService.addShowcaseReelItem(playerApiId, { url, title: videoTitle.trim() || undefined })
+      setVideoDone(true)
+      setVideoUrl('')
+      setVideoTitle('')
+      await refresh()
+      setTimeout(() => { setVideoOpen(false); setVideoDone(false) }, 1600)
+    } catch (err) {
+      setVideoError(err.body?.error || err.message || 'Failed to add video')
+    } finally {
+      setVideoBusy(false)
+    }
+  }
+
+  const openProfileDialog = () => {
+    setProfileForm({
+      bio: profile?.bio || '',
+      positions: profile?.positions || '',
+      preferred_foot: profile?.preferred_foot || '',
+      height_cm: profile?.height_cm != null ? String(profile.height_cm) : '',
+    })
+    setProfileError(null)
+    setProfileDone(false)
+    setProfileOpen(true)
+  }
+
+  const submitProfile = async () => {
+    if (profileBusy) return
+    setProfileBusy(true)
+    setProfileError(null)
+    try {
+      const heightRaw = profileForm.height_cm.trim()
+      await APIService.updateShowcaseProfile(playerApiId, {
+        bio: profileForm.bio.trim(),
+        positions: profileForm.positions.trim(),
+        preferred_foot: profileForm.preferred_foot || null,
+        height_cm: heightRaw ? parseInt(heightRaw, 10) : null,
+      })
+      setProfileDone(true)
+      await refresh()
+      setTimeout(() => setProfileOpen(false), 1600)
+    } catch (err) {
+      setProfileError(err.body?.error || err.message || 'Failed to update profile')
+    } finally {
+      setProfileBusy(false)
+    }
+  }
+
+  const moveReelItem = async (index, dir) => {
+    const target = index + dir
+    if (target < 0 || target >= reel.length || reelBusy) return
+    if (isSynthetic(reel[index]) || isSynthetic(reel[target])) return
+    const next = [...reel]
+    ;[next[index], next[target]] = [next[target], next[index]]
+    const ordered_ids = next.filter((i) => !isSynthetic(i)).map((i) => i.id)
+    setReelBusy(true)
+    try {
+      await APIService.reorderShowcaseReel(playerApiId, { ordered_ids })
+      await refresh()
+    } catch {
+      // ignore — order unchanged on failure
+    } finally {
+      setReelBusy(false)
+    }
+  }
+
+  const deleteReelItem = async (linkId) => {
+    if (reelBusy) return
+    setReelBusy(true)
+    try {
+      await APIService.deleteShowcaseReelItem(playerApiId, linkId)
+      await refresh()
+    } catch {
+      // ignore
+    } finally {
+      setReelBusy(false)
+    }
+  }
+
+  return (
+    <Card>
+      <CardContent className="space-y-8 py-6">
+        {/* Header */}
+        <SectionHeader
+          icon={Sparkles}
+          eyebrow="Showcase"
+          title={`${playerName || 'Player'} — Showcase`}
+          action={
+            isOwner ? (
+              <div className="flex shrink-0 items-center gap-2">
+                <Button variant="outline" size="sm" onClick={() => { setVideoError(null); setVideoDone(false); setVideoOpen(true) }} className="gap-1.5">
+                  <Plus className="h-3.5 w-3.5" />
+                  Add video
+                </Button>
+                <Button variant="outline" size="sm" onClick={openProfileDialog} className="gap-1.5">
+                  <Pencil className="h-3.5 w-3.5" />
+                  Edit profile
+                </Button>
+              </div>
+            ) : null
+          }
+        />
+
+        {isOwner && (
+          <p className="-mt-4 text-xs text-muted-foreground">
+            You manage this profile. Videos and profile edits are reviewed before they appear publicly.
+          </p>
+        )}
+
+        {/* 1. Highlight reel */}
+        {reel.length > 0 && (
+          <div className="space-y-3">
+            <p className="inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <Clapperboard className="h-3.5 w-3.5" />
+              Highlight reel
+            </p>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              {reel.map((item, index) => {
+                const synthetic = isSynthetic(item)
+                const pending = item.status === 'pending'
+                return (
+                  <div key={item.id} className="space-y-1.5">
+                    <div className="flex items-center justify-between gap-2 px-1">
+                      <div className="flex min-w-0 items-center gap-2">
+                        {item.title && (
+                          <span className="truncate text-sm font-medium text-foreground/80">{item.title}</span>
+                        )}
+                        {pending && (
+                          <Badge variant="outline" className="border-amber-200 bg-amber-50 text-amber-700">
+                            Pending review
+                          </Badge>
+                        )}
+                      </div>
+                      {isOwner && !synthetic && (
+                        <div className="flex shrink-0 items-center gap-0.5">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7"
+                            disabled={reelBusy || index === 0}
+                            onClick={() => moveReelItem(index, -1)}
+                            aria-label="Move up"
+                          >
+                            <ArrowUp className="h-3.5 w-3.5" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7"
+                            disabled={reelBusy || index === reorderableIds.length - 1}
+                            onClick={() => moveReelItem(index, 1)}
+                            aria-label="Move down"
+                          >
+                            <ArrowDown className="h-3.5 w-3.5" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                            disabled={reelBusy}
+                            onClick={() => deleteReelItem(item.id)}
+                            aria-label="Remove video"
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        </div>
+                      )}
+                      {isOwner && synthetic && (
+                        <span className="shrink-0 text-[11px] text-muted-foreground/70">from newsletter</span>
+                      )}
+                    </div>
+                    <VideoEmbed url={item.url} title={item.title} />
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* 2. Self-reported profile */}
+        {profile && (
+          <div className="space-y-3 rounded-lg border border-border/70 bg-secondary/40 p-4">
+            <div className="flex items-center gap-2">
+              <UserSquare className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm font-semibold text-foreground">Player profile</span>
+              <Badge variant="secondary">Self-reported</Badge>
+            </div>
+            {profile.bio && <p className="text-sm leading-relaxed text-foreground/90">{profile.bio}</p>}
+            <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm">
+              {profile.positions && (
+                <div>
+                  <span className="text-muted-foreground">Positions: </span>
+                  <span className="font-medium text-foreground">{profile.positions}</span>
+                </div>
+              )}
+              {profile.preferred_foot && (
+                <div>
+                  <span className="text-muted-foreground">Preferred foot: </span>
+                  <span className="font-medium capitalize text-foreground">{profile.preferred_foot}</span>
+                </div>
+              )}
+              {profile.height_cm != null && (
+                <div>
+                  <span className="text-muted-foreground">Height: </span>
+                  <span className="font-medium text-foreground">{profile.height_cm} cm</span>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* 3. Club-verified footage */}
+        {verified.length > 0 && (
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <ShieldCheck className="h-4 w-4 text-emerald-600" />
+              <span className="text-sm font-semibold text-foreground">Verified appearances</span>
+              <Badge className="border-emerald-200 bg-emerald-50 text-emerald-800">Club-verified</Badge>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Verified by the club from match footage (human-confirmed identity).
+            </p>
+            <div className="divide-y divide-border/60 overflow-hidden rounded-lg border border-border/70">
+              {verified.map((v) => (
+                <div key={v.match_id} className="flex flex-wrap items-center justify-between gap-2 px-3 py-2.5 text-sm">
+                  <div className="min-w-0">
+                    <p className="truncate font-medium text-foreground">
+                      {v.opponent_name ? `vs ${v.opponent_name}` : v.team_name || 'Match'}
+                    </p>
+                    {formatDate(v.match_date) && (
+                      <p className="text-xs text-muted-foreground">{formatDate(v.match_date)}</p>
+                    )}
+                  </div>
+                  <div className="flex shrink-0 items-center gap-4 text-right">
+                    {v.minutes_on_camera != null && (
+                      <div>
+                        <p className="font-semibold tabular-nums text-foreground">{v.minutes_on_camera}′</p>
+                        <p className="text-[11px] text-muted-foreground">on camera</p>
+                      </div>
+                    )}
+                    {v.pct_of_match != null && (
+                      <div>
+                        {/* pct_of_match is a 0-1 fraction from the report pipeline */}
+                        <p className="font-semibold tabular-nums text-foreground">{Math.round(v.pct_of_match * 100)}%</p>
+                        <p className="text-[11px] text-muted-foreground">of match</p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* 4. Claim strip */}
+        {showClaimStrip && (
+          <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border/70 pt-4">
+            {myClaim ? (
+              myClaim.status === 'pending' ? (
+                <p className="text-sm text-amber-700">
+                  Your claim for this profile is <span className="font-medium">pending review</span>.
+                </p>
+              ) : myClaim.status === 'rejected' ? (
+                <p className="text-sm text-muted-foreground">Your previous claim for this profile was not approved.</p>
+              ) : (
+                <p className="text-sm text-muted-foreground">You have a claim on this profile.</p>
+              )
+            ) : (
+              <>
+                <p className="text-sm text-muted-foreground">Is this you, or someone you represent?</p>
+                <Button variant="outline" size="sm" onClick={openClaimDialog}>
+                  Claim this profile
+                </Button>
+              </>
+            )}
+          </div>
+        )}
+      </CardContent>
+
+      {/* Claim dialog */}
+      <Dialog open={claimOpen} onOpenChange={setClaimOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Claim {playerName || 'this profile'}</DialogTitle>
+            <DialogDescription>
+              Tell us your connection to this player. An admin reviews every claim before granting access.
+            </DialogDescription>
+          </DialogHeader>
+          {claimDone ? (
+            <div className="flex items-center gap-2 py-4 text-sm text-emerald-600">
+              <Check className="h-4 w-4" />
+              Submitted for review
+            </div>
+          ) : (
+            <div className="space-y-4 py-2">
+              <div className="space-y-2">
+                <Label>I am the…</Label>
+                <Select value={claimRelationship} onValueChange={setClaimRelationship}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {RELATIONSHIP_OPTIONS.map((o) => (
+                      <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>Message (optional)</Label>
+                <Textarea
+                  placeholder="Anything that helps us verify your claim"
+                  value={claimMessage}
+                  onChange={(e) => setClaimMessage(e.target.value)}
+                  maxLength={1000}
+                  rows={3}
+                />
+              </div>
+              {claimError && <p className="text-xs text-destructive">{claimError}</p>}
+            </div>
+          )}
+          {!claimDone && (
+            <DialogFooter>
+              <Button variant="ghost" onClick={() => setClaimOpen(false)}>Cancel</Button>
+              <Button onClick={submitClaim} disabled={claimBusy}>
+                {claimBusy && <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />}
+                Submit claim
+              </Button>
+            </DialogFooter>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Add-video dialog */}
+      <Dialog open={videoOpen} onOpenChange={setVideoOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add a highlight video</DialogTitle>
+            <DialogDescription>
+              Paste a YouTube link. Videos are reviewed before appearing on the public profile.
+            </DialogDescription>
+          </DialogHeader>
+          {videoDone ? (
+            <div className="flex items-center gap-2 py-4 text-sm text-emerald-600">
+              <Check className="h-4 w-4" />
+              Submitted for review
+            </div>
+          ) : (
+            <div className="space-y-4 py-2">
+              <div className="space-y-2">
+                <Label>YouTube URL</Label>
+                <Input
+                  placeholder="https://youtube.com/watch?v=…"
+                  value={videoUrl}
+                  onChange={(e) => setVideoUrl(e.target.value)}
+                  type="url"
+                  maxLength={500}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Title (optional)</Label>
+                <Input
+                  placeholder="e.g. Hat-trick vs. City U21"
+                  value={videoTitle}
+                  onChange={(e) => setVideoTitle(e.target.value)}
+                  maxLength={200}
+                />
+              </div>
+              {videoError && <p className="text-xs text-destructive">{videoError}</p>}
+            </div>
+          )}
+          {!videoDone && (
+            <DialogFooter>
+              <Button variant="ghost" onClick={() => setVideoOpen(false)}>Cancel</Button>
+              <Button onClick={submitVideo} disabled={videoBusy || !videoUrl.trim()}>
+                {videoBusy && <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />}
+                Add video
+              </Button>
+            </DialogFooter>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit-profile dialog */}
+      <Dialog open={profileOpen} onOpenChange={setProfileOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit player profile</DialogTitle>
+            <DialogDescription>
+              Self-reported details. Edits are re-reviewed before they appear publicly.
+            </DialogDescription>
+          </DialogHeader>
+          {profileDone ? (
+            <div className="flex items-center gap-2 py-4 text-sm text-emerald-600">
+              <Check className="h-4 w-4" />
+              Submitted for review
+            </div>
+          ) : (
+            <div className="space-y-4 py-2">
+              <div className="space-y-2">
+                <Label>Bio</Label>
+                <Textarea
+                  placeholder="A short bio"
+                  value={profileForm.bio}
+                  onChange={(e) => setProfileForm((f) => ({ ...f, bio: e.target.value }))}
+                  maxLength={2000}
+                  rows={4}
+                />
+              </div>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label>Positions</Label>
+                  <Input
+                    placeholder="e.g. LW, ST"
+                    value={profileForm.positions}
+                    onChange={(e) => setProfileForm((f) => ({ ...f, positions: e.target.value }))}
+                    maxLength={100}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>Preferred foot</Label>
+                  <Select
+                    value={profileForm.preferred_foot}
+                    onValueChange={(v) => setProfileForm((f) => ({ ...f, preferred_foot: v }))}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {FOOT_OPTIONS.map((o) => (
+                        <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label>Height (cm)</Label>
+                <Input
+                  placeholder="e.g. 178"
+                  value={profileForm.height_cm}
+                  onChange={(e) => setProfileForm((f) => ({ ...f, height_cm: e.target.value.replace(/[^0-9]/g, '') }))}
+                  inputMode="numeric"
+                  maxLength={3}
+                />
+              </div>
+              {profileError && <p className="text-xs text-destructive">{profileError}</p>}
+            </div>
+          )}
+          {!profileDone && (
+            <DialogFooter>
+              <Button variant="ghost" onClick={() => setProfileOpen(false)}>Cancel</Button>
+              <Button onClick={submitProfile} disabled={profileBusy}>
+                {profileBusy && <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />}
+                Save changes
+              </Button>
+            </DialogFooter>
+          )}
+        </DialogContent>
+      </Dialog>
+    </Card>
+  )
+}
+
+export default ShowcaseSection

--- a/academy-watch-frontend/src/components/admin/AdminSidebar.jsx
+++ b/academy-watch-frontend/src/components/admin/AdminSidebar.jsx
@@ -20,6 +20,7 @@ import {
     Trophy,
     Wrench,
     UserCog,
+    Star,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible'
@@ -67,6 +68,7 @@ const sidebarGroups = [
         icon: Video,
         items: [
             { icon: Video, label: 'Film Room', href: '/admin/video' },
+            { icon: Star, label: 'Showcase', href: '/admin/showcase' },
         ],
     },
     {

--- a/academy-watch-frontend/src/lib/api.js
+++ b/academy-watch-frontend/src/lib/api.js
@@ -1145,6 +1145,100 @@ export class APIService {
         }, { admin: true })
     }
 
+    // ── Talent Showcase ──────────────────────────────────────────────────
+    // Public + owner-authed player showcase (highlight reel, self-reported
+    // profile, club-verified footage, profile claims). Public reads pass no
+    // third arg; owner writes rely on the stored user Bearer.
+    static async getPlayerShowcase(playerId) {
+        if (!playerId) throw new Error('playerId is required')
+        return this.request(`/players/${encodeURIComponent(playerId)}/showcase`)
+    }
+
+    static async submitProfileClaim(playerId, { relationship_type, message }) {
+        if (!playerId) throw new Error('playerId is required')
+        return this.request(`/players/${encodeURIComponent(playerId)}/claim`, {
+            method: 'POST',
+            body: JSON.stringify({ relationship_type, message }),
+        })
+    }
+
+    static async getMyClaims() {
+        return this.request('/me/claims')
+    }
+
+    static async updateShowcaseProfile(playerId, payload) {
+        if (!playerId) throw new Error('playerId is required')
+        return this.request(`/players/${encodeURIComponent(playerId)}/showcase/profile`, {
+            method: 'PUT',
+            body: JSON.stringify(payload),
+        })
+    }
+
+    static async addShowcaseReelItem(playerId, { url, title }) {
+        if (!playerId) throw new Error('playerId is required')
+        return this.request(`/players/${encodeURIComponent(playerId)}/showcase/reel`, {
+            method: 'POST',
+            body: JSON.stringify({ url, title }),
+        })
+    }
+
+    static async reorderShowcaseReel(playerId, { ordered_ids }) {
+        if (!playerId) throw new Error('playerId is required')
+        return this.request(`/players/${encodeURIComponent(playerId)}/showcase/reel/order`, {
+            method: 'PATCH',
+            body: JSON.stringify({ ordered_ids }),
+        })
+    }
+
+    static async deleteShowcaseReelItem(playerId, linkId) {
+        if (!playerId) throw new Error('playerId is required')
+        return this.request(`/players/${encodeURIComponent(playerId)}/showcase/reel/${encodeURIComponent(linkId)}`, {
+            method: 'DELETE',
+        })
+    }
+
+    // ── Talent Showcase (admin moderation + Film Room linking) ───────────
+    static async adminListShowcaseClaims(params = {}) {
+        const query = new URLSearchParams(params).toString()
+        return this.request(`/admin/showcase/claims${query ? '?' + query : ''}`, {}, { admin: true })
+    }
+
+    static async adminReviewShowcaseClaim(id, { action, note }) {
+        return this.request(`/admin/showcase/claims/${encodeURIComponent(id)}/review`, {
+            method: 'POST',
+            body: JSON.stringify({ action, note }),
+        }, { admin: true })
+    }
+
+    static async adminListShowcaseProfiles(params = {}) {
+        const query = new URLSearchParams(params).toString()
+        return this.request(`/admin/showcase/profiles${query ? '?' + query : ''}`, {}, { admin: true })
+    }
+
+    static async adminReviewShowcaseProfile(playerApiId, { action }) {
+        return this.request(`/admin/showcase/profiles/${encodeURIComponent(playerApiId)}/review`, {
+            method: 'POST',
+            body: JSON.stringify({ action }),
+        }, { admin: true })
+    }
+
+    static async adminListVideoRosters(params = {}) {
+        const query = new URLSearchParams(params).toString()
+        return this.request(`/admin/showcase/video-rosters${query ? '?' + query : ''}`, {}, { admin: true })
+    }
+
+    static async adminLinkVideoRoster(rosterId, { player_api_id }) {
+        return this.request(`/admin/showcase/video-rosters/${encodeURIComponent(rosterId)}/link`, {
+            method: 'PUT',
+            body: JSON.stringify({ player_api_id }),
+        }, { admin: true })
+    }
+
+    static async adminShowcasePlayerSearch(q) {
+        const query = new URLSearchParams({ q: q || '' }).toString()
+        return this.request(`/admin/showcase/player-search?${query}`, {}, { admin: true })
+    }
+
     // Writer Portal API methods
     static async getWriterTeams() {
         return this.request('/writer/teams')

--- a/academy-watch-frontend/src/pages/PlayerPage.jsx
+++ b/academy-watch-frontend/src/pages/PlayerPage.jsx
@@ -40,6 +40,7 @@ import { MiniProgressBar } from '@/components/MiniProgressBar'
 import { SeasonStatsPanel } from '@/components/SeasonStatsPanel'
 import { CommentSection } from '@/components/CommentSection'
 import { PlayerLinksSection } from '@/components/PlayerLinksSection'
+import { ShowcaseSection } from '@/components/ShowcaseSection'
 import { PlayerAvailability } from '@/components/PlayerAvailability'
 import { CHART_GRID_COLOR, CHART_AXIS_COLOR, CHART_TOOLTIP_BG, CHART_TOOLTIP_BORDER } from '../lib/theme-constants'
 
@@ -656,6 +657,7 @@ export function PlayerPage() {
 
             <div className="max-w-4xl mx-auto px-4 sm:px-6 py-6 pb-24 sm:pb-6">
                     <div className="space-y-8">
+                        <ShowcaseSection playerApiId={playerApiId} playerName={playerName} />
                         {stats.length === 0 && academyStats?.appearances > 0 ? (
                             /* Academy player with no loan stats — academy section below is the primary view */
                             null

--- a/academy-watch-frontend/src/pages/admin/AdminShowcase.jsx
+++ b/academy-watch-frontend/src/pages/admin/AdminShowcase.jsx
@@ -1,0 +1,563 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Link } from 'react-router-dom'
+import { APIService } from '@/lib/api'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select'
+import {
+    AlertCircle,
+    CheckCircle2,
+    Loader2,
+    Check,
+    X,
+    Undo2,
+    Search,
+    Film,
+    Star,
+    Inbox,
+    UserSquare,
+    Link2,
+} from 'lucide-react'
+
+const CLAIM_STATUS_COLORS = {
+    pending: 'bg-amber-50 text-amber-800 border-amber-200',
+    approved: 'bg-emerald-50 text-emerald-800 border-emerald-200',
+    rejected: 'bg-rose-50 text-rose-800 border-rose-200',
+    revoked: 'bg-stone-100 text-stone-700 border-stone-200',
+}
+
+const IDENTITY_COLORS = {
+    human_confirmed: 'bg-emerald-50 text-emerald-800 border-emerald-200',
+    high: 'bg-sky-50 text-sky-800 border-sky-200',
+    low: 'bg-amber-50 text-amber-800 border-amber-200',
+    unverified: 'bg-stone-100 text-stone-700 border-stone-200',
+}
+
+const RELATIONSHIP_LABELS = {
+    player: 'Player',
+    agent: 'Agent',
+    guardian: 'Parent / Guardian',
+    club_official: 'Club official',
+}
+
+function formatDate(value) {
+    if (!value) return null
+    const d = new Date(value)
+    if (Number.isNaN(d.getTime())) return null
+    return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
+function asArray(data, ...keys) {
+    if (Array.isArray(data)) return data
+    for (const k of keys) {
+        if (Array.isArray(data?.[k])) return data[k]
+    }
+    return []
+}
+
+function Loading() {
+    return (
+        <div className="flex items-center justify-center py-12">
+            <Loader2 className="mr-2 h-5 w-5 animate-spin text-muted-foreground/70" />
+            <span className="text-sm text-muted-foreground">Loading…</span>
+        </div>
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Claims
+// ---------------------------------------------------------------------------
+
+function ClaimsTab({ setMessage }) {
+    const [claims, setClaims] = useState([])
+    const [loading, setLoading] = useState(true)
+    const [status, setStatus] = useState('pending')
+    const [reloadKey, setReloadKey] = useState(0)
+    const [actingId, setActingId] = useState(null)
+
+    useEffect(() => {
+        let cancelled = false
+        setLoading(true)
+        const params = status === 'all' ? {} : { status }
+        APIService.adminListShowcaseClaims(params)
+            .then((data) => { if (!cancelled) setClaims(asArray(data, 'claims')) })
+            .catch((err) => {
+                if (!cancelled) setMessage({ type: 'error', text: err.message || 'Failed to load claims' })
+            })
+            .finally(() => { if (!cancelled) setLoading(false) })
+        return () => { cancelled = true }
+    }, [status, reloadKey, setMessage])
+
+    const act = async (claim, action) => {
+        setActingId(claim.id)
+        try {
+            await APIService.adminReviewShowcaseClaim(claim.id, { action })
+            setMessage({ type: 'success', text: `Claim ${action}d` })
+            setReloadKey((k) => k + 1)
+        } catch (err) {
+            setMessage({ type: 'error', text: err.message || 'Failed to update claim' })
+        } finally {
+            setActingId(null)
+        }
+    }
+
+    return (
+        <Card>
+            <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                    <CardTitle>Profile claims</CardTitle>
+                    <CardDescription>Players, agents and guardians requesting ownership of a profile</CardDescription>
+                </div>
+                <Select value={status} onValueChange={setStatus}>
+                    <SelectTrigger className="w-40">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="pending">Pending</SelectItem>
+                        <SelectItem value="approved">Approved</SelectItem>
+                        <SelectItem value="rejected">Rejected</SelectItem>
+                        <SelectItem value="revoked">Revoked</SelectItem>
+                        <SelectItem value="all">All</SelectItem>
+                    </SelectContent>
+                </Select>
+            </CardHeader>
+            <CardContent>
+                {loading ? (
+                    <Loading />
+                ) : claims.length === 0 ? (
+                    <p className="py-8 text-center text-sm text-muted-foreground">No {status === 'all' ? '' : status} claims.</p>
+                ) : (
+                    <div className="space-y-3">
+                        {claims.map((claim) => {
+                            const claimant = claim.claimant_display_name || claim.claimant_email || claim.user_email || `User #${claim.user_account_id ?? '—'}`
+                            return (
+                                <div key={claim.id} className="flex flex-col justify-between gap-4 rounded-lg border bg-card p-4 sm:flex-row sm:items-start">
+                                    <div className="min-w-0 flex-1 space-y-1">
+                                        <div className="flex flex-wrap items-center gap-2">
+                                            <Badge className={CLAIM_STATUS_COLORS[claim.status] || CLAIM_STATUS_COLORS.revoked}>
+                                                {claim.status}
+                                            </Badge>
+                                            <Badge variant="secondary">{RELATIONSHIP_LABELS[claim.relationship_type] || claim.relationship_type}</Badge>
+                                            <Badge variant="outline">
+                                                {claim.player_name ? claim.player_name : `Player #${claim.player_api_id}`}
+                                                {claim.player_name ? ` · #${claim.player_api_id}` : ''}
+                                            </Badge>
+                                        </div>
+                                        <p className="text-sm font-medium text-foreground">{claimant}</p>
+                                        {claim.message && (
+                                            <p className="text-sm text-muted-foreground">“{claim.message}”</p>
+                                        )}
+                                        {formatDate(claim.created_at) && (
+                                            <p className="text-xs text-muted-foreground">Submitted {formatDate(claim.created_at)}</p>
+                                        )}
+                                    </div>
+                                    <div className="flex shrink-0 items-center gap-2">
+                                        {claim.status === 'pending' && (
+                                            <>
+                                                <Button size="sm" variant="outline" className="border-emerald-600 text-emerald-600 hover:bg-emerald-50" disabled={actingId === claim.id} onClick={() => act(claim, 'approve')}>
+                                                    {actingId === claim.id ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Check className="mr-1 h-4 w-4" />}
+                                                    Approve
+                                                </Button>
+                                                <Button size="sm" variant="outline" className="border-rose-600 text-rose-600 hover:bg-rose-50" disabled={actingId === claim.id} onClick={() => act(claim, 'reject')}>
+                                                    <X className="mr-1 h-4 w-4" />
+                                                    Reject
+                                                </Button>
+                                            </>
+                                        )}
+                                        {claim.status === 'approved' && (
+                                            <Button size="sm" variant="outline" className="border-stone-400 text-stone-600 hover:bg-stone-50" disabled={actingId === claim.id} onClick={() => act(claim, 'revoke')}>
+                                                {actingId === claim.id ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Undo2 className="mr-1 h-4 w-4" />}
+                                                Revoke
+                                            </Button>
+                                        )}
+                                        {(claim.status === 'rejected' || claim.status === 'revoked') && (
+                                            <Button size="sm" variant="outline" className="border-emerald-600 text-emerald-600 hover:bg-emerald-50" disabled={actingId === claim.id} onClick={() => act(claim, 'approve')}>
+                                                {actingId === claim.id ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Check className="mr-1 h-4 w-4" />}
+                                                Approve
+                                            </Button>
+                                        )}
+                                    </div>
+                                </div>
+                            )
+                        })}
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Profile edits
+// ---------------------------------------------------------------------------
+
+function ProfilesTab({ setMessage }) {
+    const [profiles, setProfiles] = useState([])
+    const [loading, setLoading] = useState(true)
+    const [status, setStatus] = useState('pending')
+    const [reloadKey, setReloadKey] = useState(0)
+    const [actingId, setActingId] = useState(null)
+
+    useEffect(() => {
+        let cancelled = false
+        setLoading(true)
+        APIService.adminListShowcaseProfiles({ status })
+            .then((data) => { if (!cancelled) setProfiles(asArray(data, 'profiles')) })
+            .catch((err) => {
+                if (!cancelled) setMessage({ type: 'error', text: err.message || 'Failed to load profiles' })
+            })
+            .finally(() => { if (!cancelled) setLoading(false) })
+        return () => { cancelled = true }
+    }, [status, reloadKey, setMessage])
+
+    const act = async (profile, action) => {
+        setActingId(profile.id)
+        try {
+            await APIService.adminReviewShowcaseProfile(profile.player_api_id, { action })
+            setMessage({ type: 'success', text: `Profile ${action}d` })
+            setReloadKey((k) => k + 1)
+        } catch (err) {
+            setMessage({ type: 'error', text: err.message || 'Failed to update profile' })
+        } finally {
+            setActingId(null)
+        }
+    }
+
+    return (
+        <Card>
+            <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                    <CardTitle>Profile edits</CardTitle>
+                    <CardDescription>Self-reported bio, positions, foot and height awaiting review</CardDescription>
+                </div>
+                <Select value={status} onValueChange={setStatus}>
+                    <SelectTrigger className="w-40">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="pending">Pending</SelectItem>
+                        <SelectItem value="approved">Approved</SelectItem>
+                    </SelectContent>
+                </Select>
+            </CardHeader>
+            <CardContent>
+                {loading ? (
+                    <Loading />
+                ) : profiles.length === 0 ? (
+                    <p className="py-8 text-center text-sm text-muted-foreground">No {status} profile edits.</p>
+                ) : (
+                    <div className="space-y-3">
+                        {profiles.map((profile) => (
+                            <div key={profile.id} className="flex flex-col justify-between gap-4 rounded-lg border bg-card p-4 sm:flex-row sm:items-start">
+                                <div className="min-w-0 flex-1 space-y-2">
+                                    <div className="flex flex-wrap items-center gap-2">
+                                        <Badge className={CLAIM_STATUS_COLORS[profile.status] || CLAIM_STATUS_COLORS.revoked}>{profile.status}</Badge>
+                                        <Badge variant="outline">
+                                            {profile.player_name ? `${profile.player_name} · #${profile.player_api_id}` : `Player #${profile.player_api_id}`}
+                                        </Badge>
+                                    </div>
+                                    {profile.bio && <p className="text-sm text-foreground/90">{profile.bio}</p>}
+                                    <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-muted-foreground">
+                                        {profile.positions && <span>Positions: <span className="text-foreground">{profile.positions}</span></span>}
+                                        {profile.preferred_foot && <span>Foot: <span className="capitalize text-foreground">{profile.preferred_foot}</span></span>}
+                                        {profile.height_cm != null && <span>Height: <span className="text-foreground">{profile.height_cm} cm</span></span>}
+                                    </div>
+                                    {formatDate(profile.updated_at) && (
+                                        <p className="text-xs text-muted-foreground">Updated {formatDate(profile.updated_at)}</p>
+                                    )}
+                                </div>
+                                {profile.status === 'pending' && (
+                                    <div className="flex shrink-0 items-center gap-2">
+                                        <Button size="sm" variant="outline" className="border-emerald-600 text-emerald-600 hover:bg-emerald-50" disabled={actingId === profile.id} onClick={() => act(profile, 'approve')}>
+                                            {actingId === profile.id ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Check className="mr-1 h-4 w-4" />}
+                                            Approve
+                                        </Button>
+                                        <Button size="sm" variant="outline" className="border-rose-600 text-rose-600 hover:bg-rose-50" disabled={actingId === profile.id} onClick={() => act(profile, 'reject')}>
+                                            <X className="mr-1 h-4 w-4" />
+                                            Reject
+                                        </Button>
+                                    </div>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Film Room links — link finalized-match roster entries to a tracked player
+// ---------------------------------------------------------------------------
+
+function RosterLinkRow({ entry, setMessage, onChanged }) {
+    const rosterId = entry.id ?? entry.roster_id
+    const linkedApiId = entry.player_api_id ?? entry.linked_player_api_id
+    const linkedName = entry.linked_player_name ?? entry.tracked_player_name
+
+    const [query, setQuery] = useState('')
+    const [results, setResults] = useState([])
+    const [searching, setSearching] = useState(false)
+    const [open, setOpen] = useState(false)
+    const [busy, setBusy] = useState(false)
+
+    useEffect(() => {
+        const q = query.trim()
+        if (q.length < 2) { setResults([]); return }
+        let cancelled = false
+        setSearching(true)
+        const t = setTimeout(() => {
+            APIService.adminShowcasePlayerSearch(q)
+                .then((data) => { if (!cancelled) { setResults(asArray(data, 'results', 'players')); setOpen(true) } })
+                .catch(() => { if (!cancelled) setResults([]) })
+                .finally(() => { if (!cancelled) setSearching(false) })
+        }, 300)
+        return () => { cancelled = true; clearTimeout(t) }
+    }, [query])
+
+    const link = async (playerApiId) => {
+        setBusy(true)
+        try {
+            await APIService.adminLinkVideoRoster(rosterId, { player_api_id: playerApiId })
+            setMessage({ type: 'success', text: playerApiId ? 'Roster entry linked' : 'Link cleared' })
+            setQuery('')
+            setResults([])
+            setOpen(false)
+            onChanged()
+        } catch (err) {
+            setMessage({ type: 'error', text: err.message || 'Failed to update link' })
+        } finally {
+            setBusy(false)
+        }
+    }
+
+    const identity = entry.identity_confidence
+
+    return (
+        <div className="flex flex-col gap-3 rounded-lg border bg-card p-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="min-w-0 flex-1 space-y-1">
+                <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-medium text-foreground">
+                        {entry.player_name || 'Unknown player'}
+                    </span>
+                    {entry.jersey_number != null && (
+                        <Badge variant="secondary">#{entry.jersey_number}</Badge>
+                    )}
+                    {identity && (
+                        <Badge className={IDENTITY_COLORS[identity] || IDENTITY_COLORS.unverified}>
+                            {String(identity).replace('_', ' ')}
+                        </Badge>
+                    )}
+                </div>
+                {linkedApiId ? (
+                    <p className="text-xs text-emerald-700">
+                        Linked to {linkedName ? `${linkedName} · ` : ''}#{linkedApiId}
+                    </p>
+                ) : (
+                    <p className="text-xs text-muted-foreground">Not linked to a tracked player</p>
+                )}
+            </div>
+            <div className="relative w-full shrink-0 sm:w-72">
+                <div className="flex items-center gap-2">
+                    <div className="relative flex-1">
+                        <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+                        <Input
+                            value={query}
+                            onChange={(e) => setQuery(e.target.value)}
+                            onFocus={() => results.length > 0 && setOpen(true)}
+                            placeholder="Search tracked player…"
+                            className="pl-8"
+                            disabled={busy}
+                        />
+                        {searching && <Loader2 className="absolute right-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 animate-spin text-muted-foreground" />}
+                        {open && results.length > 0 && (
+                            <div className="absolute z-20 mt-1 max-h-64 w-full overflow-auto rounded-md border bg-popover shadow-md">
+                                {results.map((r) => (
+                                    <button
+                                        key={r.player_api_id}
+                                        type="button"
+                                        className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left text-sm hover:bg-accent"
+                                        onClick={() => link(r.player_api_id)}
+                                    >
+                                        <span className="font-medium text-foreground">{r.player_name} · #{r.player_api_id}</span>
+                                        <span className="text-xs text-muted-foreground">
+                                            {[r.team_name, r.status].filter(Boolean).join(' · ')}
+                                        </span>
+                                    </button>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                    {linkedApiId && (
+                        <Button size="sm" variant="ghost" className="shrink-0 text-muted-foreground hover:text-destructive" disabled={busy} onClick={() => link(null)}>
+                            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <X className="h-4 w-4" />}
+                            Unlink
+                        </Button>
+                    )}
+                </div>
+            </div>
+        </div>
+    )
+}
+
+function RostersTab({ setMessage }) {
+    const [entries, setEntries] = useState([])
+    const [loading, setLoading] = useState(true)
+    const [reloadKey, setReloadKey] = useState(0)
+
+    const reload = useCallback(() => setReloadKey((k) => k + 1), [])
+
+    useEffect(() => {
+        let cancelled = false
+        setLoading(true)
+        APIService.adminListVideoRosters()
+            .then((data) => { if (!cancelled) setEntries(asArray(data, 'rosters', 'entries')) })
+            .catch((err) => {
+                if (!cancelled) setMessage({ type: 'error', text: err.message || 'Failed to load roster entries' })
+            })
+            .finally(() => { if (!cancelled) setLoading(false) })
+        return () => { cancelled = true }
+    }, [reloadKey, setMessage])
+
+    // Group roster entries by match for readability.
+    const groups = entries.reduce((acc, entry) => {
+        const matchId = entry.match_id ?? entry.match?.id ?? 'unknown'
+        if (!acc[matchId]) {
+            acc[matchId] = {
+                matchId,
+                label: entry.opponent_name
+                    ? `${entry.team_name || 'Match'} vs ${entry.opponent_name}`
+                    : entry.match?.label || entry.team_name || `Match ${matchId}`,
+                date: entry.match_date ?? entry.match?.match_date,
+                items: [],
+            }
+        }
+        acc[matchId].items.push(entry)
+        return acc
+    }, {})
+    const groupList = Object.values(groups)
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Film Room links</CardTitle>
+                <CardDescription>
+                    Link finalized-match roster entries to a tracked player. Human-confirmed identities then surface
+                    as club-verified footage on that player&apos;s public showcase.
+                </CardDescription>
+            </CardHeader>
+            <CardContent>
+                {loading ? (
+                    <Loading />
+                ) : groupList.length === 0 ? (
+                    <p className="py-8 text-center text-sm text-muted-foreground">No finalized-match roster entries yet.</p>
+                ) : (
+                    <div className="space-y-6">
+                        {groupList.map((group) => (
+                            <div key={group.matchId} className="space-y-3">
+                                <div className="flex items-center gap-2">
+                                    <Film className="h-4 w-4 text-muted-foreground" />
+                                    <span className="text-sm font-semibold text-foreground">{group.label}</span>
+                                    {formatDate(group.date) && (
+                                        <span className="text-xs text-muted-foreground">{formatDate(group.date)}</span>
+                                    )}
+                                </div>
+                                <div className="space-y-2">
+                                    {group.items.map((entry) => (
+                                        <RosterLinkRow
+                                            key={entry.id ?? entry.roster_id}
+                                            entry={entry}
+                                            setMessage={setMessage}
+                                            onChanged={reload}
+                                        />
+                                    ))}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export function AdminShowcase() {
+    const [message, setMessage] = useState(null)
+    const [tab, setTab] = useState('claims')
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-center gap-3">
+                <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10">
+                    <Star className="h-5 w-5 text-primary" />
+                </div>
+                <div>
+                    <h2 className="text-3xl font-bold tracking-tight">Talent Showcase</h2>
+                    <p className="text-muted-foreground">Moderate profile claims, self-reported edits and Film Room evidence</p>
+                </div>
+            </div>
+
+            {message && (
+                <Alert className={message.type === 'error' ? 'border-rose-500 bg-rose-50' : 'border-emerald-500 bg-emerald-50'}>
+                    {message.type === 'error' ? <AlertCircle className="h-4 w-4 text-rose-600" /> : <CheckCircle2 className="h-4 w-4 text-emerald-600" />}
+                    <AlertDescription className={message.type === 'error' ? 'text-rose-800' : 'text-emerald-800'}>
+                        {message.text}
+                    </AlertDescription>
+                </Alert>
+            )}
+
+            <div className="flex items-center gap-2 rounded-md border border-border/70 bg-secondary/40 px-3 py-2 text-sm text-muted-foreground">
+                <Inbox className="h-4 w-4 shrink-0" />
+                <span>
+                    Highlight-reel videos are moderated in the{' '}
+                    <Link to="/admin/inbox?tab=links" className="font-medium text-primary hover:underline">Inbox → Player links</Link>{' '}
+                    queue.
+                </span>
+            </div>
+
+            <Tabs value={tab} onValueChange={setTab}>
+                <TabsList>
+                    <TabsTrigger value="claims">
+                        <UserSquare className="mr-1.5 h-4 w-4" />
+                        Claims
+                    </TabsTrigger>
+                    <TabsTrigger value="profiles">
+                        <Link2 className="mr-1.5 h-4 w-4" />
+                        Profile edits
+                    </TabsTrigger>
+                    <TabsTrigger value="rosters">
+                        <Film className="mr-1.5 h-4 w-4" />
+                        Film Room links
+                    </TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="claims" className="mt-4">
+                    {tab === 'claims' && <ClaimsTab setMessage={setMessage} />}
+                </TabsContent>
+                <TabsContent value="profiles" className="mt-4">
+                    {tab === 'profiles' && <ProfilesTab setMessage={setMessage} />}
+                </TabsContent>
+                <TabsContent value="rosters" className="mt-4">
+                    {tab === 'rosters' && <RostersTab setMessage={setMessage} />}
+                </TabsContent>
+            </Tabs>
+        </div>
+    )
+}
+
+export default AdminShowcase

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -1,0 +1,78 @@
+# Talent Showcase — Player Profiles, Claims & Club-Verified Evidence
+
+> **Living document.** Last updated **2026-07-02**. When the feature changes, update the
+> relevant section and add a line to the Changelog. Roadmap/state:
+> `ledgers/ROADMAP_talent-showcase-vision.md`.
+
+## 1. What it is
+
+Every player page carries a **Showcase** section (top of page, above stats):
+
+1. **Highlight reel** — embedded YouTube videos. Sources: owner-curated links,
+   fan-submitted links (moderated), and admin-entered newsletter YouTube links
+   (merged read-only, deduped by video id).
+2. **Player profile card** — bio / positions / preferred foot / height, always badged
+   **"Self-reported"** (never styled like verified stats).
+3. **Verified appearances** — badged **"Club-verified"** (emerald): appearance evidence
+   from Film Room reports where a **human confirmed the identity** and an admin linked
+   the roster entry to the platform player. Shows opponent, date, minutes on camera,
+   % of match.
+4. **Claim strip** — "Is this you? Claim this profile."
+
+## 2. The claim → curate lifecycle
+
+```
+user (logged in) claims player  →  admin approves (Admin → Showcase → Claims)
+  →  owner curates: add/reorder/delete reel videos, edit profile card
+  →  every content edit is PRE-MODERATED (pending → admin approves → public)
+```
+
+- Relationships: `player | agent | guardian | club_official`. Multiple approved claims
+  per player are allowed (player + agent may co-own).
+- **Safeguarding posture:** many players are minors — all owner content is pre-moderated;
+  a rejected/revoked claim can be resubmitted (resets to pending); no commentary surfaces.
+- Owners see their own pending items (amber badge); the public never does.
+- Reel link moderation reuses the existing **Admin → Inbox → Player Links** queue.
+- Profile-edit moderation lives in **Admin → Showcase → Profile edits**.
+
+## 3. Film Room → profile (the flywheel)
+
+Admin → Showcase → **Film Room links**: for finalized matches, link a roster entry
+(e.g. "Yorkies No. 2", identity `human_confirmed`) to a platform player via name search.
+Only **human-confirmed** identities ever surface publicly; linking is an explicit admin
+action; opposition players have no roster rows and can never appear.
+
+## 4. API surface (all under /api)
+
+Public: `GET /players/<id>/showcase` (optional Bearer: approved owners also get their
+pending items). User: `POST /players/<id>/claim`, `GET /me/claims`, owner-gated
+`PUT .../showcase/profile`, `POST/PATCH/DELETE .../showcase/reel*`. Admin
+(`require_api_key`): `/admin/showcase/{claims,claims/<id>/review,profiles,
+profiles/<pid>/review,video-rosters,video-rosters/<rid>/link,player-search}`.
+
+URL safety: all submitted links must be https + YouTube (server-side `_is_youtube_url`);
+`javascript:`/`data:`/http are rejected everywhere, including the pre-existing
+`POST /players/<id>/links` (hardened in this slice).
+
+## 5. Operator notes
+
+- **Migration `aw19`** merges the `cs01` + `vid02` heads back to one and adds
+  `player_profile_claims`, `player_showcase_profiles`, `player_links.sort_order`.
+  Idempotent/guarded. Note: `flask db downgrade` across any merge revision needs an
+  explicit target revision (alembic "Ambiguous walk" — same as aw17).
+- **Local dev DB caveat (2026-07-02):** the local DB is stamped `vid03` (uncommitted
+  migration); aw19's DDL was applied there manually (guarded SQL) without touching
+  `alembic_version`. After the vid-chain work lands, rebase vid03 onto aw19
+  (`down_revision="aw19"`, drop its merge) and run a normal upgrade.
+- **Known pre-existing issue:** the historical migration chain cannot replay on an EMPTY
+  database (an old unguarded migration alters the deleted `supplemental_loans` table).
+  Existing stamped DBs are unaffected.
+- Tests: `pytest tests/test_showcase.py` (40). Demo data on local dev DB: player 403064
+  (H. Amass) has a claimed profile, curated reel, and a club-verified appearance from
+  Film Room match 4.
+
+## 6. Changelog
+
+- **2026-07-02** — Initial slice shipped (P0 showcase surfacing + P1 claim & curate +
+  X Film Room verified evidence). Built multi-agent (Fable 5 orchestrating Opus 4.8
+  builders), adversarially reviewed (23 agents, 8 findings fixed), live-verified.

--- a/ledgers/ROADMAP_talent-showcase-vision.md
+++ b/ledgers/ROADMAP_talent-showcase-vision.md
@@ -1,0 +1,115 @@
+# Roadmap: Two-Sided Talent Platform (Player Showcase × Club Film Room)
+
+> Vision (MJ, 2026-07-02): a place where **players worldwide have a profile page that
+> lets them show their talents** — uploaded YouTube video, commentary, verified stats —
+> to increase **discoverability + engagement**; and where, at the **club level, verified
+> clubs upload footage and get stats about the players in it** (Film Room — "also needs
+> enhancements").
+>
+> This roadmap sequences that vision against what already ships. It does not restate the
+> two live ledgers it depends on:
+> - **Scout discovery + global footprint** — `CONTINUITY_global-talent-platform.md` (shipped)
+> - **Film Room / video analysis** — `CONTINUITY_video-analysis.md` + `../docs/film-room.md`
+
+## Strategic thesis
+
+The commodity is a highlight reel — every player already has Instagram. The **moat is
+verification**: stats pulled from real fixtures (not self-reported) and footage-derived
+stats vouched by a club. So the play is: **lead with verification, package it in a
+showcase profile, and let Film Room feed club-verified evidence into that profile.** The
+two pillars are one flywheel — Film Room manufactures the trust that makes a showcase
+credible.
+
+## What already exists (do NOT rebuild)
+
+- **Verified stats primitive** — `PlayerPage.jsx` renders `compute_stats()` totals, per-90s,
+  radar, career journey, academy stats. This is the trust layer; it's real.
+- **Scout discovery layer** — `/scout` browse/filter/leaderboards/compare/watchlist, global
+  16-league footprint, provenance-clean roster (own-academy-only, real names, ages). All
+  shipped in the global-talent ledger.
+- **`PlayerLink`** (`models/league.py:1818`) — moderated user-submitted URLs typed
+  `article | highlight | social | stats | other`, `pending→approved` flow, upvotes. A
+  highlight reel already has a data home; it just isn't surfaced as an embedded showcase.
+- **Film Room Phase A concierge** — full CV pipeline (detect→track→cluster→jersey-read→
+  chain→human tag-review→per-player report) + RLHF-style learning loop + admin routes.
+  Honestly gives identity + on-camera coverage today.
+
+## The gaps (what the vision needs that doesn't exist)
+
+**Pillar 1 — player self-showcase:** no profile ownership/claiming, no embedded video
+showcase (YouTube is a stored URL, not a curated reel), no commentary/endorsement/follow
+layer. Everything today is admin/journalist-curated, not player-owned.
+
+**Pillar 2 — Film Room enhancements:** physical metrics (distance/speed/sprints/heatmap)
+blocked on homography; touches need ball association; identity coverage/merge quality is
+the documented core R&D problem (over-merge; VLM entity-consistency gate lifted 17.5→70%);
+still concierge-only (no self-serve accounts, billing unwired, crops/boxes dev-only in prod).
+
+## Phases
+
+### Pillar 1 — Player showcase profile
+| ID | Phase | Effort | Risk | Depends on |
+|----|-------|--------|------|-----------|
+| P0 | **Surface what exists** — a "Showcase" block on PlayerPage: embed approved `PlayerLink` highlight URLs as YouTube players, lead with verified stats + radar, journey timeline. No auth, no new models. | S | low | — |
+| P1 | **Claim & curate** — player/agent identity + claim flow; owner curates an ordered highlight reel (self-submit YouTube), bio/about, self-attested position/foot/height **clearly marked self-reported vs verified**; moderation + anti-spam. | M | med | P0 |
+| P2 | **Engagement + discovery** — commentary/endorsements (verified scouts/coaches), follow/notify, public "discover talent" search (extend the scout browse toward a consumer surface). | M | med | P1 |
+
+### Pillar 2 — Club Film Room (extends the video-analysis ledger)
+| ID | Phase | Effort | Risk | Depends on |
+|----|-------|--------|------|-----------|
+| F0 | **Prod-harden output** — persist crop JPEGs + per-frame boxes to Blob (`serve_crop` is 501 in prod today), CSP `media-src`. Makes concierge output actually reviewable in prod. | S–M | low | — |
+| F1 | **Identity / merge quality** — the credibility blocker: over-merge; ship the VLM entity-consistency gate (17.5→70% precision). Reports aren't sellable until tracklets are clean. | L | high (R&D) | F0 |
+| F2 | **Physical metrics via homography** — unlock distance/speed/sprints/heatmap ("pending calibration" today). The "wow", but only once identity is trustworthy. | L | med | F1 |
+| F3 | **Ball association → touches** — beta → real. | L | med | F1 |
+| F4 | **Self-serve + billing** — graduate from concierge: club accounts, credit purchase (Stripe scaffold + `scout_tier` posture already exist). | M | med | F0 |
+
+### The flywheel
+| ID | Phase | Effort | Risk | Depends on |
+|----|-------|--------|------|-----------|
+| X | **Film Room → showcase** — a finalized per-player report attaches a **club-verified** clip + stat badge to that player's showcase profile. The unique differentiator: verified footage-derived evidence on the profile, not self-reported. | M | med | P1 + F0 |
+
+## Recommended sequence + rationale
+
+1. **P0** — cheap, uses data already in the DB, foundation for everything, ships in ~a day.
+2. **F0** — small prod-hardening; makes Film Room actually usable in prod AND unblocks the flywheel.
+3. **P1** — the headline consumer pillar; delivers "players show their talents" literally.
+4. **X** — with P1 + F0 done, the differentiator lights up for free-ish.
+5. **Then branch by bottleneck:** if the constraint is *demand-side engagement* → **P2**;
+   if it's *supply-side credibility of Film Room* → **F1** (then F2/F3/F4).
+
+Lead with cheap high-leverage surfacing, harden the moat's output, build the consumer
+headline, wire the differentiator — and defer the expensive CV R&D (F1/F2/F3) and
+productization (F4) until profiles prove demand.
+
+## Open decisions for MJ (steer before P1)
+
+- **Who can claim a profile?** player-only / player + agent / club-vouched. Determines the
+  auth + verification model.
+- **Safeguarding (minors).** Many tracked players are academy = minors. Player-uploaded
+  media + open commentary is a real constraint (mirrors Film Room's opposition-numbers-only
+  consent posture). Likely needs age-gating / guardian consent / restricted commentary.
+- **Self-reported vs verified.** How hard to visually separate on the profile (the whole
+  moat is that a scout can trust which is which).
+- **Monetization shape.** Is the showcase free top-of-funnel, with Film Room + Scout Pro the
+  paid layers? (`scout_tier` + `/pricing` already assume paid Scout Pro / Film Room.)
+
+## Status
+
+- **EXECUTING (2026-07-02)** — MJ set /goal "carry out the vision" (Fable 5 orchestrating,
+  Opus 4.8 subagents). This session builds **P0 + P1 + X** on branch
+  `feature/talent-showcase` (worktree, isolated from uncommitted Film Room work).
+- Open decisions resolved with conservative defaults (MJ can revise):
+  - **Claiming:** any authenticated UserAccount may *request* a claim; **admin approves**
+    (verification stays human). Player + agent both allowed via claim `relationship` field.
+  - **Safeguarding:** no open commentary on claimed minor profiles in this slice —
+    engagement layer (P2) deferred; curated links remain admin-moderated before display.
+  - **Self-reported vs verified:** hard visual separation — self-reported fields carry an
+    explicit "self-reported" badge; verified stats keep their existing treatment.
+  - **Monetization:** showcase is free top-of-funnel (Scout Pro / Film Room stay the paid
+    layers per /pricing).
+- Pointer added to master `CONTINUITY.md` ✓. F0/F1+ remain with the video-analysis ledger.
+- **P0 + P1 + X SHIPPED to `feature/talent-showcase` (2026-07-02)** — built multi-agent,
+  adversarially reviewed (8 findings fixed), 40 tests, live-verified end-to-end (demo:
+  player 403064 H. Amass). See `docs/showcase.md` for the operator guide. Remaining
+  phases: P2 (engagement/discovery) and the Film Room track (F0 prod-hardening → F1
+  identity quality → F2 homography → F3 touches → F4 self-serve+billing).


### PR DESCRIPTION
## The vision, first slice

Players worldwide get a **showcase profile**: curated YouTube highlights, a self-reported profile card, and **club-verified** appearance evidence — layered on top of the existing verified stats. Clubs' Film Room output now feeds player profiles (the flywheel).

**Live demo on local dev DB:** `/players/403064` (H. Amass) — claimed profile, curated reel, self-reported card, and a club-verified appearance (10′ on camera vs AFC Wyke, human-confirmed identity from Film Room match 4).

## What's in this PR

| Pillar | Delivered |
|---|---|
| **P0 surface** | `ShowcaseSection` on PlayerPage: highlight reel (PlayerLink highlights + newsletter YouTube links, video-id dedup, reuses `VideoEmbed`); Community section stops double-rendering highlights |
| **P1 claim & curate** | `POST /players/<id>/claim` (player/agent/guardian/club_official) → admin approval → owner curates reel (add/reorder/delete) + profile card. **All owner content pre-moderated** (safeguarding: many players are minors). Self-reported vs verified visually hard-separated. Rejected/revoked claims are resubmittable. |
| **X flywheel** | Admin links finalized-match roster entries → platform players (`/admin/showcase` → Film Room links, with player search). Only `human_confirmed` identities surface publicly, as emerald **Club-verified** rows. Opposition players can never appear (no roster rows exist). |
| **Admin** | New `/admin/showcase` page (Claims / Profile edits / Film Room links). Reel moderation reuses the existing AdminInbox player-links queue. |

## Migration: aw19 (READ — coordinates with the in-flight Film Room branch)

- `aw19` **merges the two open heads (`cs01` + `vid02`) back to one** — `test_alembic_has_single_head` goes red→green.
- Adds `player_profile_claims`, `player_showcase_profiles`, `player_links.sort_order`. Fully guarded/idempotent both directions.
- Verified on a real Postgres clone of the dev DB: upgrade ✓, idempotent re-run ✓. (Downgrading across any merge revision needs an explicit target — alembic "Ambiguous walk", same as the existing aw17.)
- ⚠️ **The uncommitted `vid03` migration must rebase onto aw19** before it lands: change its `down_revision` from `("aw18","vid02")` to `"aw19"` and drop the merge (its current form misses `cs01` anyway).
- 🔎 Pre-existing (not this PR): the historical chain cannot replay on an EMPTY database — an old unguarded migration alters the deleted `supplemental_loans` table. Stamped DBs are unaffected; worth a follow-up chore.

## Security

- New shared `is_safe_https_url` validator (`utils/sanitize.py`): https-only, rejects `javascript:`/`data:` — applied to all showcase submissions **and closes a pre-existing stored-XSS-on-click hole in `submit_player_link`** (URLs were stored with no scheme validation).
- Newsletter YouTube merge is filtered server-side (admin-entered rows had no write-side validation).
- Public showcase GET is optional-auth: approved owners see their pending items; any bad/expired token degrades to the public view (never 401s the page).
- Per-user rate limits on claim (3/hr) and reel writes; all free text bleach-cleaned.

## Quality gate

- Built multi-agent: 6-surface recon → contract → parallel Opus 4.8 builders → **adversarial review panel (23 agents, 5 dimensions, 2 refuters per finding): 8 confirmed findings, all fixed; 1 refuted.**
- **40 backend tests** (`tests/test_showcase.py`, incl. review-regressions); adjacent suites unchanged (scout/user-auth/auth-decorators all green); `test_migration_heads` now passes.
- ruff check + format clean; `pnpm lint` 0 errors; `pnpm build` clean.
- Live-verified end-to-end via API + real browser render (claim→approve→curate→moderate→publish, roster link→verified footage).

## After merge (operator)

1. `flask db upgrade` in the prod container (aw19).
2. No data backfill needed. Showcase content accrues organically (claims, links, roster linking is per-match admin action).

## Deliberately NOT in this slice

- P2 engagement (commentary/follow) — deferred pending safeguarding decisions.
- Auto-resolution of roster names → players at upsert (touches the dirty `routes/video.py`; concierge-phase manual linking suffices).
- Billing (showcase is free top-of-funnel per the roadmap).

Roadmap: `ledgers/ROADMAP_talent-showcase-vision.md` · Operator guide: `docs/showcase.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)