### PR TITLE
feat(follow-graph): named follow lists + worldwide shadow tracking (stacked on #565)

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -151,6 +151,36 @@ The Academy Watch — Football academy tracking platform with AI-powered newslet
   - Known pre-existing (NOT this slice): full migration chain cannot replay
     on an EMPTY DB (old unguarded supplemental_loans migration)
   - **See `ledgers/ROADMAP_talent-showcase-vision.md` + `docs/showcase.md`**
+- Follow Graph + Shadow Tracking — Phase 1 SHIPPED to branch (2026-07-02)
+  - Scouts organize tracking into named LISTS of FOLLOWS (kinds: player |
+    academy_club | geo playing_in/nationality | saved query) — one resolver
+    over the scout query engine; digest generalized ADDITIVELY (legacy
+    watchlist section byte-identical; non-default lists render as grouped
+    sections, watchlist-wins dedup; default lists are the watchlist's mirror
+    twin and never route)
+  - SHADOW TRACKING: following any untracked player worldwide mints a
+    PlayerShadow (players/profiles fetch, seed fallback offline) + dedicated
+    PlayerShadowStats (NOT PlayerStatsCache — unowned legacy, kept isolated);
+    /players/<id> profile + season-stats shadow fallbacks; worldwide name
+    search via new client method search_player_profiles_global; caps via env
+    (10 lists / 50 follows / 10 shadows per user — billing later)
+  - Migration aw20 (chains aw19, single head preserved). Watchlist backfill is
+    a cursor-paged admin endpoint + dual-write mirrors, not a data migration
+  - Adversarial review (21 agents): 8 confirmed findings ALL fixed — headline:
+    the dual-write mirror was silently rerouting watchlist users onto the list
+    digest path (grouped layout + ASC order + cap-40 truncation); redesigned to
+    additive semantics with a REAL-API-path regression test (old test was
+    blind: it seeded entries directly)
+  - 164 backend tests green (test_scout_watchlist UNMODIFIED); ruff clean;
+    lint 0 errors; live-verified incl. real worldwide search (Endrick shadow
+    mint), digest dry-run (legacy user unchanged + grouped sections + "Now
+    tracking worldwide" card), ListsPage screenshots
+  - Branch `feature/follow-graph` STACKED on feature/talent-showcase —
+    PR based on the showcase branch until #565 merges
+  - LOCAL DEV DB note: cs01 columns (player_journeys.current_status etc.) were
+    missing locally (never applied — DB stamped on vid chain); applied manually
+    2026-07-02. Local scout browse had been broken since #514 merged.
+  - **See `ledgers/research/talent-platform/` (design panel) + `docs/follow-graph.md`**
 
 ### Next
 - Run migration: `flask db upgrade`

--- a/academy-watch-backend/migrations/versions/aw20_follow_graph.py
+++ b/academy-watch-backend/migrations/versions/aw20_follow_graph.py
@@ -1,0 +1,147 @@
+"""Follow graph + shadow tracking tables.
+
+Creates the four Follow-graph surfaces:
+
+- ``follow_lists``            — named lists of follows per user
+- ``follows``                 — heterogeneous follow rows (player/academy/geo/query)
+- ``player_shadows``          — lightweight worldwide players minted on follow
+- ``follow_player_snapshots`` — per-(user, player) digest delta baseline
+- ``player_shadow_stats``     — dedicated per-season shadow stats store
+
+Idempotent (guards + helpers) — production has had objects added out-of-band,
+so every DDL op is safe to re-run in both directions. Tables + indexes only;
+the watchlist -> follow-list backfill is an admin endpoint, not a migration.
+
+Revision ID: aw20
+Revises: aw19
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from migrations._migration_helpers import (
+    create_index_safe,
+    index_exists,
+    table_exists,
+)
+
+revision = "aw20"
+down_revision = "aw19"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if not table_exists("follow_lists"):
+        op.create_table(
+            "follow_lists",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("user_account_id", sa.Integer(), sa.ForeignKey("user_accounts.id"), nullable=False),
+            sa.Column("name", sa.String(length=120), nullable=False, server_default="My Watchlist"),
+            sa.Column("cadence", sa.String(length=20), nullable=False, server_default="weekly"),
+            sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+            sa.Column("is_default", sa.Boolean(), nullable=False, server_default="false"),
+            sa.Column("player_cap", sa.Integer(), nullable=False, server_default="40"),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.UniqueConstraint("user_account_id", "name", name="uq_follow_list_user_name"),
+        )
+    create_index_safe("ix_follow_lists_user", "follow_lists", ["user_account_id"])
+
+    if not table_exists("follows"):
+        op.create_table(
+            "follows",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "list_id",
+                sa.Integer(),
+                sa.ForeignKey("follow_lists.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("kind", sa.String(length=20), nullable=False),
+            sa.Column("selector", sa.JSON(), nullable=False),
+            sa.Column("label", sa.String(length=160), nullable=True),
+            sa.Column("note", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+        )
+    create_index_safe("ix_follows_list", "follows", ["list_id"])
+
+    if not table_exists("player_shadows"):
+        op.create_table(
+            "player_shadows",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("player_api_id", sa.Integer(), nullable=False),
+            sa.Column("player_name", sa.String(length=200), nullable=False),
+            sa.Column("photo_url", sa.String(length=500), nullable=True),
+            sa.Column("position", sa.String(length=50), nullable=True),
+            sa.Column("nationality", sa.String(length=100), nullable=True),
+            sa.Column("birth_date", sa.Date(), nullable=True),
+            sa.Column("current_club_name", sa.String(length=200), nullable=True),
+            sa.Column("current_club_api_id", sa.Integer(), nullable=True),
+            sa.Column(
+                "requested_by_user_id",
+                sa.Integer(),
+                sa.ForeignKey("user_accounts.id"),
+                nullable=True,
+            ),
+            sa.Column("last_profile_sync_at", sa.DateTime(), nullable=True),
+            sa.Column("last_stats_sync_at", sa.DateTime(), nullable=True),
+            sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+        )
+    create_index_safe("ix_player_shadows_player", "player_shadows", ["player_api_id"], unique=True)
+
+    if not table_exists("follow_player_snapshots"):
+        op.create_table(
+            "follow_player_snapshots",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("user_account_id", sa.Integer(), sa.ForeignKey("user_accounts.id"), nullable=False),
+            sa.Column("player_api_id", sa.Integer(), nullable=False),
+            sa.Column("last_snapshot", sa.Text(), nullable=True),
+            sa.Column("last_digest_at", sa.DateTime(), nullable=True),
+            sa.Column("note", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.UniqueConstraint("user_account_id", "player_api_id", name="uq_follow_snapshot_user_player"),
+        )
+
+    if not table_exists("player_shadow_stats"):
+        op.create_table(
+            "player_shadow_stats",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("player_api_id", sa.Integer(), nullable=False),
+            sa.Column("team_api_id", sa.Integer(), nullable=True),
+            sa.Column("team_name", sa.String(length=200), nullable=True),
+            sa.Column("season", sa.Integer(), nullable=False),
+            sa.Column("appearances", sa.Integer(), nullable=True),
+            sa.Column("goals", sa.Integer(), nullable=True),
+            sa.Column("assists", sa.Integer(), nullable=True),
+            sa.Column("minutes", sa.Integer(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.UniqueConstraint("player_api_id", "team_api_id", "season", name="uq_shadow_stats"),
+        )
+    create_index_safe("ix_shadow_stats_player", "player_shadow_stats", ["player_api_id"])
+
+
+def downgrade():
+    if index_exists("ix_shadow_stats_player"):
+        op.drop_index("ix_shadow_stats_player", table_name="player_shadow_stats")
+    if table_exists("player_shadow_stats"):
+        op.drop_table("player_shadow_stats")
+
+    if table_exists("follow_player_snapshots"):
+        op.drop_table("follow_player_snapshots")
+
+    if index_exists("ix_player_shadows_player"):
+        op.drop_index("ix_player_shadows_player", table_name="player_shadows")
+    if table_exists("player_shadows"):
+        op.drop_table("player_shadows")
+
+    if index_exists("ix_follows_list"):
+        op.drop_index("ix_follows_list", table_name="follows")
+    if table_exists("follows"):
+        op.drop_table("follows")
+
+    if index_exists("ix_follow_lists_user"):
+        op.drop_index("ix_follow_lists_user", table_name="follow_lists")
+    if table_exists("follow_lists"):
+        op.drop_table("follow_lists")

--- a/academy-watch-backend/src/api_football_client.py
+++ b/academy-watch-backend/src/api_football_client.py
@@ -3550,6 +3550,23 @@ class APIFootballClient:
             return deepcopy(payload[0]) if payload else {}
         return deepcopy(payload)
 
+    def search_player_profiles_global(self, query: str) -> list[dict[str, Any]]:
+        """Worldwide player-profile search via ``players/profiles`` {"search": q}.
+
+        A single, league-agnostic call (unlike ``search_player_profiles`` which
+        fans out one request per supported league for a bare query) that returns
+        profile-shaped rows for shadow-player discovery. DB-cached like
+        ``get_player_profile``; returns [] for a too-short query or in stub mode.
+        """
+        q = str(query or "").strip()
+        if len(q) < 3:
+            return []
+        resp = self._make_request("players/profiles", {"search": q})
+        payload = resp.get("response") or []
+        if not isinstance(payload, list):
+            return []
+        return [deepcopy(item) for item in payload]
+
     def search_player_profiles(
         self,
         query: str,

--- a/academy-watch-backend/src/models/follow.py
+++ b/academy-watch-backend/src/models/follow.py
@@ -1,0 +1,133 @@
+"""Follow graph + shadow tracking models.
+
+Generalizes the scout watchlist into named **lists** of heterogeneous
+**follows** (kinds: ``player`` | ``academy_club`` | ``geo`` | ``query``). A
+list resolves to a player set that the scout digest reports on.
+
+Following a player *outside* the tracked universe mints a lightweight
+``PlayerShadow`` (profile + per-season ``PlayerShadowStats``), giving worldwide
+players a working player page without any league crawling.
+
+``FollowPlayerSnapshot`` is the per-(user, player) digest delta baseline —
+unlike the watchlist's per-entry snapshot it works for *dynamic* follow sets
+(geo/query/academy lists whose membership changes between digests). Its column
+names are load-bearing: a snapshot row is passed AS a digest "entry" to the
+delta engine, which reads/writes ``.player_api_id`` / ``.last_snapshot`` /
+``.last_digest_at`` and reads ``.note`` (see scout_digest_service).
+"""
+
+from datetime import UTC, datetime
+
+from src.models.league import db
+
+
+class FollowList(db.Model):
+    __tablename__ = "follow_lists"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_account_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"), nullable=False)
+    name = db.Column(db.String(120), nullable=False, default="My Watchlist")
+    # cadence is stored for a future scheduler; Phase 1 sends stay admin-triggered.
+    cadence = db.Column(db.String(20), nullable=False, default="weekly", server_default="weekly")
+    is_active = db.Column(db.Boolean, nullable=False, default=True, server_default="true")
+    is_default = db.Column(db.Boolean, nullable=False, default=False, server_default="false")
+    # Resolved-set cap the digest applies per list (resolve endpoint paginates
+    # the full set; the digest bounds the work per run).
+    player_cap = db.Column(db.Integer, nullable=False, default=40, server_default="40")
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
+    updated_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+
+    # Index names match migration aw20 exactly (prod DDL == test create_all).
+    __table_args__ = (
+        db.UniqueConstraint("user_account_id", "name", name="uq_follow_list_user_name"),
+        db.Index("ix_follow_lists_user", "user_account_id"),
+    )
+
+    # ORM cascade deletes child follows even where SQLite lacks ON DELETE CASCADE
+    # enforcement; the DB-level FK cascade (migration) backs it up in Postgres.
+    follows = db.relationship(
+        "Follow",
+        backref="follow_list",
+        lazy="dynamic",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+
+    user = db.relationship("UserAccount", backref=db.backref("follow_lists", lazy="dynamic"))
+
+
+class Follow(db.Model):
+    __tablename__ = "follows"
+
+    id = db.Column(db.Integer, primary_key=True)
+    list_id = db.Column(db.Integer, db.ForeignKey("follow_lists.id", ondelete="CASCADE"), nullable=False)
+    kind = db.Column(db.String(20), nullable=False)  # player | academy_club | geo | query
+    # Per-kind selector; see follow_resolver.validate_selector for schemas.
+    selector = db.Column(db.JSON, nullable=False)
+    label = db.Column(db.String(160))  # display label, server-derived where possible
+    note = db.Column(db.Text)  # migrated watchlist note (player kind)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
+
+    # Exact (kind, selector) duplicates within a list are rejected in code — a
+    # portable UniqueConstraint over a JSON column is not available on SQLite.
+    __table_args__ = (db.Index("ix_follows_list", "list_id"),)
+
+
+class PlayerShadow(db.Model):
+    __tablename__ = "player_shadows"
+
+    id = db.Column(db.Integer, primary_key=True)
+    player_api_id = db.Column(db.Integer, nullable=False)
+    player_name = db.Column(db.String(200), nullable=False)
+    photo_url = db.Column(db.String(500))
+    position = db.Column(db.String(50))
+    nationality = db.Column(db.String(100))
+    birth_date = db.Column(db.Date)
+    current_club_name = db.Column(db.String(200))
+    current_club_api_id = db.Column(db.Integer)
+    requested_by_user_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"), nullable=True)
+    last_profile_sync_at = db.Column(db.DateTime)
+    last_stats_sync_at = db.Column(db.DateTime)
+    is_active = db.Column(db.Boolean, nullable=False, default=True, server_default="true")
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
+
+    __table_args__ = (db.Index("ix_player_shadows_player", "player_api_id", unique=True),)
+
+
+class FollowPlayerSnapshot(db.Model):
+    __tablename__ = "follow_player_snapshots"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_account_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"), nullable=False)
+    player_api_id = db.Column(db.Integer, nullable=False)
+    last_snapshot = db.Column(db.Text)  # JSON string, same shape as the watchlist snapshot
+    last_digest_at = db.Column(db.DateTime)
+    note = db.Column(db.Text)  # copied from a player-kind follow if any
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
+    updated_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+
+    __table_args__ = (db.UniqueConstraint("user_account_id", "player_api_id", name="uq_follow_snapshot_user_player"),)
+
+
+class PlayerShadowStats(db.Model):
+    """Dedicated shadow stats store — deliberately separate from the legacy,
+    unowned PlayerStatsCache so shadow syncing never collides with (or is
+    mistaken for) tracked-player coverage."""
+
+    __tablename__ = "player_shadow_stats"
+
+    id = db.Column(db.Integer, primary_key=True)
+    player_api_id = db.Column(db.Integer, nullable=False)
+    team_api_id = db.Column(db.Integer, nullable=True)
+    team_name = db.Column(db.String(200))
+    season = db.Column(db.Integer, nullable=False)
+    appearances = db.Column(db.Integer)
+    goals = db.Column(db.Integer)
+    assists = db.Column(db.Integer)
+    minutes = db.Column(db.Integer)
+    updated_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+
+    __table_args__ = (
+        db.UniqueConstraint("player_api_id", "team_api_id", "season", name="uq_shadow_stats"),
+        db.Index("ix_shadow_stats_player", "player_api_id"),
+    )

--- a/academy-watch-backend/src/routes/players.py
+++ b/academy-watch-backend/src/routes/players.py
@@ -325,6 +325,33 @@ def get_public_player_profile(player_id: int):
                 result["owner_team_name"] = journey.current_owner_name
                 result["owner_team_logo"] = owner_team.logo if owner_team else None
 
+        # Shadow player fallback — a worldwide-followed player minted outside the
+        # tracked universe has no Player/TrackedPlayer row. Fill still-empty
+        # fields from its PlayerShadow so the profile page renders. Tracked-player
+        # payloads are untouched (this only runs when no tracked row was found).
+        if not tp:
+            from src.models.follow import PlayerShadow
+
+            shadow = PlayerShadow.query.filter_by(player_api_id=player_id, is_active=True).first()
+            if shadow:
+                result["shadow"] = True
+                if not result["name"]:
+                    result["name"] = shadow.player_name
+                if not result["photo"]:
+                    result["photo"] = shadow.photo_url
+                if not result["position"]:
+                    result["position"] = shadow.position
+                if not result["nationality"]:
+                    result["nationality"] = shadow.nationality
+                if not result["age"] and shadow.birth_date:
+                    from datetime import date as _date
+
+                    today = _date.today()
+                    bd = shadow.birth_date
+                    result["age"] = today.year - bd.year - ((today.month, today.day) < (bd.month, bd.day))
+                if not result["loan_team_name"]:
+                    result["loan_team_name"] = shadow.current_club_name
+
         if not result["position"]:
             POS_MAP = {"G": "Goalkeeper", "D": "Defender", "M": "Midfielder", "F": "Attacker"}
             recent_stats = (
@@ -479,6 +506,53 @@ def get_public_player_season_stats(player_id: int):
             return jsonify(result)
 
         if not all_tracked:
+            # Shadow player fallback — no tracked rows, but a worldwide-followed
+            # PlayerShadow exists: serve its LATEST-season PlayerShadowStats as
+            # limited coverage so the profile's stats view renders. Latest-season
+            # (not wall-clock) is immune to API-Football client season drift.
+            from src.models.follow import PlayerShadow, PlayerShadowStats
+
+            shadow = PlayerShadow.query.filter_by(player_api_id=player_id, is_active=True).first()
+            if shadow:
+                latest_season = (
+                    db.session.query(func.max(PlayerShadowStats.season))
+                    .filter(PlayerShadowStats.player_api_id == player_id)
+                    .scalar()
+                )
+                totals = (
+                    db.session.query(
+                        func.coalesce(func.sum(PlayerShadowStats.appearances), 0),
+                        func.coalesce(func.sum(PlayerShadowStats.goals), 0),
+                        func.coalesce(func.sum(PlayerShadowStats.assists), 0),
+                        func.coalesce(func.sum(PlayerShadowStats.minutes), 0),
+                    )
+                    .filter(
+                        PlayerShadowStats.player_api_id == player_id,
+                        PlayerShadowStats.season == latest_season,
+                    )
+                    .first()
+                    if latest_season is not None
+                    else None
+                )
+                apps, goals, assists, minutes = (int(v or 0) for v in (totals or (0, 0, 0, 0)))
+                result["appearances"] = apps
+                result["goals"] = goals
+                result["assists"] = assists
+                result["minutes"] = minutes
+                result["source"] = "shadow"
+                result["stats_coverage"] = "limited"
+                if shadow.current_club_name:
+                    result["loan_team"] = shadow.current_club_name
+                    result["clubs"] = [
+                        {
+                            "team_name": shadow.current_club_name,
+                            "team_logo": None,
+                            "appearances": apps,
+                            "goals": goals,
+                            "assists": assists,
+                            "is_current": True,
+                        }
+                    ]
             return jsonify(result)
 
         # Build list of clubs from FixturePlayerStats (source of truth for which

--- a/academy-watch-backend/src/routes/scout.py
+++ b/academy-watch-backend/src/routes/scout.py
@@ -24,6 +24,7 @@ per-player compute_stats() N+1 queries.
 import csv
 import io
 import logging
+import os
 from datetime import date
 
 import bleach
@@ -33,13 +34,29 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import aliased, joinedload
 from src.auth import _ensure_user_account, _safe_error_payload, require_api_key, require_user_auth
 from src.extensions import limiter
+from src.models.follow import Follow, FollowList, FollowPlayerSnapshot, PlayerShadow
 from src.models.journey import PlayerJourney
-from src.models.league import PlayerStatsCache, UserAccount, db
+from src.models.league import PlayerStatsCache, Team, UserAccount, db
 from src.models.scout_watchlist import ScoutWatchlistEntry
 from src.models.tracked_player import TrackedPlayer
 from src.models.weekly import Fixture, FixturePlayerStats
+from src.services.follow_resolver import derive_label, resolve_list, validate_selector
+from src.services.player_shadow_service import (
+    mint_shadow,
+    refresh_shadows,
+    search_players,
+    user_shadow_follow_count,
+)
+from src.utils.sanitize import sanitize_plain_text
 
 logger = logging.getLogger(__name__)
+
+# Follow-graph caps (env-configurable; tests monkeypatch these module attrs).
+MAX_FOLLOW_LISTS = int(os.getenv("MAX_FOLLOW_LISTS", "10"))
+MAX_FOLLOWS_PER_LIST = int(os.getenv("MAX_FOLLOWS_PER_LIST", "50"))
+SHADOW_FOLLOW_LIMIT = int(os.getenv("SHADOW_FOLLOW_LIMIT", "10"))
+MAX_RESOLVE_PAGE = 50
+MAX_LIST_NAME_LENGTH = 120
 
 scout_bp = Blueprint("scout", __name__)
 
@@ -742,7 +759,12 @@ def scout_watchlist():
 @require_user_auth
 @limiter.limit("30/minute", key_func=_user_rate_limit_key)
 def scout_watchlist_add():
-    """Add a player to the watchlist. Idempotent: re-adding returns 200."""
+    """Add a player to the watchlist. Idempotent: re-adding returns 200.
+
+    Watchlist entries stay TrackedPlayer-only (the 404 below is unchanged);
+    worldwide/shadow players are followable only via follow lists. Every add is
+    also mirrored into the user's default follow list.
+    """
     try:
         user = _current_user_account()
         if user is None:
@@ -754,6 +776,7 @@ def scout_watchlist_add():
 
         existing = ScoutWatchlistEntry.query.filter_by(user_account_id=user.id, player_api_id=player_api_id).first()
         if existing:
+            _mirror_watchlist_add(user, player_api_id, note=existing.note)
             players = _watched_player_dicts([player_api_id])
             return jsonify({"entry": _entry_payload(existing, players.get(player_api_id))}), 200
 
@@ -782,8 +805,10 @@ def scout_watchlist_add():
             entry = ScoutWatchlistEntry.query.filter_by(user_account_id=user.id, player_api_id=player_api_id).first()
             if entry is None:
                 raise
+            _mirror_watchlist_add(user, player_api_id, note=entry.note)
             players = _watched_player_dicts([player_api_id])
             return jsonify({"entry": _entry_payload(entry, players.get(player_api_id))}), 200
+        _mirror_watchlist_add(user, player_api_id, note=entry.note)
         players = _watched_player_dicts([player_api_id])
         return jsonify({"entry": _entry_payload(entry, players.get(player_api_id))}), 201
     except Exception as e:
@@ -806,6 +831,7 @@ def scout_watchlist_remove(player_api_id):
             return jsonify({"removed": False})
         db.session.delete(entry)
         db.session.commit()
+        _mirror_watchlist_remove(user, player_api_id)
         return jsonify({"removed": True})
     except Exception as e:
         db.session.rollback()
@@ -992,4 +1018,639 @@ def scout_admin_send_digests():
     except Exception as e:
         db.session.rollback()
         logger.error(f"Error in scout_admin_send_digests: {e}")
+        return jsonify(_safe_error_payload(e, "An unexpected error occurred. Please try again later.")), 500
+
+
+# =========================================================================== #
+# Follow lists + shadow tracking
+# =========================================================================== #
+
+
+def _player_display_name(player_api_id):
+    """Best-effort display name for a follow label (tracked, else shadow)."""
+    tracked = (
+        TrackedPlayer.query.filter_by(player_api_id=player_api_id, is_active=True)
+        .filter(TrackedPlayer.data_source != "owning-club")
+        .first()
+    )
+    if tracked:
+        return tracked.player_name
+    shadow = PlayerShadow.query.filter_by(player_api_id=player_api_id).first()
+    return shadow.player_name if shadow else None
+
+
+def _default_follow_list(user, create=True):
+    """The user's migrated-watchlist default list, created on demand."""
+    follow_list = FollowList.query.filter_by(user_account_id=user.id, is_default=True).first()
+    if follow_list is None and create:
+        follow_list = FollowList(user_account_id=user.id, name="My Watchlist", is_default=True)
+        db.session.add(follow_list)
+        db.session.flush()
+    return follow_list
+
+
+def _mirror_watchlist_add(user, player_api_id, note=None):
+    """Mirror a watchlist add into the user's default follow list.
+
+    Best-effort: a mirror failure never breaks the watchlist write. Watchlist
+    entries are always tracked players (shadow players are followable only via
+    lists), so this upserts a player-kind follow for an existing tracked player.
+    """
+    try:
+        follow_list = _default_follow_list(user, create=True)
+        for follow in follow_list.follows.filter(Follow.kind == "player").all():
+            if (follow.selector or {}).get("player_api_id") == player_api_id:
+                return
+        db.session.add(
+            Follow(
+                list_id=follow_list.id,
+                kind="player",
+                selector={"player_api_id": player_api_id},
+                label=derive_label("player", {"player_api_id": player_api_id}, _player_display_name(player_api_id)),
+                note=note,
+            )
+        )
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        logger.exception("watchlist->list mirror (add) failed for player %s", player_api_id)
+
+
+def _mirror_watchlist_remove(user, player_api_id):
+    """Remove the matching player follow from the default list only."""
+    try:
+        follow_list = FollowList.query.filter_by(user_account_id=user.id, is_default=True).first()
+        if follow_list is None:
+            return
+        removed = False
+        for follow in follow_list.follows.filter(Follow.kind == "player").all():
+            if (follow.selector or {}).get("player_api_id") == player_api_id:
+                db.session.delete(follow)
+                removed = True
+        if removed:
+            db.session.commit()
+    except Exception:
+        db.session.rollback()
+        logger.exception("watchlist->list mirror (remove) failed for player %s", player_api_id)
+
+
+def _user_already_follows_player(user_id, player_api_id):
+    """True if the user follows this player id in any of their lists."""
+    rows = (
+        db.session.query(Follow.selector)
+        .join(FollowList, FollowList.id == Follow.list_id)
+        .filter(FollowList.user_account_id == user_id, Follow.kind == "player")
+        .all()
+    )
+    return any((selector or {}).get("player_api_id") == player_api_id for (selector,) in rows)
+
+
+def _follow_label_maps(follows):
+    """Batched name lookups for read-time follow labels: player_api_id -> player
+    name (TrackedPlayer, then PlayerShadow) and teams.id -> team name."""
+    player_ids = set()
+    team_ids = set()
+    for follow in follows:
+        selector = follow.selector or {}
+        if follow.kind == "player" and selector.get("player_api_id"):
+            player_ids.add(selector["player_api_id"])
+        elif follow.kind == "academy_club" and selector.get("team_id"):
+            team_ids.add(selector["team_id"])
+
+    name_map = {}
+    if player_ids:
+        for tp in TrackedPlayer.query.filter(
+            TrackedPlayer.player_api_id.in_(player_ids),
+            TrackedPlayer.is_active.is_(True),
+            TrackedPlayer.data_source != "owning-club",
+        ).all():
+            name_map.setdefault(tp.player_api_id, tp.player_name)
+        remaining = player_ids - set(name_map)
+        if remaining:
+            for shadow in PlayerShadow.query.filter(PlayerShadow.player_api_id.in_(remaining)).all():
+                name_map.setdefault(shadow.player_api_id, shadow.player_name)
+
+    team_map = {}
+    if team_ids:
+        for team in Team.query.filter(Team.id.in_(team_ids)).all():
+            team_map.setdefault(team.id, team.name)
+    return name_map, team_map
+
+
+def _follow_read_payload(follow, name_map, team_map):
+    """A follow dict whose label is derived at read time from fresh names."""
+    selector = follow.selector or {}
+    if follow.kind == "player":
+        name = name_map.get(selector.get("player_api_id"))
+    elif follow.kind == "academy_club":
+        name = team_map.get(selector.get("team_id"))
+    else:
+        name = None
+    return {
+        "id": follow.id,
+        "kind": follow.kind,
+        "selector": follow.selector,
+        "label": derive_label(follow.kind, selector, name),
+        "note": follow.note,
+        "created_at": follow.created_at.isoformat() if follow.created_at else None,
+    }
+
+
+def _follow_list_payload(follow_list, follows=None, name_map=None, team_map=None):
+    """List payload with embedded read-time-labelled follows.
+
+    GET /scout/lists passes pre-batched ``follows`` + name/team maps (one query
+    for all lists' follows) to stay N+1-free; single-list responses pass nothing
+    and this loads that one list's follows.
+    """
+    if follows is None:
+        follows = follow_list.follows.order_by(Follow.created_at.asc(), Follow.id.asc()).all()
+        name_map, team_map = _follow_label_maps(follows)
+    return {
+        "id": follow_list.id,
+        "name": follow_list.name,
+        "cadence": follow_list.cadence,
+        "is_active": follow_list.is_active,
+        "is_default": follow_list.is_default,
+        "player_cap": follow_list.player_cap,
+        "follow_count": len(follows),
+        "follows": [_follow_read_payload(f, name_map or {}, team_map or {}) for f in follows],
+        "created_at": follow_list.created_at.isoformat() if follow_list.created_at else None,
+        "updated_at": follow_list.updated_at.isoformat() if follow_list.updated_at else None,
+    }
+
+
+def _follow_payload(follow):
+    return {
+        "id": follow.id,
+        "kind": follow.kind,
+        "selector": follow.selector,
+        "label": follow.label,
+        "note": follow.note,
+        "created_at": follow.created_at.isoformat() if follow.created_at else None,
+    }
+
+
+def _owned_list(user, list_id):
+    return FollowList.query.filter_by(id=list_id, user_account_id=user.id).first()
+
+
+def _clean_list_name(raw):
+    """(name, error) — sanitized, non-empty, length-capped list name."""
+    if not isinstance(raw, str):
+        return None, "name must be a string"
+    name = sanitize_plain_text(raw).strip()
+    if not name:
+        return None, "name is required"
+    if len(name) > MAX_LIST_NAME_LENGTH:
+        return None, f"name must be at most {MAX_LIST_NAME_LENGTH} characters"
+    return name, None
+
+
+@scout_bp.route("/scout/lists", methods=["GET"])
+@require_user_auth
+@limiter.limit("60/minute", key_func=_user_rate_limit_key)
+def scout_lists():
+    """The authenticated user's follow lists (default list first)."""
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        lists = (
+            FollowList.query.filter_by(user_account_id=user.id)
+            .order_by(FollowList.is_default.desc(), FollowList.created_at.asc(), FollowList.id.asc())
+            .all()
+        )
+        # One query for every list's follows (the dynamic relationship rules out
+        # selectinload), grouped by list, then one batched name/team lookup —
+        # N+1-free regardless of list count.
+        list_ids = [fl.id for fl in lists]
+        follows_by_list = {}
+        all_follows = []
+        if list_ids:
+            all_follows = (
+                Follow.query.filter(Follow.list_id.in_(list_ids))
+                .order_by(Follow.list_id, Follow.created_at.asc(), Follow.id.asc())
+                .all()
+            )
+            for follow in all_follows:
+                follows_by_list.setdefault(follow.list_id, []).append(follow)
+        name_map, team_map = _follow_label_maps(all_follows)
+        return jsonify(
+            {
+                "lists": [
+                    _follow_list_payload(
+                        fl, follows=follows_by_list.get(fl.id, []), name_map=name_map, team_map=team_map
+                    )
+                    for fl in lists
+                ]
+            }
+        )
+    except Exception as e:
+        logger.error(f"Error in scout_lists: {e}")
+        return jsonify(_safe_error_payload(e, "An unexpected error occurred. Please try again later.")), 500
+
+
+@scout_bp.route("/scout/lists", methods=["POST"])
+@require_user_auth
+@limiter.limit("30/minute", key_func=_user_rate_limit_key)
+def scout_lists_create():
+    """Create a follow list (capped at MAX_FOLLOW_LISTS; unique name per user)."""
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        payload = request.get_json(silent=True) or {}
+        name, error = _clean_list_name(payload.get("name", ""))
+        if error:
+            return jsonify({"error": error}), 400
+        if FollowList.query.filter_by(user_account_id=user.id).count() >= MAX_FOLLOW_LISTS:
+            return jsonify({"error": f"list limit reached ({MAX_FOLLOW_LISTS})"}), 409
+        if FollowList.query.filter_by(user_account_id=user.id, name=name).first():
+            return jsonify({"error": "a list with that name already exists"}), 409
+        follow_list = FollowList(user_account_id=user.id, name=name, is_default=False)
+        db.session.add(follow_list)
+        try:
+            db.session.commit()
+        except IntegrityError:
+            db.session.rollback()
+            return jsonify({"error": "a list with that name already exists"}), 409
+        return jsonify({"list": _follow_list_payload(follow_list, follows=[])}), 201
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f"Error in scout_lists_create: {e}")
+        return jsonify(_safe_error_payload(e, "An unexpected error occurred. Please try again later.")), 500
+
+
+@scout_bp.route("/scout/lists/<int:list_id>", methods=["PATCH"])
+@require_user_auth
+@limiter.limit("30/minute", key_func=_user_rate_limit_key)
+def scout_list_update(list_id):
+    """Rename a list or toggle is_active (owner-only)."""
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        follow_list = _owned_list(user, list_id)
+        if follow_list is None:
+            return jsonify({"error": "list not found"}), 404
+        payload = request.get_json(silent=True) or {}
+        if "name" in payload:
+            name, error = _clean_list_name(payload.get("name"))
+            if error:
+                return jsonify({"error": error}), 400
+            dup = FollowList.query.filter(
+                FollowList.user_account_id == user.id,
+                FollowList.name == name,
+                FollowList.id != follow_list.id,
+            ).first()
+            if dup:
+                return jsonify({"error": "a list with that name already exists"}), 409
+            follow_list.name = name
+        if "is_active" in payload:
+            is_active = payload.get("is_active")
+            if not isinstance(is_active, bool):
+                return jsonify({"error": "is_active must be a boolean"}), 400
+            follow_list.is_active = is_active
+        try:
+            db.session.commit()
+        except IntegrityError:
+            db.session.rollback()
+            return jsonify({"error": "a list with that name already exists"}), 409
+        return jsonify({"list": _follow_list_payload(follow_list)})
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f"Error in scout_list_update: {e}")
+        return jsonify(_safe_error_payload(e, "An unexpected error occurred. Please try again later.")), 500
+
+
+@scout_bp.route("/scout/lists/<int:list_id>", methods=["DELETE"])
+@require_user_auth
+@limiter.limit("30/minute", key_func=_user_rate_limit_key)
+def scout_list_delete(list_id):
+    """Delete a list (owner-only). The default list is not deletable."""
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        follow_list = _owned_list(user, list_id)
+        if follow_list is None:
+            return jsonify({"error": "list not found"}), 404
+        if follow_list.is_default:
+            return jsonify({"error": "the default list cannot be deleted"}), 400
+        db.session.delete(follow_list)
+        db.session.commit()
+        return jsonify({"deleted": True})
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f"Error in scout_list_delete: {e}")
+        return jsonify(_safe_error_payload(e, "An unexpected error occurred. Please try again later.")), 500
+
+
+@scout_bp.route("/scout/lists/<int:list_id>/follows", methods=["POST"])
+@require_user_auth
+@limiter.limit("30/minute", key_func=_user_rate_limit_key)
+def scout_list_add_follow(list_id):
+    """Add a follow (player | academy_club | geo | query) to a list.
+
+    A player-kind follow whose target is outside the tracked universe mints a
+    PlayerShadow, subject to SHADOW_FOLLOW_LIMIT distinct worldwide follows per
+    user.
+    """
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        follow_list = _owned_list(user, list_id)
+        if follow_list is None:
+            return jsonify({"error": "list not found"}), 404
+
+        payload = request.get_json(silent=True) or {}
+        kind = payload.get("kind")
+        clean_selector, error = validate_selector(kind, payload.get("selector"))
+        if error:
+            return jsonify({"error": error}), 400
+
+        if follow_list.follows.count() >= MAX_FOLLOWS_PER_LIST:
+            return jsonify({"error": f"follow limit reached for this list ({MAX_FOLLOWS_PER_LIST})"}), 409
+
+        for follow in follow_list.follows.filter(Follow.kind == kind).all():
+            if follow.selector == clean_selector:
+                return jsonify({"error": "this follow already exists in the list"}), 409
+
+        note = payload.get("note")
+        if note is not None:
+            if not isinstance(note, str):
+                return jsonify({"error": "note must be a string"}), 400
+            note = sanitize_plain_text(note).strip()
+            if len(note) > MAX_NOTE_LENGTH:
+                return jsonify({"error": f"note must be at most {MAX_NOTE_LENGTH} characters"}), 400
+            note = note or None
+
+        shadow_created = False
+        if kind == "player":
+            player_api_id = clean_selector["player_api_id"]
+            tracked = (
+                TrackedPlayer.query.filter_by(player_api_id=player_api_id, is_active=True)
+                .filter(TrackedPlayer.data_source != "owning-club")
+                .first()
+            )
+            if tracked:
+                label = derive_label("player", clean_selector, tracked.player_name)
+            else:
+                shadow = PlayerShadow.query.filter_by(player_api_id=player_api_id, is_active=True).first()
+                # Cap distinct worldwide follows per user (a new shadow, or an
+                # existing shadow this user does not already follow).
+                if not _user_already_follows_player(user.id, player_api_id):
+                    if user_shadow_follow_count(user.id) >= SHADOW_FOLLOW_LIMIT:
+                        return jsonify({"error": f"worldwide follow limit reached ({SHADOW_FOLLOW_LIMIT})"}), 403
+                if shadow is None:
+                    seed = payload.get("seed") if isinstance(payload.get("seed"), dict) else None
+                    shadow = mint_shadow(player_api_id, seed=seed, requested_by=user.id, api_client=_get_api_client())
+                    shadow_created = True
+                label = derive_label("player", clean_selector, shadow.player_name)
+        elif kind == "academy_club":
+            team = Team.query.filter_by(id=clean_selector["team_id"]).first()
+            label = derive_label("academy_club", clean_selector, team.name if team else None)
+        else:
+            label = derive_label(kind, clean_selector)
+
+        follow = Follow(list_id=follow_list.id, kind=kind, selector=clean_selector, label=label, note=note)
+        db.session.add(follow)
+        db.session.commit()
+        return jsonify({"follow": _follow_payload(follow), "shadow_created": shadow_created}), 201
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f"Error in scout_list_add_follow: {e}")
+        return jsonify(_safe_error_payload(e, "An unexpected error occurred. Please try again later.")), 500
+
+
+@scout_bp.route("/scout/lists/<int:list_id>/follows/<int:follow_id>", methods=["DELETE"])
+@require_user_auth
+@limiter.limit("30/minute", key_func=_user_rate_limit_key)
+def scout_list_remove_follow(list_id, follow_id):
+    """Remove a follow from a list (owner-only). Idempotent."""
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        follow_list = _owned_list(user, list_id)
+        if follow_list is None:
+            return jsonify({"error": "list not found"}), 404
+        follow = Follow.query.filter_by(id=follow_id, list_id=follow_list.id).first()
+        if follow is None:
+            return jsonify({"removed": False})
+        db.session.delete(follow)
+        db.session.commit()
+        return jsonify({"removed": True})
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f"Error in scout_list_remove_follow: {e}")
+        return jsonify(_safe_error_payload(e, "An unexpected error occurred. Please try again later.")), 500
+
+
+@scout_bp.route("/scout/lists/<int:list_id>/resolve", methods=["GET"])
+@require_user_auth
+@limiter.limit("60/minute", key_func=_user_rate_limit_key)
+def scout_list_resolve(list_id):
+    """Resolved player preview for a list (owner-only), paginated."""
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        follow_list = _owned_list(user, list_id)
+        if follow_list is None:
+            return jsonify({"error": "list not found"}), 404
+
+        limit = min(max(request.args.get("limit", 25, type=int), 1), MAX_RESOLVE_PAGE)
+        offset = max(request.args.get("offset", 0, type=int), 0)
+
+        resolved = resolve_list(follow_list)
+        total = len(resolved)
+        page = resolved[offset : offset + limit]
+
+        tracked_ids = [item["player_api_id"] for item in page if item["source"] == "tracked"]
+        shadow_ids = [item["player_api_id"] for item in page if item["source"] == "shadow"]
+        tracked_dicts = _watched_player_dicts(tracked_ids)
+        shadows = {}
+        if shadow_ids:
+            for shadow in PlayerShadow.query.filter(PlayerShadow.player_api_id.in_(shadow_ids)).all():
+                shadows[shadow.player_api_id] = shadow
+
+        players = []
+        for item in page:
+            player_api_id = item["player_api_id"]
+            if item["source"] == "tracked":
+                enriched = tracked_dicts.get(player_api_id)
+                players.append(
+                    {
+                        "player_api_id": player_api_id,
+                        "player_name": enriched.get("player_name") if enriched else None,
+                        "source": "tracked",
+                        "team_name": (enriched.get("loan_team_name") or enriched.get("primary_team_name"))
+                        if enriched
+                        else None,
+                        "status": enriched.get("status") if enriched else None,
+                        "photo": enriched.get("player_photo") if enriched else None,
+                    }
+                )
+            else:
+                shadow = shadows.get(player_api_id)
+                players.append(
+                    {
+                        "player_api_id": player_api_id,
+                        "player_name": shadow.player_name if shadow else None,
+                        "source": "shadow",
+                        "team_name": shadow.current_club_name if shadow else None,
+                        "status": None,
+                        "photo": shadow.photo_url if shadow else None,
+                    }
+                )
+        return jsonify({"players": players, "total": total})
+    except Exception as e:
+        logger.error(f"Error in scout_list_resolve: {e}")
+        return jsonify(_safe_error_payload(e, "An unexpected error occurred. Please try again later.")), 500
+
+
+@scout_bp.route("/scout/player-search", methods=["GET"])
+@require_user_auth
+@limiter.limit("10/minute", key_func=_user_rate_limit_key)
+def scout_player_search():
+    """Worldwide player search for adding follows. Stub-safe (returns [])."""
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        query = request.args.get("q", "").strip()
+        results = search_players(query, api_client=_get_api_client())
+        return jsonify({"players": results})
+    except Exception as e:
+        logger.error(f"Error in scout_player_search: {e}")
+        return jsonify(_safe_error_payload(e, "An unexpected error occurred. Please try again later.")), 500
+
+
+@scout_bp.route("/admin/scout/shadow-refresh", methods=["POST"])
+@require_api_key
+def scout_admin_shadow_refresh():
+    """Refresh the N stalest active shadows (profile + season stats)."""
+    try:
+        payload = request.get_json(silent=True) or {}
+        limit = payload.get("limit", 25)
+        if not isinstance(limit, int) or isinstance(limit, bool) or limit < 1:
+            return jsonify({"error": "limit must be a positive integer"}), 400
+        cursor = payload.get("cursor")
+        if cursor is not None and (not isinstance(cursor, int) or isinstance(cursor, bool) or cursor < 0):
+            return jsonify({"error": "cursor must be a non-negative integer"}), 400
+        result = refresh_shadows(limit=limit, cursor=cursor, api_client=_get_api_client())
+        return jsonify(result)
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f"Error in scout_admin_shadow_refresh: {e}")
+        return jsonify(_safe_error_payload(e, "An unexpected error occurred. Please try again later.")), 500
+
+
+@scout_bp.route("/admin/scout/backfill-follow-lists", methods=["POST"])
+@require_api_key
+def scout_admin_backfill_follow_lists():
+    """Backfill a default follow list from each user's watchlist (cursor-paged).
+
+    Per user with watchlist entries and no default list: create a default
+    FollowList + one player follow per entry (carrying its note) and copy the
+    entry's last_snapshot into a FollowPlayerSnapshot. Idempotent — users who
+    already have a default list are skipped.
+    """
+    try:
+        payload = request.get_json(silent=True) or {}
+        dry_run = payload.get("dry_run", True)
+        if not isinstance(dry_run, bool):
+            return jsonify({"error": "dry_run must be a boolean"}), 400
+        limit = payload.get("limit", 50)
+        if not isinstance(limit, int) or isinstance(limit, bool) or limit < 1:
+            return jsonify({"error": "limit must be a positive integer"}), 400
+        limit = min(limit, 200)
+        cursor = payload.get("cursor", 0)
+        if not isinstance(cursor, int) or isinstance(cursor, bool) or cursor < 0:
+            return jsonify({"error": "cursor must be a non-negative integer"}), 400
+
+        has_watchlist = exists().where(ScoutWatchlistEntry.user_account_id == UserAccount.id)
+        has_default = exists().where(
+            and_(FollowList.user_account_id == UserAccount.id, FollowList.is_default.is_(True))
+        )
+        users = (
+            db.session.query(UserAccount)
+            .filter(UserAccount.id > cursor, has_watchlist, ~has_default)
+            .order_by(UserAccount.id)
+            .limit(limit)
+            .all()
+        )
+        next_cursor = users[-1].id if len(users) == limit else None
+
+        lists_created = 0
+        follows_created = 0
+        snapshots_created = 0
+        for user in users:
+            follow_list = FollowList(user_account_id=user.id, name="My Watchlist", is_default=True)
+            db.session.add(follow_list)
+            db.session.flush()
+            lists_created += 1
+
+            entries = ScoutWatchlistEntry.query.filter_by(user_account_id=user.id).all()
+            pids = [entry.player_api_id for entry in entries]
+            name_map = {}
+            if pids:
+                name_map = {
+                    tp.player_api_id: tp.player_name
+                    for tp in TrackedPlayer.query.filter(
+                        TrackedPlayer.player_api_id.in_(pids),
+                        TrackedPlayer.is_active.is_(True),
+                        TrackedPlayer.data_source != "owning-club",
+                    ).all()
+                }
+            for entry in entries:
+                db.session.add(
+                    Follow(
+                        list_id=follow_list.id,
+                        kind="player",
+                        selector={"player_api_id": entry.player_api_id},
+                        label=derive_label(
+                            "player",
+                            {"player_api_id": entry.player_api_id},
+                            name_map.get(entry.player_api_id),
+                        ),
+                        note=entry.note,
+                    )
+                )
+                follows_created += 1
+                existing_snap = FollowPlayerSnapshot.query.filter_by(
+                    user_account_id=user.id, player_api_id=entry.player_api_id
+                ).first()
+                if existing_snap is None:
+                    db.session.add(
+                        FollowPlayerSnapshot(
+                            user_account_id=user.id,
+                            player_api_id=entry.player_api_id,
+                            last_snapshot=entry.last_snapshot,
+                            last_digest_at=entry.last_digest_at,
+                            note=entry.note,
+                        )
+                    )
+                    snapshots_created += 1
+
+        result = {
+            "users_processed": len(users),
+            "lists_created": lists_created,
+            "follows_created": follows_created,
+            "snapshots_created": snapshots_created,
+            "next_cursor": next_cursor,
+            "dry_run": dry_run,
+            "applied": not dry_run,
+        }
+        if dry_run:
+            db.session.rollback()
+        else:
+            db.session.commit()
+        return jsonify(result)
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f"Error in scout_admin_backfill_follow_lists: {e}")
         return jsonify(_safe_error_payload(e, "An unexpected error occurred. Please try again later.")), 500

--- a/academy-watch-backend/src/services/follow_resolver.py
+++ b/academy-watch-backend/src/services/follow_resolver.py
@@ -1,0 +1,301 @@
+"""Follow resolver — turn a FollowList's heterogeneous follows into a player set.
+
+A list resolves to an ordered, deduped list of ``{player_api_id, source}`` where
+source is ``tracked`` (an active academy/loan TrackedPlayer) or ``shadow`` (a
+worldwide PlayerShadow). Per-kind resolution reuses the scout blueprint's base
+query (``_base_scout_query``) so the owning-club exclusion, preferred-row
+de-duplication, and is_active filters stay identical to the scout hub.
+
+Selector validation is strict (unknown keys rejected) and lives here so both the
+follows endpoint (create-time) and the resolver share one source of truth.
+"""
+
+import logging
+
+from src.models.follow import Follow, PlayerShadow
+from src.models.tracked_player import TrackedPlayer
+
+logger = logging.getLogger(__name__)
+
+FOLLOW_KINDS = ("player", "academy_club", "geo", "query")
+GEO_MATCH_MODES = ("playing_in", "nationality")
+MAX_GEO_COUNTRIES = 10
+MAX_COUNTRY_LEN = 50
+QUERY_ARG_KEYS = ("position", "status", "min_age", "max_age", "nationality", "min_minutes")
+
+# A ``query`` follow is capped tighter than a whole list (a saved filter can match
+# a very large slice); geo/academy contributions get a generous safety cap so a
+# single country follow can't try to load the entire tracked universe into memory.
+QUERY_FOLLOW_CAP = 100
+MAX_RESOLVE_PER_FOLLOW = 500
+
+
+# --------------------------------------------------------------------------- #
+# Selector validation
+# --------------------------------------------------------------------------- #
+
+
+def _positive_int(value) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
+def _non_negative_int(value) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def validate_selector(kind: str, selector) -> tuple[dict | None, str | None]:
+    """Return (clean_selector, error). error is a user-facing 400 message."""
+    if kind not in FOLLOW_KINDS:
+        return None, f"Unknown follow kind '{kind}'. One of: {sorted(FOLLOW_KINDS)}"
+    if not isinstance(selector, dict):
+        return None, "selector must be an object"
+    if kind == "player":
+        return _validate_player(selector)
+    if kind == "academy_club":
+        return _validate_academy_club(selector)
+    if kind == "geo":
+        return _validate_geo(selector)
+    return _validate_query(selector)
+
+
+def _validate_player(selector: dict):
+    extra = set(selector) - {"player_api_id"}
+    if extra:
+        return None, f"unexpected keys for player selector: {sorted(extra)}"
+    pid = selector.get("player_api_id")
+    if not _positive_int(pid):
+        return None, "player_api_id must be a positive integer"
+    return {"player_api_id": int(pid)}, None
+
+
+def _validate_academy_club(selector: dict):
+    extra = set(selector) - {"team_id"}
+    if extra:
+        return None, f"unexpected keys for academy_club selector: {sorted(extra)}"
+    team_id = selector.get("team_id")
+    if not _positive_int(team_id):
+        return None, "team_id must be a positive integer (internal teams.id)"
+    return {"team_id": int(team_id)}, None
+
+
+def _validate_geo(selector: dict):
+    extra = set(selector) - {"countries", "match"}
+    if extra:
+        return None, f"unexpected keys for geo selector: {sorted(extra)}"
+    countries = selector.get("countries")
+    if not isinstance(countries, list) or not (1 <= len(countries) <= MAX_GEO_COUNTRIES):
+        return None, f"countries must be a list of 1..{MAX_GEO_COUNTRIES} strings"
+    clean = []
+    for country in countries:
+        if not isinstance(country, str):
+            return None, "each country must be a string"
+        trimmed = country.strip()
+        if not trimmed or len(trimmed) > MAX_COUNTRY_LEN:
+            return None, f"each country must be 1..{MAX_COUNTRY_LEN} characters"
+        # Preserve the user's casing (str.title() corrupts "Bosnia and
+        # Herzegovina" → "Bosnia And Herzegovina"); matching is case-insensitive.
+        clean.append(trimmed)
+    match = selector.get("match", "playing_in")
+    if match not in GEO_MATCH_MODES:
+        return None, f"match must be one of {list(GEO_MATCH_MODES)}"
+    deduped = list(dict.fromkeys(clean))
+    return {"countries": deduped, "match": match}, None
+
+
+def _validate_query(selector: dict):
+    from src.routes.scout import VALID_POSITIONS, VALID_STATUSES
+
+    extra = set(selector) - {"scout_args"}
+    if extra:
+        return None, f"unexpected keys for query selector: {sorted(extra)}"
+    scout_args = selector.get("scout_args")
+    if not isinstance(scout_args, dict):
+        return None, "scout_args must be an object"
+    bad = set(scout_args) - set(QUERY_ARG_KEYS)
+    if bad:
+        return None, f"unexpected scout_args keys: {sorted(bad)}"
+
+    clean: dict = {}
+    if "position" in scout_args:
+        position = scout_args["position"]
+        if position not in VALID_POSITIONS:
+            return None, f"Invalid position. One of: {sorted(VALID_POSITIONS)}"
+        clean["position"] = position
+    if "status" in scout_args:
+        status = scout_args["status"]
+        statuses = [status] if isinstance(status, str) else status
+        if not isinstance(statuses, list) or not statuses:
+            return None, "status must be a string or non-empty list"
+        for value in statuses:
+            if value not in VALID_STATUSES:
+                return None, f"Invalid status {value}. One of: {sorted(VALID_STATUSES)}"
+        clean["status"] = list(statuses)
+    for key in ("min_age", "max_age", "min_minutes"):
+        if key in scout_args:
+            value = scout_args[key]
+            if not _non_negative_int(value):
+                return None, f"{key} must be a non-negative integer"
+            clean[key] = int(value)
+    if "nationality" in scout_args:
+        nationality = scout_args["nationality"]
+        if not isinstance(nationality, str) or not nationality.strip():
+            return None, "nationality must be a non-empty string"
+        clean["nationality"] = nationality.strip()
+    if not clean:
+        return None, "scout_args must include at least one filter"
+    return {"scout_args": clean}, None
+
+
+def derive_label(kind: str, selector: dict, name: str | None = None) -> str:
+    """Server-derived display label for a follow.
+
+    ``name`` is the resolved player/team name (passed by callers that resolve it
+    at read time); when absent a stable id-based placeholder is used.
+    """
+    if kind == "player":
+        return (name or f"Player {selector.get('player_api_id')}")[:160]
+    if kind == "academy_club":
+        return (f"Club academy: {name}" if name else f"Club academy #{selector.get('team_id')}")[:160]
+    if kind == "geo":
+        countries = ", ".join(selector.get("countries", []))
+        prefix = "Nationality" if selector.get("match") == "nationality" else "Playing in"
+        return f"{prefix}: {countries}"[:160]
+    scout_args = selector.get("scout_args", {})
+    parts = []
+    if scout_args.get("position"):
+        parts.append(scout_args["position"])
+    if scout_args.get("status"):
+        parts.append("/".join(scout_args["status"]))
+    if scout_args.get("nationality"):
+        parts.append(scout_args["nationality"])
+    if scout_args.get("min_age") is not None or scout_args.get("max_age") is not None:
+        parts.append(f"age {scout_args.get('min_age', '')}-{scout_args.get('max_age', '')}")
+    if scout_args.get("min_minutes"):
+        parts.append(f"{scout_args['min_minutes']}+ mins")
+    return ("Filter: " + ", ".join(parts))[:160] if parts else "Filter"
+
+
+# --------------------------------------------------------------------------- #
+# Resolution
+# --------------------------------------------------------------------------- #
+
+
+def _resolve_player(selector: dict) -> list[tuple[int, str]]:
+    pid = selector.get("player_api_id")
+    if not pid:
+        return []
+    tracked = (
+        TrackedPlayer.query.filter_by(player_api_id=pid, is_active=True)
+        .filter(TrackedPlayer.data_source != "owning-club")
+        .first()
+    )
+    if tracked:
+        return [(pid, "tracked")]
+    shadow = PlayerShadow.query.filter_by(player_api_id=pid, is_active=True).first()
+    if shadow:
+        return [(pid, "shadow")]
+    return []
+
+
+def _resolve_academy_club(selector: dict, limit: int | None) -> list[tuple[int, str]]:
+    from src.routes.scout import _base_scout_query
+
+    team_id = selector.get("team_id")
+    if not team_id:
+        return []
+    query, _ = _base_scout_query()
+    query = query.filter(TrackedPlayer.team_id == team_id)
+    cap = min(limit or MAX_RESOLVE_PER_FOLLOW, MAX_RESOLVE_PER_FOLLOW)
+    rows = query.order_by(TrackedPlayer.id).limit(cap).all()
+    return [(row[0].player_api_id, "tracked") for row in rows]
+
+
+def _resolve_geo(selector: dict, limit: int | None) -> list[tuple[int, str]]:
+    from sqlalchemy import func
+    from sqlalchemy.orm import aliased
+    from src.models.league import Team
+    from src.routes.scout import _base_scout_query
+
+    countries = selector.get("countries") or []
+    if not countries:
+        return []
+    match = selector.get("match") or "playing_in"
+    lowered = [c.lower() for c in countries]
+    query, _ = _base_scout_query()
+    if match == "nationality":
+        query = query.filter(func.lower(TrackedPlayer.nationality).in_(lowered))
+    else:
+        # current_club_db_id is nullable; the inner join naturally drops players
+        # with no resolved current club (correct for "players playing in X").
+        current_club = aliased(Team)
+        query = query.join(current_club, current_club.id == TrackedPlayer.current_club_db_id).filter(
+            func.lower(current_club.country).in_(lowered)
+        )
+    cap = min(limit or MAX_RESOLVE_PER_FOLLOW, MAX_RESOLVE_PER_FOLLOW)
+    rows = query.order_by(TrackedPlayer.id).limit(cap).all()
+    return [(row[0].player_api_id, "tracked") for row in rows]
+
+
+def _resolve_query(selector: dict, limit: int | None) -> list[tuple[int, str]]:
+    from src.routes.scout import _age_expression, _base_scout_query
+
+    scout_args = selector.get("scout_args") or {}
+    query, columns = _base_scout_query()
+
+    if scout_args.get("position"):
+        query = query.filter(TrackedPlayer.position == scout_args["position"])
+    if scout_args.get("status"):
+        query = query.filter(columns["effective_status"].in_(scout_args["status"]))
+    min_age = scout_args.get("min_age")
+    max_age = scout_args.get("max_age")
+    if min_age is not None or max_age is not None:
+        age_expr = _age_expression()
+        if min_age is not None:
+            query = query.filter(age_expr >= min_age)
+        if max_age is not None:
+            query = query.filter(age_expr <= max_age)
+    if scout_args.get("nationality"):
+        query = query.filter(TrackedPlayer.nationality.ilike(f"%{scout_args['nationality']}%"))
+    if scout_args.get("min_minutes"):
+        query = query.filter(columns["minutes_played"] >= scout_args["min_minutes"])
+
+    cap = min(limit or QUERY_FOLLOW_CAP, QUERY_FOLLOW_CAP)
+    rows = query.order_by(TrackedPlayer.id).limit(cap).all()
+    return [(row[0].player_api_id, "tracked") for row in rows]
+
+
+def resolve_list(follow_list, limit: int | None = None) -> list[dict]:
+    """Ordered, deduped [{player_api_id, source}] for a FollowList.
+
+    Follows are resolved in creation order; the first follow to yield a player
+    wins (later duplicates are dropped). ``limit`` caps the returned set (the
+    digest passes ``list.player_cap``; the resolve endpoint paginates the full
+    set by passing None).
+    """
+    follows = follow_list.follows.order_by(Follow.created_at.asc(), Follow.id.asc()).all()
+    seen: set[int] = set()
+    result: list[dict] = []
+    for follow in follows:
+        selector = follow.selector or {}
+        try:
+            if follow.kind == "player":
+                pairs = _resolve_player(selector)
+            elif follow.kind == "academy_club":
+                pairs = _resolve_academy_club(selector, limit)
+            elif follow.kind == "geo":
+                pairs = _resolve_geo(selector, limit)
+            elif follow.kind == "query":
+                pairs = _resolve_query(selector, limit)
+            else:
+                pairs = []
+        except Exception:
+            logger.exception("Follow resolution failed for follow %s (kind=%s)", follow.id, follow.kind)
+            pairs = []
+        for pid, source in pairs:
+            if pid in seen:
+                continue
+            seen.add(pid)
+            result.append({"player_api_id": pid, "source": source})
+            if limit is not None and len(result) >= limit:
+                return result
+    return result

--- a/academy-watch-backend/src/services/player_shadow_service.py
+++ b/academy-watch-backend/src/services/player_shadow_service.py
@@ -1,0 +1,391 @@
+"""Shadow player service — worldwide tracking without league crawling.
+
+Following a player outside the tracked universe mints a lightweight
+``PlayerShadow`` (profile) plus per-season ``PlayerShadowStats``, giving that
+player a working profile/season-stats page. Discovery is a single worldwide
+``players/profiles`` name search; refresh is an operator-paced, quota-capped
+batch.
+
+Client injection everywhere (test-safety): every function takes
+``api_client=None`` and resolves the shared singleton lazily. Never construct
+APIFootballClient directly. In stub mode the profiles endpoint returns
+``{"response": []}`` so mint falls back to its seed, search returns [], and
+refresh no-ops — none of these paths raise.
+"""
+
+import logging
+from datetime import UTC, date, datetime, timedelta
+
+from src.models.follow import PlayerShadow, PlayerShadowStats
+from src.models.league import db
+from src.models.tracked_player import TrackedPlayer
+from src.utils.sanitize import is_safe_https_url, sanitize_plain_text
+
+logger = logging.getLogger(__name__)
+
+SHADOW_PROFILE_STALE_DAYS = 7
+MAX_SEARCH_RESULTS = 10
+
+
+def _get_api_client():
+    from src.routes.api import api_client
+
+    return api_client
+
+
+def _resolve_client(api_client):
+    return api_client if api_client is not None else _get_api_client()
+
+
+def _parse_birth_date(value):
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(str(value)[:10])
+    except (ValueError, TypeError):
+        return None
+
+
+def _as_naive(value):
+    """Normalize a datetime to naive UTC so aware/naive comparisons never raise
+    (SQLite reads stored datetimes back as naive)."""
+    if value is not None and value.tzinfo is not None:
+        return value.replace(tzinfo=None)
+    return value
+
+
+def _current_season_start_year(client=None) -> int:
+    year = getattr(client, "current_season_start_year", None)
+    if isinstance(year, int):
+        return year
+    now = datetime.now(UTC)
+    return now.year if now.month >= 8 else now.year - 1
+
+
+# --------------------------------------------------------------------------- #
+# Mint
+# --------------------------------------------------------------------------- #
+
+
+def _clean_seed(seed):
+    """Sanitize the attacker-controlled seed dict from the follow payload."""
+    if not isinstance(seed, dict):
+        return {}
+    cleaned = {}
+    for key in ("name", "position", "nationality", "club_name"):
+        value = seed.get(key)
+        if isinstance(value, str) and value.strip():
+            text = sanitize_plain_text(value).strip()
+            if text:
+                cleaned[key] = text
+    photo = seed.get("photo")
+    if isinstance(photo, str) and is_safe_https_url(photo):
+        cleaned["photo"] = photo
+    club_api_id = seed.get("club_api_id")
+    if isinstance(club_api_id, int) and club_api_id > 0:
+        cleaned["club_api_id"] = club_api_id
+    return cleaned
+
+
+def mint_shadow(player_api_id, seed=None, requested_by=None, api_client=None):
+    """Get-or-create the PlayerShadow for ``player_api_id``.
+
+    The profile comes from ``players/profiles``; on any error (or stub mode) it
+    falls back to the ``seed`` fields carried by the search result so the mint
+    always succeeds offline.
+    """
+    existing = PlayerShadow.query.filter_by(player_api_id=player_api_id).first()
+    if existing:
+        if not existing.is_active:
+            existing.is_active = True
+        # Re-follow churn guard: refresh the profile only when it is stale
+        # (>7d), so unfollow/refollow spam costs zero upstream calls (on top of
+        # the DB api_cache) for a shadow that was just synced.
+        last_profile = _as_naive(existing.last_profile_sync_at)
+        stale_before = _as_naive(datetime.now(UTC)) - timedelta(days=SHADOW_PROFILE_STALE_DAYS)
+        if last_profile is None or last_profile < stale_before:
+            if _refresh_profile(_resolve_client(api_client), existing):
+                existing.last_profile_sync_at = datetime.now(UTC)
+        return existing
+
+    client = _resolve_client(api_client)
+    profile = {}
+    try:
+        profile = client.get_player_profile(player_api_id) or {}
+    except Exception:
+        logger.warning("Shadow profile fetch failed for %s; falling back to seed", player_api_id)
+        profile = {}
+
+    info = (profile.get("player") if isinstance(profile, dict) else None) or {}
+    # Seed values are ATTACKER-CONTROLLED request payload (the search result the
+    # frontend echoes back) — bleach-clean every text field and https-validate
+    # the photo URL before they land on a globally-shared row. API-sourced
+    # values win over seed values wherever both exist.
+    seed = _clean_seed(seed)
+    name = (info.get("name") or seed.get("name") or f"Player {player_api_id}").strip() or f"Player {player_api_id}"
+
+    def _clip(value, length):
+        return str(value)[:length] if value else None
+
+    shadow = PlayerShadow(
+        player_api_id=player_api_id,
+        player_name=name[:200],
+        photo_url=_clip(info.get("photo") or seed.get("photo"), 500),
+        position=_clip(info.get("position") or seed.get("position"), 50),
+        nationality=_clip(info.get("nationality") or seed.get("nationality"), 100),
+        birth_date=_parse_birth_date((info.get("birth") or {}).get("date")),
+        current_club_name=_clip(seed.get("club_name"), 200),
+        current_club_api_id=seed.get("club_api_id"),
+        requested_by_user_id=requested_by,
+        last_profile_sync_at=datetime.now(UTC) if info else None,
+        is_active=True,
+    )
+    db.session.add(shadow)
+    db.session.flush()
+    return shadow
+
+
+# --------------------------------------------------------------------------- #
+# Search
+# --------------------------------------------------------------------------- #
+
+
+def search_players(q, api_client=None):
+    """Worldwide player search for the shadow-follow UI.
+
+    Returns up to 10 [{player_api_id, name, age?, nationality?, photo?,
+    club_name?, tracked, shadow}]. Stub-safe: returns [] on empty query, no
+    key, or any client error.
+    """
+    query = str(q or "").strip()
+    if len(query) < 3:
+        return []
+
+    client = _resolve_client(api_client)
+    rows = []
+    try:
+        rows = client.search_player_profiles_global(query) or []
+    except Exception:
+        logger.warning("Global profile search failed for %r", query)
+        rows = []
+    if not rows:
+        try:
+            rows = client.search_player_profiles(query) or []
+        except Exception:
+            logger.warning("Fallback player search failed for %r", query)
+            rows = []
+
+    results = []
+    seen = set()
+    for row in rows:
+        player = (row or {}).get("player") or {}
+        pid = player.get("id")
+        if not isinstance(pid, int) or pid in seen:
+            continue
+        seen.add(pid)
+        stats = row.get("statistics") if isinstance(row, dict) else None
+        club_name = None
+        if stats:
+            club_name = ((stats[0] or {}).get("team") or {}).get("name")
+        results.append(
+            {
+                "player_api_id": pid,
+                "name": player.get("name") or f"Player {pid}",
+                "age": player.get("age"),
+                "nationality": player.get("nationality"),
+                "photo": player.get("photo"),
+                "club_name": club_name,
+            }
+        )
+        if len(results) >= MAX_SEARCH_RESULTS:
+            break
+
+    pids = [r["player_api_id"] for r in results]
+    tracked_ids: set[int] = set()
+    shadow_ids: set[int] = set()
+    if pids:
+        tracked_ids = {
+            row[0]
+            for row in db.session.query(TrackedPlayer.player_api_id)
+            .filter(
+                TrackedPlayer.player_api_id.in_(pids),
+                TrackedPlayer.is_active.is_(True),
+                TrackedPlayer.data_source != "owning-club",
+            )
+            .all()
+        }
+        shadow_ids = {
+            row[0]
+            for row in db.session.query(PlayerShadow.player_api_id)
+            .filter(PlayerShadow.player_api_id.in_(pids), PlayerShadow.is_active.is_(True))
+            .all()
+        }
+    for result in results:
+        result["tracked"] = result["player_api_id"] in tracked_ids
+        result["shadow"] = result["player_api_id"] in shadow_ids
+    return results
+
+
+def user_shadow_follow_count(user_id: int) -> int:
+    """Distinct shadow players the user follows across all their lists — the
+    quantity capped by SHADOW_FOLLOW_LIMIT."""
+    from src.models.follow import Follow, FollowList
+
+    rows = (
+        db.session.query(Follow.selector)
+        .join(FollowList, FollowList.id == Follow.list_id)
+        .filter(FollowList.user_account_id == user_id, Follow.kind == "player")
+        .all()
+    )
+    pids = {(selector or {}).get("player_api_id") for (selector,) in rows}
+    pids.discard(None)
+    if not pids:
+        return 0
+    shadow_ids = {
+        row[0]
+        for row in db.session.query(PlayerShadow.player_api_id)
+        .filter(PlayerShadow.player_api_id.in_(pids), PlayerShadow.is_active.is_(True))
+        .all()
+    }
+    return len(shadow_ids)
+
+
+# --------------------------------------------------------------------------- #
+# Refresh (operator-paced batch)
+# --------------------------------------------------------------------------- #
+
+
+def _fetch_season_data(client, player_api_id, season):
+    resp = client._make_request("players", {"id": player_api_id, "season": season})
+    data = resp.get("response", []) if isinstance(resp, dict) else []
+    return data[0] if data else None
+
+
+def _aggregate_season_stats(data) -> dict:
+    """Sum statistics[] blocks per team into one row per team."""
+    if not data:
+        return {}
+    per_team: dict = {}
+    for stat in data.get("statistics", []) or []:
+        team = stat.get("team") or {}
+        team_api_id = team.get("id")
+        games = stat.get("games") or {}
+        goals = stat.get("goals") or {}
+        apps = games.get("appearences") or games.get("appearances") or 0
+        agg = per_team.setdefault(
+            team_api_id,
+            {
+                "team_api_id": team_api_id,
+                "team_name": team.get("name"),
+                "appearances": 0,
+                "goals": 0,
+                "assists": 0,
+                "minutes": 0,
+            },
+        )
+        agg["appearances"] += int(apps or 0)
+        agg["goals"] += int(goals.get("total") or 0)
+        agg["assists"] += int(goals.get("assists") or 0)
+        agg["minutes"] += int(games.get("minutes") or 0)
+    return per_team
+
+
+def _upsert_shadow_stats(player_api_id, team_api_id, season, agg):
+    row = PlayerShadowStats.query.filter_by(player_api_id=player_api_id, team_api_id=team_api_id, season=season).first()
+    if row is None:
+        row = PlayerShadowStats(player_api_id=player_api_id, team_api_id=team_api_id, season=season)
+        db.session.add(row)
+    row.team_name = agg.get("team_name")
+    row.appearances = agg["appearances"]
+    row.goals = agg["goals"]
+    row.assists = agg["assists"]
+    row.minutes = agg["minutes"]
+
+
+def _refresh_profile(client, shadow) -> bool:
+    try:
+        profile = client.get_player_profile(shadow.player_api_id) or {}
+    except Exception:
+        return False
+    info = (profile.get("player") if isinstance(profile, dict) else None) or {}
+    if not info:
+        return False
+    if info.get("name"):
+        shadow.player_name = str(info["name"])[:200]
+    if info.get("photo"):
+        shadow.photo_url = str(info["photo"])[:500]
+    if info.get("position"):
+        shadow.position = str(info["position"])[:50]
+    if info.get("nationality"):
+        shadow.nationality = str(info["nationality"])[:100]
+    birth = _parse_birth_date((info.get("birth") or {}).get("date"))
+    if birth:
+        shadow.birth_date = birth
+    return True
+
+
+def refresh_shadows(limit=25, cursor=None, api_client=None) -> dict:
+    """Refresh the N stalest active shadows (default) or an id-paged sweep.
+
+    Default (no cursor): stalest-first by ``last_stats_sync_at`` — successful
+    refreshes update that column, so repeated operator-paced calls naturally
+    walk the whole population. Passing ``cursor`` switches to a deterministic
+    id-paged sweep with backfill-names next_cursor semantics.
+
+    Per shadow: fetch current-season data, sum per-team stat blocks into
+    PlayerShadowStats, and refresh the profile when stale (>7d). Failures are
+    isolated per row. Quota safety = the DB api_cache TTL + the client quota
+    gate; no extra rate-limiter for operator-paced batches.
+    """
+    client = _resolve_client(api_client)
+    limit = max(1, min(int(limit or 25), 200))
+
+    query = PlayerShadow.query.filter(PlayerShadow.is_active.is_(True))
+    if cursor:
+        query = query.filter(PlayerShadow.id > cursor).order_by(PlayerShadow.id.asc())
+    else:
+        query = query.order_by(PlayerShadow.last_stats_sync_at.asc().nullsfirst(), PlayerShadow.id.asc())
+    shadows = query.limit(limit).all()
+    next_cursor = shadows[-1].id if (cursor and len(shadows) == limit) else None
+
+    season = _current_season_start_year(client)
+    now = datetime.now(UTC)
+    stale_before = _as_naive(now) - timedelta(days=SHADOW_PROFILE_STALE_DAYS)
+
+    considered = 0
+    stats_upserted = 0
+    profiles_refreshed = 0
+    failed = 0
+
+    for shadow in shadows:
+        considered += 1
+        try:
+            data = _fetch_season_data(client, shadow.player_api_id, season)
+            per_team = _aggregate_season_stats(data)
+            for team_api_id, agg in per_team.items():
+                _upsert_shadow_stats(shadow.player_api_id, team_api_id, season, agg)
+                stats_upserted += 1
+            if per_team:
+                top = max(per_team.values(), key=lambda a: a["appearances"])
+                shadow.current_club_api_id = top["team_api_id"]
+                shadow.current_club_name = top["team_name"] or shadow.current_club_name
+            shadow.last_stats_sync_at = now
+
+            last_profile = _as_naive(shadow.last_profile_sync_at)
+            if last_profile is None or last_profile < stale_before:
+                if _refresh_profile(client, shadow):
+                    profiles_refreshed += 1
+                shadow.last_profile_sync_at = now
+        except Exception:
+            logger.exception("Shadow refresh failed for player %s", shadow.player_api_id)
+            failed += 1
+            continue
+
+    db.session.commit()
+    return {
+        "considered": considered,
+        "stats_upserted": stats_upserted,
+        "profiles_refreshed": profiles_refreshed,
+        "failed": failed,
+        "next_cursor": next_cursor,
+    }

--- a/academy-watch-backend/src/services/scout_digest_service.py
+++ b/academy-watch-backend/src/services/scout_digest_service.py
@@ -1,9 +1,16 @@
-"""Scout digest service — per-user watchlist email digests.
+"""Scout digest service — per-user watchlist / follow-list email digests.
 
-For each watchlist entry the digest compares current stats (via
-TrackedPlayer.compute_stats(); watchlists are small so per-entry queries are
-fine in a batch job) against the entry's last_snapshot JSON and renders delta
-chips, status-change headlines, and best-effort new-absence counts.
+Two shapes share one delta engine:
+
+- **Watchlist (legacy) users** — each ScoutWatchlistEntry compares current stats
+  (via TrackedPlayer.compute_stats()) against the entry's last_snapshot and
+  renders delta chips, status-change headlines, and best-effort new-absence
+  counts. This path is byte-for-byte unchanged.
+- **Follow-list users** — each active FollowList resolves to a player set; a
+  per-(user, player) FollowPlayerSnapshot row is the delta baseline (works for
+  dynamic geo/query/academy membership) and is passed AS the "entry" to the same
+  engine. Players outside the tracked universe render from their PlayerShadow.
+  The email gains per-list sections; a user with no lists gets the legacy email.
 """
 
 import json
@@ -12,6 +19,8 @@ import os
 from datetime import UTC, datetime
 
 from flask import render_template
+from sqlalchemy import and_, exists, func, or_
+from src.models.follow import FollowList, FollowPlayerSnapshot, PlayerShadow, PlayerShadowStats
 from src.models.league import UserAccount, db
 from src.models.scout_watchlist import ScoutWatchlistEntry
 from src.models.tracked_player import TrackedPlayer
@@ -19,8 +28,8 @@ from src.models.tracked_player import TrackedPlayer
 logger = logging.getLogger(__name__)
 
 MAX_DIGEST_USERS = 200
-# One run touches at most this many watchlist entries across all users —
-# keeps a synchronous admin request bounded; callers page with `cursor`.
+# One run touches at most this many entries across all users — keeps a
+# synchronous admin request bounded; callers page with `cursor`.
 MAX_DIGEST_ENTRIES = 2000
 # Full rendered HTML only for the first few dry-run previews; at 200 users
 # the response would otherwise be a multi-megabyte JSON blob.
@@ -60,6 +69,37 @@ def _preferred_tracked_player(player_api_id: int):
     )
 
 
+def _active_shadow(player_api_id: int):
+    return PlayerShadow.query.filter_by(player_api_id=player_api_id, is_active=True).first()
+
+
+def _shadow_stats(player_api_id: int) -> dict:
+    """Latest-season totals from PlayerShadowStats (summed across teams).
+
+    Reads the newest season present for the player rather than a wall-clock
+    season, so it is immune to API-Football client season drift (a shadow
+    synced against season N stays visible when the clock ticks to N+1)."""
+    latest_season = (
+        db.session.query(func.max(PlayerShadowStats.season))
+        .filter(PlayerShadowStats.player_api_id == player_api_id)
+        .scalar()
+    )
+    if latest_season is None:
+        return {"appearances": 0, "goals": 0, "assists": 0, "minutes_played": 0}
+    row = (
+        db.session.query(
+            func.coalesce(func.sum(PlayerShadowStats.appearances), 0),
+            func.coalesce(func.sum(PlayerShadowStats.goals), 0),
+            func.coalesce(func.sum(PlayerShadowStats.assists), 0),
+            func.coalesce(func.sum(PlayerShadowStats.minutes), 0),
+        )
+        .filter(PlayerShadowStats.player_api_id == player_api_id, PlayerShadowStats.season == latest_season)
+        .first()
+    )
+    apps, goals, assists, minutes = (int(value or 0) for value in (row or (0, 0, 0, 0)))
+    return {"appearances": apps, "goals": goals, "assists": assists, "minutes_played": minutes}
+
+
 def _absence_count(api_client, player_api_id: int) -> int | None:
     """Best-effort season absence count; None when unavailable."""
     if api_client is None:
@@ -71,7 +111,7 @@ def _absence_count(api_client, player_api_id: int) -> int | None:
         return None
 
 
-def _load_snapshot(entry: ScoutWatchlistEntry) -> dict | None:
+def _load_snapshot(entry) -> dict | None:
     if not entry.last_snapshot:
         return None
     try:
@@ -81,27 +121,69 @@ def _load_snapshot(entry: ScoutWatchlistEntry) -> dict | None:
         return None
 
 
-def _player_state(player_api_id: int, cache: dict, api_client=None) -> tuple:
-    """(tracked_player, stats, absences) memoised per run — many users watch
-    the same players, so stats and injuries are computed once per player."""
+def _player_state(player_api_id: int, cache: dict, api_client=None) -> dict:
+    """Memoised per run — many users watch the same players, so stats and
+    injuries are computed once per player.
+
+    Returns a dict with ``kind`` in {tracked, shadow, none}. A tracked player
+    NEVER goes through the shadow branch (compute_stats stays authoritative);
+    only players with no active tracked row fall back to a PlayerShadow.
+    """
     if player_api_id in cache:
         return cache[player_api_id]
     tracked_player = _preferred_tracked_player(player_api_id)
-    stats = tracked_player.compute_stats() if tracked_player else None
-    absences = _absence_count(api_client, player_api_id) if tracked_player else None
-    state = (tracked_player, stats, absences)
+    if tracked_player is not None:
+        state = {
+            "kind": "tracked",
+            "tracked": tracked_player,
+            "shadow": None,
+            "stats": tracked_player.compute_stats(),
+            "absences": _absence_count(api_client, player_api_id),
+        }
+    else:
+        shadow = _active_shadow(player_api_id)
+        if shadow is not None:
+            state = {
+                "kind": "shadow",
+                "tracked": None,
+                "shadow": shadow,
+                "stats": _shadow_stats(player_api_id),
+                "absences": None,
+            }
+        else:
+            state = {"kind": "none", "tracked": None, "shadow": None, "stats": None, "absences": None}
     cache[player_api_id] = state
     return state
 
 
-def _entry_update(entry: ScoutWatchlistEntry, cache: dict, api_client=None) -> dict | None:
-    """Card + fresh snapshot for one entry; None when the player is no longer tracked."""
-    tracked_player, stats, absences = _player_state(entry.player_api_id, cache, api_client=api_client)
-    if tracked_player is None:
+def _entry_update(entry, cache: dict, api_client=None) -> dict | None:
+    """Card + fresh snapshot for one entry; None when the player is neither a
+    tracked player nor an active shadow. ``entry`` is a ScoutWatchlistEntry
+    (watchlist path) or a FollowPlayerSnapshot (list path) — both expose
+    player_api_id / last_snapshot / note."""
+    state = _player_state(entry.player_api_id, cache, api_client=api_client)
+    if state["kind"] == "none":
         return None
 
+    stats = state["stats"]
     previous = _load_snapshot(entry)
-    name = tracked_player.player_name
+
+    if state["kind"] == "tracked":
+        tracked_player = state["tracked"]
+        name = tracked_player.player_name
+        status = tracked_player.status
+        parent_club = tracked_player.team.name if tracked_player.team else None
+        current_club = tracked_player.current_club_name
+        absences = state["absences"]
+        new_headline = "Added to your watchlist"
+    else:
+        shadow = state["shadow"]
+        name = shadow.player_name
+        status = None
+        parent_club = None
+        current_club = shadow.current_club_name
+        absences = None
+        new_headline = "Now tracking worldwide"
 
     season_line = " · ".join(
         [
@@ -117,7 +199,7 @@ def _entry_update(entry: ScoutWatchlistEntry, cache: dict, api_client=None) -> d
     card_headline = None
 
     if previous is None:
-        card_headline = "Added to your watchlist"
+        card_headline = new_headline
     else:
         new_apps = int(stats.get("appearances") or 0) - int(previous.get("appearances") or 0)
         new_goals = int(stats.get("goals") or 0) - int(previous.get("goals") or 0)
@@ -132,9 +214,10 @@ def _entry_update(entry: ScoutWatchlistEntry, cache: dict, api_client=None) -> d
         if new_minutes > 0:
             chips.append(f"+{new_minutes} mins")
 
+        # Status headlines only apply to tracked players (shadows have no status).
         previous_status = previous.get("status")
-        if previous_status and tracked_player.status and previous_status != tracked_player.status:
-            label = _STATUS_LABELS.get(tracked_player.status, f"Status changed to {tracked_player.status}")
+        if status and previous_status and previous_status != status:
+            label = _STATUS_LABELS.get(status, f"Status changed to {status}")
             card_headline = label
             headlines.append(f"{name}: {label}")
 
@@ -150,7 +233,7 @@ def _entry_update(entry: ScoutWatchlistEntry, cache: dict, api_client=None) -> d
         "goals": int(stats.get("goals") or 0),
         "assists": int(stats.get("assists") or 0),
         "minutes_played": int(stats.get("minutes_played") or 0),
-        "status": tracked_player.status,
+        "status": status,
         "absences": absences if absences is not None else int((previous or {}).get("absences") or 0),
         "taken_at": datetime.now(UTC).isoformat(),
     }
@@ -159,9 +242,9 @@ def _entry_update(entry: ScoutWatchlistEntry, cache: dict, api_client=None) -> d
         "player_api_id": entry.player_api_id,
         "player_name": name,
         "player_url": f"{_public_base_url()}/players/{entry.player_api_id}",
-        "parent_club": tracked_player.team.name if tracked_player.team else None,
-        "current_club": tracked_player.current_club_name,
-        "status": tracked_player.status,
+        "parent_club": parent_club,
+        "current_club": current_club,
+        "status": status,
         "is_new": previous is None,
         "season_line": season_line,
         "chips": chips,
@@ -172,68 +255,163 @@ def _entry_update(entry: ScoutWatchlistEntry, cache: dict, api_client=None) -> d
     return {"entry": entry, "card": card, "snapshot": snapshot, "headlines": headlines}
 
 
-def _digest_text(headlines: list[str], cards: list[dict], watchlist_url: str) -> str:
+def _card_text_lines(card: dict) -> list[str]:
+    club_line = " -> ".join(part for part in (card["parent_club"], card["current_club"]) if part)
+    lines = [f"{card['player_name']} ({club_line or 'club unknown'}) [{card['status'] or 'worldwide'}]"]
+    if card["headline"]:
+        lines.append(f"  {card['headline']}")
+    lines.append(f"  {card['season_line']}")
+    if card["chips"]:
+        lines.append(f"  {', '.join(card['chips'])}")
+    lines.append(f"  {card['player_url']}")
+    lines.append("")
+    return lines
+
+
+def _digest_text(headlines: list[str], cards: list[dict], watchlist_url: str, groups=None) -> str:
     lines = ["THE ACADEMY WATCH — Scout Digest", ""]
     if headlines:
         lines.append("Headlines:")
         lines.extend(f"- {headline}" for headline in headlines)
         lines.append("")
+    # Flat watchlist section first (byte-identical to the legacy digest when it
+    # is all a user has), then any per-list grouped sections.
     for card in cards:
-        club_line = " -> ".join(part for part in (card["parent_club"], card["current_club"]) if part)
-        lines.append(f"{card['player_name']} ({club_line or 'club unknown'}) [{card['status']}]")
-        if card["headline"]:
-            lines.append(f"  {card['headline']}")
-        lines.append(f"  {card['season_line']}")
-        if card["chips"]:
-            lines.append(f"  {', '.join(card['chips'])}")
-        lines.append(f"  {card['player_url']}")
-        lines.append("")
+        lines.extend(_card_text_lines(card))
+    if groups:
+        for group in groups:
+            lines.append(group["name"].upper())
+            lines.append("")
+            for card in group["cards"]:
+                lines.extend(_card_text_lines(card))
     lines.append(f"Manage this digest from your watchlist: {watchlist_url}")
     return "\n".join(lines)
 
 
-def _render_digest(user: UserAccount, updates: list[dict]) -> dict | None:
-    if not updates:
+def _render_digest(user: UserAccount, flat_updates: list[dict], groups=None, group_updates=None) -> dict | None:
+    """Render a digest as a flat watchlist section (``flat_updates``) followed by
+    optional per-list grouped sections (``groups`` + their ``group_updates``).
+
+    A user with only watchlist entries passes no groups → the template's legacy
+    flat layout renders byte-identically."""
+    group_updates = group_updates or []
+    all_updates = list(flat_updates) + list(group_updates)
+    if not all_updates:
         return None
-    cards = [update["card"] for update in updates]
-    headlines = [headline for update in updates for headline in update["headlines"]]
-    count = len(cards)
+    flat_cards = [update["card"] for update in flat_updates]
+    headlines = [headline for update in all_updates for headline in update["headlines"]]
+    count = len(all_updates)
     subject = f"Scout Digest — {_plural(count, 'player')} on your watchlist"
     watchlist_url = f"{_public_base_url()}/scout/watchlist"
     html = render_template(
         "scout_digest_email.html",
         headlines=headlines,
-        players=cards,
+        players=flat_cards,
+        groups=groups or None,
         player_count=count,
         watchlist_url=watchlist_url,
     )
     return {
         "subject": subject,
         "html": html,
-        "text": _digest_text(headlines, cards, watchlist_url),
+        "text": _digest_text(headlines, flat_cards, watchlist_url, groups=groups),
         "players": count,
     }
 
 
 def build_user_digest(user: UserAccount, entries: list[ScoutWatchlistEntry], api_client=None) -> dict | None:
-    """Render one user's digest; None when there is nothing to send."""
+    """Render one watchlist user's (flat) digest; None when nothing to send."""
     cache: dict = {}
-    updates = [u for u in (_entry_update(entry, cache, api_client=api_client) for entry in entries) if u]
-    return _render_digest(user, updates)
+    flat_updates = [u for u in (_entry_update(entry, cache, api_client=api_client) for entry in entries) if u]
+    return _render_digest(user, flat_updates)
+
+
+# --------------------------------------------------------------------------- #
+# Follow-list digest assembly
+# --------------------------------------------------------------------------- #
+
+
+def _list_player_notes(lists) -> dict:
+    """player_api_id -> note, from player-kind follows across the user's lists."""
+    from src.models.follow import Follow
+
+    notes: dict = {}
+    for follow_list in lists:
+        for follow in follow_list.follows.filter(Follow.kind == "player").all():
+            pid = (follow.selector or {}).get("player_api_id")
+            if pid and pid not in notes and follow.note:
+                notes[pid] = follow.note
+    return notes
+
+
+def _get_or_transient_snapshot(user_id: int, player_api_id: int, note):
+    """Existing FollowPlayerSnapshot, or a transient one (NOT added to the
+    session) so dry runs never persist a baseline."""
+    snap = FollowPlayerSnapshot.query.filter_by(user_account_id=user_id, player_api_id=player_api_id).first()
+    if snap is None:
+        snap = FollowPlayerSnapshot(user_account_id=user_id, player_api_id=player_api_id, note=note)
+    return snap
+
+
+def _build_list_updates(user: UserAccount, lists, cache: dict, api_client=None, seen=None):
+    """Resolve a user's lists into (groups, updates).
+
+    A player is shown once — the first list to resolve it wins, and any player
+    already in ``seen`` (e.g. the watchlist section — watchlist wins) is
+    skipped. Each resolved player gets a get-or-transient FollowPlayerSnapshot
+    that carries the delta baseline and is the "entry" handed to the shared
+    delta engine.
+    """
+    from src.services.follow_resolver import resolve_list
+
+    note_map = _list_player_notes(lists)
+    groups = []
+    updates = []
+    seen = set(seen) if seen else set()
+    for follow_list in lists:
+        resolved = resolve_list(follow_list, limit=follow_list.player_cap)
+        cards = []
+        for item in resolved:
+            pid = item["player_api_id"]
+            if pid in seen:
+                continue
+            seen.add(pid)
+            snap = _get_or_transient_snapshot(user.id, pid, note_map.get(pid))
+            update = _entry_update(snap, cache, api_client=api_client)
+            if update is None:
+                continue
+            cards.append(update["card"])
+            updates.append(update)
+        if cards:
+            groups.append({"name": follow_list.name, "cards": cards})
+    return groups, updates
+
+
+def _assemble_user_updates(user: UserAccount, watchlist_entries, routed_lists, cache: dict, api_client=None):
+    """(flat_updates, groups, group_updates) for one user — ADDITIVE.
+
+    The flat section comes from the watchlist (legacy ordering/snapshots/caps);
+    the grouped sections come from ``routed_lists`` and exclude any player
+    already on the watchlist (watchlist wins) so a player is never shown twice.
+    """
+    flat_updates = [u for u in (_entry_update(e, cache, api_client=api_client) for e in watchlist_entries) if u]
+    seen = {entry.player_api_id for entry in watchlist_entries}
+    groups, group_updates = _build_list_updates(user, routed_lists, cache, api_client=api_client, seen=seen)
+    return flat_updates, groups, group_updates
 
 
 def send_scout_digests(dry_run: bool = True, limit: int = 50, api_client=None, cursor: int = 0) -> dict:
-    """Build (and optionally send) digests for eligible watchlist users.
+    """Build (and optionally send) digests for eligible users.
 
-    Eligibility (opt-in true, email present) is filtered in SQL so ineligible
-    users never consume slots. `cursor` is the last fully-processed
-    user_account_id; the result's `next_cursor` is non-null while more users
-    remain, so repeated calls walk the whole population instead of re-picking
-    the same first page forever.
+    Eligibility (opt-in true, email present, AND has watchlist entries OR an
+    active follow list) is filtered in SQL so ineligible users never consume
+    slots. `cursor` is the last fully-processed user_account_id; the result's
+    `next_cursor` is non-null while more users remain.
 
-    dry_run renders previews without sending and without mutating snapshots.
-    Real runs persist each entry's last_snapshot/last_digest_at after a
-    successful send.
+    A user with active follow lists gets the generalized per-list digest; a
+    user with only a watchlist gets the legacy digest (byte-identical). dry_run
+    renders previews without sending and without mutating snapshots. Real runs
+    persist each entry's last_snapshot/last_digest_at after a successful send.
     """
     from src.services.email_service import email_service  # lazy so tests can monkeypatch send_email
 
@@ -247,17 +425,18 @@ def send_scout_digests(dry_run: bool = True, limit: int = 50, api_client=None, c
     except (TypeError, ValueError):
         cursor = 0
 
+    has_watchlist = exists().where(ScoutWatchlistEntry.user_account_id == UserAccount.id)
+    has_list = exists().where(and_(FollowList.user_account_id == UserAccount.id, FollowList.is_active.is_(True)))
     user_ids = [
         row[0]
-        for row in db.session.query(ScoutWatchlistEntry.user_account_id)
-        .join(UserAccount, UserAccount.id == ScoutWatchlistEntry.user_account_id)
+        for row in db.session.query(UserAccount.id)
         .filter(
-            ScoutWatchlistEntry.user_account_id > cursor,
+            UserAccount.id > cursor,
             UserAccount.email.isnot(None),
             UserAccount.scout_digest_opt_in.is_(True),
+            or_(has_watchlist, has_list),
         )
-        .distinct()
-        .order_by(ScoutWatchlistEntry.user_account_id)
+        .order_by(UserAccount.id)
         .limit(limit)
         .all()
     ]
@@ -282,18 +461,32 @@ def send_scout_digests(dry_run: bool = True, limit: int = 50, api_client=None, c
             last_processed = user_id
             continue
 
-        entries = (
+        # Additive routing: the watchlist is always the flat section; active
+        # NON-DEFAULT lists append grouped sections. The default list is the
+        # watchlist's mirror twin and never routes — EXCEPT as a fallback when
+        # the watchlist is empty (a user who cleared their watchlist but whose
+        # mirror follows remain still gets that content).
+        watchlist_entries = (
             ScoutWatchlistEntry.query.filter_by(user_account_id=user_id)
             .order_by(ScoutWatchlistEntry.created_at.desc(), ScoutWatchlistEntry.id.desc())
             .all()
         )
-        if len(entries) > entry_budget:
+        active_lists = FollowList.query.filter_by(user_account_id=user_id, is_active=True).order_by(FollowList.id).all()
+        routed_lists = [fl for fl in active_lists if not fl.is_default]
+        if not watchlist_entries:
+            routed_lists += [fl for fl in active_lists if fl.is_default]
+
+        flat_updates, groups, group_updates = _assemble_user_updates(
+            user, watchlist_entries, routed_lists, player_cache, api_client=api_client
+        )
+        total_updates = len(flat_updates) + len(group_updates)
+        if total_updates > entry_budget:
             exhausted_budget = True
             break
-        entry_budget -= len(entries)
+        entry_budget -= total_updates
+        updates = list(flat_updates) + list(group_updates)
+        digest = _render_digest(user, flat_updates, groups=groups, group_updates=group_updates)
 
-        updates = [u for u in (_entry_update(entry, player_cache, api_client=api_client) for entry in entries) if u]
-        digest = _render_digest(user, updates)
         if digest is None:
             skipped += 1
             last_processed = user_id
@@ -328,8 +521,13 @@ def send_scout_digests(dry_run: bool = True, limit: int = 50, api_client=None, c
             continue
 
         for update in updates:
-            update["entry"].last_snapshot = json.dumps(update["snapshot"])
-            update["entry"].last_digest_at = now
+            entry = update["entry"]
+            # List-path FollowPlayerSnapshot rows may be transient (first digest);
+            # persist them only now, on a real, successful send.
+            if entry not in db.session:
+                db.session.add(entry)
+            entry.last_snapshot = json.dumps(update["snapshot"])
+            entry.last_digest_at = now
         db.session.commit()
         sent += 1
         previews.append(preview)

--- a/academy-watch-backend/src/templates/scout_digest_email.html
+++ b/academy-watch-backend/src/templates/scout_digest_email.html
@@ -231,7 +231,40 @@
                 {% endif %}
               </div>
               {% endfor %}
-
+{% if groups %}
+              {% for group in groups %}
+              <div class="group-label" style="font-size:12px;text-transform:uppercase;letter-spacing:1.5px;color:#9a9a9a;margin:24px 0 12px;">{{ group.name }}</div>
+              {% for player in group.cards %}
+              <div class="player-card">
+                <p class="player-name">
+                  <a href="{{ player.player_url }}" target="_blank" rel="noopener">{{ player.player_name }}</a>
+                </p>
+                <div class="player-clubs">
+                  {% if player.parent_club %}{{ player.parent_club }}{% endif %}
+                  {% if player.parent_club and player.current_club %} → {% endif %}
+                  {% if player.current_club %}{{ player.current_club }}{% endif %}
+                </div>
+                {% if player.status %}
+                <span class="player-status">{{ player.status | replace('_', ' ') }}</span>
+                {% endif %}
+                {% if player.headline %}
+                <p class="player-headline">{{ player.headline }}</p>
+                {% endif %}
+                <p class="season-line">{{ player.season_line }}</p>
+                {% if player.chips %}
+                <div>
+                  {% for chip in player.chips %}
+                  <span class="chip">{{ chip }}</span>
+                  {% endfor %}
+                </div>
+                {% endif %}
+                {% if player.note %}
+                <p class="player-note">{{ player.note }}</p>
+                {% endif %}
+              </div>
+              {% endfor %}
+              {% endfor %}
+              {% endif %}
               <div class="footer">
                 <p>
                   <a href="{{ watchlist_url }}" target="_blank" rel="noopener">Manage this digest from your

--- a/academy-watch-backend/tests/test_follow_graph.py
+++ b/academy-watch-backend/tests/test_follow_graph.py
@@ -1,0 +1,979 @@
+"""Tests for the Follow Graph + Shadow Tracking feature.
+
+Covers lists CRUD/caps/owner-gates, per-kind selector validation, the resolver
+(each kind + union dedup + caps), shadow mint/cap/search stub-safety, the
+watchlist->list dual-write mirror, the backfill admin endpoint
+(dry-run/real/idempotent/cursor), digest generalization (per-list sections +
+shadow "now tracking" card + FollowPlayerSnapshot persistence) with the
+watchlist-only regression, and the profile/season-stats shadow fallbacks.
+"""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+from src.models.follow import Follow, FollowList, FollowPlayerSnapshot, PlayerShadow, PlayerShadowStats
+from src.models.league import League, Team, db
+from src.models.scout_watchlist import ScoutWatchlistEntry
+from src.models.tracked_player import TrackedPlayer
+from src.models.weekly import Fixture, FixturePlayerStats
+
+ADMIN_KEY = "test-admin-key"
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("SKIP_API_HANDSHAKE", "1")
+    monkeypatch.setenv("API_USE_STUB_DATA", "true")
+    monkeypatch.setenv("ADMIN_API_KEY", ADMIN_KEY)
+    monkeypatch.setenv("ADMIN_IP_WHITELIST", "")
+
+    from src.routes.players import players_bp
+    from src.routes.scout import scout_bp
+
+    template_dir = Path(__file__).resolve().parent.parent / "src" / "templates"
+    flask_app = Flask(__name__, template_folder=str(template_dir))
+    flask_app.config.update(
+        TESTING=True,
+        SECRET_KEY="test-secret-key",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        RATELIMIT_ENABLED=False,
+    )
+    db.init_app(flask_app)
+    flask_app.register_blueprint(players_bp, url_prefix="/api")
+    flask_app.register_blueprint(scout_bp, url_prefix="/api")
+
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def seeded(app):
+    """Parent academy + Brazilian loan club, two tracked players, one shadow."""
+    league = League(league_id=39, name="Premier League", country="England", season=2025, is_european_top_league=True)
+    db.session.add(league)
+    db.session.flush()
+
+    parent = Team(
+        team_id=33, name="Manchester United", country="England", season=2025, league_id=league.id, is_active=True
+    )
+    loan_club = Team(team_id=901, name="Rio FC", country="Brazil", season=2025, league_id=league.id, is_active=True)
+    db.session.add_all([parent, loan_club])
+    db.session.flush()
+
+    striker = TrackedPlayer(
+        player_api_id=1001,
+        player_name="Alfie Striker",
+        position="Attacker",
+        nationality="England",
+        age=19,
+        team_id=parent.id,
+        status="on_loan",
+        current_club_api_id=901,
+        current_club_name="Rio FC",
+        current_club_db_id=loan_club.id,
+        data_depth="full_stats",
+        is_active=True,
+    )
+    keeper = TrackedPlayer(
+        player_api_id=1003,
+        player_name="Charlie Gloves",
+        position="Goalkeeper",
+        nationality="Japan",
+        age=18,
+        team_id=parent.id,
+        status="first_team",
+        data_depth="full_stats",
+        is_active=True,
+    )
+    ghost = TrackedPlayer(
+        player_api_id=1005,
+        player_name="Danny Ghost",
+        position="Defender",
+        age=20,
+        team_id=parent.id,
+        status="released",
+        is_active=False,
+    )
+    db.session.add_all([striker, keeper, ghost])
+
+    fixtures = [
+        Fixture(
+            fixture_id_api=5000 + i,
+            season=2025,
+            home_team_api_id=901,
+            away_team_api_id=950 + i,
+            date_utc=datetime(2025, 9, 1 + 7 * i),
+        )
+        for i in range(2)
+    ]
+    db.session.add_all(fixtures)
+    db.session.flush()
+    db.session.add_all(
+        [
+            FixturePlayerStats(
+                fixture_id=fixtures[0].id,
+                player_api_id=1001,
+                team_api_id=901,
+                minutes=90,
+                goals=2,
+                assists=1,
+                rating=8.2,
+            ),
+            FixturePlayerStats(
+                fixture_id=fixtures[1].id,
+                player_api_id=1001,
+                team_api_id=901,
+                minutes=80,
+                goals=1,
+                assists=0,
+                rating=7.0,
+            ),
+        ]
+    )
+
+    # A shadow player (worldwide) with current-season stats.
+    shadow = PlayerShadow(
+        player_api_id=2001,
+        player_name="Shadow Prospect",
+        position="Midfielder",
+        nationality="Argentina",
+        current_club_name="Boca",
+        current_club_api_id=7001,
+        is_active=True,
+    )
+    db.session.add(shadow)
+    db.session.add(
+        PlayerShadowStats(
+            player_api_id=2001,
+            team_api_id=7001,
+            team_name="Boca",
+            season=2025,
+            appearances=6,
+            goals=2,
+            assists=3,
+            minutes=520,
+        )
+    )
+    db.session.commit()
+    return {"parent": parent, "loan_club": loan_club}
+
+
+def _make_user(email, **overrides):
+    from src.auth import _ensure_user_account
+
+    user = _ensure_user_account(email)
+    for key, value in overrides.items():
+        setattr(user, key, value)
+    db.session.commit()
+    return user
+
+
+def _headers(email="scout@example.com"):
+    from src.auth import issue_user_token
+
+    return {"Authorization": f"Bearer {issue_user_token(email)['token']}"}
+
+
+def _admin_headers():
+    from src.auth import issue_user_token
+
+    token = issue_user_token("admin@example.com", role="admin")["token"]
+    return {"Authorization": f"Bearer {token}", "X-API-Key": ADMIN_KEY}
+
+
+class _FakeApiClient:
+    """Profile + season-data source for mint/refresh; no injuries."""
+
+    current_season_start_year = 2025
+
+    def get_player_profile(self, player_id):
+        return {
+            "player": {
+                "id": player_id,
+                "name": "Minted Guy",
+                "photo": "http://img/p.png",
+                "position": "Attacker",
+                "nationality": "Argentina",
+                "birth": {"date": "2004-03-01"},
+            }
+        }
+
+    def get_player_injuries(self, player_id, season=None):
+        return []
+
+    def _make_request(self, endpoint, params=None):
+        if endpoint == "players":
+            return {
+                "response": [
+                    {
+                        "statistics": [
+                            {
+                                "team": {"id": 7001, "name": "Boca"},
+                                "games": {"appearences": 5, "minutes": 400},
+                                "goals": {"total": 3, "assists": 1},
+                            },
+                        ]
+                    }
+                ]
+            }
+        return {"response": []}
+
+
+def _use_client(monkeypatch, client_obj):
+    import src.routes.scout as scout_module
+
+    monkeypatch.setattr(scout_module, "_get_api_client", lambda: client_obj)
+
+
+# --------------------------------------------------------------------------- #
+# Auth
+# --------------------------------------------------------------------------- #
+
+
+class TestAuth:
+    @pytest.mark.parametrize(
+        ("method", "path"),
+        [
+            ("get", "/api/scout/lists"),
+            ("post", "/api/scout/lists"),
+            ("patch", "/api/scout/lists/1"),
+            ("delete", "/api/scout/lists/1"),
+            ("post", "/api/scout/lists/1/follows"),
+            ("get", "/api/scout/lists/1/resolve"),
+            ("get", "/api/scout/player-search?q=abc"),
+        ],
+    )
+    def test_user_endpoints_require_auth(self, client, method, path):
+        assert getattr(client, method)(path).status_code == 401
+
+    def test_admin_endpoints_require_admin(self, client):
+        assert client.post("/api/admin/scout/shadow-refresh", json={}).status_code == 401
+        assert client.post("/api/admin/scout/backfill-follow-lists", json={}, headers=_headers()).status_code == 401
+
+
+# --------------------------------------------------------------------------- #
+# Lists CRUD
+# --------------------------------------------------------------------------- #
+
+
+class TestListsCrud:
+    def test_create_and_list(self, client, seeded):
+        resp = client.post("/api/scout/lists", json={"name": "Wonderkids"}, headers=_headers())
+        assert resp.status_code == 201
+        created = resp.get_json()["list"]
+        assert created["name"] == "Wonderkids"
+        assert created["is_default"] is False
+        assert created["follow_count"] == 0
+
+        listing = client.get("/api/scout/lists", headers=_headers()).get_json()["lists"]
+        assert [x["name"] for x in listing] == ["Wonderkids"]
+
+    def test_duplicate_name_409(self, client, seeded):
+        client.post("/api/scout/lists", json={"name": "Dupe"}, headers=_headers())
+        resp = client.post("/api/scout/lists", json={"name": "Dupe"}, headers=_headers())
+        assert resp.status_code == 409
+
+    def test_blank_name_400(self, client, seeded):
+        assert client.post("/api/scout/lists", json={"name": "   "}, headers=_headers()).status_code == 400
+        assert client.post("/api/scout/lists", json={}, headers=_headers()).status_code == 400
+
+    def test_list_cap_409(self, client, seeded, monkeypatch):
+        import src.routes.scout as scout_module
+
+        monkeypatch.setattr(scout_module, "MAX_FOLLOW_LISTS", 1)
+        assert client.post("/api/scout/lists", json={"name": "One"}, headers=_headers()).status_code == 201
+        resp = client.post("/api/scout/lists", json={"name": "Two"}, headers=_headers())
+        assert resp.status_code == 409
+        assert "list limit reached" in resp.get_json()["error"]
+
+    def test_rename_and_toggle(self, client, seeded):
+        lid = client.post("/api/scout/lists", json={"name": "Old"}, headers=_headers()).get_json()["list"]["id"]
+        resp = client.patch(f"/api/scout/lists/{lid}", json={"name": "New", "is_active": False}, headers=_headers())
+        assert resp.status_code == 200
+        payload = resp.get_json()["list"]
+        assert payload["name"] == "New"
+        assert payload["is_active"] is False
+
+    def test_owner_gate_on_other_users_list(self, client, seeded):
+        lid = client.post("/api/scout/lists", json={"name": "Mine"}, headers=_headers("owner@example.com")).get_json()[
+            "list"
+        ]["id"]
+        assert (
+            client.patch(
+                f"/api/scout/lists/{lid}", json={"name": "Hijack"}, headers=_headers("intruder@example.com")
+            ).status_code
+            == 404
+        )
+        assert client.delete(f"/api/scout/lists/{lid}", headers=_headers("intruder@example.com")).status_code == 404
+
+    def test_default_list_not_deletable(self, client, seeded):
+        # Adding a watchlist player mints the default list via the dual-write.
+        client.post("/api/scout/watchlist", json={"player_api_id": 1001}, headers=_headers())
+        default = FollowList.query.filter_by(is_default=True).one()
+        resp = client.delete(f"/api/scout/lists/{default.id}", headers=_headers())
+        assert resp.status_code == 400
+        assert "default list" in resp.get_json()["error"]
+
+
+# --------------------------------------------------------------------------- #
+# Follows + selector validation
+# --------------------------------------------------------------------------- #
+
+
+class TestFollowValidation:
+    def _list(self, client, email="scout@example.com"):
+        return client.post("/api/scout/lists", json={"name": "L"}, headers=_headers(email)).get_json()["list"]["id"]
+
+    def test_unknown_kind_400(self, client, seeded):
+        lid = self._list(client)
+        resp = client.post(
+            f"/api/scout/lists/{lid}/follows", json={"kind": "wizard", "selector": {}}, headers=_headers()
+        )
+        assert resp.status_code == 400
+
+    def test_player_unexpected_keys_400(self, client, seeded):
+        lid = self._list(client)
+        resp = client.post(
+            f"/api/scout/lists/{lid}/follows",
+            json={"kind": "player", "selector": {"player_api_id": 1001, "x": 1}},
+            headers=_headers(),
+        )
+        assert resp.status_code == 400
+
+    def test_geo_bad_match_and_too_many_countries_400(self, client, seeded):
+        lid = self._list(client)
+        assert (
+            client.post(
+                f"/api/scout/lists/{lid}/follows",
+                json={"kind": "geo", "selector": {"countries": ["Brazil"], "match": "nope"}},
+                headers=_headers(),
+            ).status_code
+            == 400
+        )
+        assert (
+            client.post(
+                f"/api/scout/lists/{lid}/follows",
+                json={"kind": "geo", "selector": {"countries": [f"C{i}" for i in range(11)]}},
+                headers=_headers(),
+            ).status_code
+            == 400
+        )
+
+    def test_query_unknown_scout_arg_400(self, client, seeded):
+        lid = self._list(client)
+        resp = client.post(
+            f"/api/scout/lists/{lid}/follows",
+            json={"kind": "query", "selector": {"scout_args": {"team": 1}}},
+            headers=_headers(),
+        )
+        assert resp.status_code == 400
+
+    def test_add_tracked_player_follow_and_dedup(self, client, seeded):
+        lid = self._list(client)
+        resp = client.post(
+            f"/api/scout/lists/{lid}/follows",
+            json={"kind": "player", "selector": {"player_api_id": 1001}},
+            headers=_headers(),
+        )
+        assert resp.status_code == 201
+        body = resp.get_json()
+        assert body["shadow_created"] is False
+        assert body["follow"]["label"] == "Alfie Striker"
+        # duplicate (kind, selector) rejected
+        dup = client.post(
+            f"/api/scout/lists/{lid}/follows",
+            json={"kind": "player", "selector": {"player_api_id": 1001}},
+            headers=_headers(),
+        )
+        assert dup.status_code == 409
+
+    def test_follow_cap_409(self, client, seeded, monkeypatch):
+        import src.routes.scout as scout_module
+
+        monkeypatch.setattr(scout_module, "MAX_FOLLOWS_PER_LIST", 1)
+        lid = self._list(client)
+        assert (
+            client.post(
+                f"/api/scout/lists/{lid}/follows",
+                json={"kind": "geo", "selector": {"countries": ["Brazil"]}},
+                headers=_headers(),
+            ).status_code
+            == 201
+        )
+        resp = client.post(
+            f"/api/scout/lists/{lid}/follows",
+            json={"kind": "geo", "selector": {"countries": ["Spain"]}},
+            headers=_headers(),
+        )
+        assert resp.status_code == 409
+
+    def test_remove_follow(self, client, seeded):
+        lid = self._list(client)
+        fid = client.post(
+            f"/api/scout/lists/{lid}/follows",
+            json={"kind": "geo", "selector": {"countries": ["Brazil"]}},
+            headers=_headers(),
+        ).get_json()["follow"]["id"]
+        assert client.delete(f"/api/scout/lists/{lid}/follows/{fid}", headers=_headers()).get_json() == {
+            "removed": True
+        }
+        assert client.delete(f"/api/scout/lists/{lid}/follows/{fid}", headers=_headers()).get_json() == {
+            "removed": False
+        }
+
+
+class TestEmbeddedFollows:
+    """GET /scout/lists embeds each list's follows with read-time labels."""
+
+    def test_get_lists_embeds_follows_with_labels(self, client, seeded):
+        lid = client.post("/api/scout/lists", json={"name": "Board"}, headers=_headers()).get_json()["list"]["id"]
+        for body in (
+            {"kind": "player", "selector": {"player_api_id": 1001}},
+            {"kind": "academy_club", "selector": {"team_id": seeded["parent"].id}},
+            {"kind": "geo", "selector": {"countries": ["Brazil"], "match": "playing_in"}},
+            {"kind": "geo", "selector": {"countries": ["Japan"], "match": "nationality"}},
+            {"kind": "query", "selector": {"scout_args": {"position": "Attacker"}}},
+        ):
+            assert client.post(f"/api/scout/lists/{lid}/follows", json=body, headers=_headers()).status_code == 201
+
+        lists = client.get("/api/scout/lists", headers=_headers()).get_json()["lists"]
+        board = next(x for x in lists if x["id"] == lid)
+        assert board["follow_count"] == 5
+        follows = board["follows"]
+        assert set(follows[0].keys()) == {"id", "kind", "selector", "label", "note", "created_at"}
+        labels = {f["kind"]: f["label"] for f in follows if f["kind"] != "geo"}
+        geo_labels = {f["label"] for f in follows if f["kind"] == "geo"}
+        assert labels["player"] == "Alfie Striker"  # resolved player name
+        assert labels["academy_club"] == "Club academy: Manchester United"
+        assert labels["query"] == "Filter: Attacker"
+        assert geo_labels == {"Playing in: Brazil", "Nationality: Japan"}
+
+    def test_created_list_has_empty_follows(self, client, seeded):
+        created = client.post("/api/scout/lists", json={"name": "Fresh"}, headers=_headers()).get_json()["list"]
+        assert created["follows"] == []
+        assert created["follow_count"] == 0
+
+    def test_player_label_falls_back_to_shadow_name(self, client, seeded):
+        lid = client.post("/api/scout/lists", json={"name": "WW"}, headers=_headers()).get_json()["list"]["id"]
+        # 2001 is a shadow (no tracked row); its label resolves to the shadow name.
+        client.post(
+            f"/api/scout/lists/{lid}/follows",
+            json={"kind": "player", "selector": {"player_api_id": 2001}},
+            headers=_headers(),
+        )
+        lists = client.get("/api/scout/lists", headers=_headers()).get_json()["lists"]
+        board = next(x for x in lists if x["id"] == lid)
+        assert board["follows"][0]["label"] == "Shadow Prospect"
+
+
+# --------------------------------------------------------------------------- #
+# Shadow mint + search
+# --------------------------------------------------------------------------- #
+
+
+class TestShadow:
+    def _list(self, client, email="scout@example.com"):
+        return client.post("/api/scout/lists", json={"name": "L"}, headers=_headers(email)).get_json()["list"]["id"]
+
+    def test_follow_untracked_mints_shadow(self, client, seeded, monkeypatch):
+        _use_client(monkeypatch, _FakeApiClient())
+        lid = self._list(client)
+        resp = client.post(
+            f"/api/scout/lists/{lid}/follows",
+            json={"kind": "player", "selector": {"player_api_id": 4242}},
+            headers=_headers(),
+        )
+        assert resp.status_code == 201
+        assert resp.get_json()["shadow_created"] is True
+        shadow = PlayerShadow.query.filter_by(player_api_id=4242).one()
+        assert shadow.player_name == "Minted Guy"
+        assert shadow.nationality == "Argentina"
+
+    def test_shadow_follow_limit_403(self, client, seeded, monkeypatch):
+        import src.routes.scout as scout_module
+
+        _use_client(monkeypatch, _FakeApiClient())
+        monkeypatch.setattr(scout_module, "SHADOW_FOLLOW_LIMIT", 1)
+        lid = self._list(client)
+        assert (
+            client.post(
+                f"/api/scout/lists/{lid}/follows",
+                json={"kind": "player", "selector": {"player_api_id": 3001}},
+                headers=_headers(),
+            ).status_code
+            == 201
+        )
+        resp = client.post(
+            f"/api/scout/lists/{lid}/follows",
+            json={"kind": "player", "selector": {"player_api_id": 3002}},
+            headers=_headers(),
+        )
+        assert resp.status_code == 403
+        assert "worldwide follow limit" in resp.get_json()["error"]
+
+    def test_mint_offline_falls_back_to_seed(self, client, seeded, monkeypatch):
+        class _Broken:
+            def get_player_profile(self, pid):
+                raise RuntimeError("no api")
+
+        _use_client(monkeypatch, _Broken())
+        lid = self._list(client)
+        resp = client.post(
+            f"/api/scout/lists/{lid}/follows",
+            json={
+                "kind": "player",
+                "selector": {"player_api_id": 7777},
+                "seed": {"name": "Seeded Name", "club_name": "Seed FC"},
+            },
+            headers=_headers(),
+        )
+        assert resp.status_code == 201
+        shadow = PlayerShadow.query.filter_by(player_api_id=7777).one()
+        assert shadow.player_name == "Seeded Name"
+        assert shadow.current_club_name == "Seed FC"
+
+    def test_player_search_found(self, client, seeded, monkeypatch):
+        class _Found:
+            def search_player_profiles_global(self, q):
+                return [
+                    {
+                        "player": {"id": 2001, "name": "Shadow Prospect", "age": 20, "nationality": "Argentina"},
+                        "statistics": [{"team": {"name": "Boca"}}],
+                    },
+                    {"player": {"id": 1001, "name": "Alfie Striker"}},
+                ]
+
+        _use_client(monkeypatch, _Found())
+        resp = client.get("/api/scout/player-search?q=pro", headers=_headers())
+        assert resp.status_code == 200
+        results = {r["player_api_id"]: r for r in resp.get_json()["players"]}
+        assert results[2001]["shadow"] is True and results[2001]["tracked"] is False
+        assert results[1001]["tracked"] is True
+
+    def test_player_search_stub_safe_on_error(self, client, seeded, monkeypatch):
+        class _Raises:
+            def search_player_profiles_global(self, q):
+                raise RuntimeError("boom")
+
+            def search_player_profiles(self, q, **kw):
+                raise RuntimeError("boom")
+
+        _use_client(monkeypatch, _Raises())
+        resp = client.get("/api/scout/player-search?q=abc", headers=_headers())
+        assert resp.status_code == 200
+        assert resp.get_json()["players"] == []
+
+    def test_shadow_refresh_endpoint(self, client, seeded, monkeypatch):
+        _use_client(monkeypatch, _FakeApiClient())
+        # Remove existing stats so we can observe the upsert repopulate them.
+        PlayerShadowStats.query.delete()
+        db.session.commit()
+        resp = client.post("/api/admin/scout/shadow-refresh", json={"limit": 5}, headers=_admin_headers())
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["considered"] == 1
+        assert data["stats_upserted"] == 1
+        row = PlayerShadowStats.query.filter_by(player_api_id=2001, season=2025).one()
+        assert row.appearances == 5 and row.goals == 3
+
+
+# --------------------------------------------------------------------------- #
+# Resolver
+# --------------------------------------------------------------------------- #
+
+
+class TestResolver:
+    def _make_list(self, user):
+        fl = FollowList(user_account_id=user.id, name="R")
+        db.session.add(fl)
+        db.session.flush()
+        return fl
+
+    def _add(self, fl, kind, selector):
+        db.session.add(Follow(list_id=fl.id, kind=kind, selector=selector))
+        db.session.commit()
+
+    def test_player_tracked_and_shadow(self, app, seeded):
+        from src.services.follow_resolver import resolve_list
+
+        user = _make_user("r@example.com")
+        fl = self._make_list(user)
+        self._add(fl, "player", {"player_api_id": 1001})
+        self._add(fl, "player", {"player_api_id": 2001})
+        resolved = {r["player_api_id"]: r["source"] for r in resolve_list(fl)}
+        assert resolved == {1001: "tracked", 2001: "shadow"}
+
+    def test_academy_club(self, app, seeded):
+        from src.services.follow_resolver import resolve_list
+
+        user = _make_user("r@example.com")
+        fl = self._make_list(user)
+        self._add(fl, "academy_club", {"team_id": seeded["parent"].id})
+        ids = {r["player_api_id"] for r in resolve_list(fl)}
+        assert ids == {1001, 1003}  # both active academy players, ghost excluded
+
+    def test_geo_playing_in_vs_nationality(self, app, seeded):
+        from src.services.follow_resolver import resolve_list
+
+        user = _make_user("r@example.com")
+        # playing_in Brazil -> striker (current club Rio FC); keeper has no current club
+        fl_playing = self._make_list(user)
+        self._add(fl_playing, "geo", {"countries": ["Brazil"], "match": "playing_in"})
+        assert {r["player_api_id"] for r in resolve_list(fl_playing)} == {1001}
+
+        # nationality Japan -> keeper
+        fl_nat = FollowList(user_account_id=user.id, name="Nat")
+        db.session.add(fl_nat)
+        db.session.flush()
+        self._add(fl_nat, "geo", {"countries": ["Japan"], "match": "nationality"})
+        assert {r["player_api_id"] for r in resolve_list(fl_nat)} == {1003}
+
+    def test_query_kind(self, app, seeded):
+        from src.services.follow_resolver import resolve_list
+
+        user = _make_user("r@example.com")
+        fl = self._make_list(user)
+        self._add(fl, "query", {"scout_args": {"position": "Attacker"}})
+        assert {r["player_api_id"] for r in resolve_list(fl)} == {1001}
+
+    def test_union_dedup_and_cap(self, app, seeded):
+        from src.services.follow_resolver import resolve_list
+
+        user = _make_user("r@example.com")
+        fl = self._make_list(user)
+        # Two follows both resolving the striker -> deduped once.
+        self._add(fl, "player", {"player_api_id": 1001})
+        self._add(fl, "academy_club", {"team_id": seeded["parent"].id})
+        full = resolve_list(fl)
+        assert [r["player_api_id"] for r in full].count(1001) == 1
+        assert len(resolve_list(fl, limit=1)) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Dual-write mirror
+# --------------------------------------------------------------------------- #
+
+
+class TestDualWrite:
+    def test_watchlist_add_mirrors_default_list(self, client, seeded):
+        client.post("/api/scout/watchlist", json={"player_api_id": 1001}, headers=_headers())
+        default = FollowList.query.filter_by(is_default=True).one()
+        assert default.name == "My Watchlist"
+        follow = default.follows.one()
+        assert follow.kind == "player"
+        assert follow.selector == {"player_api_id": 1001}
+
+    def test_watchlist_remove_mirrors_default_list(self, client, seeded):
+        client.post("/api/scout/watchlist", json={"player_api_id": 1001}, headers=_headers())
+        client.delete("/api/scout/watchlist/1001", headers=_headers())
+        default = FollowList.query.filter_by(is_default=True).one()
+        assert default.follows.count() == 0
+
+
+# --------------------------------------------------------------------------- #
+# Backfill
+# --------------------------------------------------------------------------- #
+
+
+class TestBackfill:
+    def _seed_watchlist_user(self, email, player_api_id=1001, note="keep", snapshot=None):
+        user = _make_user(email)
+        db.session.add(
+            ScoutWatchlistEntry(user_account_id=user.id, player_api_id=player_api_id, note=note, last_snapshot=snapshot)
+        )
+        db.session.commit()
+        return user
+
+    def test_dry_run_creates_nothing(self, client, seeded):
+        self._seed_watchlist_user("wl@example.com")
+        resp = client.post("/api/admin/scout/backfill-follow-lists", json={"dry_run": True}, headers=_admin_headers())
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["users_processed"] == 1 and data["lists_created"] == 1 and data["follows_created"] == 1
+        assert FollowList.query.count() == 0  # rolled back
+
+    def test_real_run_and_idempotent(self, client, seeded):
+        snap = json.dumps(
+            {"appearances": 2, "goals": 1, "assists": 0, "minutes_played": 90, "status": "on_loan", "absences": 0}
+        )
+        self._seed_watchlist_user("wl@example.com", snapshot=snap)
+        first = client.post("/api/admin/scout/backfill-follow-lists", json={"dry_run": False}, headers=_admin_headers())
+        assert first.get_json()["lists_created"] == 1
+        assert FollowList.query.filter_by(is_default=True).count() == 1
+        assert Follow.query.count() == 1
+        snapshot = FollowPlayerSnapshot.query.one()
+        assert json.loads(snapshot.last_snapshot)["goals"] == 1
+        assert snapshot.note == "keep"
+
+        # Re-running skips users that already have a default list.
+        second = client.post(
+            "/api/admin/scout/backfill-follow-lists", json={"dry_run": False}, headers=_admin_headers()
+        )
+        assert second.get_json()["users_processed"] == 0
+        assert FollowList.query.count() == 1
+
+    def test_cursor_pages(self, client, seeded):
+        self._seed_watchlist_user("a@example.com")
+        self._seed_watchlist_user("b@example.com", player_api_id=1003)
+        resp = client.post(
+            "/api/admin/scout/backfill-follow-lists", json={"dry_run": False, "limit": 1}, headers=_admin_headers()
+        )
+        data = resp.get_json()
+        assert data["users_processed"] == 1
+        assert data["next_cursor"] is not None
+        resp2 = client.post(
+            "/api/admin/scout/backfill-follow-lists",
+            json={"dry_run": False, "limit": 1, "cursor": data["next_cursor"]},
+            headers=_admin_headers(),
+        )
+        assert resp2.get_json()["users_processed"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# Digest generalization + regression
+# --------------------------------------------------------------------------- #
+
+
+class TestDigest:
+    def _admin_send(self, client, body):
+        return client.post("/api/scout/admin/send-digests", json=body, headers=_admin_headers())
+
+    def test_watchlist_only_user_unchanged(self, client, seeded, monkeypatch):
+        _use_client(monkeypatch, _FakeApiClient())
+        user = _make_user("wl@example.com")
+        # Seed the watchlist entry directly (no dual-write) so this user has NO list.
+        db.session.add(ScoutWatchlistEntry(user_account_id=user.id, player_api_id=1001))
+        db.session.commit()
+
+        resp = self._admin_send(client, {"dry_run": True})
+        preview = resp.get_json()["previews"][0]
+        assert "group-label" not in preview["html"]  # legacy flat layout
+        assert "Alfie Striker" in preview["html"]
+        assert "Added to your watchlist" in preview["html"]
+
+    def test_list_user_gets_sections_and_shadow_card(self, client, seeded, monkeypatch):
+        _use_client(monkeypatch, _FakeApiClient())
+        user = _make_user("list@example.com")
+        fl = FollowList(user_account_id=user.id, name="Prospects", is_active=True)
+        db.session.add(fl)
+        db.session.flush()
+        db.session.add_all(
+            [
+                Follow(list_id=fl.id, kind="player", selector={"player_api_id": 1001}),
+                Follow(list_id=fl.id, kind="player", selector={"player_api_id": 2001}),
+            ]
+        )
+        db.session.commit()
+
+        resp = self._admin_send(client, {"dry_run": True})
+        preview = resp.get_json()["previews"][0]
+        assert preview["email"] == "list@example.com"
+        assert "group-label" in preview["html"]
+        assert "Prospects" in preview["html"]
+        assert "Shadow Prospect" in preview["html"]
+        assert "Now tracking worldwide" in preview["html"]  # shadow first-time card
+
+    def test_real_send_persists_follow_snapshots(self, client, seeded, monkeypatch):
+        _use_client(monkeypatch, _FakeApiClient())
+        sends = []
+        from src.services.email_service import email_service
+
+        monkeypatch.setattr(
+            email_service,
+            "send_email",
+            lambda **kwargs: (
+                sends.append(kwargs)
+                or SimpleNamespace(success=True, message_id="x", provider="f", http_status=200, error=None)
+            ),
+        )
+        user = _make_user("list@example.com")
+        fl = FollowList(user_account_id=user.id, name="Prospects", is_active=True)
+        db.session.add(fl)
+        db.session.flush()
+        db.session.add(Follow(list_id=fl.id, kind="player", selector={"player_api_id": 2001}))
+        db.session.commit()
+
+        resp = self._admin_send(client, {"dry_run": False})
+        assert resp.get_json()["sent"] == 1
+        assert len(sends) == 1
+        snap = FollowPlayerSnapshot.query.filter_by(user_account_id=user.id, player_api_id=2001).one()
+        stored = json.loads(snap.last_snapshot)
+        assert stored["goals"] == 2 and stored["appearances"] == 6  # from PlayerShadowStats
+        assert snap.last_digest_at is not None
+
+    def test_mirror_path_watchlist_is_byte_identical_to_legacy(self, client, seeded, monkeypatch):
+        """The KEY regression: adding via POST /scout/watchlist mints a default
+        list under the hood, but that default list must NOT flip the user onto
+        the grouped/ASC/truncated list path. The email must be byte-identical to
+        a user with the same watchlist and no lists at all."""
+        _use_client(monkeypatch, _FakeApiClient())
+        # User A: real mirror path (POST creates a default list twin).
+        client.post("/api/scout/watchlist", json={"player_api_id": 1001}, headers=_headers("a@example.com"))
+        client.post("/api/scout/watchlist", json={"player_api_id": 1003}, headers=_headers("a@example.com"))
+        assert FollowList.query.filter_by(is_default=True).count() == 1  # mirror created it
+        # User B: identical watchlist seeded directly — NO list.
+        user_b = _make_user("b@example.com")
+        db.session.add_all(
+            [
+                ScoutWatchlistEntry(user_account_id=user_b.id, player_api_id=1001),
+                ScoutWatchlistEntry(user_account_id=user_b.id, player_api_id=1003),
+            ]
+        )
+        db.session.commit()
+
+        previews = {p["email"]: p for p in self._admin_send(client, {"dry_run": True}).get_json()["previews"]}
+        a_html = previews["a@example.com"]["html"]
+        b_html = previews["b@example.com"]["html"]
+        assert "group-label" not in a_html  # flat layout, not grouped
+        assert a_html == b_html  # default-list twin does not change the digest
+        assert a_html.count('class="player-card"') == 2  # all watchlist players present
+        assert a_html.index("Charlie Gloves") < a_html.index("Alfie Striker")  # DESC order preserved
+
+    def test_watchlist_plus_custom_list_dedup(self, client, seeded, monkeypatch):
+        """Flat watchlist section + grouped custom-list section, with the
+        watchlist winning dedup (a watched player never repeats in a group)."""
+        _use_client(monkeypatch, _FakeApiClient())
+        hdr = _headers("mix@example.com")
+        client.post("/api/scout/watchlist", json={"player_api_id": 1001}, headers=hdr)
+        lid = client.post("/api/scout/lists", json={"name": "Extras"}, headers=hdr).get_json()["list"]["id"]
+        client.post(
+            f"/api/scout/lists/{lid}/follows", json={"kind": "player", "selector": {"player_api_id": 1003}}, headers=hdr
+        )
+        client.post(
+            f"/api/scout/lists/{lid}/follows", json={"kind": "player", "selector": {"player_api_id": 1001}}, headers=hdr
+        )
+
+        html = self._admin_send(client, {"dry_run": True}).get_json()["previews"][0]["html"]
+        assert "group-label" in html and "Extras" in html
+        assert html.count("Alfie Striker") == 1  # watchlist wins — not duplicated in the group
+        assert "Charlie Gloves" in html  # 1003 delivered via the custom list
+
+    def test_default_list_only_fallback_when_watchlist_empty(self, client, seeded, monkeypatch):
+        """Edge case: a user who cleared their watchlist but whose mirror follows
+        remain still gets the default list's content (default routes as fallback)."""
+        _use_client(monkeypatch, _FakeApiClient())
+        hdr = _headers("cleared@example.com")
+        client.post("/api/scout/watchlist", json={"player_api_id": 1001}, headers=hdr)
+        # Simulate a desync: clear the watchlist entry directly (bypassing the
+        # remove-mirror) so the default list follow survives.
+        ScoutWatchlistEntry.query.delete()
+        db.session.commit()
+        default = FollowList.query.filter_by(is_default=True).one()
+        assert default.follows.count() == 1  # mirror follow survived
+
+        previews = self._admin_send(client, {"dry_run": True}).get_json()["previews"]
+        assert len(previews) == 1
+        html = previews[0]["html"]
+        assert "Alfie Striker" in html  # default-list content still delivered
+        assert "My Watchlist" in html  # rendered as a group section
+
+
+# --------------------------------------------------------------------------- #
+# Mint churn guard
+# --------------------------------------------------------------------------- #
+
+
+class _CountingProfileClient:
+    def __init__(self, name="Refreshed"):
+        self.calls = 0
+        self._name = name
+
+    def get_player_profile(self, player_id):
+        self.calls += 1
+        return {"player": {"id": player_id, "name": self._name}}
+
+
+class TestMintChurnGuard:
+    def test_existing_fresh_shadow_skips_profile_fetch(self, app, seeded):
+        from datetime import UTC, datetime
+
+        from src.services import player_shadow_service as svc
+
+        shadow = PlayerShadow.query.filter_by(player_api_id=2001).one()
+        shadow.last_profile_sync_at = datetime.now(UTC)
+        db.session.commit()
+        client = _CountingProfileClient()
+        result = svc.mint_shadow(2001, api_client=client)
+        assert client.calls == 0  # fresh -> zero upstream calls
+        assert result.player_api_id == 2001
+
+    def test_existing_stale_shadow_refetches_profile(self, app, seeded):
+        from datetime import UTC, datetime, timedelta
+
+        from src.services import player_shadow_service as svc
+
+        shadow = PlayerShadow.query.filter_by(player_api_id=2001).one()
+        shadow.last_profile_sync_at = datetime.now(UTC) - timedelta(days=30)
+        db.session.commit()
+        client = _CountingProfileClient(name="Refreshed")
+        svc.mint_shadow(2001, api_client=client)
+        assert client.calls == 1
+        assert PlayerShadow.query.filter_by(player_api_id=2001).one().player_name == "Refreshed"
+
+
+# --------------------------------------------------------------------------- #
+# Profile / season-stats shadow fallbacks
+# --------------------------------------------------------------------------- #
+
+
+class TestProfileFallback:
+    def test_profile_shadow_fill(self, client, seeded):
+        resp = client.get("/api/players/2001/profile")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["shadow"] is True
+        assert data["name"] == "Shadow Prospect"
+        assert data["position"] == "Midfielder"
+        assert data["loan_team_name"] == "Boca"
+
+    def test_profile_unknown_player_unchanged(self, client, seeded):
+        data = client.get("/api/players/999999/profile").get_json()
+        assert "shadow" not in data
+        assert data["name"] == "Player #999999"
+
+    def test_season_stats_shadow_branch(self, client, seeded):
+        resp = client.get("/api/players/2001/season-stats")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["source"] == "shadow"
+        assert data["stats_coverage"] == "limited"
+        assert data["appearances"] == 6 and data["goals"] == 2 and data["assists"] == 3
+        assert data["clubs"][0]["team_name"] == "Boca"
+        assert data["clubs"][0]["team_logo"] is None
+
+    def test_season_stats_unknown_player_empty(self, client, seeded):
+        data = client.get("/api/players/999999/season-stats").get_json()
+        assert data["source"] == "none"
+        assert data["clubs"] == []
+
+    def test_season_stats_uses_latest_season(self, client, seeded):
+        # Seed has 2001 @ season 2025 (apps=6); add a newer 2026 row and assert
+        # the endpoint reports the LATEST season, immune to wall-clock drift.
+        db.session.add(
+            PlayerShadowStats(
+                player_api_id=2001,
+                team_api_id=7001,
+                team_name="Boca",
+                season=2026,
+                appearances=9,
+                goals=4,
+                assists=2,
+                minutes=700,
+            )
+        )
+        db.session.commit()
+        data = client.get("/api/players/2001/season-stats").get_json()
+        assert data["appearances"] == 9 and data["goals"] == 4  # 2026, not 2025

--- a/academy-watch-frontend/src/App.jsx
+++ b/academy-watch-frontend/src/App.jsx
@@ -86,6 +86,7 @@ import { PublicFormationBuilder } from '@/pages/PublicFormationBuilder'
 import { CohortBrowser } from '@/pages/CohortBrowser'
 import { ScoutPage } from '@/pages/ScoutPage'
 import { WatchlistPage } from '@/pages/WatchlistPage'
+import { ListsPage } from '@/pages/ListsPage'
 import { PricingPage } from '@/pages/PricingPage'
 import { CohortDetail } from '@/pages/CohortDetail'
 import { CohortAnalytics } from '@/pages/CohortAnalytics'
@@ -4026,6 +4027,7 @@ function AppRoutes() {
       <Route path="/flag" element={<FlagData />} />
       <Route path="/scout" element={<ScoutPage />} />
       <Route path="/scout/watchlist" element={<WatchlistPage />} />
+      <Route path="/scout/lists" element={<ListsPage />} />
       <Route path="/pricing" element={<PricingPage />} />
       <Route path="/academy" element={<CohortBrowser />} />
       <Route path="/academy/cohorts/:cohortId" element={<CohortDetail />} />

--- a/academy-watch-frontend/src/App.jsx
+++ b/academy-watch-frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo, useCallback, useRef, Fragment } from 'rea
 import { BrowserRouter as Router, Routes, Route, Link, Navigate, useLocation, useParams, useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button.jsx'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card.jsx'
+import { Switch } from '@/components/ui/switch.jsx'
 import { Badge } from '@/components/ui/badge.jsx'
 import { Input } from '@/components/ui/input.jsx'
 import { Label } from '@/components/ui/label.jsx'
@@ -2944,10 +2945,34 @@ function SettingsPage() {
   const [displayNameStatus, setDisplayNameStatus] = useState(null)
   const [displayNameBusy, setDisplayNameBusy] = useState(false)
 
-  // Email delivery preference state
+  // Email delivery preference state (team newsletters)
   const [emailPreference, setEmailPreference] = useState('individual')
   const [emailPrefLoading, setEmailPrefLoading] = useState(false)
   const [emailPrefStatus, setEmailPrefStatus] = useState(null)
+
+  // Scout Digest opt-in (covers Watchlist + Lists)
+  const [scoutDigestOptIn, setScoutDigestOptIn] = useState(null)
+  const [scoutDigestBusy, setScoutDigestBusy] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    APIService.getScoutWatchlist()
+      .then((data) => { if (!cancelled) setScoutDigestOptIn(data?.digest_opt_in !== false) })
+      .catch(() => { if (!cancelled) setScoutDigestOptIn(null) })
+    return () => { cancelled = true }
+  }, [])
+
+  const handleScoutDigestToggle = async (checked) => {
+    setScoutDigestOptIn(checked)
+    setScoutDigestBusy(true)
+    try {
+      await APIService.updateScoutWatchlistSettings({ digest_opt_in: checked })
+    } catch {
+      setScoutDigestOptIn(!checked) // revert on failure
+    } finally {
+      setScoutDigestBusy(false)
+    }
+  }
 
   // Journalist Profile State
   const [journalistProfile, setJournalistProfile] = useState({ bio: '', profile_image_url: '' })
@@ -3280,14 +3305,14 @@ function SettingsPage() {
               </CardContent>
             </Card>
 
-            {/* Email Delivery Preferences */}
+            {/* Email Delivery Preferences — team newsletters lane */}
             <Card>
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
                   <Mail className="h-5 w-5" />
-                  Email Delivery
+                  Team newsletters
                 </CardTitle>
-                <CardDescription>Choose how you want to receive newsletters when subscribed to multiple teams.</CardDescription>
+                <CardDescription>How to receive the editorial team newsletters you subscribe to (below) when you follow multiple teams.</CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
                 <div className="space-y-3">
@@ -3346,6 +3371,40 @@ function SettingsPage() {
                     Saving preference...
                   </div>
                 )}
+              </CardContent>
+            </Card>
+
+            {/* Scout Digest — the personal tracking lane (watchlist + lists) */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <ListChecks className="h-5 w-5" />
+                  Scout Digest
+                </CardTitle>
+                <CardDescription>
+                  Your personal tracking email — covers your{' '}
+                  <Link to="/scout/watchlist" className="underline underline-offset-2">Watchlist</Link> and your{' '}
+                  <Link to="/scout/lists" className="underline underline-offset-2">Lists</Link>{' '}
+                  (goals, minutes, status changes, new worldwide players you follow).
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center justify-between gap-4">
+                  <div className="text-sm text-muted-foreground">
+                    {scoutDigestOptIn === null
+                      ? 'Sign-in required to manage this.'
+                      : scoutDigestOptIn
+                        ? 'You will receive the Scout Digest.'
+                        : 'You are opted out of the Scout Digest.'}
+                    <span className="block text-xs mt-1">Per-list schedules (weekly / matchday) are coming — for now the digest is one email.</span>
+                  </div>
+                  <Switch
+                    checked={scoutDigestOptIn === true}
+                    disabled={scoutDigestOptIn === null || scoutDigestBusy}
+                    onCheckedChange={handleScoutDigestToggle}
+                    aria-label="Scout Digest opt-in"
+                  />
+                </div>
               </CardContent>
             </Card>
 

--- a/academy-watch-frontend/src/App.jsx
+++ b/academy-watch-frontend/src/App.jsx
@@ -30,6 +30,7 @@ import {
   Trophy,
   TrendingUp,
   Globe,
+  ListChecks,
   Star,
   ArrowLeft,
   ArrowRight,
@@ -540,7 +541,8 @@ function Navigation() {
       { path: '/', label: 'Home', icon: Home },
       { path: '/scout', label: 'Scout', icon: Globe },
       { path: '/teams', label: 'Teams', icon: Users },
-      { path: '/dream-team', label: 'Dream XI', icon: Trophy },
+      // Dream XI demoted from top-level nav (2026-07-02, MJ) — the page stays
+      // at /dream-team and is featured on the Home grid.
       { path: '/newsletters', label: 'Newsletters', icon: FileText },
       { path: '/journalists', label: 'Journalists', icon: UserPlus },
       { path: '/pricing', label: 'Pricing', icon: CreditCard },
@@ -552,6 +554,8 @@ function Navigation() {
       items.push({ path: '/curator/dashboard', label: 'Curator', icon: FileText })
     }
     if (token) {
+      // The retention surface: logged-in scouts jump straight to their lists.
+      items.push({ path: '/scout/lists', label: 'Lists', icon: ListChecks })
       items.push({ path: '/settings', label: 'Settings', icon: UserCog })
     }
     if (adminUnlocked) {

--- a/academy-watch-frontend/src/lib/api.js
+++ b/academy-watch-frontend/src/lib/api.js
@@ -516,6 +516,52 @@ export class APIService {
         return blob
     }
 
+    // --- Follow lists (scout follow graph) — user-authed ---
+    static async getFollowLists() {
+        return this.request('/scout/lists')
+    }
+
+    static async createFollowList(name) {
+        return this.request('/scout/lists', {
+            method: 'POST',
+            body: JSON.stringify({ name })
+        })
+    }
+
+    static async updateFollowList(listId, payload) {
+        return this.request(`/scout/lists/${listId}`, {
+            method: 'PATCH',
+            body: JSON.stringify(payload)
+        })
+    }
+
+    static async deleteFollowList(listId) {
+        return this.request(`/scout/lists/${listId}`, { method: 'DELETE' })
+    }
+
+    static async addFollow(listId, { kind, selector, note } = {}) {
+        const body = { kind, selector }
+        if (note) body.note = note
+        return this.request(`/scout/lists/${listId}/follows`, {
+            method: 'POST',
+            body: JSON.stringify(body)
+        })
+    }
+
+    static async removeFollow(listId, followId) {
+        return this.request(`/scout/lists/${listId}/follows/${followId}`, { method: 'DELETE' })
+    }
+
+    static async resolveFollowList(listId, { limit = 20, offset = 0 } = {}) {
+        const params = new URLSearchParams({ limit: String(limit), offset: String(offset) })
+        return this.request(`/scout/lists/${listId}/resolve?${params}`)
+    }
+
+    static async scoutPlayerSearch(q) {
+        const params = new URLSearchParams({ q })
+        return this.request(`/scout/player-search?${params}`)
+    }
+
     static async getPlayerAvailability(playerId, season) {
         const query = season ? `?season=${season}` : ''
         return this.request(`/players/${playerId}/availability${query}`)

--- a/academy-watch-frontend/src/pages/ListsPage.jsx
+++ b/academy-watch-frontend/src/pages/ListsPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { APIService } from '@/lib/api'
 import { useAuth, useAuthUI } from '@/context/AuthContext'
@@ -42,7 +42,7 @@ const KIND_META = [
   { kind: 'player', title: 'Players', icon: Star },
   { kind: 'academy_club', title: 'Club academies', icon: Users },
   { kind: 'geo', title: 'Countries', icon: MapPin },
-  { kind: 'query', title: 'Saved filters', icon: Filter },
+  { kind: 'query', title: 'Saved searches', icon: Filter },
 ]
 
 const titleCase = (s) => (s || '')
@@ -319,22 +319,42 @@ function FiltersTab({ onAdd, adding, addError }) {
   const [minAge, setMinAge] = useState('')
   const [maxAge, setMaxAge] = useState('')
   const [minMinutes, setMinMinutes] = useState('')
+  const [preview, setPreview] = useState(null)
+  const [previewLoading, setPreviewLoading] = useState(false)
 
-  const buildArgs = () => {
-    const args = {}
-    if (position !== 'all') args.position = position
-    if (status !== 'all') args.status = status
+  const args = useMemo(() => {
+    const built = {}
+    if (position !== 'all') built.position = position
+    if (status !== 'all') built.status = status
     const minA = parseInt(minAge, 10)
     const maxA = parseInt(maxAge, 10)
     const minM = parseInt(minMinutes, 10)
-    if (Number.isInteger(minA)) args.min_age = minA
-    if (Number.isInteger(maxA)) args.max_age = maxA
-    if (Number.isInteger(minM)) args.min_minutes = minM
-    return args
-  }
-
-  const args = buildArgs()
+    if (Number.isInteger(minA)) built.min_age = minA
+    if (Number.isInteger(maxA)) built.max_age = maxA
+    if (Number.isInteger(minM)) built.min_minutes = minM
+    return built
+  }, [position, status, minAge, maxAge, minMinutes])
   const hasArgs = Object.keys(args).length > 0
+
+  // Live preview: show who the standing search catches TODAY before following.
+  useEffect(() => {
+    if (!hasArgs) { setPreview(null); return undefined }
+    let cancelled = false
+    setPreviewLoading(true)
+    const timer = setTimeout(() => {
+      APIService.getScoutPlayers({ ...args, per_page: 3 })
+        .then((data) => {
+          if (cancelled) return
+          setPreview({
+            total: data?.total ?? 0,
+            names: (data?.players || []).map((p) => p.player_name).filter(Boolean),
+          })
+        })
+        .catch(() => { if (!cancelled) setPreview(null) })
+        .finally(() => { if (!cancelled) setPreviewLoading(false) })
+    }, 400)
+    return () => { cancelled = true; clearTimeout(timer) }
+  }, [args, hasArgs])
 
   const handleAdd = async () => {
     if (!hasArgs) return
@@ -345,7 +365,9 @@ function FiltersTab({ onAdd, adding, addError }) {
   return (
     <div className="space-y-3">
       <p className="text-sm text-muted-foreground">
-        Save a filter as a follow — the list always resolves to whoever currently matches.
+        A standing scouting brief: whoever matches is in your list — including{' '}
+        <span className="font-medium text-foreground">new players who qualify later, automatically</span>.
+        Use it to catch risers you don&apos;t know about yet.
       </p>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         <label className="space-y-1">
@@ -381,10 +403,33 @@ function FiltersTab({ onAdd, adding, addError }) {
           <Input type="number" inputMode="numeric" min="0" value={minMinutes} onChange={(e) => setMinMinutes(e.target.value)} placeholder="270" />
         </label>
       </div>
+      {hasArgs && (
+        <div className="rounded-md border border-border/60 bg-secondary/40 px-3 py-2 text-sm">
+          {previewLoading ? (
+            <span className="flex items-center gap-2 text-muted-foreground">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" /> Checking who matches…
+            </span>
+          ) : preview ? (
+            preview.total > 0 ? (
+              <span>
+                Catches <span className="font-semibold text-foreground">{preview.total.toLocaleString()}</span>{' '}
+                {preview.total === 1 ? 'player' : 'players'} today
+                {preview.names.length > 0 && (
+                  <span className="text-muted-foreground"> — e.g. {preview.names.join(', ')}</span>
+                )}
+              </span>
+            ) : (
+              <span className="text-muted-foreground">
+                No players match today — the search stays live and future risers who qualify will appear automatically.
+              </span>
+            )
+          ) : null}
+        </div>
+      )}
       {addError && <p className="text-xs text-destructive">{addError}</p>}
       <Button onClick={handleAdd} disabled={!hasArgs || adding} className="w-full sm:w-auto">
         {adding ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Plus className="mr-1.5 h-4 w-4" />}
-        Add filter follow
+        Follow this search
       </Button>
     </div>
   )
@@ -410,7 +455,7 @@ function AddFollowDialog({ open, onOpenChange, onAdd, adding, addError }) {
         <DialogHeader>
           <DialogTitle>Add a follow</DialogTitle>
           <DialogDescription>
-            Follow a specific player, a club&apos;s academy, countries, or a saved filter.
+            Follow a specific player, a club&apos;s academy, countries — or save a search that keeps catching new players.
           </DialogDescription>
         </DialogHeader>
         <Tabs value={tab} onValueChange={setTab}>
@@ -418,7 +463,7 @@ function AddFollowDialog({ open, onOpenChange, onAdd, adding, addError }) {
             <TabsTrigger value="player">Player</TabsTrigger>
             <TabsTrigger value="academy_club">Club</TabsTrigger>
             <TabsTrigger value="geo">Countries</TabsTrigger>
-            <TabsTrigger value="query">Filter</TabsTrigger>
+            <TabsTrigger value="query">Saved search</TabsTrigger>
           </TabsList>
           <TabsContent value="player" className="pt-3">
             <PlayerSearchTab onAdd={handleAdd} adding={adding} addError={tab === 'player' ? addError : null} />
@@ -665,7 +710,7 @@ export function ListsPage() {
             <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">Your Lists</h1>
             <p className="mt-2 max-w-2xl text-sm text-muted-foreground sm:text-base">
               Organize who you track into named lists. Follow players, whole club academies, countries,
-              or a saved filter — each list resolves to a live player set.
+              or a saved search — each list resolves to a live player set.
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-2 lg:shrink-0 lg:pt-7">
@@ -834,7 +879,7 @@ export function ListsPage() {
                   <CardContent className="p-0">
                     {!(selectedList.follows && selectedList.follows.length) ? (
                       <p className="px-4 py-8 text-center text-sm text-muted-foreground">
-                        No follows yet. Use “Add follow” to track players, clubs, countries or a saved filter.
+                        No follows yet. Use “Add follow” to track players, clubs, countries or a saved search.
                       </p>
                     ) : (
                       KIND_META.map((meta) => {

--- a/academy-watch-frontend/src/pages/ListsPage.jsx
+++ b/academy-watch-frontend/src/pages/ListsPage.jsx
@@ -1,0 +1,970 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { Link } from 'react-router-dom'
+import { APIService } from '@/lib/api'
+import { useAuth, useAuthUI } from '@/context/AuthContext'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import { Switch } from '@/components/ui/switch'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import TeamSelect from '@/components/ui/TeamSelect'
+import { StatusBadge, PlayerCell } from './ScoutPage'
+import {
+  ListChecks, Plus, X, Loader2, Search, Trash2, Star, Users, MapPin, Filter, Check,
+} from 'lucide-react'
+
+const POSITION_OPTIONS = [
+  { value: 'Goalkeeper', label: 'Goalkeeper' },
+  { value: 'Defender', label: 'Defender' },
+  { value: 'Midfielder', label: 'Midfielder' },
+  { value: 'Attacker', label: 'Attacker' },
+]
+
+const STATUS_OPTIONS = [
+  { value: 'academy', label: 'Academy' },
+  { value: 'on_loan', label: 'On loan' },
+  { value: 'first_team', label: 'First team' },
+  { value: 'sold', label: 'Sold' },
+  { value: 'released', label: 'Released' },
+  { value: 'left', label: 'Left' },
+]
+
+const KIND_META = [
+  { kind: 'player', title: 'Players', icon: Star },
+  { kind: 'academy_club', title: 'Club academies', icon: Users },
+  { kind: 'geo', title: 'Countries', icon: MapPin },
+  { kind: 'query', title: 'Saved filters', icon: Filter },
+]
+
+const titleCase = (s) => (s || '')
+  .trim()
+  .replace(/\s+/g, ' ')
+  .split(' ')
+  .map((w) => (w ? w[0].toUpperCase() + w.slice(1).toLowerCase() : ''))
+  .join(' ')
+
+// Human label for a follow — prefer the server-derived label, fall back to selector.
+function followLabel(follow) {
+  if (follow.label) return follow.label
+  const sel = follow.selector || {}
+  switch (follow.kind) {
+    case 'player':
+      return sel.player_api_id ? `Player #${sel.player_api_id}` : 'Player'
+    case 'academy_club':
+      return sel.team_id ? `Club academy #${sel.team_id}` : 'Club academy'
+    case 'geo': {
+      const countries = (sel.countries || []).join(', ')
+      const verb = sel.match === 'nationality' ? 'Nationality' : 'Playing in'
+      return `${verb}: ${countries || '—'}`
+    }
+    case 'query': {
+      const args = sel.scout_args || {}
+      const parts = []
+      if (args.position) parts.push(args.position)
+      if (args.status) parts.push(String(args.status).replace('_', ' '))
+      if (args.min_age || args.max_age) parts.push(`${args.min_age || ''}-${args.max_age || ''} yrs`.trim())
+      if (args.nationality) parts.push(args.nationality)
+      if (args.min_minutes) parts.push(`${args.min_minutes}+ mins`)
+      return `Filter: ${parts.join(', ') || 'any'}`
+    }
+    default:
+      return follow.kind
+  }
+}
+
+function PlayerSearchTab({ onAdd, adding, addError }) {
+  const [query, setQuery] = useState('')
+  const [debounced, setDebounced] = useState('')
+  const [results, setResults] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const [added, setAdded] = useState(() => new Set())
+  const timer = useRef(null)
+
+  useEffect(() => {
+    clearTimeout(timer.current)
+    timer.current = setTimeout(() => setDebounced(query.trim()), 300)
+    return () => clearTimeout(timer.current)
+  }, [query])
+
+  useEffect(() => {
+    if (debounced.length < 3) {
+      setResults([])
+      setError(null)
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    APIService.scoutPlayerSearch(debounced)
+      .then((data) => { if (!cancelled) setResults(data?.players || []) })
+      .catch((err) => { if (!cancelled) { setError(err.message || 'Search failed'); setResults([]) } })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [debounced])
+
+  const handleAdd = async (row) => {
+    const ok = await onAdd({ kind: 'player', selector: { player_api_id: row.player_api_id } })
+    if (ok) setAdded((prev) => new Set(prev).add(row.player_api_id))
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search players worldwide by name…"
+          className="pl-9"
+          aria-label="Search players"
+          autoFocus
+        />
+      </div>
+      {addError && <p className="text-xs text-destructive">{addError}</p>}
+      {query.trim().length > 0 && query.trim().length < 3 && (
+        <p className="text-xs text-muted-foreground">Type at least 3 characters to search.</p>
+      )}
+      <div className="max-h-72 overflow-y-auto">
+        {loading ? (
+          <div className="space-y-2">
+            {[0, 1, 2].map((i) => <Skeleton key={i} className="h-11 w-full" />)}
+          </div>
+        ) : error ? (
+          <p className="py-6 text-center text-sm text-destructive">{error}</p>
+        ) : results.length ? (
+          <ul className="divide-y divide-border/50">
+            {results.map((row) => {
+              const isAdded = added.has(row.player_api_id)
+              return (
+                <li key={row.player_api_id}>
+                  <button
+                    type="button"
+                    onClick={() => handleAdd(row)}
+                    disabled={isAdded || adding}
+                    className="flex w-full items-center gap-3 rounded-md px-2 py-2 text-left transition-colors hover:bg-secondary/60 disabled:opacity-70"
+                  >
+                    {row.photo ? (
+                      <img src={row.photo} alt="" loading="lazy" className="h-9 w-9 shrink-0 rounded-full bg-secondary object-cover" />
+                    ) : (
+                      <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-secondary text-xs font-semibold text-muted-foreground">
+                        {row.name?.slice(0, 2).toUpperCase()}
+                      </span>
+                    )}
+                    <span className="min-w-0 flex-1">
+                      <span className="flex items-center gap-2">
+                        <span className="truncate text-sm font-medium text-foreground">{row.name}</span>
+                        {!row.tracked && (
+                          <Badge variant="outline" className="shrink-0 text-[10px] font-normal">
+                            {row.shadow ? 'Worldwide' : 'Worldwide — will start tracking'}
+                          </Badge>
+                        )}
+                      </span>
+                      <span className="block truncate text-xs text-muted-foreground">
+                        {[row.nationality, row.age ? `${row.age} yrs` : null, row.club_name].filter(Boolean).join(' · ') || '—'}
+                      </span>
+                    </span>
+                    {isAdded ? (
+                      <Check className="h-4 w-4 shrink-0 text-emerald-500" />
+                    ) : (
+                      <Plus className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    )}
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        ) : debounced.length >= 3 ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">No players found for “{debounced}”.</p>
+        ) : (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            Search any player in the world. Following one outside the tracked universe starts tracking them.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ClubTab({ onAdd, adding, addError }) {
+  const [teams, setTeams] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [teamId, setTeamId] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    // All supported regions — the follow graph is a worldwide feature
+    APIService.getTeams()
+      .then((data) => { if (!cancelled) setTeams(Array.isArray(data) ? data : (data?.teams || [])) })
+      .catch((err) => { console.error('Failed to load teams', err); if (!cancelled) setTeams([]) })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [])
+
+  const handleAdd = async () => {
+    if (!teamId) return
+    const ok = await onAdd({ kind: 'academy_club', selector: { team_id: teamId } })
+    if (ok) setTeamId(null)
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-muted-foreground">
+        Follow a club&apos;s whole academy — every tracked player from that club stays in this list.
+      </p>
+      {loading ? (
+        <Skeleton className="h-10 w-full" />
+      ) : (
+        <TeamSelect teams={teams} value={teamId} onChange={setTeamId} placeholder="Select a club…" />
+      )}
+      {addError && <p className="text-xs text-destructive">{addError}</p>}
+      <Button onClick={handleAdd} disabled={!teamId || adding} className="w-full sm:w-auto">
+        {adding ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Plus className="mr-1.5 h-4 w-4" />}
+        Add club academy
+      </Button>
+    </div>
+  )
+}
+
+function CountriesTab({ onAdd, adding, addError }) {
+  const [input, setInput] = useState('')
+  const [countries, setCountries] = useState([])
+  const [match, setMatch] = useState('playing_in')
+
+  const addCountry = () => {
+    const value = titleCase(input)
+    if (!value) return
+    if (value.length > 50) return
+    setCountries((prev) => (prev.includes(value) || prev.length >= 10 ? prev : [...prev, value]))
+    setInput('')
+  }
+
+  const removeCountry = (value) => setCountries((prev) => prev.filter((c) => c !== value))
+
+  const handleAdd = async () => {
+    if (!countries.length) return
+    const ok = await onAdd({ kind: 'geo', selector: { countries, match } })
+    if (ok) { setCountries([]); setInput('') }
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-muted-foreground">
+        Follow players by country — either where they currently play or their nationality.
+      </p>
+      <ToggleGroup
+        type="single"
+        value={match}
+        onValueChange={(v) => v && setMatch(v)}
+        variant="outline"
+        className="w-full"
+      >
+        <ToggleGroupItem value="playing_in" className="flex-1">Playing in</ToggleGroupItem>
+        <ToggleGroupItem value="nationality" className="flex-1">Nationality</ToggleGroupItem>
+      </ToggleGroup>
+      <div className="flex gap-2">
+        <Input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addCountry() } }}
+          placeholder="Type a country and press Enter…"
+          aria-label="Add country"
+          disabled={countries.length >= 10}
+        />
+        <Button type="button" variant="outline" onClick={addCountry} disabled={!input.trim() || countries.length >= 10}>
+          Add
+        </Button>
+      </div>
+      {countries.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {countries.map((c) => (
+            <span key={c} className="inline-flex items-center gap-1 rounded-full bg-secondary px-2.5 py-1 text-xs font-medium text-foreground">
+              {c}
+              <button
+                type="button"
+                onClick={() => removeCountry(c)}
+                className="text-muted-foreground hover:text-destructive"
+                aria-label={`Remove ${c}`}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+      <p className="text-[11px] text-muted-foreground">{countries.length}/10 countries</p>
+      {addError && <p className="text-xs text-destructive">{addError}</p>}
+      <Button onClick={handleAdd} disabled={!countries.length || adding} className="w-full sm:w-auto">
+        {adding ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Plus className="mr-1.5 h-4 w-4" />}
+        Add country follow
+      </Button>
+    </div>
+  )
+}
+
+function FiltersTab({ onAdd, adding, addError }) {
+  const [position, setPosition] = useState('all')
+  const [status, setStatus] = useState('all')
+  const [minAge, setMinAge] = useState('')
+  const [maxAge, setMaxAge] = useState('')
+  const [minMinutes, setMinMinutes] = useState('')
+
+  const buildArgs = () => {
+    const args = {}
+    if (position !== 'all') args.position = position
+    if (status !== 'all') args.status = status
+    const minA = parseInt(minAge, 10)
+    const maxA = parseInt(maxAge, 10)
+    const minM = parseInt(minMinutes, 10)
+    if (Number.isInteger(minA)) args.min_age = minA
+    if (Number.isInteger(maxA)) args.max_age = maxA
+    if (Number.isInteger(minM)) args.min_minutes = minM
+    return args
+  }
+
+  const args = buildArgs()
+  const hasArgs = Object.keys(args).length > 0
+
+  const handleAdd = async () => {
+    if (!hasArgs) return
+    const ok = await onAdd({ kind: 'query', selector: { scout_args: args } })
+    if (ok) { setPosition('all'); setStatus('all'); setMinAge(''); setMaxAge(''); setMinMinutes('') }
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-muted-foreground">
+        Save a filter as a follow — the list always resolves to whoever currently matches.
+      </p>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <label className="space-y-1">
+          <span className="text-xs font-medium text-muted-foreground">Position</span>
+          <Select value={position} onValueChange={setPosition}>
+            <SelectTrigger className="w-full" aria-label="Position"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Any position</SelectItem>
+              {POSITION_OPTIONS.map((o) => <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </label>
+        <label className="space-y-1">
+          <span className="text-xs font-medium text-muted-foreground">Status</span>
+          <Select value={status} onValueChange={setStatus}>
+            <SelectTrigger className="w-full" aria-label="Status"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Any status</SelectItem>
+              {STATUS_OPTIONS.map((o) => <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </label>
+        <label className="space-y-1">
+          <span className="text-xs font-medium text-muted-foreground">Min age</span>
+          <Input type="number" inputMode="numeric" min="14" max="45" value={minAge} onChange={(e) => setMinAge(e.target.value)} placeholder="16" />
+        </label>
+        <label className="space-y-1">
+          <span className="text-xs font-medium text-muted-foreground">Max age</span>
+          <Input type="number" inputMode="numeric" min="14" max="45" value={maxAge} onChange={(e) => setMaxAge(e.target.value)} placeholder="21" />
+        </label>
+        <label className="space-y-1 sm:col-span-2">
+          <span className="text-xs font-medium text-muted-foreground">Min minutes played</span>
+          <Input type="number" inputMode="numeric" min="0" value={minMinutes} onChange={(e) => setMinMinutes(e.target.value)} placeholder="270" />
+        </label>
+      </div>
+      {addError && <p className="text-xs text-destructive">{addError}</p>}
+      <Button onClick={handleAdd} disabled={!hasArgs || adding} className="w-full sm:w-auto">
+        {adding ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Plus className="mr-1.5 h-4 w-4" />}
+        Add filter follow
+      </Button>
+    </div>
+  )
+}
+
+function AddFollowDialog({ open, onOpenChange, onAdd, adding, addError }) {
+  const [tab, setTab] = useState('player')
+
+  useEffect(() => {
+    if (open) setTab('player')
+  }, [open])
+
+  // Wrap onAdd so any tab closes only the ones that make sense; player tab stays open.
+  const handleAdd = useCallback(async (payload) => {
+    const ok = await onAdd(payload)
+    if (ok && payload.kind !== 'player') onOpenChange(false)
+    return ok
+  }, [onAdd, onOpenChange])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Add a follow</DialogTitle>
+          <DialogDescription>
+            Follow a specific player, a club&apos;s academy, countries, or a saved filter.
+          </DialogDescription>
+        </DialogHeader>
+        <Tabs value={tab} onValueChange={setTab}>
+          <TabsList className="grid w-full grid-cols-4">
+            <TabsTrigger value="player">Player</TabsTrigger>
+            <TabsTrigger value="academy_club">Club</TabsTrigger>
+            <TabsTrigger value="geo">Countries</TabsTrigger>
+            <TabsTrigger value="query">Filter</TabsTrigger>
+          </TabsList>
+          <TabsContent value="player" className="pt-3">
+            <PlayerSearchTab onAdd={handleAdd} adding={adding} addError={tab === 'player' ? addError : null} />
+          </TabsContent>
+          <TabsContent value="academy_club" className="pt-3">
+            <ClubTab onAdd={handleAdd} adding={adding} addError={tab === 'academy_club' ? addError : null} />
+          </TabsContent>
+          <TabsContent value="geo" className="pt-3">
+            <CountriesTab onAdd={handleAdd} adding={adding} addError={tab === 'geo' ? addError : null} />
+          </TabsContent>
+          <TabsContent value="query" className="pt-3">
+            <FiltersTab onAdd={handleAdd} adding={adding} addError={tab === 'query' ? addError : null} />
+          </TabsContent>
+        </Tabs>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function ListsPage() {
+  const auth = useAuth()
+  const { openLoginModal } = useAuthUI()
+
+  const [lists, setLists] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [selectedListId, setSelectedListId] = useState(null)
+
+  const [creating, setCreating] = useState(false)
+  const [newName, setNewName] = useState('')
+  const [createSaving, setCreateSaving] = useState(false)
+  const [createError, setCreateError] = useState(null)
+
+  const [addOpen, setAddOpen] = useState(false)
+  const [adding, setAdding] = useState(false)
+  const [addError, setAddError] = useState(null)
+
+  const [preview, setPreview] = useState({ players: [], total: 0, offset: 0 })
+  const [previewLoading, setPreviewLoading] = useState(false)
+  const [previewError, setPreviewError] = useState(null)
+  const [previewNonce, setPreviewNonce] = useState(0)
+
+  const selectedList = lists.find((l) => l.id === selectedListId) || null
+
+  // Load lists when signed in
+  useEffect(() => {
+    if (!auth?.token) {
+      setLists([])
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    APIService.getFollowLists()
+      .then((data) => {
+        if (cancelled) return
+        const arr = data?.lists || []
+        setLists(arr)
+        setSelectedListId((prev) => (prev && arr.some((l) => l.id === prev) ? prev : (arr[0]?.id ?? null)))
+      })
+      .catch((err) => { if (!cancelled) setError(err.message || 'Failed to load lists') })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [auth?.token])
+
+  // Load resolved preview for the selected list
+  useEffect(() => {
+    if (!selectedListId) {
+      setPreview({ players: [], total: 0, offset: 0 })
+      return
+    }
+    let cancelled = false
+    setPreviewLoading(true)
+    setPreviewError(null)
+    APIService.resolveFollowList(selectedListId, { limit: 20, offset: 0 })
+      .then((data) => {
+        if (cancelled) return
+        const players = data?.players || []
+        setPreview({ players, total: data?.total ?? players.length, offset: players.length })
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setPreviewError(err.message || 'Failed to resolve list')
+        setPreview({ players: [], total: 0, offset: 0 })
+      })
+      .finally(() => { if (!cancelled) setPreviewLoading(false) })
+    return () => { cancelled = true }
+  }, [selectedListId, previewNonce])
+
+  const reloadPreview = useCallback(() => setPreviewNonce((n) => n + 1), [])
+
+  const loadMorePreview = useCallback(async () => {
+    if (!selectedListId || previewLoading) return
+    setPreviewLoading(true)
+    try {
+      const data = await APIService.resolveFollowList(selectedListId, { limit: 20, offset: preview.offset })
+      const more = data?.players || []
+      setPreview((prev) => ({
+        players: [...prev.players, ...more],
+        total: data?.total ?? prev.total,
+        offset: prev.offset + more.length,
+      }))
+    } catch (err) {
+      setPreviewError(err.message || 'Failed to load more')
+    } finally {
+      setPreviewLoading(false)
+    }
+  }, [selectedListId, previewLoading, preview.offset])
+
+  const handleCreate = useCallback(async () => {
+    const name = newName.trim()
+    if (!name) return
+    setCreateSaving(true)
+    setCreateError(null)
+    try {
+      const res = await APIService.createFollowList(name)
+      const created = res?.list
+      if (created) {
+        setLists((prev) => [...prev, created])
+        setSelectedListId(created.id)
+      }
+      setNewName('')
+      setCreating(false)
+    } catch (err) {
+      setCreateError(err.body?.error || err.message || 'Failed to create list')
+    } finally {
+      setCreateSaving(false)
+    }
+  }, [newName])
+
+  const handleToggleActive = useCallback((list, checked) => {
+    setLists((prev) => prev.map((l) => (l.id === list.id ? { ...l, is_active: checked } : l)))
+    APIService.updateFollowList(list.id, { is_active: checked }).catch((err) => {
+      console.error('Failed to toggle list', err)
+      setLists((prev) => prev.map((l) => (l.id === list.id ? { ...l, is_active: !checked } : l)))
+    })
+  }, [])
+
+  const handleDelete = useCallback((list) => {
+    let removedIndex = -1
+    setLists((prev) => {
+      removedIndex = prev.findIndex((l) => l.id === list.id)
+      return prev.filter((l) => l.id !== list.id)
+    })
+    setSelectedListId((prev) => {
+      if (prev !== list.id) return prev
+      const remaining = lists.filter((l) => l.id !== list.id)
+      return remaining[0]?.id ?? null
+    })
+    APIService.deleteFollowList(list.id).catch((err) => {
+      console.error('Failed to delete list', err)
+      // Revert
+      setLists((prev) => {
+        if (prev.some((l) => l.id === list.id)) return prev
+        const next = [...prev]
+        next.splice(Math.min(Math.max(removedIndex, 0), next.length), 0, list)
+        return next
+      })
+    })
+  }, [lists])
+
+  const handleAddFollow = useCallback(async (payload) => {
+    if (!selectedListId) return false
+    setAdding(true)
+    setAddError(null)
+    try {
+      const res = await APIService.addFollow(selectedListId, payload)
+      const follow = res?.follow
+      if (follow) {
+        setLists((prev) => prev.map((l) => (
+          l.id === selectedListId
+            ? { ...l, follows: [...(l.follows || []), follow], follow_count: (l.follow_count ?? (l.follows || []).length) + 1 }
+            : l
+        )))
+      }
+      reloadPreview()
+      return true
+    } catch (err) {
+      setAddError(err.body?.error || err.message || 'Failed to add follow')
+      return false
+    } finally {
+      setAdding(false)
+    }
+  }, [selectedListId, reloadPreview])
+
+  const handleRemoveFollow = useCallback((follow) => {
+    if (!selectedListId) return
+    setLists((prev) => prev.map((l) => (
+      l.id === selectedListId
+        ? {
+            ...l,
+            follows: (l.follows || []).filter((f) => f.id !== follow.id),
+            follow_count: Math.max(0, (l.follow_count ?? (l.follows || []).length) - 1),
+          }
+        : l
+    )))
+    APIService.removeFollow(selectedListId, follow.id)
+      .then(() => reloadPreview())
+      .catch((err) => {
+        console.error('Failed to remove follow', err)
+        setLists((prev) => prev.map((l) => (
+          l.id === selectedListId && !(l.follows || []).some((f) => f.id === follow.id)
+            ? { ...l, follows: [...(l.follows || []), follow], follow_count: (l.follow_count ?? (l.follows || []).length) + 1 }
+            : l
+        )))
+      })
+  }, [selectedListId, reloadPreview])
+
+  const followCount = (list) => (list.follows ? list.follows.length : (list.follow_count ?? 0))
+
+  // Signed out
+  if (!auth?.token) {
+    return (
+      <div className="min-h-screen bg-gradient-to-b from-secondary to-background">
+        <div className="mx-auto flex max-w-7xl items-center justify-center px-4 py-24 sm:px-6 lg:px-8">
+          <Card className="w-full max-w-md overflow-hidden border-border/80">
+            <CardContent className="flex flex-col items-center gap-4 px-8 py-12 text-center">
+              <span className="inline-flex h-14 w-14 items-center justify-center rounded-full bg-primary/10">
+                <ListChecks className="h-6 w-6 text-primary" />
+              </span>
+              <h1 className="text-xl font-bold tracking-tight text-foreground">Sign in to organize your scouting</h1>
+              <p className="text-sm text-muted-foreground">
+                Group who you track into named lists — players, whole club academies, countries, or saved filters.
+              </p>
+              <Button onClick={openLoginModal}>Sign in</Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-secondary to-background">
+      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        {/* Header */}
+        <header className="mb-8 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <p className="mb-2 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-primary">
+              <ListChecks className="h-3.5 w-3.5" />
+              Scout Pro — free during beta
+            </p>
+            <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">Your Lists</h1>
+            <p className="mt-2 max-w-2xl text-sm text-muted-foreground sm:text-base">
+              Organize who you track into named lists. Follow players, whole club academies, countries,
+              or a saved filter — each list resolves to a live player set.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2 lg:shrink-0 lg:pt-7">
+            <Button variant="outline" size="sm" asChild>
+              <Link to="/scout/watchlist" className="no-underline hover:no-underline">
+                <Star className="mr-1.5 h-4 w-4" />
+                Watchlist
+              </Link>
+            </Button>
+            <Button size="sm" asChild>
+              <Link to="/scout" className="no-underline hover:no-underline">
+                <Search className="mr-1.5 h-4 w-4" />
+                Find players
+              </Link>
+            </Button>
+          </div>
+        </header>
+
+        {error && <p className="mb-4 text-sm text-destructive">{error}</p>}
+
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+          {/* Left: list cards */}
+          <div className="space-y-3 lg:col-span-1">
+            <div className="flex items-center justify-between">
+              <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Lists</h2>
+              {!creating && (
+                <Button variant="outline" size="sm" onClick={() => { setCreating(true); setCreateError(null) }}>
+                  <Plus className="mr-1.5 h-4 w-4" />
+                  New list
+                </Button>
+              )}
+            </div>
+
+            {creating && (
+              <Card className="border-border/80">
+                <CardContent className="space-y-2 p-3">
+                  <Input
+                    value={newName}
+                    onChange={(e) => setNewName(e.target.value)}
+                    onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); handleCreate() } }}
+                    placeholder="List name…"
+                    maxLength={120}
+                    aria-label="New list name"
+                    autoFocus
+                  />
+                  {createError && <p className="text-xs text-destructive">{createError}</p>}
+                  <div className="flex items-center justify-end gap-2">
+                    <Button variant="ghost" size="sm" onClick={() => { setCreating(false); setNewName(''); setCreateError(null) }}>
+                      Cancel
+                    </Button>
+                    <Button size="sm" onClick={handleCreate} disabled={createSaving || !newName.trim()}>
+                      {createSaving ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : null}
+                      Create
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+
+            {loading ? (
+              <div className="space-y-2">
+                {[0, 1, 2].map((i) => <Skeleton key={i} className="h-16 w-full" />)}
+              </div>
+            ) : lists.length ? (
+              lists.map((list) => {
+                const selected = list.id === selectedListId
+                return (
+                  <Card key={list.id} className={`overflow-hidden border-border/80 transition-shadow ${selected ? 'ring-2 ring-primary' : ''}`}>
+                    <CardContent className="p-3">
+                      <div className="flex items-start justify-between gap-2">
+                        <button
+                          type="button"
+                          onClick={() => setSelectedListId(list.id)}
+                          className="min-w-0 flex-1 text-left"
+                        >
+                          <span className="flex items-center gap-2">
+                            <span className="truncate text-sm font-semibold text-foreground">{list.name}</span>
+                            {list.is_default && <Badge variant="secondary" className="shrink-0 text-[10px]">Default</Badge>}
+                            {list.is_active === false && <Badge variant="outline" className="shrink-0 text-[10px]">Paused</Badge>}
+                          </span>
+                          <span className="mt-0.5 block text-xs text-muted-foreground">
+                            {followCount(list)} {followCount(list) === 1 ? 'follow' : 'follows'}
+                          </span>
+                        </button>
+                        <div className="flex shrink-0 items-center gap-1.5">
+                          <Switch
+                            checked={list.is_active !== false}
+                            onCheckedChange={(c) => handleToggleActive(list, c)}
+                            aria-label={`${list.is_active !== false ? 'Pause' : 'Activate'} ${list.name}`}
+                          />
+                          {!list.is_default && (
+                            <AlertDialog>
+                              <AlertDialogTrigger asChild>
+                                <button
+                                  type="button"
+                                  className="inline-flex h-7 w-7 items-center justify-center rounded-full text-muted-foreground/60 transition-colors hover:bg-secondary hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                  aria-label={`Delete ${list.name}`}
+                                  title="Delete list"
+                                >
+                                  <Trash2 className="h-4 w-4" />
+                                </button>
+                              </AlertDialogTrigger>
+                              <AlertDialogContent>
+                                <AlertDialogHeader>
+                                  <AlertDialogTitle>Delete “{list.name}”?</AlertDialogTitle>
+                                  <AlertDialogDescription>
+                                    This removes the list and all of its follows. This cannot be undone.
+                                  </AlertDialogDescription>
+                                </AlertDialogHeader>
+                                <AlertDialogFooter>
+                                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                  <AlertDialogAction onClick={() => handleDelete(list)}>Delete</AlertDialogAction>
+                                </AlertDialogFooter>
+                              </AlertDialogContent>
+                            </AlertDialog>
+                          )}
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                )
+              })
+            ) : !creating ? (
+              <Card className="border-border/80">
+                <CardContent className="flex flex-col items-center gap-3 px-6 py-10 text-center">
+                  <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+                    <ListChecks className="h-5 w-5 text-primary" />
+                  </span>
+                  <p className="text-sm text-muted-foreground">No lists yet. Create your first list to start following.</p>
+                  <Button size="sm" onClick={() => { setCreating(true); setCreateError(null) }}>
+                    <Plus className="mr-1.5 h-4 w-4" />
+                    New list
+                  </Button>
+                </CardContent>
+              </Card>
+            ) : null}
+          </div>
+
+          {/* Right: selected list detail + resolved preview */}
+          <div className="lg:col-span-2">
+            {!selectedList ? (
+              <Card className="border-border/80">
+                <CardContent className="px-6 py-16 text-center text-sm text-muted-foreground">
+                  {lists.length ? 'Select a list to manage its follows.' : 'Create a list to get started.'}
+                </CardContent>
+              </Card>
+            ) : (
+              <div className="space-y-6">
+                {/* Detail header */}
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <h2 className="text-xl font-bold tracking-tight text-foreground">{selectedList.name}</h2>
+                    <p className="text-xs text-muted-foreground">
+                      {followCount(selectedList)} {followCount(selectedList) === 1 ? 'follow' : 'follows'}
+                      {selectedList.is_default ? ' · default list' : ''}
+                    </p>
+                  </div>
+                  <Button size="sm" onClick={() => { setAddError(null); setAddOpen(true) }}>
+                    <Plus className="mr-1.5 h-4 w-4" />
+                    Add follow
+                  </Button>
+                </div>
+
+                {/* Follows grouped by kind */}
+                <Card className="overflow-hidden border-border/80">
+                  <CardContent className="p-0">
+                    {!(selectedList.follows && selectedList.follows.length) ? (
+                      <p className="px-4 py-8 text-center text-sm text-muted-foreground">
+                        No follows yet. Use “Add follow” to track players, clubs, countries or a saved filter.
+                      </p>
+                    ) : (
+                      KIND_META.map((meta) => {
+                        const rows = (selectedList.follows || []).filter((f) => f.kind === meta.kind)
+                        if (!rows.length) return null
+                        const Icon = meta.icon
+                        return (
+                          <div key={meta.kind} className="border-b border-border/50 last:border-b-0">
+                            <div className="flex items-center gap-2 bg-secondary/50 px-4 py-2">
+                              <Icon className="h-3.5 w-3.5 text-primary" />
+                              <span className="text-xs font-semibold uppercase tracking-wider text-foreground/70">{meta.title}</span>
+                            </div>
+                            <ul className="divide-y divide-border/40">
+                              {rows.map((follow) => (
+                                <li key={follow.id} className="flex items-center justify-between gap-3 px-4 py-2.5">
+                                  <div className="min-w-0">
+                                    <span className="block truncate text-sm text-foreground">{followLabel(follow)}</span>
+                                    {follow.note && (
+                                      <span className="block max-w-full truncate text-xs italic text-primary/80" title={follow.note}>
+                                        “{follow.note}”
+                                      </span>
+                                    )}
+                                  </div>
+                                  <button
+                                    type="button"
+                                    onClick={() => handleRemoveFollow(follow)}
+                                    className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-muted-foreground/60 transition-colors hover:bg-secondary hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                    aria-label={`Remove ${followLabel(follow)}`}
+                                    title="Remove follow"
+                                  >
+                                    <X className="h-4 w-4" />
+                                  </button>
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        )
+                      })
+                    )}
+                  </CardContent>
+                </Card>
+
+                {/* Resolved preview */}
+                <div>
+                  <div className="mb-2 flex items-center justify-between">
+                    <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                      Resolved players
+                    </h3>
+                    {preview.total > 0 && (
+                      <span className="text-xs text-muted-foreground tabular-nums">
+                        {preview.players.length} of {preview.total.toLocaleString()}
+                      </span>
+                    )}
+                  </div>
+                  <Card className="overflow-hidden border-border/80">
+                    {previewError ? (
+                      <p className="px-4 py-8 text-center text-sm text-destructive">{previewError}</p>
+                    ) : (
+                      <div className="overflow-x-auto">
+                        <table className="w-full min-w-[480px] border-collapse">
+                          <thead>
+                            <tr className="border-b border-border/60 bg-secondary/60">
+                              <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Player</th>
+                              <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Status</th>
+                              <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Club</th>
+                            </tr>
+                          </thead>
+                          <tbody className="divide-y divide-border/40">
+                            {previewLoading && !preview.players.length ? (
+                              Array.from({ length: 5 }).map((_, i) => (
+                                <tr key={i}><td colSpan={3} className="px-3 py-2.5"><Skeleton className="h-9 w-full" /></td></tr>
+                              ))
+                            ) : preview.players.length ? (
+                              preview.players.map((p) => {
+                                const cellPlayer = {
+                                  player_id: p.player_api_id,
+                                  player_name: p.player_name,
+                                  player_photo: p.photo,
+                                }
+                                return (
+                                  <tr key={`${p.source}-${p.player_api_id}`} className="transition-colors hover:bg-secondary/40">
+                                    <td className="px-3 py-2.5">
+                                      <div className="flex items-center gap-2">
+                                        <PlayerCell player={cellPlayer} />
+                                        {p.source === 'shadow' && (
+                                          <Badge variant="outline" className="shrink-0 text-[10px] font-normal">Worldwide</Badge>
+                                        )}
+                                      </div>
+                                    </td>
+                                    <td className="px-3 py-2.5"><StatusBadge status={p.status} /></td>
+                                    <td className="px-3 py-2.5 max-w-44">
+                                      <span className="block truncate text-sm text-foreground/90">{p.team_name || '—'}</span>
+                                    </td>
+                                  </tr>
+                                )
+                              })
+                            ) : (
+                              <tr>
+                                <td colSpan={3} className="px-3 py-12 text-center text-sm text-muted-foreground">
+                                  No players resolve from this list yet.
+                                </td>
+                              </tr>
+                            )}
+                          </tbody>
+                        </table>
+                      </div>
+                    )}
+                    {preview.players.length < preview.total && (
+                      <div className="border-t border-border/60 px-4 py-3 text-center">
+                        <Button variant="outline" size="sm" onClick={loadMorePreview} disabled={previewLoading}>
+                          {previewLoading ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : null}
+                          Load more
+                        </Button>
+                      </div>
+                    )}
+                  </Card>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <AddFollowDialog
+          open={addOpen}
+          onOpenChange={setAddOpen}
+          onAdd={handleAddFollow}
+          adding={adding}
+          addError={addError}
+        />
+      </div>
+    </div>
+  )
+}

--- a/academy-watch-frontend/src/pages/PublicFormationBuilder.jsx
+++ b/academy-watch-frontend/src/pages/PublicFormationBuilder.jsx
@@ -51,7 +51,8 @@ export function PublicFormationBuilder() {
     let cancelled = false
     async function load() {
       try {
-        const data = await APIService.getTeams({ european_only: 'true', has_loans: 'true' })
+        // All supported regions — Dream XI should work for worldwide clubs too
+        const data = await APIService.getTeams({ has_loans: 'true' })
         if (!cancelled) {
           const list = Array.isArray(data) ? data : []
           setTeams(list)

--- a/academy-watch-frontend/src/pages/ScoutPage.jsx
+++ b/academy-watch-frontend/src/pages/ScoutPage.jsx
@@ -13,7 +13,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import {
   Loader2, Search, ArrowUpDown, ArrowLeft, ArrowRight,
   Trophy, Zap, Clock, Gauge, X, GitCompareArrows, Globe,
-  Star, Download, Link2,
+  Star, Download, Link2, ListChecks,
 } from 'lucide-react'
 import { STATUS_BADGE_CLASSES } from '../lib/theme-constants'
 
@@ -532,6 +532,12 @@ export function ScoutPage() {
                     {watchedIds.size}
                   </span>
                 )}
+              </Link>
+            </Button>
+            <Button variant="outline" size="sm" asChild>
+              <Link to="/scout/lists" className="no-underline hover:no-underline">
+                <ListChecks className="mr-1.5 h-4 w-4" />
+                Lists
               </Link>
             </Button>
             <Button variant="outline" size="sm" onClick={handleExportCsv} disabled={exporting}>

--- a/academy-watch-frontend/src/pages/WatchlistPage.jsx
+++ b/academy-watch-frontend/src/pages/WatchlistPage.jsx
@@ -8,7 +8,7 @@ import { Switch } from '@/components/ui/switch'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Textarea } from '@/components/ui/textarea'
-import { Star, Download, StickyNote, X, Loader2, Search } from 'lucide-react'
+import { Star, Download, StickyNote, X, Loader2, Search, ListChecks } from 'lucide-react'
 import { FormIndicator, StatusBadge, PlayerCell } from './ScoutPage'
 
 const NOTE_MAX = 2000
@@ -218,6 +218,12 @@ export function WatchlistPage() {
               />
               Weekly digest
             </label>
+            <Button variant="outline" size="sm" asChild>
+              <Link to="/scout/lists" className="no-underline hover:no-underline">
+                <ListChecks className="mr-1.5 h-4 w-4" />
+                Lists
+              </Link>
+            </Button>
             <Button variant="outline" size="sm" onClick={handleExportCsv} disabled={exporting || !entries.length}>
               {exporting ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Download className="mr-1.5 h-4 w-4" />}
               Export CSV
@@ -230,6 +236,16 @@ export function WatchlistPage() {
             </Button>
           </div>
         </header>
+
+        {/* Lists cross-link */}
+        <div className="mb-6 flex flex-wrap items-center justify-between gap-2 rounded-lg border border-border/70 bg-primary/5 px-4 py-2.5">
+          <span className="text-sm text-foreground/80">
+            Your watchlist is now also a <span className="font-semibold text-foreground">List</span> — manage richer follows (clubs, countries, saved filters) in Lists.
+          </span>
+          <Button variant="ghost" size="sm" asChild className="shrink-0">
+            <Link to="/scout/lists" className="no-underline hover:no-underline">Open Lists</Link>
+          </Button>
+        </div>
 
         {error && (
           <p className="mb-4 text-sm text-destructive">{error}</p>

--- a/docs/follow-graph.md
+++ b/docs/follow-graph.md
@@ -1,0 +1,64 @@
+# Follow Graph & Worldwide Shadow Tracking (Phase 1)
+
+> **Living document.** Last updated **2026-07-02**. Design rationale:
+> `ledgers/research/talent-platform/`. Roadmap: `ledgers/ROADMAP_talent-showcase-vision.md`.
+
+## 1. What it is
+
+Scouts organize who they track into **named lists** at `/scout/lists`. A list holds
+**follows** of four kinds, and resolves to a live player set:
+
+| Kind | Example | Resolves via |
+|---|---|---|
+| Player | Endrick | tracked player, else a **shadow** (see §3) |
+| Club academy | "Club academy: Ajax" | all active tracked players of that parent club |
+| Countries | "Playing in: Ecuador, Colombia" or "Nationality: …" | current-club country / nationality (case-insensitive) |
+| Saved filter | "Filter: Attacker, age -19, 270+ mins" | the Scout Desk query engine |
+
+## 2. The digest (additive semantics — important)
+
+The weekly scout digest now renders: the **legacy watchlist section first
+(byte-identical to before this feature)**, then one grouped section per active
+non-default list (players already in the watchlist section are not repeated).
+The auto-created "My Watchlist" default list mirrors watchlist adds/removes and
+**never** routes the digest (fallback: it resolves only if the watchlist is empty).
+Sends remain admin-triggered: `POST /api/scout/admin/send-digests {dry_run, limit, cursor}`.
+
+## 3. Shadow tracking (worldwide)
+
+Following a player outside the tracked universe **mints a shadow**: profile from
+API-Football `players/profiles` (name search: `GET /api/scout/player-search?q=`,
+min 3 chars), season stats into the dedicated `player_shadow_stats` table (NEVER
+`player_stats_cache` — unowned legacy, kept isolated; scout surfaces unaffected).
+Shadow players get working pages: profile fallback + `stats_coverage='limited'`
+season stats. They are followable only via lists (the legacy watchlist stays
+tracked-players-only). Caps (env): `MAX_FOLLOW_LISTS=10`, `MAX_FOLLOWS_PER_LIST=50`,
+`SHADOW_FOLLOW_LIMIT=10` distinct worldwide players per user — these become the
+Scout Pro entitlement levers when billing wires up.
+
+Refresh (operator-paced, quota-capped, mirrors backfill-names):
+`POST /api/admin/scout/shadow-refresh {limit}` — stalest-first profile+stats refresh.
+Quota safety: 24h/7d DB api_cache + the client's daily quota gate.
+
+## 4. Operator notes
+
+- **Migration `aw20`** (chains aw19 — REQUIRES the Talent Showcase branch/PR #565
+  first). Tables: follow_lists, follows, player_shadows, follow_player_snapshots,
+  player_shadow_stats. Idempotent both directions.
+- **Backfill** (after upgrade): `POST /api/admin/scout/backfill-follow-lists
+  {dry_run, limit, cursor}` — copies each user's watchlist into their default list
+  (notes + snapshots carried). Loop on next_cursor. Idempotent.
+- **LOCAL DEV DB**: cs01's `player_journeys.current_status` columns were missing
+  locally until 2026-07-02 (DB stamped on the vid chain; cs01 never ran) — local
+  scout browse 500'd since PR #514. Applied manually; a future full-chain upgrade
+  no-ops (guarded).
+- Tests: `pytest tests/test_follow_graph.py` (54). The digest regression bar is
+  enforced by a REAL-API-path test (adds via POST /scout/watchlist, then diffs the
+  rendered email against the legacy render).
+
+## 5. Changelog
+
+- **2026-07-02** — Phase 1 shipped: follow graph (4 kinds), worldwide shadow
+  tracking, additive digest generalization, ListsPage UI. Adversarially reviewed
+  (8 findings fixed — headline: dual-write mirror silently rerouted watchlist
+  users onto the list digest path; redesigned to additive semantics).


### PR DESCRIPTION
> **STACKED PR** — base is `feature/talent-showcase` (#565): migration `aw20` chains off `aw19`. Merge #565 first, then retarget/merge this. Diff shown here is follow-graph only.

## What this is

Phase 1 of the personalized-tracking architecture ([design panel](../tree/feature/follow-graph/ledgers/research/talent-platform)): **scouts organize who they track into named lists** — and can now **follow any player on Earth**, not just the tracked academy universe.

### Follow lists (`/scout/lists`)
One list = a live player set compiled from follows of four kinds:

| Kind | Example | Resolves via |
|---|---|---|
| Player | Endrick | tracked player, else **mints a shadow** |
| Club academy | "Club academy: Ajax" | that parent club's active tracked players |
| Countries | "Playing in: Ecuador, Colombia" / "Nationality: …" | current-club country / nationality (case-insensitive) |
| Saved filter | "Filter: Attacker, age -19" | the existing Scout Desk query engine |

### Worldwide shadow tracking
Following an untracked player mints a `PlayerShadow` (profile via new single-call `players/profiles` search) + dedicated `PlayerShadowStats` (deliberately **not** the unowned legacy `PlayerStatsCache`). Shadow players get working player pages (profile fill + limited-coverage season stats). Quota economics: per-player, demand-driven, protected by the 24h/7d api-cache + daily quota gate + per-user caps (10 lists / 50 follows / 10 shadows — the future Scout Pro entitlement levers).

### Digest: additive, regression-proof
The scout digest renders the **legacy watchlist section byte-identical first**, then grouped sections per non-default list (watchlist-wins dedup). The auto-created default list (watchlist's dual-write mirror) never routes the digest. Verified live: a watchlist-only user's email is unchanged; a list user gets "South American Watch" sections + "Now tracking worldwide" shadow cards.

## Review provenance

Adversarial panel (21 agents, 5 dimensions, 2 refuters per finding): **8 confirmed, 0 refuted, all fixed.** Headline catch: the dual-write mirror silently rerouted watchlist users onto the list digest path (grouped layout + reversed ordering + cap-40 truncation) — the old regression test was blind because it seeded entries directly; the fix ships with a test that goes through the **real** `POST /scout/watchlist` mirror path and diffs the rendered email against the legacy render. Also fixed: `str.title()` corrupting "Bosnia and Herzegovina"-class country matches, attacker-controlled shadow-seed sanitization (bleach + https-only photos), shadow-stats season drift, mint churn guard, model↔migration index-name parity.

## Quality gate
- **164 backend tests green** (`test_follow_graph` 54 new; `test_scout_watchlist` passes **UNMODIFIED**; migration single-head test green at aw20)
- ruff check+format clean; eslint 0 errors; build clean
- Live-verified: real worldwide search (Endrick shadow-minted from the live API), resolve union (tracked + shadow), profile/season-stats fallbacks, digest dry-run, ListsPage screenshots

## After merge (operator)
1. `flask db upgrade` (aw20, after aw19)
2. `POST /api/admin/scout/backfill-follow-lists {dry_run:true}` then real, loop `next_cursor` — copies watchlists into default lists
3. Optional: `POST /api/admin/scout/shadow-refresh {limit}` on a cadence once shadows accumulate

## Notes
- **Local dev DB fix (unrelated to this diff, worth knowing):** `player_journeys.current_status` (cs01) was never applied locally — local scout browse had been 500ing since #514 merged. Applied manually; guarded migrations no-op later.
- Accepted-risk (documented): cumulative shadow-mint quota is bounded by rate limits + api-cache rather than a lifetime cap; revisit with billing.
- Deferred to Phase 2/3 per the roadmap: cadence scheduler, pulse/cached AI cards, smart groups, Scout Pro billing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)