### PR TITLE
feat(analytics): first-party product events — batched ingest, useTrack, admin summary

### DIFF
--- a/academy-watch-backend/migrations/versions/aw21_product_events.py
+++ b/academy-watch-backend/migrations/versions/aw21_product_events.py
@@ -1,0 +1,51 @@
+"""Product analytics events table.
+
+Creates ``product_events`` — first-party telemetry rows (pageview, follow_added,
+...). No cookies / IP / user-agent columns by design.
+
+Idempotent (guards + helpers) — production has had objects added out-of-band,
+so every DDL op is safe to re-run in both directions.
+
+Revision ID: aw21
+Revises: vid03
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from migrations._migration_helpers import (
+    create_index_safe,
+    index_exists,
+    table_exists,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "aw21"
+down_revision = "vid03"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if not table_exists("product_events"):
+        op.create_table(
+            "product_events",
+            sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+            sa.Column("event_name", sa.String(length=64), nullable=False),
+            sa.Column("user_email", sa.String(length=320), nullable=True),
+            sa.Column("session_id", sa.String(length=64), nullable=True),
+            sa.Column("path", sa.String(length=512), nullable=True),
+            sa.Column("referrer", sa.String(length=512), nullable=True),
+            sa.Column("props", JSONB(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")),
+        )
+    create_index_safe("ix_product_events_name_created", "product_events", ["event_name", "created_at"])
+    create_index_safe("ix_product_events_created", "product_events", ["created_at"])
+
+
+def downgrade():
+    if index_exists("ix_product_events_created"):
+        op.drop_index("ix_product_events_created", table_name="product_events")
+    if index_exists("ix_product_events_name_created"):
+        op.drop_index("ix_product_events_name_created", table_name="product_events")
+    if table_exists("product_events"):
+        op.drop_table("product_events")

--- a/academy-watch-backend/src/main.py
+++ b/academy-watch-backend/src/main.py
@@ -22,6 +22,7 @@ from src.routes.auth_routes import auth_bp
 from src.routes.cohort import cohort_bp
 from src.routes.community_takes import community_takes_bp
 from src.routes.curator import curator_bp
+from src.routes.events import events_bp
 from src.routes.feeder import feeder_bp
 from src.routes.formation import formation_bp
 from src.routes.gol import gol_bp
@@ -101,6 +102,7 @@ app.register_blueprint(auth_bp, url_prefix="/api")
 app.register_blueprint(journalist_bp, url_prefix="/api")
 app.register_blueprint(newsletter_deadline_bp, url_prefix="/api")
 app.register_blueprint(community_takes_bp, url_prefix="/api")
+app.register_blueprint(events_bp, url_prefix="/api")
 app.register_blueprint(academy_bp, url_prefix="/api")
 app.register_blueprint(cohort_bp, url_prefix="/api")
 app.register_blueprint(gol_bp, url_prefix="/api")

--- a/academy-watch-backend/src/models/product_event.py
+++ b/academy-watch-backend/src/models/product_event.py
@@ -1,0 +1,42 @@
+"""Product analytics event model — first-party, privacy-light telemetry.
+
+One row per tracked event (pageview, follow_added, ...). No cookies, no IPs,
+no user-agent: identity is only ever the verified user email when a token is
+present, otherwise anonymous.
+"""
+
+from sqlalchemy.dialects.postgresql import JSONB
+from src.models.league import db
+
+
+class ProductEvent(db.Model):
+    __tablename__ = "product_events"
+
+    # BigInteger PK: SQLite only aliases INTEGER PRIMARY KEY to rowid, so fall
+    # back to Integer under the test harness while keeping BIGINT in Postgres.
+    id = db.Column(db.BigInteger().with_variant(db.Integer, "sqlite"), primary_key=True, autoincrement=True)
+    event_name = db.Column(db.String(64), nullable=False)
+    user_email = db.Column(db.String(320), nullable=True)
+    session_id = db.Column(db.String(64), nullable=True)
+    path = db.Column(db.String(512), nullable=True)
+    referrer = db.Column(db.String(512), nullable=True)
+    props = db.Column(JSONB, nullable=True)
+    created_at = db.Column(db.DateTime, nullable=False, server_default=db.func.now())
+
+    __table_args__ = (
+        # Index names must match the migration exactly (prod DDL == test create_all).
+        db.Index("ix_product_events_name_created", "event_name", "created_at"),
+        db.Index("ix_product_events_created", "created_at"),
+    )
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "event_name": self.event_name,
+            "user_email": self.user_email,
+            "session_id": self.session_id,
+            "path": self.path,
+            "referrer": self.referrer,
+            "props": self.props,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+        }

--- a/academy-watch-backend/src/routes/events.py
+++ b/academy-watch-backend/src/routes/events.py
@@ -1,0 +1,169 @@
+"""Product analytics endpoints for The Academy Watch.
+
+- ``POST /api/events`` — anonymous, batched event ingestion (privacy-light:
+  no cookies / IP / user-agent; identity only from a verified token if present).
+- ``GET /api/admin/analytics/summary`` — admin-only aggregate rollup.
+"""
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+from flask import Blueprint, jsonify, request
+from sqlalchemy import func
+from src.auth import _get_authorized_email, require_api_key
+from src.extensions import limiter
+from src.models.league import db
+from src.models.product_event import ProductEvent
+
+events_bp = Blueprint("events", __name__)
+logger = logging.getLogger(__name__)
+
+# Exactly these names are accepted; anything else is silently dropped so one
+# bad client event never fails the rest of the batch.
+ALLOWED_EVENTS = frozenset(
+    {
+        "pageview",
+        "claim_submitted",
+        "follow_added",
+        "shadow_minted",
+        "search_performed",
+        "list_created",
+    }
+)
+
+MAX_BATCH = 25
+
+# Mirrors the community-takes submit endpoint (per-IP, in-memory storage).
+RATE_LIMIT_PER_MINUTE = "10 per minute"
+RATE_LIMIT_PER_HOUR = "30 per hour"
+
+# Column length caps (match the model); overlong values are clipped, not rejected.
+_MAX_SESSION_ID = 64
+_MAX_PATH = 512
+_MAX_REFERRER = 512
+
+# Admin summary defaults/caps.
+DEFAULT_SUMMARY_DAYS = 7
+MAX_SUMMARY_DAYS = 90
+TOP_PATHS_LIMIT = 10
+
+
+def _clip(value, length):
+    """Coerce to a stripped string clipped to `length`, or None."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text[:length]
+
+
+@events_bp.route("/events", methods=["POST"])
+@limiter.limit(RATE_LIMIT_PER_MINUTE)
+@limiter.limit(RATE_LIMIT_PER_HOUR)
+def ingest_events():
+    """Ingest a batch of product-analytics events.
+
+    Body: ``{"events": [{name, path?, referrer?, props?, session_id?}]}``.
+    Works anonymously; user_email is resolved only from a verified Bearer token.
+    """
+    # force=True so sendBeacon payloads (non-JSON content-type) still parse.
+    data = request.get_json(silent=True, force=True) or {}
+    events = data.get("events")
+    if not isinstance(events, list):
+        return jsonify({"error": "events must be a list"}), 400
+    if len(events) > MAX_BATCH:
+        return jsonify({"error": f"max {MAX_BATCH} events per batch"}), 413
+
+    user_email = _get_authorized_email()
+
+    accepted = 0
+    for ev in events:
+        if not isinstance(ev, dict):
+            continue
+        name = ev.get("name")
+        # isinstance guard first: a non-scalar JSON name (list/dict) is unhashable
+        # and would raise TypeError on the frozenset membership test, 500-ing the
+        # whole batch. Drop it silently instead.
+        if not isinstance(name, str) or name not in ALLOWED_EVENTS:
+            continue
+        props = ev.get("props")
+        if not isinstance(props, dict):
+            props = None
+        db.session.add(
+            ProductEvent(
+                event_name=name,
+                user_email=user_email,
+                session_id=_clip(ev.get("session_id"), _MAX_SESSION_ID),
+                path=_clip(ev.get("path"), _MAX_PATH),
+                referrer=_clip(ev.get("referrer"), _MAX_REFERRER),
+                props=props,
+            )
+        )
+        accepted += 1
+
+    if accepted:
+        db.session.commit()
+    return jsonify({"accepted": accepted}), 202
+
+
+@events_bp.route("/admin/analytics/summary", methods=["GET"])
+@require_api_key
+def analytics_summary():
+    """Aggregate product-event rollup over the last N days (admin only)."""
+    days = min(request.args.get("days", DEFAULT_SUMMARY_DAYS, type=int), MAX_SUMMARY_DAYS)
+    if days < 1:
+        days = 1
+    # Naive UTC cutoff to compare against the naive timestamps stored by the DB.
+    cutoff = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=days)
+
+    totals_rows = (
+        db.session.query(ProductEvent.event_name, func.count(ProductEvent.id))
+        .filter(ProductEvent.created_at >= cutoff)
+        .group_by(ProductEvent.event_name)
+        .all()
+    )
+    totals = {name: count for name, count in totals_rows}
+
+    day_col = func.date(ProductEvent.created_at)
+    daily_rows = (
+        db.session.query(day_col.label("day"), func.count(ProductEvent.id))
+        .filter(ProductEvent.created_at >= cutoff)
+        .group_by(day_col)
+        .order_by(day_col)
+        .all()
+    )
+    daily = [
+        {"date": day.isoformat() if hasattr(day, "isoformat") else str(day), "count": count}
+        for day, count in daily_rows
+    ]
+
+    top_paths_rows = (
+        db.session.query(ProductEvent.path, func.count(ProductEvent.id).label("cnt"))
+        .filter(
+            ProductEvent.created_at >= cutoff,
+            ProductEvent.event_name == "pageview",
+            ProductEvent.path.isnot(None),
+        )
+        .group_by(ProductEvent.path)
+        .order_by(func.count(ProductEvent.id).desc())
+        .limit(TOP_PATHS_LIMIT)
+        .all()
+    )
+    top_paths = [{"path": path, "count": count} for path, count in top_paths_rows]
+
+    distinct_sessions = (
+        db.session.query(func.count(func.distinct(ProductEvent.session_id)))
+        .filter(ProductEvent.created_at >= cutoff, ProductEvent.session_id.isnot(None))
+        .scalar()
+    ) or 0
+
+    return jsonify(
+        {
+            "days": days,
+            "totals": totals,
+            "daily": daily,
+            "top_paths": top_paths,
+            "distinct_sessions": distinct_sessions,
+        }
+    )

--- a/academy-watch-backend/tests/test_product_events.py
+++ b/academy-watch-backend/tests/test_product_events.py
@@ -1,0 +1,221 @@
+"""Tests for the product-analytics endpoints.
+
+Exercises the real blueprint path via a Flask test client:
+- POST /api/events: batch accept + persistence, invalid-name drop, oversize
+  rejection, anonymous vs. token-attributed identity.
+- GET /api/admin/analytics/summary: SQL aggregation correctness across days,
+  and the dual-factor admin gate.
+"""
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from flask import Flask
+from src.models.league import db
+from src.models.product_event import ProductEvent
+
+ADMIN_KEY = "test-admin-key"
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("SKIP_API_HANDSHAKE", "1")
+    monkeypatch.setenv("API_USE_STUB_DATA", "true")
+    monkeypatch.setenv("ADMIN_API_KEY", ADMIN_KEY)
+    monkeypatch.setenv("ADMIN_IP_WHITELIST", "")
+
+    from src.routes.events import events_bp
+
+    template_dir = Path(__file__).resolve().parent.parent / "src" / "templates"
+    flask_app = Flask(__name__, template_folder=str(template_dir))
+    flask_app.config.update(
+        TESTING=True,
+        SECRET_KEY="test-secret-key",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        RATELIMIT_ENABLED=False,
+    )
+    db.init_app(flask_app)
+    flask_app.register_blueprint(events_bp, url_prefix="/api")
+
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _headers(email="scout@example.com"):
+    from src.auth import issue_user_token
+
+    return {"Authorization": f"Bearer {issue_user_token(email)['token']}"}
+
+
+def _admin_headers():
+    from src.auth import issue_user_token
+
+    token = issue_user_token("admin@example.com", role="admin")["token"]
+    return {"Authorization": f"Bearer {token}", "X-API-Key": ADMIN_KEY}
+
+
+# ---------------------------------------------------------------------------
+# POST /api/events
+# ---------------------------------------------------------------------------
+
+
+def test_batch_accept_and_persist(client, app):
+    payload = {
+        "events": [
+            {"name": "pageview", "path": "/scout", "session_id": "s1"},
+            {"name": "search_performed", "props": {"surface": "scout"}, "session_id": "s1"},
+            {"name": "list_created", "session_id": "s1"},
+        ]
+    }
+    res = client.post("/api/events", json=payload)
+    assert res.status_code == 202
+    assert res.get_json() == {"accepted": 3}
+
+    with app.app_context():
+        rows = ProductEvent.query.order_by(ProductEvent.id).all()
+        assert [r.event_name for r in rows] == ["pageview", "search_performed", "list_created"]
+        assert rows[0].path == "/scout"
+        assert rows[1].props == {"surface": "scout"}
+        # No token → anonymous.
+        assert all(r.user_email is None for r in rows)
+        # created_at populated by server default.
+        assert all(r.created_at is not None for r in rows)
+
+
+def test_invalid_names_dropped(client, app):
+    payload = {
+        "events": [
+            {"name": "pageview", "path": "/a"},
+            {"name": "not_a_real_event", "path": "/b"},
+            {"name": "follow_added"},
+            {"name": ""},
+            {"path": "/no-name"},
+        ]
+    }
+    res = client.post("/api/events", json=payload)
+    assert res.status_code == 202
+    # Only the two allowlisted names survive; the batch still succeeds.
+    assert res.get_json() == {"accepted": 2}
+
+    with app.app_context():
+        names = sorted(r.event_name for r in ProductEvent.query.all())
+        assert names == ["follow_added", "pageview"]
+
+
+def test_oversize_batch_rejected(client, app):
+    payload = {"events": [{"name": "pageview", "path": f"/p{i}"} for i in range(26)]}
+    res = client.post("/api/events", json=payload)
+    assert res.status_code == 413
+
+    with app.app_context():
+        assert ProductEvent.query.count() == 0
+
+
+def test_non_list_body_rejected(client):
+    assert client.post("/api/events", json={"events": "nope"}).status_code == 400
+
+
+def test_anonymous_ok(client, app):
+    res = client.post("/api/events", json={"events": [{"name": "pageview", "path": "/"}]})
+    assert res.status_code == 202
+    with app.app_context():
+        row = ProductEvent.query.one()
+        assert row.user_email is None
+
+
+def test_identity_resolved_from_token(client, app):
+    res = client.post(
+        "/api/events",
+        json={"events": [{"name": "claim_submitted", "props": {"player_api_id": 42}}]},
+        headers=_headers("scout@example.com"),
+    )
+    assert res.status_code == 202
+    with app.app_context():
+        row = ProductEvent.query.one()
+        assert row.user_email == "scout@example.com"
+
+
+def test_beacon_content_type_parsed(client, app):
+    # navigator.sendBeacon sends a Blob; the handler uses force=True to parse it.
+    res = client.post(
+        "/api/events",
+        data='{"events": [{"name": "pageview", "path": "/beacon"}]}',
+        content_type="text/plain;charset=UTF-8",
+    )
+    assert res.status_code == 202
+    assert res.get_json() == {"accepted": 1}
+    with app.app_context():
+        assert ProductEvent.query.count() == 1
+
+
+# ---------------------------------------------------------------------------
+# GET /api/admin/analytics/summary
+# ---------------------------------------------------------------------------
+
+
+def _seed_summary(app):
+    with app.app_context():
+        now = datetime.now(UTC).replace(tzinfo=None)
+        yesterday = now - timedelta(days=1)
+        long_ago = now - timedelta(days=40)
+        rows = [
+            ProductEvent(event_name="pageview", path="/a", session_id="s1", created_at=now),
+            ProductEvent(event_name="pageview", path="/a", session_id="s2", created_at=now),
+            ProductEvent(event_name="pageview", path="/b", session_id="s1", created_at=now),
+            ProductEvent(event_name="follow_added", session_id="s1", created_at=yesterday),
+            ProductEvent(event_name="follow_added", session_id="s2", created_at=yesterday),
+            # Outside a 7-day window — must be excluded.
+            ProductEvent(event_name="pageview", path="/old", session_id="s9", created_at=long_ago),
+        ]
+        db.session.add_all(rows)
+        db.session.commit()
+
+
+def test_summary_aggregates(client, app):
+    _seed_summary(app)
+    res = client.get("/api/admin/analytics/summary?days=7", headers=_admin_headers())
+    assert res.status_code == 200
+    body = res.get_json()
+
+    assert body["days"] == 7
+    # 40-day-old pageview excluded by the window.
+    assert body["totals"] == {"pageview": 3, "follow_added": 2}
+
+    # Two calendar days in-window (today + yesterday), counts sum to 5.
+    assert len(body["daily"]) == 2
+    assert sum(d["count"] for d in body["daily"]) == 5
+
+    # Pageviews only, top 10, ordered by count desc.
+    top = {p["path"]: p["count"] for p in body["top_paths"]}
+    assert top == {"/a": 2, "/b": 1}
+    assert body["top_paths"][0]["path"] == "/a"
+
+    # Distinct sessions in-window: s1, s2 (s9 is out of window).
+    assert body["distinct_sessions"] == 2
+
+
+def test_summary_days_capped(client, app):
+    _seed_summary(app)
+    res = client.get("/api/admin/analytics/summary?days=1000", headers=_admin_headers())
+    assert res.status_code == 200
+    body = res.get_json()
+    assert body["days"] == 90
+    # With a 90-day window the old pageview is now counted.
+    assert body["totals"]["pageview"] == 4
+
+
+def test_summary_requires_admin(client):
+    # No credentials at all.
+    assert client.get("/api/admin/analytics/summary").status_code == 401
+    # A plain (non-admin) user token must not pass the admin gate.
+    assert client.get("/api/admin/analytics/summary", headers=_headers()).status_code == 401

--- a/academy-watch-frontend/src/App.jsx
+++ b/academy-watch-frontend/src/App.jsx
@@ -115,6 +115,7 @@ import {
 import { NewsletterView } from '@/components/newsletter/NewsletterView'
 
 import { APIService } from '@/lib/api'
+import { trackPageview } from '@/lib/track'
 import { UniversalDatePicker } from '@/components/ui/UniversalDatePicker'
 import { AuthContext, AuthUIContext, useAuth, useAuthUI, buildAuthSnapshot } from '@/context/AuthContext'
 import { GlobalSearchContext, useGlobalSearchContext } from '@/context/GlobalSearchContext'
@@ -4031,6 +4032,12 @@ function StatsPage() {
 // Inner app component with Router context (for useNavigate in GlobalSearchDialog)
 function AppWithRouter() {
   const globalSearch = useGlobalSearch()
+  const location = useLocation()
+
+  // Central pageview tracking — fires on every route change (inside <Router> so useLocation is safe)
+  useEffect(() => {
+    trackPageview(location.pathname + location.search)
+  }, [location.pathname, location.search])
 
   return (
     <GlobalSearchContext.Provider value={globalSearch}>

--- a/academy-watch-frontend/src/components/ShowcaseSection.jsx
+++ b/academy-watch-frontend/src/components/ShowcaseSection.jsx
@@ -35,6 +35,7 @@ import {
   Sparkles,
 } from 'lucide-react'
 import { APIService } from '@/lib/api'
+import { track } from '@/lib/track'
 import { isYouTubeUrl } from '@/lib/youtube'
 import { VideoEmbed } from '@/components/VideoEmbed'
 import { useAuth, useAuthUI } from '@/context/AuthContext'
@@ -212,6 +213,7 @@ export function ShowcaseSection({ playerApiId, playerName }) {
         relationship_type: claimRelationship,
         message: claimMessage.trim() || undefined,
       })
+      track('claim_submitted', { player_api_id: playerApiId, relationship: claimRelationship })
       setClaimDone(true)
       await refresh()
       setTimeout(() => setClaimOpen(false), 1600)

--- a/academy-watch-frontend/src/lib/api.js
+++ b/academy-watch-frontend/src/lib/api.js
@@ -1971,6 +1971,10 @@ export class APIService {
         return this.request('/cohorts/analytics')
     }
 
+    static async getAnalyticsSummary(days = 7) {
+        return this.request(`/admin/analytics/summary?days=${days}`, {}, { admin: true })
+    }
+
     static async adminSeedCohort(data) {
         return this.request('/admin/cohorts/seed', {
             method: 'POST',

--- a/academy-watch-frontend/src/lib/track.js
+++ b/academy-watch-frontend/src/lib/track.js
@@ -1,0 +1,200 @@
+// Self-contained first-party product analytics client.
+// Design constraints (frozen contract):
+//   - No cookies, no external SDK. Uses raw fetch / sendBeacon only.
+//   - Analytics must NEVER break the app: every path fails silently.
+//   - Respects a localStorage opt-out flag ("aw_analytics_optout").
+//   - Only these event names are emitted by callers; the server also
+//     re-validates against its allowlist.
+
+const ENDPOINT = (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_API_BASE
+    ? import.meta.env.VITE_API_BASE
+    : '/api') + '/events'
+
+const SESSION_KEY = 'aw_analytics_session'
+const OPTOUT_KEY = 'aw_analytics_optout'
+const FLUSH_AT = 10        // flush when the queue reaches this many events
+const FLUSH_INTERVAL = 5000 // ms — periodic flush timer
+
+// Query params that can carry a secret / login-granting capability from
+// email links (/verify, /unsubscribe, /manage, /claim-account all use ?token=).
+// These must never be persisted to the analytics store, so they are stripped
+// from both the pageview `path` and the `referrer` before an event is queued.
+const SENSITIVE_PARAMS = [
+    'token', 'code', 'key', 'secret', 'auth', 'access_token',
+    'refresh_token', 'jwt', 'password', 'pwd', 'session',
+]
+
+let queue = []
+let timer = null
+
+function isBrowser() {
+    return typeof window !== 'undefined'
+}
+
+// Remove sensitive query params from a path or full URL. On any parse failure
+// the whole query string is dropped, which fails safe (never leaks a token).
+function sanitizeUrl(url) {
+    if (!url) return url
+    const qIndex = url.indexOf('?')
+    if (qIndex === -1) return url
+    const base = url.slice(0, qIndex)
+    const query = url.slice(qIndex + 1)
+    try {
+        const params = new URLSearchParams(query)
+        let changed = false
+        for (const name of SENSITIVE_PARAMS) {
+            while (params.has(name)) {
+                params.delete(name)
+                changed = true
+            }
+        }
+        if (!changed) return url
+        const rest = params.toString()
+        return rest ? `${base}?${rest}` : base
+    } catch {
+        // Malformed query — drop it entirely rather than risk leaking a secret.
+        return base
+    }
+}
+
+function currentPath() {
+    try {
+        return (window.location && (window.location.pathname + window.location.search)) || null
+    } catch {
+        return null
+    }
+}
+
+function isOptedOut() {
+    try {
+        return isBrowser() && window.localStorage.getItem(OPTOUT_KEY) === '1'
+    } catch {
+        return false
+    }
+}
+
+function getSessionId() {
+    try {
+        let id = window.sessionStorage.getItem(SESSION_KEY)
+        if (!id) {
+            id = (window.crypto && typeof window.crypto.randomUUID === 'function')
+                ? window.crypto.randomUUID()
+                : `s-${Date.now()}-${Math.random().toString(16).slice(2)}`
+            window.sessionStorage.setItem(SESSION_KEY, id)
+        }
+        return id
+    } catch {
+        return null
+    }
+}
+
+function currentReferrer() {
+    try {
+        return sanitizeUrl(document.referrer || null)
+    } catch {
+        return null
+    }
+}
+
+function scheduleFlush() {
+    if (timer !== null) return
+    try {
+        timer = setTimeout(() => {
+            timer = null
+            flush()
+        }, FLUSH_INTERVAL)
+    } catch {
+        timer = null
+    }
+}
+
+// Send whatever is queued. `useBeacon` picks sendBeacon (for unload paths);
+// otherwise a keepalive fetch is used so an in-flight POST survives navigation.
+function flush(useBeacon = false) {
+    if (queue.length === 0) return
+    if (timer !== null) {
+        try { clearTimeout(timer) } catch { /* noop */ }
+        timer = null
+    }
+
+    const batch = queue
+    queue = []
+    const payload = { events: batch }
+
+    try {
+        if (useBeacon && isBrowser() && navigator && typeof navigator.sendBeacon === 'function') {
+            // Use a CORS-safelisted content type (text/plain) so the cross-origin
+            // unload beacon is NOT held back by a preflight — an OPTIONS+POST is
+            // unreliable during pagehide/visibilitychange and would silently drop
+            // exit events. Flask still parses the JSON body via get_json(force=True).
+            const blob = new Blob([JSON.stringify(payload)], { type: 'text/plain' })
+            navigator.sendBeacon(ENDPOINT, blob)
+            return
+        }
+        fetch(ENDPOINT, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+            keepalive: true,
+        }).catch(() => { /* silent */ })
+    } catch {
+        // Never let analytics throw into the app.
+    }
+}
+
+function enqueue(name, props) {
+    if (!name || isOptedOut() || !isBrowser()) return
+    try {
+        const event = {
+            name,
+            path: sanitizeUrl(currentPath()),
+            referrer: currentReferrer(),
+            session_id: getSessionId(),
+        }
+        if (props && typeof props === 'object') event.props = props
+        queue.push(event)
+        if (queue.length >= FLUSH_AT) {
+            flush()
+        } else {
+            scheduleFlush()
+        }
+    } catch {
+        // Never let analytics throw into the app.
+    }
+}
+
+export function track(name, props) {
+    enqueue(name, props)
+}
+
+export function trackPageview(path) {
+    if (isOptedOut() || !isBrowser()) return
+    try {
+        const event = {
+            name: 'pageview',
+            path: sanitizeUrl(path || currentPath()),
+            referrer: currentReferrer(),
+            session_id: getSessionId(),
+        }
+        queue.push(event)
+        if (queue.length >= FLUSH_AT) {
+            flush()
+        } else {
+            scheduleFlush()
+        }
+    } catch {
+        // Never let analytics throw into the app.
+    }
+}
+
+// Flush on tab hide / unload via sendBeacon so queued events aren't lost.
+if (isBrowser()) {
+    try {
+        window.addEventListener('visibilitychange', () => {
+            if (document.visibilityState === 'hidden') flush(true)
+        })
+        window.addEventListener('pagehide', () => flush(true))
+    } catch {
+        // Environment without these events — ignore.
+    }
+}

--- a/academy-watch-frontend/src/pages/ListsPage.jsx
+++ b/academy-watch-frontend/src/pages/ListsPage.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { APIService } from '@/lib/api'
+import { track } from '@/lib/track'
 import { useAuth, useAuthUI } from '@/context/AuthContext'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -106,6 +107,7 @@ function PlayerSearchTab({ onAdd, adding, addError }) {
     let cancelled = false
     setLoading(true)
     setError(null)
+    track('search_performed', { q_len: debounced.length, surface: 'lists' })
     APIService.scoutPlayerSearch(debounced)
       .then((data) => { if (!cancelled) setResults(data?.players || []) })
       .catch((err) => { if (!cancelled) { setError(err.message || 'Search failed'); setResults([]) } })
@@ -583,6 +585,7 @@ export function ListsPage() {
       const res = await APIService.createFollowList(name)
       const created = res?.list
       if (created) {
+        track('list_created', { list_id: created.id })
         setLists((prev) => [...prev, created])
         setSelectedListId(created.id)
       }
@@ -633,6 +636,10 @@ export function ListsPage() {
     try {
       const res = await APIService.addFollow(selectedListId, payload)
       const follow = res?.follow
+      track('follow_added', { kind: payload.kind })
+      if (res?.shadow_created === true) {
+        track('shadow_minted', { player_api_id: payload.selector?.player_api_id })
+      }
       if (follow) {
         setLists((prev) => prev.map((l) => (
           l.id === selectedListId

--- a/academy-watch-frontend/src/pages/ScoutPage.jsx
+++ b/academy-watch-frontend/src/pages/ScoutPage.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo, useCallback, useRef, Fragment } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { APIService } from '@/lib/api'
+import { track } from '@/lib/track'
 import { useAuth, useAuthUI } from '@/context/AuthContext'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -423,6 +424,10 @@ export function ScoutPage() {
     searchTimer.current = setTimeout(() => setDebouncedSearch(search.trim()), 300)
     return () => clearTimeout(searchTimer.current)
   }, [search])
+
+  useEffect(() => {
+    if (debouncedSearch) track('search_performed', { q_len: debouncedSearch.length, surface: 'scout' })
+  }, [debouncedSearch])
 
   const filterParams = useMemo(() => {
     const params = {}

--- a/academy-watch-frontend/src/pages/admin/AdminDashboard.jsx
+++ b/academy-watch-frontend/src/pages/admin/AdminDashboard.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
-import { Mail, Users, Shield, GraduationCap, Inbox, Sprout, ArrowRight, Activity } from 'lucide-react'
+import { Mail, Users, Shield, GraduationCap, Inbox, Sprout, ArrowRight, Activity, BarChart3 } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { APIService } from '@/lib/api'
@@ -72,6 +72,122 @@ function StatTile({ label, value, ok, okLabel = 'OK', warnLabel = 'needs repair'
                 )}
             </div>
         </div>
+    )
+}
+
+// Product analytics — counts by event + a simple daily sparkline (7/30-day toggle).
+const ANALYTICS_EVENTS = [
+    ['pageview', 'Pageviews'],
+    ['search_performed', 'Searches'],
+    ['follow_added', 'Follows'],
+    ['shadow_minted', 'Shadows minted'],
+    ['list_created', 'Lists created'],
+    ['claim_submitted', 'Claims'],
+]
+
+function AnalyticsSummaryCard() {
+    const [days, setDays] = useState(7)
+    const [summary, setSummary] = useState(null)
+    const [failed, setFailed] = useState(false)
+
+    useEffect(() => {
+        let cancelled = false
+        setSummary(null)
+        setFailed(false)
+        const load = async () => {
+            try {
+                const data = await APIService.getAnalyticsSummary(days)
+                if (!cancelled) setSummary(data)
+            } catch {
+                if (!cancelled) setFailed(true)
+            }
+        }
+        load()
+        return () => { cancelled = true }
+    }, [days])
+
+    const totals = summary?.totals || {}
+    const daily = summary?.daily || []
+    const maxDaily = daily.reduce((m, d) => Math.max(m, d.count || 0), 0)
+
+    return (
+        <Card data-testid="analytics-summary">
+            <CardHeader className="pb-3">
+                <div className="flex items-center justify-between">
+                    <div>
+                        <CardTitle className="text-base flex items-center gap-2">
+                            <BarChart3 className="h-4 w-4" />
+                            Product Analytics
+                        </CardTitle>
+                        <CardDescription>First-party events, last {days} days</CardDescription>
+                    </div>
+                    <div className="flex gap-1">
+                        <Button
+                            variant={days === 7 ? 'default' : 'outline'}
+                            size="sm"
+                            onClick={() => setDays(7)}
+                            data-testid="analytics-range-7"
+                        >
+                            7d
+                        </Button>
+                        <Button
+                            variant={days === 30 ? 'default' : 'outline'}
+                            size="sm"
+                            onClick={() => setDays(30)}
+                            data-testid="analytics-range-30"
+                        >
+                            30d
+                        </Button>
+                    </div>
+                </div>
+            </CardHeader>
+            <CardContent>
+                {failed ? (
+                    <p className="text-sm text-muted-foreground">
+                        Analytics summary unavailable.
+                    </p>
+                ) : !summary ? (
+                    <div className="grid gap-3 grid-cols-2 md:grid-cols-3">
+                        {[0, 1, 2, 3, 4, 5].map((i) => <Skeleton key={i} className="h-16 rounded-lg" />)}
+                    </div>
+                ) : (
+                    <div className="space-y-4">
+                        <div className="grid gap-3 grid-cols-2 md:grid-cols-3">
+                            {ANALYTICS_EVENTS.map(([key, label]) => (
+                                <StatTile
+                                    key={key}
+                                    label={label}
+                                    value={totals[key] ?? 0}
+                                    testId={`analytics-tile-${key}`}
+                                />
+                            ))}
+                        </div>
+                        <div>
+                            <div className="flex items-center justify-between mb-2">
+                                <p className="text-xs text-muted-foreground">Events per day</p>
+                                <p className="text-xs text-muted-foreground" data-testid="analytics-sessions">
+                                    {summary.distinct_sessions ?? 0} sessions
+                                </p>
+                            </div>
+                            {daily.length === 0 ? (
+                                <p className="text-xs text-muted-foreground">No activity in this window.</p>
+                            ) : (
+                                <div className="flex items-end gap-0.5 h-16" data-testid="analytics-sparkline">
+                                    {daily.map((d) => (
+                                        <div
+                                            key={d.date}
+                                            className="flex-1 bg-primary/70 rounded-sm min-h-[2px]"
+                                            style={{ height: `${maxDaily > 0 ? Math.round(((d.count || 0) / maxDaily) * 100) : 0}%` }}
+                                            title={`${d.date}: ${d.count}`}
+                                        />
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                )}
+            </CardContent>
+        </Card>
     )
 }
 
@@ -335,6 +451,9 @@ export function AdminDashboard() {
                 <OpsSnapshotStrip />
                 <InboxPendingStrip />
             </div>
+
+            {/* Product analytics summary */}
+            <AnalyticsSummaryCard />
 
             {/* Seeding & Rebuild pointer (Full Rebuild moved to /admin/seeding) */}
             <Card className="border-amber-200 bg-amber-50/30" data-testid="seeding-pointer">


### PR DESCRIPTION
## What

First-party product analytics (ledger §3.1 — recommended first slice). Rationale: the follow-graph rollout revealed **0 prod users had watchlists** — every product decision is being made blind. No third-party trackers.

- **`product_events`** (migration `aw21`, chained off `vid03`, guarded DDL): `event_name`, optional `user_email`, `session_id`, `path`, `referrer`, `props` JSONB, `created_at`; indexed `(event_name, created_at)`.
- **`POST /api/events`** — anonymous batched ingest (≤25/batch), allowlisted names (`pageview`, `claim_submitted`, `follow_added`, `shadow_minted`, `search_performed`, `list_created`), invalid events silently dropped, rate-limited like community-takes, responds 202 fast. **No cookies, no IP, no user-agent stored.**
- **`GET /api/admin/analytics/summary?days=N`** (admin-gated) — SQL-aggregated totals by event, daily series, top pageview paths, distinct sessions.
- **`src/lib/track.js`** — queued flush (10 events/5s, keepalive) + `sendBeacon` on pagehide (`text/plain` so the unload beacon isn't preflight-dropped), `aw_analytics_optout` respected, **URL sanitizer strips token/code/key/auth params from path and referrer** (email-link routes carry capability tokens — they must never enter the analytics store), silent failure everywhere.
- Pageviews wired at router level; 5 action events instrumented at their success sites; AdminDashboard summary card (7/30-day toggle).

## Verification

- 10 new backend tests through the real endpoint path; **65 total pass** (incl. the 55-video-test canary). Single migration head `aw21`. ruff + eslint clean; `pnpm build` green.
- Built by a scout→builders→verify→review→fix Opus workflow; adversarial review confirmed and fixed 3 findings (500-able batch on unhashable name; capability-token leak via query strings; sendBeacon preflight loss).

## Deploy notes

- After merge: `flask db upgrade` to `aw21` on prod (one new table; additive, safe before or after code rollout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBNsWRHccFp44PzYUiukhd