### PR TITLE
feat(pulse): deterministic player pulse + shared AI card cache + digest assembly

### DIFF
--- a/academy-watch-backend/migrations/versions/aw22_player_pulse_cards.py
+++ b/academy-watch-backend/migrations/versions/aw22_player_pulse_cards.py
@@ -1,0 +1,61 @@
+"""Player pulse + shared AI card cache tables.
+
+Creates the two Phase-2 surfaces that split digest generation into a cheap
+deterministic layer and a shared LLM layer:
+
+- ``player_pulse``      — deterministic per-(player, window) newsworthiness score
+- ``player_card_cache`` — the ONE cached LLM card per (player, window), reused
+                          across every user's digest
+
+Both are keyed on ``(player_api_id, window_end)`` (composite PK, no surrogate id)
+matching ledgers/research/talent-platform/panel-grouping.md.
+
+Idempotent (guards + helpers) — production has had objects added out-of-band,
+so every DDL op is safe to re-run in both directions. Tables only; the PKs are
+the sole indexes the design requires.
+
+Revision ID: aw22
+Revises: aw21
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from migrations._migration_helpers import table_exists
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "aw22"
+down_revision = "aw21"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if not table_exists("player_pulse"):
+        op.create_table(
+            "player_pulse",
+            sa.Column("player_api_id", sa.Integer(), nullable=False),
+            sa.Column("window_end", sa.Date(), nullable=False),
+            sa.Column("score", sa.Float(), nullable=False),
+            sa.Column("delta_json", JSONB(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=True, server_default=sa.text("now()")),
+            sa.PrimaryKeyConstraint("player_api_id", "window_end", name="pk_player_pulse"),
+        )
+
+    if not table_exists("player_card_cache"):
+        op.create_table(
+            "player_card_cache",
+            sa.Column("player_api_id", sa.Integer(), nullable=False),
+            sa.Column("window_end", sa.Date(), nullable=False),
+            sa.Column("card_html", sa.Text(), nullable=False),
+            sa.Column("card_text", sa.Text(), nullable=False),
+            sa.Column("model", sa.String(length=40), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True, server_default=sa.text("now()")),
+            sa.PrimaryKeyConstraint("player_api_id", "window_end", name="pk_player_card_cache"),
+        )
+
+
+def downgrade():
+    if table_exists("player_card_cache"):
+        op.drop_table("player_card_cache")
+    if table_exists("player_pulse"):
+        op.drop_table("player_pulse")

--- a/academy-watch-backend/src/models/pulse.py
+++ b/academy-watch-backend/src/models/pulse.py
@@ -1,0 +1,68 @@
+"""Player pulse + shared AI card cache models.
+
+Two composite-key tables that split editorial digest generation into a cheap
+deterministic layer and a shared LLM layer:
+
+- ``PlayerPulse`` — deterministic per-player-per-window newsworthiness score with
+  full signal provenance in ``delta_json``. Computed ONCE per (player, window)
+  regardless of how many users follow the player (see player_pulse_service).
+- ``PlayerCardCache`` — the ONE place LLM output lives: a 2-3 sentence card per
+  player per window, generated once and reused across every user's digest (see
+  player_card_service).
+
+Both are keyed on ``(player_api_id, window_end)`` — no surrogate id — mirroring
+the data-model in ledgers/research/talent-platform/panel-grouping.md.
+"""
+
+from datetime import UTC, datetime
+
+from sqlalchemy.dialects.postgresql import JSONB
+from src.models.league import db
+
+
+class PlayerPulse(db.Model):
+    __tablename__ = "player_pulse"
+
+    player_api_id = db.Column(db.Integer, nullable=False)
+    window_end = db.Column(db.Date, nullable=False)
+    # REAL in Postgres; deterministic weighted sum of the signals in delta_json.
+    score = db.Column(db.Float, nullable=False)
+    # Every contributing signal with its raw value + weight + points (provenance)
+    # plus the player context block the card prompt is allowed to read.
+    delta_json = db.Column(JSONB, nullable=False)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
+
+    __table_args__ = (db.PrimaryKeyConstraint("player_api_id", "window_end", name="pk_player_pulse"),)
+
+    def to_dict(self):
+        return {
+            "player_api_id": self.player_api_id,
+            "window_end": self.window_end.isoformat() if self.window_end else None,
+            "score": self.score,
+            "delta_json": self.delta_json,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+        }
+
+
+class PlayerCardCache(db.Model):
+    __tablename__ = "player_card_cache"
+
+    player_api_id = db.Column(db.Integer, nullable=False)
+    window_end = db.Column(db.Date, nullable=False)
+    # Outlook-safe HTML fragment (plain <p>/<strong> only) for the email template.
+    card_html = db.Column(db.Text, nullable=False)
+    card_text = db.Column(db.Text, nullable=False)  # plaintext equivalent
+    model = db.Column(db.String(40))  # resolved LLM model string
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
+
+    __table_args__ = (db.PrimaryKeyConstraint("player_api_id", "window_end", name="pk_player_card_cache"),)
+
+    def to_dict(self):
+        return {
+            "player_api_id": self.player_api_id,
+            "window_end": self.window_end.isoformat() if self.window_end else None,
+            "card_html": self.card_html,
+            "card_text": self.card_text,
+            "model": self.model,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+        }

--- a/academy-watch-backend/src/routes/scout.py
+++ b/academy-watch-backend/src/routes/scout.py
@@ -57,6 +57,9 @@ MAX_FOLLOWS_PER_LIST = int(os.getenv("MAX_FOLLOWS_PER_LIST", "50"))
 SHADOW_FOLLOW_LIMIT = int(os.getenv("SHADOW_FOLLOW_LIMIT", "10"))
 MAX_RESOLVE_PAGE = 50
 MAX_LIST_NAME_LENGTH = 120
+# Endpoint sanity cap for the pulse card-generation batch (env PULSE_CARD_LIMIT
+# supplies the default; player_card_service enforces its own hard per-run cap).
+MAX_PULSE_CARD_LIMIT = 500
 
 scout_bp = Blueprint("scout", __name__)
 
@@ -1653,4 +1656,103 @@ def scout_admin_backfill_follow_lists():
     except Exception as e:
         db.session.rollback()
         logger.error(f"Error in scout_admin_backfill_follow_lists: {e}")
+        return jsonify(_safe_error_payload(e, "An unexpected error occurred. Please try again later.")), 500
+
+
+# =========================================================================== #
+# Player pulse + shared AI cards (admin ops until the Phase-3 scheduler exists)
+# =========================================================================== #
+
+
+def _parse_window_end(raw):
+    """(date, error). Defaults to today when omitted/blank."""
+    if raw is None or raw == "":
+        return date.today(), None
+    if not isinstance(raw, str):
+        return None, "window_end must be a date string (YYYY-MM-DD)"
+    try:
+        return date.fromisoformat(raw), None
+    except ValueError:
+        return None, "window_end must be a valid date (YYYY-MM-DD)"
+
+
+@scout_bp.route("/admin/pulse/compute", methods=["POST"])
+@require_api_key
+def scout_admin_pulse_compute():
+    """Compute deterministic player_pulse scores for a window (admin; NO LLM).
+
+    Body: {window_end?: "YYYY-MM-DD" (default today), dry_run?: bool (default
+    True)}. compute_pulse dedups every followed player across all active lists +
+    legacy watchlists and upserts one row per (player, window); it owns its own
+    persistence and honours dry_run (score + preview, write nothing). Returns the
+    service's counts + top scored preview.
+    """
+    try:
+        payload = request.get_json(silent=True) or {}
+        window_end, error = _parse_window_end(payload.get("window_end"))
+        if error:
+            return jsonify({"error": error}), 400
+        dry_run = payload.get("dry_run", True)
+        if not isinstance(dry_run, bool):
+            return jsonify({"error": "dry_run must be a boolean"}), 400
+
+        from src.services.player_pulse_service import compute_pulse
+
+        result = compute_pulse(window_end, dry_run=dry_run)
+        if not isinstance(result, dict):
+            result = {"result": result}
+        result.setdefault("window_end", window_end.isoformat())
+        result["dry_run"] = dry_run
+        result["applied"] = not dry_run
+        return jsonify(result)
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f"Error in scout_admin_pulse_compute: {e}")
+        return jsonify(_safe_error_payload(e, "An unexpected error occurred. Please try again later.")), 500
+
+
+@scout_bp.route("/admin/pulse/generate-cards", methods=["POST"])
+@require_api_key
+def scout_admin_pulse_generate_cards():
+    """Generate shared AI cards for high-pulse players (admin; THE LLM step).
+
+    Body: {window_end?, threshold? (default env PULSE_CARD_THRESHOLD=3.0),
+    limit? (default env PULSE_CARD_LIMIT=100), dry_run? (default True)}.
+    generate_cards owns persistence + honours dry_run — a dry run lists the
+    candidates (pulse >= threshold with no cached card) and makes ZERO LLM calls /
+    writes nothing. Returns {generated, skipped_cached, candidates, ...}.
+    """
+    try:
+        payload = request.get_json(silent=True) or {}
+        window_end, error = _parse_window_end(payload.get("window_end"))
+        if error:
+            return jsonify({"error": error}), 400
+        dry_run = payload.get("dry_run", True)
+        if not isinstance(dry_run, bool):
+            return jsonify({"error": "dry_run must be a boolean"}), 400
+
+        threshold = payload.get("threshold")
+        if threshold is not None and (isinstance(threshold, bool) or not isinstance(threshold, (int, float))):
+            return jsonify({"error": "threshold must be a number"}), 400
+
+        limit = payload.get("limit")
+        if limit is not None:
+            if not isinstance(limit, int) or isinstance(limit, bool) or limit < 1:
+                return jsonify({"error": "limit must be a positive integer"}), 400
+            limit = min(limit, MAX_PULSE_CARD_LIMIT)
+
+        # threshold/limit left as None fall back to the service's env defaults
+        # (PULSE_CARD_THRESHOLD / PULSE_CARD_LIMIT).
+        from src.services.player_card_service import generate_cards
+
+        result = generate_cards(window_end, threshold, limit, dry_run=dry_run)
+        if not isinstance(result, dict):
+            result = {"result": result}
+        result.setdefault("window_end", window_end.isoformat())
+        result["dry_run"] = dry_run
+        result["applied"] = not dry_run
+        return jsonify(result)
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f"Error in scout_admin_pulse_generate_cards: {e}")
         return jsonify(_safe_error_payload(e, "An unexpected error occurred. Please try again later.")), 500

--- a/academy-watch-backend/src/services/player_card_service.py
+++ b/academy-watch-backend/src/services/player_card_service.py
@@ -1,0 +1,262 @@
+"""Player card generation — the ONLY LLM step in the digest pipeline.
+
+For each ``player_pulse`` row above threshold that has no cached card yet, this
+generates a 2-3 sentence editorial card ONCE and writes it to
+``player_card_cache``. Every user following that player reuses the same cached
+card, so LLM cost scales with the newsworthy slice of the content universe, never
+with audience size.
+
+Honesty contract: the prompt receives ONLY verified structured numbers pulled
+from the pulse row's ``delta_json`` (never free text, never fabricated stats).
+Every number in a card comes from that payload.
+
+The LLM client + model + call shape mirror the Groq chat-completions helpers in
+``agents/weekly_newsletter_agent.py`` (``_summarize_player_with_groq``), but the
+client is built lazily so importing this module triggers NO network / no client
+construction. Failures skip the player (no cache row) so the next run retries.
+"""
+
+import html
+import json
+import logging
+import os
+from datetime import UTC, date, datetime
+
+from sqlalchemy import func
+from src.models.league import db
+from src.models.pulse import PlayerCardCache, PlayerPulse
+
+logger = logging.getLogger(__name__)
+
+# Env-tunable, mirroring the contract + the newsletter Groq conventions.
+_DEFAULT_MODEL = "openai/gpt-oss-120b"
+DEFAULT_CARD_THRESHOLD = float(os.getenv("PULSE_CARD_THRESHOLD", "3.0"))
+DEFAULT_CARD_LIMIT = int(os.getenv("PULSE_CARD_LIMIT", "100"))
+
+_GROQ_CLIENT = None
+
+CARD_SYSTEM_PROMPT = (
+    "You are a football scout writing a terse card for an academy-player digest. "
+    "You receive a JSON payload of VERIFIED stats and highlights for one player over "
+    "a recent window. Write 2-3 sentences that read like a scout's notebook entry.\n\n"
+    "STRICT RULES (never break these):\n"
+    "- Use ONLY the numbers and facts in the payload. Never invent goals, assists, "
+    "minutes, appearances, milestones, clubs, opponents, dates, or context.\n"
+    "- Keep every number exactly as given.\n"
+    "- Only claim a debut / first goal / first start / promotion if it appears in "
+    "'highlights'.\n"
+    "- No weather, crowd, scorelines, or match narrative that is not in the payload.\n"
+    "- Plain prose only: NO markdown, NO headings, NO bullet points, NO emoji.\n\n"
+    "Aim for 2-3 sentences, warm but factual."
+)
+
+
+def _get_groq_client():
+    """Lazy Groq client (mirrors weekly_newsletter_agent._get_groq_client).
+
+    Built on first use only, so importing this module never constructs a client
+    or touches the network."""
+    global _GROQ_CLIENT
+    if _GROQ_CLIENT is not None:
+        return _GROQ_CLIENT
+    try:
+        from groq import Groq
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError("groq package is not installed") from exc
+    api_key = os.getenv("GROQ_API_KEY")
+    if not api_key:
+        raise RuntimeError("GROQ_API_KEY is not configured")
+    _GROQ_CLIENT = Groq(api_key=api_key)
+    return _GROQ_CLIENT
+
+
+def _resolve_model() -> str:
+    model = os.getenv("PULSE_CARD_MODEL") or os.getenv("NEWSLETTER_GROQ_MODEL") or _DEFAULT_MODEL
+    return model[:40]  # player_card_cache.model is VARCHAR(40)
+
+
+def _coerce_window_end(window_end) -> date:
+    if window_end is None:
+        return datetime.now(UTC).date()
+    if isinstance(window_end, datetime):
+        return window_end.date()
+    if isinstance(window_end, date):
+        return window_end
+    return date.fromisoformat(str(window_end))
+
+
+def _ensure_period(text: str) -> str:
+    stripped = (text or "").strip()
+    if not stripped:
+        return ""
+    if stripped[-1] in ".!?":
+        return stripped
+    if stripped[-1] in ",;:":
+        stripped = stripped[:-1].rstrip()
+        if not stripped:
+            return ""
+    return stripped + "."
+
+
+def _clean_card_text(content: str) -> str:
+    """Trim to the last complete sentence and ensure terminal punctuation —
+    matches the newsletter agent's post-processing."""
+    content = (content or "").strip()
+    if not content:
+        return ""
+    last_stop = max(content.rfind("."), content.rfind("!"), content.rfind("?"))
+    if last_stop != -1:
+        content = content[: last_stop + 1].strip()
+    return _ensure_period(content)
+
+
+def _build_card_payload(pulse_row: PlayerPulse) -> dict:
+    """Verified-only payload for the prompt, from the pulse row's delta_json."""
+    delta = pulse_row.delta_json or {}
+    context = delta.get("context") or {}
+    totals = delta.get("window_totals") or {}
+    signals = delta.get("signals") or {}
+    highlights = [sig["label"] for sig in signals.values() if isinstance(sig, dict) and sig.get("label")]
+    return {
+        "player": {
+            "name": context.get("name"),
+            "position": context.get("position"),
+            "parent_club": context.get("parent_club"),
+            "current_club": context.get("current_club"),
+            "status": context.get("status"),
+            "level": context.get("current_level"),
+        },
+        "window": {
+            "start": delta.get("window_start"),
+            "end": delta.get("window_end"),
+            "days": delta.get("window_days"),
+        },
+        "stats": {
+            "goals": totals.get("goals", 0),
+            "assists": totals.get("assists", 0),
+            "appearances": totals.get("appearances", 0),
+            "starts": totals.get("starts", 0),
+            "minutes": totals.get("minutes", 0),
+        },
+        "highlights": highlights,
+    }
+
+
+def _generate_card_text(payload: dict, model: str) -> str:
+    """THE ONLY function that calls the LLM. Tests monkeypatch this by name so a
+    live call never runs. Returns the RAW model content; ``generate_cards`` trims
+    it to whole sentences (so the trim/empty-skip logic runs on mocked output
+    too)."""
+    client = _get_groq_client()
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": CARD_SYSTEM_PROMPT},
+            {"role": "user", "content": json.dumps(payload, ensure_ascii=False)},
+        ],
+        temperature=0.3,
+        max_tokens=200,
+    )
+    return response.choices[0].message.content if response.choices else ""
+
+
+def _to_card_html(text: str) -> str:
+    """Outlook-safe fragment: a single escaped ``<p>`` (plain <p>/<strong> only)."""
+    return f"<p>{html.escape(text)}</p>" if text else ""
+
+
+def generate_cards(window_end, threshold=None, limit=None, *, dry_run: bool = False) -> dict:
+    """Generate + cache cards for the highest-scoring uncached pulse rows.
+
+    Selects ``player_pulse`` rows for ``window_end`` with ``score >= threshold``
+    that have no ``player_card_cache`` row yet, ordered by score, capped at
+    ``limit``. Each generates ONE card via the LLM (mocked in tests) and writes a
+    cache row. Cache reuse is automatic: a second run for the same window finds
+    every card already cached and generates 0. ``dry_run`` lists candidates and
+    makes ZERO LLM calls / writes nothing.
+
+    Returns ``{generated, skipped_cached, candidates, ...}``.
+    """
+    window_end = _coerce_window_end(window_end)
+    threshold = DEFAULT_CARD_THRESHOLD if threshold is None else float(threshold)
+    limit = DEFAULT_CARD_LIMIT if limit is None else int(limit)
+    limit = max(limit, 0)
+    model = _resolve_model()
+
+    above = (
+        PlayerPulse.query.filter(PlayerPulse.window_end == window_end, PlayerPulse.score >= threshold)
+        .order_by(PlayerPulse.score.desc(), PlayerPulse.player_api_id.asc())
+        .all()
+    )
+    cached_ids = {
+        pid for (pid,) in db.session.query(PlayerCardCache.player_api_id).filter_by(window_end=window_end).all()
+    }
+    eligible = [row for row in above if row.player_api_id not in cached_ids]
+    skipped_cached = len(above) - len(eligible)
+    batch = eligible[:limit]
+    candidates = [{"player_api_id": row.player_api_id, "score": row.score} for row in batch]
+
+    generated = 0
+    failed = 0
+    if not dry_run:
+        for row in batch:
+            payload = _build_card_payload(row)
+            try:
+                raw = _generate_card_text(payload, model)
+            except Exception as exc:
+                logger.warning("Card generation failed for player %s: %s", row.player_api_id, exc)
+                failed += 1
+                continue
+            text = _clean_card_text(raw)
+            if not text:
+                failed += 1
+                continue
+            db.session.add(
+                PlayerCardCache(
+                    player_api_id=row.player_api_id,
+                    window_end=window_end,
+                    card_html=_to_card_html(text),
+                    card_text=text,
+                    model=model,
+                )
+            )
+            generated += 1
+        if generated:
+            db.session.commit()
+
+    return {
+        "window_end": window_end.isoformat(),
+        "threshold": threshold,
+        "limit": limit,
+        "model": model,
+        "dry_run": dry_run,
+        "candidates_total": len(eligible),
+        "skipped_cached": skipped_cached,
+        "generated": generated,
+        "failed": failed,
+        "candidates": candidates,
+    }
+
+
+def latest_card_window() -> date | None:
+    """Most recent window_end with any cached card — the render seam's default
+    window for the digest lookup."""
+    return db.session.query(func.max(PlayerCardCache.window_end)).scalar()
+
+
+def get_cards_for_window(window_end, player_api_ids=None) -> dict[int, dict]:
+    """Batch render lookup: ``{player_api_id: {card_html, card_text, model}}`` for
+    a window. Empty dict when nothing is cached (so the digest falls through to
+    its byte-identical legacy output). This is the additive seam Builder B reads
+    at render time."""
+    window_end = _coerce_window_end(window_end)
+    query = PlayerCardCache.query.filter_by(window_end=window_end)
+    if player_api_ids is not None:
+        ids = [int(pid) for pid in player_api_ids]
+        if not ids:
+            return {}
+        query = query.filter(PlayerCardCache.player_api_id.in_(ids))
+    return {
+        row.player_api_id: {"card_html": row.card_html, "card_text": row.card_text, "model": row.model}
+        for row in query.all()
+    }

--- a/academy-watch-backend/src/services/player_pulse_service.py
+++ b/academy-watch-backend/src/services/player_pulse_service.py
@@ -1,0 +1,625 @@
+"""Player pulse — deterministic per-player-per-window newsworthiness scoring.
+
+This is the CHEAP half of the digest split: no LLM, no per-audience work. Every
+followed player (deduped across all active follow lists + the legacy watchlist)
+is scored ONCE per window into ``player_pulse``. LLM cost (the separate card
+step) then scales with the newsworthy slice of the content universe, never with
+audience size.
+
+Signals (documented weighted sum — see ``PULSE_WEIGHTS``):
+
+- stat deltas — goals / assists / appearances / minutes in the window, windowed
+  by ``Fixture.date_utc`` at the player's current club (the same delta concept
+  scout_digest_service renders today, computed globally instead of per user).
+- status change — ``PlayerJourney.current_status`` coalesced with
+  ``TrackedPlayer.status`` vs the previous window's recorded status.
+- milestones — first senior appearance (debut), first senior goal, first senior
+  start, and level jump (U18 -> U21 -> ... -> Senior) vs the prior window. The
+  "firsts" are inferred from partial-coverage FixturePlayerStats, so they fire
+  ONLY when the fuller career history (PlayerJourney entries + PlayerStatsCache)
+  corroborates them (``_senior_career_evidence``) — otherwise a player whose
+  earlier senior career lives out of coverage would fabricate a career-first.
+- per-90 spike — this window's goal-involvement per 90 vs the player's own
+  prior-fixtures baseline (reuses ``radar_stats_service.compute_player_per90``).
+- injury new / cleared — OPT-IN only: skipped unless an ``api_client`` is passed
+  explicitly. The bulk path never passes one, so pulse makes ZERO live API
+  calls — the load-bearing "flat cost / audience-independent" invariant.
+
+``delta_json`` records every contributing signal with its raw value, weight and
+points (provenance) plus a small verified player-context block the card prompt is
+allowed to read. Upserts are idempotent so re-running a window is a no-op.
+"""
+
+import logging
+import os
+from datetime import UTC, date, datetime, time, timedelta
+
+from sqlalchemy import func, or_
+from src.models.follow import FollowList, PlayerShadow
+from src.models.journey import PlayerJourney
+from src.models.league import PlayerStatsCache, db
+from src.models.pulse import PlayerPulse
+from src.models.scout_watchlist import ScoutWatchlistEntry
+from src.models.tracked_player import TrackedPlayer
+from src.models.weekly import Fixture, FixturePlayerStats
+
+logger = logging.getLogger(__name__)
+
+# Window length (days) ending on window_end. Weekly by default; env-tunable.
+DEFAULT_WINDOW_DAYS = int(os.getenv("PULSE_WINDOW_DAYS", "7"))
+
+# Documented weighted sum. Each signal contributes ``value * weight`` (counting
+# signals) or a flat ``weight`` (event signals). Tuned so a single high-value
+# event (promotion, debut, first goal, brace) clears the default card threshold
+# (PULSE_CARD_THRESHOLD=3.0) on its own.
+PULSE_WEIGHTS = {
+    "goal": 2.0,  # per goal in window
+    "assist": 1.5,  # per assist in window
+    "appearance": 0.5,  # per appearance in window
+    "minutes": 0.5,  # per full 90 played in window (minutes / 90 * weight)
+    "status_change": 3.5,  # promoted / loaned / sold / released this window
+    "milestone_debut": 4.0,  # first ever senior appearance
+    "milestone_first_goal": 3.5,  # first ever senior goal
+    "milestone_first_start": 2.5,  # first ever senior start
+    "milestone_level_jump": 3.5,  # U18 -> U21 -> ... -> Senior
+    "per90_spike": 2.0,  # goal-involvement per 90 spiking vs own baseline
+    "injury_new": 1.5,  # new absence(s) since last window (opt-in)
+    "injury_cleared": 1.5,  # absence(s) cleared since last window (opt-in)
+}
+
+# Per-90 spike gates: enough evidence both sides, and a real jump.
+PER90_SPIKE_RATIO = 1.5
+PER90_MIN_WINDOW_MINUTES = 45
+PER90_MIN_BASELINE_MINUTES = 180
+
+# Ordered levels for jump detection (higher rank = more advanced).
+_LEVEL_RANK = {
+    "U15": 1,
+    "U16": 2,
+    "U17": 3,
+    "U18": 4,
+    "U19": 5,
+    "U21": 6,
+    "U23": 7,
+    "Reserve": 8,
+    "Senior": 9,
+    "First Team": 9,
+}
+
+# Local copy (not imported) so pulse does not couple to scout_digest_service.
+_STATUS_LABELS = {
+    "first_team": "Promoted to first team",
+    "on_loan": "Sent on loan",
+    "sold": "Sold",
+    "released": "Released",
+    "academy": "Back in the academy",
+    "left": "Left the club",
+}
+
+# Top-N preview returned to the admin compute endpoint.
+_TOP_PREVIEW = 10
+
+
+def _coerce_window_end(window_end) -> date:
+    """Accept a date, datetime, ISO string, or None (-> today, UTC)."""
+    if window_end is None:
+        return datetime.now(UTC).date()
+    if isinstance(window_end, datetime):
+        return window_end.date()
+    if isinstance(window_end, date):
+        return window_end
+    return date.fromisoformat(str(window_end))
+
+
+def _window_bounds(window_end: date, window_days: int):
+    """(start_dt, end_dt, start_date) — half-open [start_dt, end_dt) covering the
+    ``window_days`` calendar days ending on (and including) window_end."""
+    start_date = window_end - timedelta(days=window_days - 1)
+    start_dt = datetime.combine(start_date, time.min)
+    end_dt = datetime.combine(window_end + timedelta(days=1), time.min)
+    return start_dt, end_dt, start_date
+
+
+def _all_followed_player_ids() -> set[int]:
+    """Every player followed by anyone: legacy watchlist DISTINCT ids UNION each
+    active FollowList's resolved set (dedup handled by the resolver, which also
+    inherits the owning-club exclusion). Computed once, reused across the run."""
+    from src.services.follow_resolver import resolve_list
+
+    ids: set[int] = set()
+    for (pid,) in db.session.query(ScoutWatchlistEntry.player_api_id).distinct():
+        if pid is not None:
+            ids.add(int(pid))
+    for follow_list in FollowList.query.filter_by(is_active=True).all():
+        try:
+            for item in resolve_list(follow_list, limit=None):
+                ids.add(int(item["player_api_id"]))
+        except Exception:
+            logger.exception("resolve_list failed for follow_list %s", follow_list.id)
+    return ids
+
+
+def _player_context(player_api_id: int) -> dict | None:
+    """Verified display/status context, or None when the player is neither an
+    active academy-origin TrackedPlayer nor an active PlayerShadow.
+
+    owning-club rows are excluded (deprecated everywhere else on the scout
+    surface); the player-level journey status overrides the academy-relative
+    TrackedPlayer.status when set."""
+    tracked = (
+        TrackedPlayer.query.filter_by(player_api_id=player_api_id, is_active=True)
+        .filter(TrackedPlayer.data_source != "owning-club")
+        .order_by(TrackedPlayer.id)
+        .first()
+    )
+    journey = PlayerJourney.query.filter_by(player_api_id=player_api_id).first()
+    if tracked is not None:
+        status = (journey.current_status if journey else None) or tracked.status
+        level = tracked.current_level or (journey.current_level if journey else None)
+        return {
+            "kind": "tracked",
+            "name": tracked.player_name,
+            "position": tracked.position,
+            "parent_club": tracked.team.name if tracked.team else None,
+            "current_club": tracked.current_club_name,
+            "current_club_api_id": tracked.current_club_api_id,
+            "status": status,
+            "current_level": level,
+        }
+    shadow = PlayerShadow.query.filter_by(player_api_id=player_api_id, is_active=True).first()
+    if shadow is not None:
+        return {
+            "kind": "shadow",
+            "name": shadow.player_name,
+            "position": shadow.position,
+            "parent_club": None,
+            "current_club": shadow.current_club_name,
+            "current_club_api_id": shadow.current_club_api_id,
+            "status": (journey.current_status if journey else None),
+            "current_level": (journey.current_level if journey else None),
+        }
+    return None
+
+
+def _windowed_rows(player_api_id: int, start_dt: datetime, end_dt: datetime) -> list:
+    """FixturePlayerStats rows (all teams) whose fixture falls in the window."""
+    return (
+        db.session.query(FixturePlayerStats)
+        .join(Fixture, FixturePlayerStats.fixture_id == Fixture.id)
+        .filter(
+            FixturePlayerStats.player_api_id == player_api_id,
+            Fixture.date_utc >= start_dt,
+            Fixture.date_utc < end_dt,
+        )
+        .all()
+    )
+
+
+def _is_start(row) -> bool:
+    return not bool(row.substitute) and int(row.minutes or 0) > 0
+
+
+def _aggregate_rows(rows) -> dict:
+    apps = len(rows)
+    goals = sum(int(r.goals or 0) for r in rows)
+    assists = sum(int(r.assists or 0) for r in rows)
+    minutes = sum(int(r.minutes or 0) for r in rows)
+    starts = sum(1 for r in rows if _is_start(r))
+    return {"appearances": apps, "goals": goals, "assists": assists, "minutes": minutes, "starts": starts}
+
+
+def _cumulative_before(player_api_id: int, start_dt: datetime) -> dict:
+    """Career totals (all teams) strictly BEFORE the window — for milestone
+    firsts and the per-90 baseline."""
+    row = (
+        db.session.query(
+            func.count().label("appearances"),
+            func.coalesce(func.sum(FixturePlayerStats.goals), 0).label("goals"),
+            func.coalesce(func.sum(FixturePlayerStats.assists), 0).label("assists"),
+            func.coalesce(func.sum(FixturePlayerStats.minutes), 0).label("minutes"),
+        )
+        .join(Fixture, FixturePlayerStats.fixture_id == Fixture.id)
+        .filter(
+            FixturePlayerStats.player_api_id == player_api_id,
+            Fixture.date_utc < start_dt,
+        )
+        .first()
+    )
+    starts = (
+        db.session.query(func.count())
+        .select_from(FixturePlayerStats)
+        .join(Fixture, FixturePlayerStats.fixture_id == Fixture.id)
+        .filter(
+            FixturePlayerStats.player_api_id == player_api_id,
+            Fixture.date_utc < start_dt,
+            or_(FixturePlayerStats.substitute.is_(False), FixturePlayerStats.substitute.is_(None)),
+            FixturePlayerStats.minutes > 0,
+        )
+        .scalar()
+    )
+    if row is None:
+        return {"appearances": 0, "goals": 0, "assists": 0, "minutes": 0, "starts": int(starts or 0)}
+    return {
+        "appearances": int(row.appearances or 0),
+        "goals": int(row.goals or 0),
+        "assists": int(row.assists or 0),
+        "minutes": int(row.minutes or 0),
+        "starts": int(starts or 0),
+    }
+
+
+def _senior_career_evidence(player_api_id: int) -> dict:
+    """Fuller-career senior appearance/goal totals used to CORROBORATE milestone
+    "firsts" that are otherwise inferred from partial-coverage FixturePlayerStats.
+
+    ``FixturePlayerStats`` only covers top leagues, so a player whose earlier
+    senior career lives in a lower league (``PlayerStatsCache``) or a foreign /
+    prior club (``PlayerJourney`` career entries) has ``_cumulative_before`` == 0
+    even though he is not a debutant — which would fabricate a career-first
+    milestone. This reads the authoritative career sources so the caller can
+    require positive corroboration before claiming a first.
+
+    Returns ``has_journey`` (whether ANY career record exists to corroborate
+    against — absent one we cannot confirm a first at all) plus the highest
+    senior appearance / goal totals known to those sources (senior = non-youth,
+    non-international journey entries; PlayerStatsCache rows are senior)."""
+    journey = PlayerJourney.query.filter_by(player_api_id=player_api_id).first()
+    journey_apps = 0
+    journey_goals = 0
+    if journey is not None:
+        for entry in journey.entries.all():
+            if entry.is_youth or entry.is_international:
+                continue
+            journey_apps += int(entry.appearances or 0)
+            journey_goals += int(entry.goals or 0)
+    cache_row = (
+        db.session.query(
+            func.coalesce(func.sum(PlayerStatsCache.appearances), 0),
+            func.coalesce(func.sum(PlayerStatsCache.goals), 0),
+        )
+        .filter(PlayerStatsCache.player_api_id == player_api_id)
+        .first()
+    )
+    cache_apps = int(cache_row[0] or 0) if cache_row else 0
+    cache_goals = int(cache_row[1] or 0) if cache_row else 0
+    return {
+        "has_journey": journey is not None,
+        "apps": max(journey_apps, cache_apps),
+        "goals": max(journey_goals, cache_goals),
+    }
+
+
+def _involvement_per90(minutes: int, goals: int, assists: int) -> float:
+    if minutes <= 0:
+        return 0.0
+    return round((goals + assists) * 90.0 / minutes, 3)
+
+
+def _window_per90_involvement(club_rows) -> float:
+    """Reuse the radar per-90 pure function for the window's goal involvement."""
+    from src.services.radar_stats_service import compute_player_per90
+
+    fixtures_data = [
+        {"stats": {"minutes": int(r.minutes or 0), "goals": int(r.goals or 0), "assists": int(r.assists or 0)}}
+        for r in club_rows
+    ]
+    per90 = compute_player_per90(fixtures_data)
+    return round(float(per90.get("goals", 0.0)) + float(per90.get("assists", 0.0)), 3)
+
+
+def _absence_count(api_client, player_api_id: int) -> int | None:
+    if api_client is None:
+        return None
+    try:
+        return len(api_client.get_player_injuries(player_api_id) or [])
+    except Exception as exc:
+        logger.warning("Absence lookup failed for player %s: %s", player_api_id, exc)
+        return None
+
+
+def _previous_pulse(player_api_id: int, window_end: date) -> PlayerPulse | None:
+    return (
+        PlayerPulse.query.filter(
+            PlayerPulse.player_api_id == player_api_id,
+            PlayerPulse.window_end < window_end,
+        )
+        .order_by(PlayerPulse.window_end.desc())
+        .first()
+    )
+
+
+def _add_signal(signals: dict, name: str, *, value, weight: float, points: float, **extra) -> float:
+    signals[name] = {"value": value, "weight": weight, "points": round(points, 3), **extra}
+    return points
+
+
+def _score_player(
+    player_api_id: int,
+    context: dict,
+    window_end: date,
+    start_dt: datetime,
+    end_dt: datetime,
+    start_date: date,
+    window_days: int,
+    api_client,
+) -> tuple[float, dict]:
+    """Return (score, delta_json) for one player. Deterministic given DB state
+    (+ the prior pulse row for status/level/injury baselines)."""
+    all_rows = _windowed_rows(player_api_id, start_dt, end_dt)
+    club_api_id = context.get("current_club_api_id")
+    club_rows = [r for r in all_rows if club_api_id and int(r.team_api_id or 0) == int(club_api_id)]
+    window_all = _aggregate_rows(all_rows)
+    window_club = _aggregate_rows(club_rows)
+    before = _cumulative_before(player_api_id, start_dt)
+    prev = _previous_pulse(player_api_id, window_end)
+    prev_ctx = ((prev.delta_json or {}).get("context") if prev else None) or {}
+
+    signals: dict = {}
+    score = 0.0
+
+    # --- stat deltas (current club, mirrors compute_stats' team filter) --------
+    if window_club["goals"] > 0:
+        score += _add_signal(
+            signals,
+            "goals",
+            value=window_club["goals"],
+            weight=PULSE_WEIGHTS["goal"],
+            points=window_club["goals"] * PULSE_WEIGHTS["goal"],
+        )
+    if window_club["assists"] > 0:
+        score += _add_signal(
+            signals,
+            "assists",
+            value=window_club["assists"],
+            weight=PULSE_WEIGHTS["assist"],
+            points=window_club["assists"] * PULSE_WEIGHTS["assist"],
+        )
+    if window_club["appearances"] > 0:
+        score += _add_signal(
+            signals,
+            "appearances",
+            value=window_club["appearances"],
+            weight=PULSE_WEIGHTS["appearance"],
+            points=window_club["appearances"] * PULSE_WEIGHTS["appearance"],
+        )
+    if window_club["minutes"] > 0:
+        score += _add_signal(
+            signals,
+            "minutes",
+            value=window_club["minutes"],
+            weight=PULSE_WEIGHTS["minutes"],
+            points=window_club["minutes"] / 90.0 * PULSE_WEIGHTS["minutes"],
+        )
+
+    # --- milestones (career firsts, all teams) --------------------------------
+    # "Firsts" are inferred from FixturePlayerStats, which is PARTIAL coverage
+    # (top leagues only). A player whose earlier senior career lives elsewhere
+    # (PlayerStatsCache lower-league rows, or PlayerJourney career entries for a
+    # foreign / prior club) has _cumulative_before == 0 yet is no debutant, so a
+    # raw fire would fabricate a career-first that ships to every subscriber as
+    # an authorized claim. Only fire when the fuller career history POSITIVELY
+    # corroborates the first (FixturePlayerStats holds the player's ENTIRE senior
+    # history for that stat); absent a career record we stay silent.
+    maybe_debut = before["appearances"] == 0 and window_all["appearances"] > 0
+    maybe_first_goal = before["goals"] == 0 and window_all["goals"] > 0
+    maybe_first_start = before["starts"] == 0 and window_all["starts"] > 0
+    if maybe_debut or maybe_first_goal or maybe_first_start:
+        evidence = _senior_career_evidence(player_api_id)
+        fps_total_apps = before["appearances"] + window_all["appearances"]
+        fps_total_goals = before["goals"] + window_all["goals"]
+        apps_are_first = evidence["has_journey"] and evidence["apps"] <= fps_total_apps
+        goals_are_first = evidence["has_journey"] and evidence["goals"] <= fps_total_goals
+        if maybe_debut and apps_are_first:
+            score += _add_signal(
+                signals,
+                "milestone_debut",
+                value=True,
+                weight=PULSE_WEIGHTS["milestone_debut"],
+                points=PULSE_WEIGHTS["milestone_debut"],
+                label="Senior debut",
+            )
+        if maybe_first_goal and goals_are_first:
+            score += _add_signal(
+                signals,
+                "milestone_first_goal",
+                value=True,
+                weight=PULSE_WEIGHTS["milestone_first_goal"],
+                points=PULSE_WEIGHTS["milestone_first_goal"],
+                label="First senior goal",
+            )
+        # A first start requires full appearance coverage: if any senior
+        # appearance is unknown to FixturePlayerStats it may have been a start.
+        if maybe_first_start and apps_are_first:
+            score += _add_signal(
+                signals,
+                "milestone_first_start",
+                value=True,
+                weight=PULSE_WEIGHTS["milestone_first_start"],
+                points=PULSE_WEIGHTS["milestone_first_start"],
+                label="First senior start",
+            )
+
+    # --- status change (vs prior window) --------------------------------------
+    status = context.get("status")
+    prev_status = prev_ctx.get("status")
+    if status and prev_status and prev_status != status:
+        label = _STATUS_LABELS.get(status, f"Status changed to {status}")
+        score += _add_signal(
+            signals,
+            "status_change",
+            value=status,
+            weight=PULSE_WEIGHTS["status_change"],
+            points=PULSE_WEIGHTS["status_change"],
+            from_status=prev_status,
+            to_status=status,
+            label=label,
+        )
+
+    # --- level jump (vs prior window) -----------------------------------------
+    level = context.get("current_level")
+    prev_level = prev_ctx.get("current_level")
+    cur_rank = _LEVEL_RANK.get(level or "")
+    prev_rank = _LEVEL_RANK.get(prev_level or "")
+    if cur_rank and prev_rank and cur_rank > prev_rank:
+        score += _add_signal(
+            signals,
+            "milestone_level_jump",
+            value=level,
+            weight=PULSE_WEIGHTS["milestone_level_jump"],
+            points=PULSE_WEIGHTS["milestone_level_jump"],
+            from_level=prev_level,
+            to_level=level,
+            label=f"Stepped up from {prev_level} to {level}",
+        )
+
+    # --- per-90 spike vs own baseline -----------------------------------------
+    baseline_per90 = _involvement_per90(before["minutes"], before["goals"], before["assists"])
+    window_per90 = _window_per90_involvement(club_rows)
+    if (
+        window_club["minutes"] >= PER90_MIN_WINDOW_MINUTES
+        and before["minutes"] >= PER90_MIN_BASELINE_MINUTES
+        and baseline_per90 > 0
+        and window_per90 >= PER90_SPIKE_RATIO * baseline_per90
+    ):
+        score += _add_signal(
+            signals,
+            "per90_spike",
+            value=window_per90,
+            weight=PULSE_WEIGHTS["per90_spike"],
+            points=PULSE_WEIGHTS["per90_spike"],
+            baseline_per90=baseline_per90,
+            label="Form spike vs baseline",
+        )
+
+    # --- injury new / cleared (OPT-IN; bulk path passes api_client=None) -------
+    absences = _absence_count(api_client, player_api_id)
+    prev_absences = prev_ctx.get("absences")
+    if absences is not None and prev_absences is not None:
+        delta = absences - int(prev_absences or 0)
+        if delta > 0:
+            score += _add_signal(
+                signals,
+                "injury_new",
+                value=delta,
+                weight=PULSE_WEIGHTS["injury_new"],
+                points=PULSE_WEIGHTS["injury_new"],
+                label="New absence",
+            )
+        elif delta < 0:
+            score += _add_signal(
+                signals,
+                "injury_cleared",
+                value=-delta,
+                weight=PULSE_WEIGHTS["injury_cleared"],
+                points=PULSE_WEIGHTS["injury_cleared"],
+                label="Back from absence",
+            )
+
+    context_block = {
+        "name": context.get("name"),
+        "position": context.get("position"),
+        "parent_club": context.get("parent_club"),
+        "current_club": context.get("current_club"),
+        "status": status,
+        "current_level": level,
+        # Carried forward so the NEXT window can diff status/level/injuries.
+        "absences": absences,
+    }
+    delta_json = {
+        "window_start": start_date.isoformat(),
+        "window_end": window_end.isoformat(),
+        "window_days": window_days,
+        "signals": signals,
+        "window_totals": {
+            "appearances": window_club["appearances"],
+            "goals": window_club["goals"],
+            "assists": window_club["assists"],
+            "minutes": window_club["minutes"],
+            "starts": window_club["starts"],
+        },
+        "context": context_block,
+        "score": round(score, 2),
+    }
+    return round(score, 2), delta_json
+
+
+def _upsert_pulse(player_api_id: int, window_end: date, score: float, delta_json: dict) -> None:
+    existing = PlayerPulse.query.filter_by(player_api_id=player_api_id, window_end=window_end).first()
+    if existing is not None:
+        existing.score = score
+        existing.delta_json = delta_json
+    else:
+        db.session.add(
+            PlayerPulse(player_api_id=player_api_id, window_end=window_end, score=score, delta_json=delta_json)
+        )
+
+
+def compute_pulse(
+    window_end,
+    player_api_ids=None,
+    *,
+    api_client=None,
+    window_days: int | None = None,
+    dry_run: bool = False,
+) -> dict:
+    """Score followed players once for the window ending ``window_end``.
+
+    ``player_api_ids=None`` scores every player followed by anyone (legacy
+    watchlist + active follow lists, deduped). A passed iterable is a targeted
+    recompute. Each player is scored EXACTLY ONCE (deduped) and upserted into
+    ``player_pulse`` (idempotent: re-running the same window overwrites rows,
+    never duplicates). ``dry_run`` computes + previews without writing.
+
+    ``api_client`` is OPT-IN and defaults to None so the bulk path makes ZERO
+    live API calls (injury signals are simply absent). Returns counts + a
+    top-``10`` scored preview.
+    """
+    window_end = _coerce_window_end(window_end)
+    window_days = int(window_days) if window_days else DEFAULT_WINDOW_DAYS
+    start_dt, end_dt, start_date = _window_bounds(window_end, window_days)
+
+    if player_api_ids is None:
+        ids = _all_followed_player_ids()
+    else:
+        ids = {int(pid) for pid in player_api_ids}
+
+    results: list[dict] = []
+    considered = 0
+    scored = 0
+    upserted = 0
+    for player_api_id in sorted(ids):
+        context = _player_context(player_api_id)
+        if context is None:
+            continue
+        considered += 1
+        score, delta_json = _score_player(
+            player_api_id, context, window_end, start_dt, end_dt, start_date, window_days, api_client
+        )
+        if score > 0:
+            scored += 1
+        if not dry_run:
+            _upsert_pulse(player_api_id, window_end, score, delta_json)
+            upserted += 1
+        results.append(
+            {
+                "player_api_id": player_api_id,
+                "name": context.get("name"),
+                "score": score,
+                "signals": sorted(delta_json["signals"].keys()),
+            }
+        )
+
+    if not dry_run:
+        db.session.commit()
+
+    results.sort(key=lambda r: (-r["score"], r["player_api_id"]))
+    return {
+        "window_end": window_end.isoformat(),
+        "window_start": start_date.isoformat(),
+        "window_days": window_days,
+        "dry_run": dry_run,
+        "players_considered": considered,
+        "scored": scored,
+        "upserted": upserted,
+        "top": results[:_TOP_PREVIEW],
+    }

--- a/academy-watch-backend/src/services/scout_digest_service.py
+++ b/academy-watch-backend/src/services/scout_digest_service.py
@@ -100,6 +100,37 @@ def _shadow_stats(player_api_id: int) -> dict:
     return {"appearances": apps, "goals": goals, "assists": assists, "minutes_played": minutes}
 
 
+# Memo key (namespaced string so it never collides with the int player_api_id
+# keys _player_state stores in the same per-run cache dict).
+_PULSE_CARDS_KEY = "__pulse_cards__"
+
+
+def _pulse_cards_map(cache: dict) -> dict:
+    """{player_api_id: {card_html, card_text, model}} for the current window.
+
+    Reads player_card_service's shared render seam ONCE per run (memoised): the
+    latest cached window, then every card in it. Returns {} when no cards exist —
+    or when the pulse infra is absent (a test app that never registered the
+    tables / the service) — so the digest renders EXACTLY as it did before pulse
+    cards existed. A query failure rolls the session back so surrounding stat
+    queries stay usable.
+    """
+    if _PULSE_CARDS_KEY in cache:
+        return cache[_PULSE_CARDS_KEY]
+    cards: dict = {}
+    try:
+        from src.services.player_card_service import get_cards_for_window, latest_card_window
+
+        window = latest_card_window()
+        if window is not None:
+            cards = get_cards_for_window(window)
+    except Exception:
+        db.session.rollback()
+        cards = {}
+    cache[_PULSE_CARDS_KEY] = cards
+    return cards
+
+
 def _absence_count(api_client, player_api_id: int) -> int | None:
     """Best-effort season absence count; None when unavailable."""
     if api_client is None:
@@ -152,6 +183,10 @@ def _player_state(player_api_id: int, cache: dict, api_client=None) -> dict:
             }
         else:
             state = {"kind": "none", "tracked": None, "shadow": None, "stats": None, "absences": None}
+    # Shared per-window AI card (looked up from a once-per-run memoised map).
+    # Absent when no card exists for the current window — the digest then renders
+    # the legacy delta line.
+    state["pulse_card"] = _pulse_cards_map(cache).get(player_api_id)
     cache[player_api_id] = state
     return state
 
@@ -252,6 +287,14 @@ def _entry_update(entry, cache: dict, api_client=None) -> dict | None:
         "note": entry.note,
     }
 
+    # ADDITIVE: when a shared card exists for this player's current window, the
+    # provenance-clean card text supersedes the raw delta line. The keys are
+    # only ADDED when a card exists, so a card-less digest is byte-identical.
+    pulse_card = state.get("pulse_card")
+    if pulse_card:
+        card["pulse_html"] = pulse_card["card_html"]
+        card["pulse_text"] = pulse_card["card_text"]
+
     return {"entry": entry, "card": card, "snapshot": snapshot, "headlines": headlines}
 
 
@@ -260,9 +303,14 @@ def _card_text_lines(card: dict) -> list[str]:
     lines = [f"{card['player_name']} ({club_line or 'club unknown'}) [{card['status'] or 'worldwide'}]"]
     if card["headline"]:
         lines.append(f"  {card['headline']}")
-    lines.append(f"  {card['season_line']}")
-    if card["chips"]:
-        lines.append(f"  {', '.join(card['chips'])}")
+    # The shared card text supersedes the raw delta line when present; otherwise
+    # the season line + chips render exactly as before (byte-identical).
+    if card.get("pulse_text"):
+        lines.append(f"  {card['pulse_text']}")
+    else:
+        lines.append(f"  {card['season_line']}")
+        if card["chips"]:
+            lines.append(f"  {', '.join(card['chips'])}")
     lines.append(f"  {card['player_url']}")
     lines.append("")
     return lines

--- a/academy-watch-backend/src/templates/scout_digest_email.html
+++ b/academy-watch-backend/src/templates/scout_digest_email.html
@@ -218,6 +218,9 @@
                 {% if player.headline %}
                 <p class="player-headline">{{ player.headline }}</p>
                 {% endif %}
+                {%- if player.pulse_html %}
+                <div class="pulse-card">{{ player.pulse_html | safe }}</div>
+                {%- else %}
                 <p class="season-line">{{ player.season_line }}</p>
                 {% if player.chips %}
                 <div>
@@ -226,6 +229,7 @@
                   {% endfor %}
                 </div>
                 {% endif %}
+                {%- endif %}
                 {% if player.note %}
                 <p class="player-note">{{ player.note }}</p>
                 {% endif %}
@@ -250,6 +254,9 @@
                 {% if player.headline %}
                 <p class="player-headline">{{ player.headline }}</p>
                 {% endif %}
+                {%- if player.pulse_html %}
+                <div class="pulse-card">{{ player.pulse_html | safe }}</div>
+                {%- else %}
                 <p class="season-line">{{ player.season_line }}</p>
                 {% if player.chips %}
                 <div>
@@ -258,6 +265,7 @@
                   {% endfor %}
                 </div>
                 {% endif %}
+                {%- endif %}
                 {% if player.note %}
                 <p class="player-note">{{ player.note }}</p>
                 {% endif %}

--- a/academy-watch-backend/tests/test_player_cards.py
+++ b/academy-watch-backend/tests/test_player_cards.py
@@ -1,0 +1,221 @@
+"""Tests for player_card_service — the single cached LLM step.
+
+The LLM client is ALWAYS mocked (monkeypatch ``_generate_card_text`` by name);
+no live call ever runs. Covers: threshold + limit selection, cache reuse
+(second run generates 0), dry-run makes zero LLM calls and writes nothing, the
+prompt payload carries ONLY verified numbers from delta_json, Outlook-safe HTML,
+failure-skips-player, and the render-seam lookups.
+"""
+
+from datetime import date
+
+import pytest
+from flask import Flask
+from src.models.league import db
+from src.models.pulse import PlayerCardCache, PlayerPulse
+from src.services import player_card_service as cards
+
+WINDOW_END = date(2025, 9, 8)
+
+
+@pytest.fixture
+def app():
+    flask_app = Flask(__name__)
+    flask_app.config.update(
+        TESTING=True,
+        SECRET_KEY="test-secret-key",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+    db.init_app(flask_app)
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+        db.drop_all()
+
+
+def _add_pulse(pid, score, *, name="Player", goals=0, assists=0, apps=0, minutes=0, labels=(), window_end=WINDOW_END):
+    signals = {f"sig{i}": {"label": lbl, "value": True} for i, lbl in enumerate(labels)}
+    db.session.add(
+        PlayerPulse(
+            player_api_id=pid,
+            window_end=window_end,
+            score=score,
+            delta_json={
+                "window_start": "2025-09-02",
+                "window_end": window_end.isoformat(),
+                "window_days": 7,
+                "signals": signals,
+                "window_totals": {
+                    "goals": goals,
+                    "assists": assists,
+                    "appearances": apps,
+                    "minutes": minutes,
+                    "starts": 0,
+                },
+                "context": {
+                    "name": name,
+                    "position": "Attacker",
+                    "parent_club": "Man Utd",
+                    "current_club": "Rio FC",
+                    "status": "on_loan",
+                    "current_level": "Senior",
+                    "absences": None,
+                },
+                "score": score,
+            },
+        )
+    )
+    db.session.commit()
+
+
+def _mock_llm(monkeypatch, text="He bagged a brace and an assist.", *, raise_exc=False):
+    """Patch the ONE LLM function; return the list of payloads it was called with."""
+    calls = []
+
+    def fake(payload, model):
+        calls.append({"payload": payload, "model": model})
+        if raise_exc:
+            raise RuntimeError("boom")
+        return text
+
+    monkeypatch.setattr(cards, "_generate_card_text", fake)
+    return calls
+
+
+class TestSelection:
+    def test_only_above_threshold_generate(self, app, monkeypatch):
+        _add_pulse(1, 5.0)
+        _add_pulse(2, 2.0)  # below default 3.0
+        calls = _mock_llm(monkeypatch)
+        result = cards.generate_cards(WINDOW_END)
+        assert result["generated"] == 1
+        assert len(calls) == 1
+        assert {c.player_api_id for c in PlayerCardCache.query.all()} == {1}
+
+    def test_threshold_param_respected(self, app, monkeypatch):
+        _add_pulse(1, 5.0)
+        _add_pulse(2, 3.5)
+        _mock_llm(monkeypatch)
+        result = cards.generate_cards(WINDOW_END, threshold=4.0)
+        assert result["generated"] == 1
+        assert {c.player_api_id for c in PlayerCardCache.query.all()} == {1}
+
+    def test_limit_respected(self, app, monkeypatch):
+        for pid in (1, 2, 3):
+            _add_pulse(pid, 5.0 + pid)
+        calls = _mock_llm(monkeypatch)
+        result = cards.generate_cards(WINDOW_END, limit=2)
+        assert result["generated"] == 2
+        assert result["candidates_total"] == 3
+        assert len(result["candidates"]) == 2
+        assert len(calls) == 2
+        # Highest scores first (pid 3 then 2)
+        assert [c["payload"]["player"]["name"] for c in calls] == ["Player", "Player"]
+        assert {c.player_api_id for c in PlayerCardCache.query.all()} == {3, 2}
+
+
+class TestCacheReuse:
+    def test_second_run_generates_zero(self, app, monkeypatch):
+        _add_pulse(1, 5.0)
+        _add_pulse(2, 6.0)
+        _mock_llm(monkeypatch)
+        first = cards.generate_cards(WINDOW_END)
+        assert first["generated"] == 2
+
+        calls = _mock_llm(monkeypatch)
+        second = cards.generate_cards(WINDOW_END)
+        assert second["generated"] == 0
+        assert second["skipped_cached"] == 2
+        assert len(calls) == 0  # no LLM call on the reuse run
+        assert PlayerCardCache.query.count() == 2
+
+
+class TestDryRun:
+    def test_dry_run_no_llm_no_write(self, app, monkeypatch):
+        _add_pulse(1, 5.0)
+        _add_pulse(2, 6.0)
+        calls = _mock_llm(monkeypatch)
+        result = cards.generate_cards(WINDOW_END, dry_run=True)
+        assert result["dry_run"] is True
+        assert result["generated"] == 0
+        assert len(calls) == 0
+        assert PlayerCardCache.query.count() == 0
+        assert {c["player_api_id"] for c in result["candidates"]} == {1, 2}
+
+
+class TestProvenance:
+    def test_payload_contains_only_verified_numbers(self, app, monkeypatch):
+        _add_pulse(
+            1,
+            9.0,
+            name="Alfie Striker",
+            goals=3,
+            assists=1,
+            apps=2,
+            minutes=170,
+            labels=["First senior goal", "Promoted to first team"],
+        )
+        calls = _mock_llm(monkeypatch)
+        cards.generate_cards(WINDOW_END)
+        payload = calls[0]["payload"]
+        # Numbers come verbatim from delta_json window_totals
+        assert payload["stats"] == {"goals": 3, "assists": 1, "appearances": 2, "starts": 0, "minutes": 170}
+        assert payload["player"]["name"] == "Alfie Striker"
+        assert payload["highlights"] == ["First senior goal", "Promoted to first team"]
+        # Payload shape is closed — no free-text fields leak in
+        assert set(payload) == {"player", "window", "stats", "highlights"}
+
+
+class TestOutput:
+    def test_card_html_is_outlook_safe_and_escaped(self, app, monkeypatch):
+        _add_pulse(1, 5.0)
+        _mock_llm(monkeypatch, text="Goals & glory for the kid.")
+        cards.generate_cards(WINDOW_END)
+        row = PlayerCardCache.query.filter_by(player_api_id=1, window_end=WINDOW_END).one()
+        assert row.card_html == "<p>Goals &amp; glory for the kid.</p>"
+        assert row.card_text == "Goals & glory for the kid."
+        assert row.model == "openai/gpt-oss-120b"
+
+    def test_llm_output_trimmed_to_last_sentence(self, app, monkeypatch):
+        _add_pulse(1, 5.0)
+        _mock_llm(monkeypatch, text="A tidy brace. And a dangling frag")
+        cards.generate_cards(WINDOW_END)
+        row = PlayerCardCache.query.filter_by(player_api_id=1, window_end=WINDOW_END).one()
+        assert row.card_text == "A tidy brace."
+
+
+class TestFailureHandling:
+    def test_empty_output_skips_player(self, app, monkeypatch):
+        _add_pulse(1, 5.0)
+        _mock_llm(monkeypatch, text="   ")
+        result = cards.generate_cards(WINDOW_END)
+        assert result["generated"] == 0
+        assert result["failed"] == 1
+        assert PlayerCardCache.query.count() == 0
+
+    def test_exception_skips_player_no_cache_row(self, app, monkeypatch):
+        _add_pulse(1, 5.0)
+        _mock_llm(monkeypatch, raise_exc=True)
+        result = cards.generate_cards(WINDOW_END)
+        assert result["generated"] == 0
+        assert result["failed"] == 1
+        assert PlayerCardCache.query.count() == 0
+
+
+class TestRenderSeam:
+    def test_get_cards_for_window_and_latest(self, app, monkeypatch):
+        _add_pulse(1, 5.0)
+        _add_pulse(2, 6.0)
+        _mock_llm(monkeypatch, text="Solid week.")
+        cards.generate_cards(WINDOW_END)
+
+        assert cards.latest_card_window() == WINDOW_END
+        mapping = cards.get_cards_for_window(WINDOW_END)
+        assert set(mapping) == {1, 2}
+        assert mapping[1]["card_text"] == "Solid week."
+        assert mapping[1]["card_html"] == "<p>Solid week.</p>"
+        # Subset filter + empty list short-circuit
+        assert set(cards.get_cards_for_window(WINDOW_END, player_api_ids=[2])) == {2}
+        assert cards.get_cards_for_window(WINDOW_END, player_api_ids=[]) == {}

--- a/academy-watch-backend/tests/test_player_pulse.py
+++ b/academy-watch-backend/tests/test_player_pulse.py
@@ -1,0 +1,449 @@
+"""Tests for player_pulse_service — deterministic newsworthiness scoring.
+
+Covers: each signal contributes as documented (stat deltas, milestones, status
+change, level jump, per-90 spike, opt-in injuries), the total weighted sum,
+scoring determinism, upsert idempotence, dry-run writes nothing, the injury
+signal stays OFF unless an api_client is explicitly passed, and the followed-
+player enumeration dedups a player across watchlist + follow list.
+
+Exercises the service directly (no HTTP): the admin endpoints are Builder B's.
+"""
+
+from datetime import date, datetime
+
+import pytest
+from flask import Flask
+from src.models.follow import Follow, FollowList
+from src.models.journey import PlayerJourney, PlayerJourneyEntry
+from src.models.league import League, PlayerStatsCache, Team, db
+from src.models.pulse import PlayerPulse
+from src.models.scout_watchlist import ScoutWatchlistEntry
+from src.models.tracked_player import TrackedPlayer
+from src.models.weekly import Fixture, FixturePlayerStats
+from src.services import player_pulse_service as pulse
+
+WINDOW_END = date(2025, 9, 8)  # window covers 2025-09-02 .. 2025-09-08
+
+
+@pytest.fixture
+def app():
+    flask_app = Flask(__name__)
+    flask_app.config.update(
+        TESTING=True,
+        SECRET_KEY="test-secret-key",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+    db.init_app(flask_app)
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def seeded(app):
+    """A parent academy + loan club and a handful of tracked players with
+    fixtures shaped for each signal."""
+    league = League(league_id=39, name="Premier League", country="England", season=2025, is_european_top_league=True)
+    db.session.add(league)
+    db.session.flush()
+    parent = Team(team_id=33, name="Manchester United", country="England", season=2025, league_id=league.id)
+    loan_club = Team(team_id=901, name="Rio FC", country="Brazil", season=2025, league_id=league.id)
+    db.session.add_all([parent, loan_club])
+    db.session.flush()
+
+    # 1001: in-form loan striker (stat deltas + form spike, no milestones)
+    striker = TrackedPlayer(
+        player_api_id=1001,
+        player_name="Alfie Striker",
+        position="Attacker",
+        team_id=parent.id,
+        status="on_loan",
+        current_club_api_id=901,
+        current_club_name="Rio FC",
+        current_club_db_id=loan_club.id,
+        data_depth="full_stats",
+        is_active=True,
+    )
+    # 1003: keeper, first_team, no fixtures (used for status-change + injury tests)
+    keeper = TrackedPlayer(
+        player_api_id=1003,
+        player_name="Charlie Gloves",
+        position="Goalkeeper",
+        team_id=parent.id,
+        status="first_team",
+        data_depth="full_stats",
+        is_active=True,
+    )
+    db.session.add_all([striker, keeper])
+    db.session.flush()
+
+    # Baseline fixtures BEFORE the window for 1001 (so debut/first-goal never fire)
+    _add_stats(_fixture(datetime(2025, 8, 10), 901), 1001, 901, minutes=90, goals=1)
+    _add_stats(_fixture(datetime(2025, 8, 17), 901), 1001, 901, minutes=90, assists=1)
+    _add_stats(_fixture(datetime(2025, 8, 24), 901), 1001, 901, minutes=90)
+    # Window fixtures for 1001: 3 goals, 1 assist, 2 apps, 170 mins
+    _add_stats(_fixture(datetime(2025, 9, 3), 901), 1001, 901, minutes=90, goals=2, assists=1)
+    _add_stats(_fixture(datetime(2025, 9, 6), 901), 1001, 901, minutes=80, goals=1)
+    db.session.commit()
+    return {"parent": parent, "loan_club": loan_club}
+
+
+_FIXTURE_SEQ = [0]
+
+
+def _fixture(when: datetime, home_api_id: int) -> Fixture:
+    _FIXTURE_SEQ[0] += 1
+    fx = Fixture(fixture_id_api=_FIXTURE_SEQ[0], season=2025, home_team_api_id=home_api_id, date_utc=when)
+    db.session.add(fx)
+    db.session.flush()
+    return fx
+
+
+def _add_stats(fx, player_api_id, team_api_id, *, minutes=0, goals=0, assists=0, substitute=False):
+    db.session.add(
+        FixturePlayerStats(
+            fixture_id=fx.id,
+            player_api_id=player_api_id,
+            team_api_id=team_api_id,
+            minutes=minutes,
+            goals=goals,
+            assists=assists,
+            substitute=substitute,
+        )
+    )
+
+
+def _seed_prev_pulse(pid, context, window_end=date(2025, 9, 1), score=0.0):
+    db.session.add(
+        PlayerPulse(
+            player_api_id=pid,
+            window_end=window_end,
+            score=score,
+            delta_json={"context": context, "signals": {}, "window_totals": {}, "score": score},
+        )
+    )
+    db.session.commit()
+
+
+class _InjuryClient:
+    def __init__(self, count):
+        self._count = count
+
+    def get_player_injuries(self, player_id, season=None):
+        return [{"n": i} for i in range(self._count)]
+
+
+# --------------------------------------------------------------------------- #
+# Stat-delta signals + total weighted sum
+# --------------------------------------------------------------------------- #
+
+
+class TestStatDeltas:
+    def test_in_form_striker_scores_all_stat_signals(self, seeded):
+        result = pulse.compute_pulse(WINDOW_END, player_api_ids=[1001])
+        row = PlayerPulse.query.filter_by(player_api_id=1001, window_end=WINDOW_END).one()
+        signals = row.delta_json["signals"]
+        assert set(signals) == {"goals", "assists", "appearances", "minutes", "per90_spike"}
+        assert signals["goals"]["value"] == 3
+        assert signals["goals"]["points"] == 6.0
+        assert signals["assists"]["value"] == 1
+        assert signals["assists"]["points"] == 1.5
+        assert signals["appearances"]["value"] == 2
+        assert signals["minutes"]["value"] == 170
+        # 6.0 + 1.5 + 1.0 + (170/90*0.5) + 2.0 (spike) = 11.44
+        assert row.score == 11.44
+        assert result["scored"] == 1
+        assert result["top"][0]["player_api_id"] == 1001
+
+    def test_window_totals_and_context_are_provenance(self, seeded):
+        pulse.compute_pulse(WINDOW_END, player_api_ids=[1001])
+        row = PlayerPulse.query.filter_by(player_api_id=1001, window_end=WINDOW_END).one()
+        assert row.delta_json["window_totals"] == {
+            "appearances": 2,
+            "goals": 3,
+            "assists": 1,
+            "minutes": 170,
+            "starts": 2,
+        }
+        ctx = row.delta_json["context"]
+        assert ctx["name"] == "Alfie Striker"
+        assert ctx["status"] == "on_loan"
+        assert ctx["current_club"] == "Rio FC"
+
+    def test_quiet_player_scores_zero(self, seeded):
+        # keeper 1003 has no fixtures and no prior pulse → nothing fires
+        pulse.compute_pulse(WINDOW_END, player_api_ids=[1003])
+        row = PlayerPulse.query.filter_by(player_api_id=1003, window_end=WINDOW_END).one()
+        assert row.score == 0.0
+        assert row.delta_json["signals"] == {}
+
+
+# --------------------------------------------------------------------------- #
+# Milestones
+# --------------------------------------------------------------------------- #
+
+
+class TestMilestones:
+    def _add_newbie(self, seeded, player_api_id=1002):
+        newbie = TrackedPlayer(
+            player_api_id=player_api_id,
+            player_name="Debut Kid",
+            position="Midfielder",
+            team_id=seeded["parent"].id,
+            status="academy",
+            current_club_api_id=901,
+            current_club_name="Rio FC",
+            data_depth="full_stats",
+            is_active=True,
+        )
+        db.session.add(newbie)
+        db.session.flush()
+        _add_stats(_fixture(datetime(2025, 9, 3), 901), player_api_id, 901, minutes=90, goals=1, substitute=False)
+        db.session.commit()
+
+    def _add_journey(self, player_api_id, entries=()):
+        journey = PlayerJourney(player_api_id=player_api_id, player_name="Debut Kid")
+        db.session.add(journey)
+        db.session.flush()
+        for e in entries:
+            db.session.add(PlayerJourneyEntry(journey_id=journey.id, **e))
+        db.session.commit()
+        return journey
+
+    def test_debut_first_goal_first_start(self, seeded):
+        # Genuine academy debutant: journey exists and shows NO senior history
+        # (only youth apps), so the fuller-career check corroborates the firsts.
+        self._add_newbie(seeded)
+        self._add_journey(
+            1002,
+            entries=[
+                {
+                    "season": 2024,
+                    "club_api_id": 33,
+                    "level": "U21",
+                    "entry_type": "academy",
+                    "is_youth": True,
+                    "appearances": 20,
+                    "goals": 6,
+                }
+            ],
+        )
+
+        pulse.compute_pulse(WINDOW_END, player_api_ids=[1002])
+        signals = PlayerPulse.query.filter_by(player_api_id=1002, window_end=WINDOW_END).one().delta_json["signals"]
+        assert signals["milestone_debut"]["points"] == 4.0
+        assert signals["milestone_first_goal"]["points"] == 3.5
+        assert signals["milestone_first_start"]["points"] == 2.5
+
+    def test_no_milestone_without_career_corroboration(self, seeded):
+        # FixturePlayerStats-before is empty but there is NO career record to
+        # confirm this is a first (e.g. rollout ingestion) → stay silent rather
+        # than fabricate a debut/first-goal/first-start.
+        self._add_newbie(seeded, player_api_id=1010)
+        pulse.compute_pulse(WINDOW_END, player_api_ids=[1010])
+        signals = PlayerPulse.query.filter_by(player_api_id=1010, window_end=WINDOW_END).one().delta_json["signals"]
+        assert "milestone_debut" not in signals
+        assert "milestone_first_goal" not in signals
+        assert "milestone_first_start" not in signals
+
+    def test_no_debut_when_prior_senior_history_in_journey(self, seeded):
+        # 27-year-old signing into a covered league from an UNCOVERED one: no
+        # FixturePlayerStats before the window, but the journey shows a long
+        # senior career → no fabricated debut / first goal / first start.
+        self._add_newbie(seeded, player_api_id=1011)
+        self._add_journey(
+            1011,
+            entries=[
+                {
+                    "season": 2023,
+                    "club_api_id": 5000,
+                    "level": "First Team",
+                    "entry_type": "first_team",
+                    "is_youth": False,
+                    "appearances": 120,
+                    "goals": 40,
+                }
+            ],
+        )
+        pulse.compute_pulse(WINDOW_END, player_api_ids=[1011])
+        signals = PlayerPulse.query.filter_by(player_api_id=1011, window_end=WINDOW_END).one().delta_json["signals"]
+        assert "milestone_debut" not in signals
+        assert "milestone_first_goal" not in signals
+        assert "milestone_first_start" not in signals
+
+    def test_no_first_goal_when_prior_senior_goals_in_stats_cache(self, seeded):
+        # Prior senior goals live in PlayerStatsCache (lower-league coverage), so
+        # a covered-league goal this window is NOT his first senior goal. The
+        # debut is likewise suppressed (cache shows prior senior appearances).
+        self._add_newbie(seeded, player_api_id=1012)
+        self._add_journey(1012)  # journey present but sparse; cache carries history
+        db.session.add(PlayerStatsCache(player_api_id=1012, team_api_id=7000, season=2024, appearances=30, goals=9))
+        db.session.commit()
+        pulse.compute_pulse(WINDOW_END, player_api_ids=[1012])
+        signals = PlayerPulse.query.filter_by(player_api_id=1012, window_end=WINDOW_END).one().delta_json["signals"]
+        assert "milestone_first_goal" not in signals
+        assert "milestone_debut" not in signals
+
+    def test_no_debut_when_prior_appearances_exist(self, seeded):
+        # 1001 has August fixtures → no debut / first-goal milestone in the window
+        pulse.compute_pulse(WINDOW_END, player_api_ids=[1001])
+        signals = PlayerPulse.query.filter_by(player_api_id=1001, window_end=WINDOW_END).one().delta_json["signals"]
+        assert "milestone_debut" not in signals
+        assert "milestone_first_goal" not in signals
+
+
+# --------------------------------------------------------------------------- #
+# Status change + level jump (vs prior window)
+# --------------------------------------------------------------------------- #
+
+
+class TestStatusAndLevel:
+    def test_status_change_fires_against_prior_window(self, seeded):
+        _seed_prev_pulse(1003, {"status": "on_loan", "current_level": None})
+        pulse.compute_pulse(WINDOW_END, player_api_ids=[1003])
+        signals = PlayerPulse.query.filter_by(player_api_id=1003, window_end=WINDOW_END).one().delta_json["signals"]
+        assert signals["status_change"]["from_status"] == "on_loan"
+        assert signals["status_change"]["to_status"] == "first_team"
+        assert signals["status_change"]["label"] == "Promoted to first team"
+        assert signals["status_change"]["points"] == 3.5
+
+    def test_no_status_change_without_prior_window(self, seeded):
+        pulse.compute_pulse(WINDOW_END, player_api_ids=[1003])
+        signals = PlayerPulse.query.filter_by(player_api_id=1003, window_end=WINDOW_END).one().delta_json["signals"]
+        assert "status_change" not in signals
+
+    def test_level_jump_fires(self, seeded):
+        prospect = TrackedPlayer(
+            player_api_id=1004,
+            player_name="Riser",
+            position="Defender",
+            team_id=seeded["parent"].id,
+            status="academy",
+            current_level="Senior",
+            data_depth="full_stats",
+            is_active=True,
+        )
+        db.session.add(prospect)
+        db.session.commit()
+        _seed_prev_pulse(1004, {"status": "academy", "current_level": "U21"})
+        pulse.compute_pulse(WINDOW_END, player_api_ids=[1004])
+        signals = PlayerPulse.query.filter_by(player_api_id=1004, window_end=WINDOW_END).one().delta_json["signals"]
+        assert signals["milestone_level_jump"]["from_level"] == "U21"
+        assert signals["milestone_level_jump"]["to_level"] == "Senior"
+        assert signals["milestone_level_jump"]["points"] == 3.5
+
+    def test_journey_current_status_overrides_tracked_status(self, seeded):
+        db.session.add(PlayerJourney(player_api_id=1003, current_status="sold"))
+        db.session.commit()
+        pulse.compute_pulse(WINDOW_END, player_api_ids=[1003])
+        ctx = PlayerPulse.query.filter_by(player_api_id=1003, window_end=WINDOW_END).one().delta_json["context"]
+        assert ctx["status"] == "sold"
+
+
+# --------------------------------------------------------------------------- #
+# Per-90 spike
+# --------------------------------------------------------------------------- #
+
+
+class TestPer90Spike:
+    def test_spike_present_for_in_form_striker(self, seeded):
+        pulse.compute_pulse(WINDOW_END, player_api_ids=[1001])
+        signals = PlayerPulse.query.filter_by(player_api_id=1001, window_end=WINDOW_END).one().delta_json["signals"]
+        assert "per90_spike" in signals
+        assert signals["per90_spike"]["points"] == 2.0
+        assert signals["per90_spike"]["baseline_per90"] > 0
+
+    def test_no_spike_without_baseline_minutes(self, seeded):
+        # Fresh player with only window minutes → baseline below the gate
+        p = TrackedPlayer(
+            player_api_id=1006,
+            player_name="No Base",
+            position="Attacker",
+            team_id=seeded["parent"].id,
+            status="on_loan",
+            current_club_api_id=901,
+            current_club_name="Rio FC",
+            data_depth="full_stats",
+            is_active=True,
+        )
+        db.session.add(p)
+        db.session.flush()
+        _add_stats(_fixture(datetime(2025, 9, 4), 901), 1006, 901, minutes=90, goals=1)
+        db.session.commit()
+        pulse.compute_pulse(WINDOW_END, player_api_ids=[1006])
+        signals = PlayerPulse.query.filter_by(player_api_id=1006, window_end=WINDOW_END).one().delta_json["signals"]
+        assert "per90_spike" not in signals
+
+
+# --------------------------------------------------------------------------- #
+# Injury (opt-in only)
+# --------------------------------------------------------------------------- #
+
+
+class TestInjurySignal:
+    def test_injury_new_fires_with_client(self, seeded):
+        _seed_prev_pulse(1003, {"status": "first_team", "absences": 0})
+        pulse.compute_pulse(WINDOW_END, player_api_ids=[1003], api_client=_InjuryClient(2))
+        signals = PlayerPulse.query.filter_by(player_api_id=1003, window_end=WINDOW_END).one().delta_json["signals"]
+        assert signals["injury_new"]["value"] == 2
+        assert signals["injury_new"]["points"] == 1.5
+
+    def test_injury_cleared_fires_with_client(self, seeded):
+        _seed_prev_pulse(1003, {"status": "first_team", "absences": 3})
+        pulse.compute_pulse(WINDOW_END, player_api_ids=[1003], api_client=_InjuryClient(1))
+        signals = PlayerPulse.query.filter_by(player_api_id=1003, window_end=WINDOW_END).one().delta_json["signals"]
+        assert signals["injury_cleared"]["value"] == 2
+
+    def test_no_injury_signal_without_client(self, seeded):
+        # Even with a prior absence baseline, the bulk path (api_client=None)
+        # never calls the network and records no injury signal.
+        _seed_prev_pulse(1003, {"status": "first_team", "absences": 0})
+        pulse.compute_pulse(WINDOW_END, player_api_ids=[1003])
+        row = PlayerPulse.query.filter_by(player_api_id=1003, window_end=WINDOW_END).one()
+        assert "injury_new" not in row.delta_json["signals"]
+        assert row.delta_json["context"]["absences"] is None
+
+
+# --------------------------------------------------------------------------- #
+# Idempotence / determinism / dry-run / enumeration
+# --------------------------------------------------------------------------- #
+
+
+class TestUpsertAndRun:
+    def test_upsert_idempotent_and_deterministic(self, seeded):
+        first = pulse.compute_pulse(WINDOW_END, player_api_ids=[1001])
+        first_score = PlayerPulse.query.filter_by(player_api_id=1001, window_end=WINDOW_END).one().score
+        second = pulse.compute_pulse(WINDOW_END, player_api_ids=[1001])
+        rows = PlayerPulse.query.filter_by(player_api_id=1001, window_end=WINDOW_END).all()
+        assert len(rows) == 1  # upsert, not duplicate
+        assert rows[0].score == first_score  # deterministic
+        assert first["top"][0]["score"] == second["top"][0]["score"]
+
+    def test_dry_run_writes_nothing(self, seeded):
+        result = pulse.compute_pulse(WINDOW_END, player_api_ids=[1001], dry_run=True)
+        assert result["dry_run"] is True
+        assert result["upserted"] == 0
+        assert PlayerPulse.query.count() == 0
+        assert result["top"][0]["player_api_id"] == 1001  # preview still computed
+
+    def test_followed_ids_dedup_across_watchlist_and_list(self, seeded):
+        # 1001 followed twice (watchlist + a player-kind follow); 1003 via list.
+        db.session.add(ScoutWatchlistEntry(user_account_id=1, player_api_id=1001))
+        fl = FollowList(user_account_id=1, name="My List", is_active=True)
+        db.session.add(fl)
+        db.session.flush()
+        db.session.add_all(
+            [
+                Follow(list_id=fl.id, kind="player", selector={"player_api_id": 1001}),
+                Follow(list_id=fl.id, kind="player", selector={"player_api_id": 1003}),
+            ]
+        )
+        db.session.commit()
+
+        result = pulse.compute_pulse(WINDOW_END)  # player_api_ids=None → enumerate all
+        assert result["players_considered"] == 2  # 1001 counted once
+        assert PlayerPulse.query.filter_by(player_api_id=1001).count() == 1
+        assert PlayerPulse.query.filter_by(player_api_id=1003).count() == 1

--- a/academy-watch-backend/tests/test_pulse_digest_integration.py
+++ b/academy-watch-backend/tests/test_pulse_digest_integration.py
@@ -1,0 +1,482 @@
+"""Digest integration for player pulse + shared AI cards (Builder B).
+
+Two guarantees are load-bearing here:
+
+1. **Byte-identical legacy behaviour.** With empty ``player_pulse`` /
+   ``player_card_cache`` tables the rendered digest (HTML + text) is EXACTLY
+   what it was before pulse cards existed. Proven additively/reversibly: render
+   → insert a card → render → delete the card → render, and assert the first and
+   last renders are byte-identical while the middle one differs.
+2. **Additive card slot-in.** When a ``player_card_cache`` row exists for the
+   player's current window, the provenance-clean card supersedes the raw delta
+   line (season line + chips) in both the HTML and plaintext bodies.
+
+Plus the two admin ops endpoints (``/api/admin/pulse/compute`` and
+``/api/admin/pulse/generate-cards``): auth, validation, dry-run semantics
+(compute rolls back; generate-cards lists candidates with ZERO LLM calls), and
+threshold/limit passthrough. Builder A's services are treated as their contract
+signatures — ``compute_pulse(window_end, player_api_ids=None)`` and
+``generate_cards(window_end, threshold, limit)`` — and are stubbed here so no
+live scoring/LLM call ever runs (and the tests pass whether or not those service
+modules exist yet).
+"""
+
+import importlib
+import json
+import sys
+import types
+from datetime import date, datetime
+from pathlib import Path
+
+import pytest
+from flask import Flask
+from src.models.league import League, Team, db
+from src.models.pulse import PlayerCardCache, PlayerPulse  # registers the tables for create_all
+from src.models.scout_watchlist import ScoutWatchlistEntry
+from src.models.tracked_player import TrackedPlayer
+from src.models.weekly import Fixture, FixturePlayerStats
+
+ADMIN_KEY = "test-admin-key"
+WINDOW = date(2025, 9, 15)
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("SKIP_API_HANDSHAKE", "1")
+    monkeypatch.setenv("API_USE_STUB_DATA", "true")
+    monkeypatch.setenv("ADMIN_API_KEY", ADMIN_KEY)
+    monkeypatch.setenv("ADMIN_IP_WHITELIST", "")
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://example.com")
+
+    from src.routes.players import players_bp
+    from src.routes.scout import scout_bp
+
+    template_dir = Path(__file__).resolve().parent.parent / "src" / "templates"
+    flask_app = Flask(__name__, template_folder=str(template_dir))
+    flask_app.config.update(
+        TESTING=True,
+        SECRET_KEY="test-secret-key",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        RATELIMIT_ENABLED=False,
+    )
+    db.init_app(flask_app)
+    flask_app.register_blueprint(players_bp, url_prefix="/api")
+    flask_app.register_blueprint(scout_bp, url_prefix="/api")
+
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def seeded(app):
+    """Parent academy + loan club, one striker with two scored fixtures."""
+    league = League(league_id=39, name="Premier League", country="England", season=2025, is_european_top_league=True)
+    db.session.add(league)
+    db.session.flush()
+
+    parent = Team(
+        team_id=33, name="Manchester United", country="England", season=2025, league_id=league.id, is_active=True
+    )
+    loan_club = Team(team_id=901, name="Rio FC", country="Brazil", season=2025, league_id=league.id, is_active=True)
+    db.session.add_all([parent, loan_club])
+    db.session.flush()
+
+    striker = TrackedPlayer(
+        player_api_id=1001,
+        player_name="Alfie Striker",
+        position="Attacker",
+        nationality="England",
+        age=19,
+        team_id=parent.id,
+        status="on_loan",
+        current_club_api_id=901,
+        current_club_name="Rio FC",
+        current_club_db_id=loan_club.id,
+        data_depth="full_stats",
+        is_active=True,
+    )
+    keeper = TrackedPlayer(
+        player_api_id=1003,
+        player_name="Charlie Gloves",
+        position="Goalkeeper",
+        nationality="Japan",
+        age=18,
+        team_id=parent.id,
+        status="first_team",
+        data_depth="full_stats",
+        is_active=True,
+    )
+    db.session.add_all([striker, keeper])
+
+    fixtures = [
+        Fixture(
+            fixture_id_api=5000 + i,
+            season=2025,
+            home_team_api_id=901,
+            away_team_api_id=950 + i,
+            date_utc=datetime(2025, 9, 1 + 7 * i),
+        )
+        for i in range(2)
+    ]
+    db.session.add_all(fixtures)
+    db.session.flush()
+    db.session.add_all(
+        [
+            FixturePlayerStats(
+                fixture_id=fixtures[0].id,
+                player_api_id=1001,
+                team_api_id=901,
+                minutes=90,
+                goals=2,
+                assists=1,
+                rating=8.2,
+            ),
+            FixturePlayerStats(
+                fixture_id=fixtures[1].id,
+                player_api_id=1001,
+                team_api_id=901,
+                minutes=80,
+                goals=1,
+                assists=0,
+                rating=7.0,
+            ),
+        ]
+    )
+    db.session.commit()
+    return {"parent": parent, "loan_club": loan_club}
+
+
+def _make_user(email):
+    from src.auth import _ensure_user_account
+
+    user = _ensure_user_account(email)
+    db.session.commit()
+    return user
+
+
+def _watchlist_user(email="wl@example.com", player_api_id=1001, note="watch this", snapshot=True):
+    user = _make_user(email)
+    last_snapshot = None
+    if snapshot:
+        last_snapshot = json.dumps(
+            {"appearances": 1, "goals": 1, "assists": 0, "minutes_played": 90, "status": "on_loan", "absences": 0}
+        )
+    entry = ScoutWatchlistEntry(
+        user_account_id=user.id, player_api_id=player_api_id, note=note, last_snapshot=last_snapshot
+    )
+    db.session.add(entry)
+    db.session.commit()
+    return user
+
+
+def _render(user):
+    from src.services.scout_digest_service import build_user_digest
+
+    entries = ScoutWatchlistEntry.query.filter_by(user_account_id=user.id).all()
+    return build_user_digest(user, entries, api_client=None)
+
+
+def _add_card(player_api_id=1001, window=WINDOW, html=None, text=None):
+    db.session.add(PlayerPulse(player_api_id=player_api_id, window_end=window, score=7.5, delta_json={"goals": 3}))
+    db.session.add(
+        PlayerCardCache(
+            player_api_id=player_api_id,
+            window_end=window,
+            card_html=html or "<p><strong>Alfie Striker</strong> scored 3 goals across 2 apps this week.</p>",
+            card_text=text or "Alfie Striker scored 3 goals across 2 apps this week.",
+            model="test-model",
+        )
+    )
+    db.session.commit()
+
+
+def _admin_headers():
+    from src.auth import issue_user_token
+
+    token = issue_user_token("admin@example.com", role="admin")["token"]
+    return {"Authorization": f"Bearer {token}", "X-API-Key": ADMIN_KEY}
+
+
+def _install_service(monkeypatch, module_name, **fns):
+    """Bind stub functions on Builder A's service module — importing it if it
+    already exists, otherwise registering a fake module (so these tests pass
+    before those service files land). All changes are undone by monkeypatch."""
+    try:
+        mod = importlib.import_module(module_name)
+        created = False
+    except ModuleNotFoundError:
+        mod = types.ModuleType(module_name)
+        created = True
+    for key, value in fns.items():
+        monkeypatch.setattr(mod, key, value, raising=False)
+    if created:
+        monkeypatch.setitem(sys.modules, module_name, mod)
+        parent_name, _, child = module_name.rpartition(".")
+        parent = importlib.import_module(parent_name)
+        monkeypatch.setattr(parent, child, mod, raising=False)
+    return mod
+
+
+# --------------------------------------------------------------------------- #
+# Byte-identical regression + additive card slot-in
+# --------------------------------------------------------------------------- #
+
+
+class TestDigestByteIdentical:
+    def test_empty_pulse_tables_are_additive_and_reversible(self, app, seeded):
+        """The load-bearing invariant: with no card row the digest is unchanged,
+        and adding then removing a card restores byte-identical output."""
+        user = _watchlist_user()
+
+        before = _render(user)
+        assert PlayerCardCache.query.count() == 0
+        assert 'class="season-line"' in before["html"]
+        assert "pulse-card" not in before["html"]
+
+        _add_card()
+        with_card = _render(user)
+        assert with_card["html"] != before["html"]
+        assert "pulse-card" in with_card["html"]
+
+        PlayerPulse.query.delete()
+        PlayerCardCache.query.delete()
+        db.session.commit()
+        after = _render(user)
+
+        assert after["html"] == before["html"]  # byte-identical HTML
+        assert after["text"] == before["text"]  # byte-identical plaintext
+
+    def test_two_identical_watchlists_render_identically_when_empty(self, app, seeded):
+        """Direct analog of the follow-graph a_html == b_html regression."""
+        user_a = _watchlist_user("a@example.com")
+        user_b = _watchlist_user("b@example.com")
+        assert _render(user_a)["html"] == _render(user_b)["html"]
+
+    def test_card_supersedes_delta_line_in_html_and_text(self, app, seeded):
+        user = _watchlist_user()
+        _add_card()
+        digest = _render(user)
+
+        # HTML: the card fragment renders; the raw delta line is gone.
+        assert "pulse-card" in digest["html"]
+        assert "scored 3 goals across 2 apps this week" in digest["html"]
+        assert 'class="season-line"' not in digest["html"]
+        assert 'class="chip"' not in digest["html"]
+        # Note (unrelated to the delta line) is still rendered — purely additive.
+        assert "watch this" in digest["html"]
+
+        # Plaintext: card text replaces the "2 apps · 3 goals ..." delta line.
+        assert "Alfie Striker scored 3 goals across 2 apps this week." in digest["text"]
+        assert "2 apps · 3 goals" not in digest["text"]
+
+    def test_card_for_other_window_is_ignored(self, app, seeded):
+        """A card row for a different window than the current one must not leak
+        into the digest (the current window is the latest cached window)."""
+        user = _watchlist_user()
+        # Only a stale-window card exists -> current window is that window, but the
+        # player's row IS at that window, so add a card at a DIFFERENT player to
+        # advance the window without giving THIS player a current-window card.
+        _add_card(player_api_id=1003, window=date(2025, 10, 1))
+        digest = _render(user)
+        # Current window = 2025-10-01 (latest). Player 1001 has no card there.
+        assert "pulse-card" not in digest["html"]
+        assert 'class="season-line"' in digest["html"]
+
+
+# --------------------------------------------------------------------------- #
+# Card rendering through the real send path
+# --------------------------------------------------------------------------- #
+
+
+class TestSendDigestPath:
+    def test_admin_send_digests_renders_card(self, app, client, seeded):
+        _watchlist_user()
+        _add_card()
+        resp = client.post("/api/scout/admin/send-digests", json={"dry_run": True}, headers=_admin_headers())
+        assert resp.status_code == 200
+        preview = resp.get_json()["previews"][0]
+        assert "pulse-card" in preview["html"]
+        assert "scored 3 goals across 2 apps this week" in preview["html"]
+        assert 'class="season-line"' not in preview["html"]
+
+
+# --------------------------------------------------------------------------- #
+# Admin op: /api/admin/pulse/compute
+# --------------------------------------------------------------------------- #
+
+
+class TestPulseCompute:
+    """The endpoint delegates persistence + dry_run to compute_pulse and passes
+    the service's result (counts + top preview) straight through."""
+
+    def test_requires_admin(self, client, seeded):
+        assert client.post("/api/admin/pulse/compute", json={}).status_code == 401
+
+    def test_bad_window_end_400(self, client, seeded):
+        resp = client.post("/api/admin/pulse/compute", json={"window_end": "not-a-date"}, headers=_admin_headers())
+        assert resp.status_code == 400
+
+    def test_bad_dry_run_400(self, client, seeded):
+        resp = client.post("/api/admin/pulse/compute", json={"dry_run": "yes"}, headers=_admin_headers())
+        assert resp.status_code == 400
+
+    def _stub_compute(self):
+        def compute_pulse(window_end, player_api_ids=None, *, dry_run=False, **kwargs):
+            top = [
+                {"player_api_id": 1001, "name": "Alfie Striker", "score": 9.0, "signals": ["goals"]},
+                {"player_api_id": 1003, "name": "Charlie Gloves", "score": 4.0, "signals": ["minutes"]},
+            ]
+            if not dry_run:  # real runs own their persistence (upsert + commit)
+                db.session.add_all(
+                    [
+                        PlayerPulse(player_api_id=1001, window_end=window_end, score=9.0, delta_json={"goals": 3}),
+                        PlayerPulse(player_api_id=1003, window_end=window_end, score=4.0, delta_json={"minutes": 200}),
+                    ]
+                )
+                db.session.commit()
+            return {
+                "window_end": window_end.isoformat(),
+                "players_considered": 2,
+                "scored": 2,
+                "upserted": 0 if dry_run else 2,
+                "dry_run": dry_run,
+                "top": top,
+            }
+
+        return compute_pulse
+
+    def test_dry_run_previews_without_writing(self, client, seeded, monkeypatch):
+        _install_service(monkeypatch, "src.services.player_pulse_service", compute_pulse=self._stub_compute())
+        resp = client.post(
+            "/api/admin/pulse/compute",
+            json={"window_end": WINDOW.isoformat(), "dry_run": True},
+            headers=_admin_headers(),
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["dry_run"] is True and data["applied"] is False
+        assert data["scored"] == 2
+        assert [p["player_api_id"] for p in data["top"]] == [1001, 1003]  # score-DESC preview
+        assert PlayerPulse.query.count() == 0  # nothing persisted
+
+    def test_real_run_persists(self, client, seeded, monkeypatch):
+        _install_service(monkeypatch, "src.services.player_pulse_service", compute_pulse=self._stub_compute())
+        resp = client.post(
+            "/api/admin/pulse/compute",
+            json={"window_end": WINDOW.isoformat(), "dry_run": False},
+            headers=_admin_headers(),
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["applied"] is True
+        assert PlayerPulse.query.filter_by(window_end=WINDOW).count() == 2
+
+    def test_delegates_dry_run_and_default_window_to_service(self, client, seeded, monkeypatch):
+        received = {}
+
+        def compute_pulse(window_end, player_api_ids=None, *, dry_run=False, **kwargs):
+            received["dry_run"] = dry_run
+            received["window_end"] = window_end
+            return {"scored": 0, "top": []}
+
+        _install_service(monkeypatch, "src.services.player_pulse_service", compute_pulse=compute_pulse)
+        resp = client.post("/api/admin/pulse/compute", json={"dry_run": True}, headers=_admin_headers())
+        assert resp.get_json()["window_end"] == date.today().isoformat()
+        assert received["dry_run"] is True
+        assert received["window_end"] == date.today()  # default window
+
+
+# --------------------------------------------------------------------------- #
+# Admin op: /api/admin/pulse/generate-cards
+# --------------------------------------------------------------------------- #
+
+
+class TestGenerateCards:
+    """The endpoint validates threshold/limit, then delegates the LLM step +
+    dry_run to generate_cards and passes its result straight through."""
+
+    def _seed_pulse(self):
+        # Two above the default 3.0 threshold, one below.
+        db.session.add_all(
+            [
+                PlayerPulse(player_api_id=1001, window_end=WINDOW, score=9.0, delta_json={"goals": 3}),
+                PlayerPulse(player_api_id=1003, window_end=WINDOW, score=4.0, delta_json={"assists": 2}),
+                PlayerPulse(player_api_id=1007, window_end=WINDOW, score=1.0, delta_json={"minutes": 30}),
+            ]
+        )
+        db.session.commit()
+
+    def test_requires_admin(self, client, seeded):
+        assert client.post("/api/admin/pulse/generate-cards", json={}).status_code == 401
+
+    def test_bad_threshold_400(self, client, seeded):
+        resp = client.post("/api/admin/pulse/generate-cards", json={"threshold": "high"}, headers=_admin_headers())
+        assert resp.status_code == 400
+
+    def test_bad_limit_400(self, client, seeded):
+        resp = client.post("/api/admin/pulse/generate-cards", json={"limit": 0}, headers=_admin_headers())
+        assert resp.status_code == 400
+
+    def test_real_seam_dry_run_lists_candidates_no_llm(self, client, seeded):
+        """No stub — hits Builder A's real generate_cards dry_run path (pure
+        queries, ZERO LLM calls, writes nothing)."""
+        self._seed_pulse()
+        db.session.add(
+            PlayerCardCache(player_api_id=1003, window_end=WINDOW, card_html="<p>x</p>", card_text="x", model="m")
+        )
+        db.session.commit()
+        resp = client.post(
+            "/api/admin/pulse/generate-cards",
+            json={"window_end": WINDOW.isoformat(), "dry_run": True},
+            headers=_admin_headers(),
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["dry_run"] is True and data["applied"] is False
+        assert data["generated"] == 0
+        assert data["skipped_cached"] == 1  # 1003 already cached
+        assert [c["player_api_id"] for c in data["candidates"]] == [1001]  # 1007 below threshold
+        assert PlayerCardCache.query.count() == 1  # nothing new written
+
+    def test_delegates_args_and_dry_run(self, client, seeded, monkeypatch):
+        received = {}
+
+        def generate_cards(window_end, threshold=None, limit=None, *, dry_run=False):
+            received["args"] = (window_end, threshold, limit, dry_run)
+            return {"generated": 2, "skipped_cached": 0, "candidates": []}
+
+        _install_service(monkeypatch, "src.services.player_card_service", generate_cards=generate_cards)
+        resp = client.post(
+            "/api/admin/pulse/generate-cards",
+            json={"window_end": WINDOW.isoformat(), "threshold": 5.0, "limit": 7, "dry_run": False},
+            headers=_admin_headers(),
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["generated"] == 2 and data["applied"] is True
+        assert received["args"] == (WINDOW, 5.0, 7, False)
+
+    def test_limit_capped_before_service(self, client, seeded, monkeypatch):
+        received = {}
+
+        def generate_cards(window_end, threshold=None, limit=None, *, dry_run=False):
+            received["limit"] = limit
+            return {"generated": 0, "skipped_cached": 0, "candidates": []}
+
+        _install_service(monkeypatch, "src.services.player_card_service", generate_cards=generate_cards)
+        client.post(
+            "/api/admin/pulse/generate-cards",
+            json={"window_end": WINDOW.isoformat(), "limit": 100000, "dry_run": False},
+            headers=_admin_headers(),
+        )
+        from src.routes.scout import MAX_PULSE_CARD_LIMIT
+
+        assert received["limit"] == MAX_PULSE_CARD_LIMIT  # sanity cap applied


### PR DESCRIPTION
## What

Phase 2 of the talent-platform plan (`ledgers/research/talent-platform/panel-grouping.md` §b,c): **editorial-quality personalized digests at flat LLM cost**. Expensive per-player content is computed/generated once and shared; per-user assembly stays deterministic. LLM cost scales with the ~3.4k-player content universe, never with audience size.

- **`player_pulse` + `player_card_cache`** (migration `aw22`, chained off `aw21`, guarded DDL) — pulse rows carry a deterministic newsworthiness score plus `delta_json` provenance for every contributing signal.
- **`player_pulse_service`** — no LLM: stat deltas, status changes, milestones, injury new/cleared, per-90 spikes; each followed player computed once per window; idempotent upserts. **Honesty gate:** career-first milestones (debut / first senior goal / first start) fire only when `PlayerJourney` + `PlayerStatsCache` positively corroborate them — partial `FixturePlayerStats` coverage can never mint a false "senior debut" claim.
- **`player_card_service`** — the only LLM step: 2–3 sentence cards once per (player, window) above `PULSE_CARD_THRESHOLD`, cached and reused by every recipient; the prompt receives only verified numbers from the pulse payload; lazy client init; `PULSE_CARD_LIMIT` cap.
- **Digest integration is strictly additive** at the `build_user_digest` seam: cached cards render when present; with empty pulse tables the digest output is **byte-identical** (regression-tested).
- **Admin ops endpoints** (until the Phase-3 scheduler): `POST /api/admin/pulse/compute` and `/generate-cards`, both `dry_run`-capable — dry runs proven side-effect-free (0 LLM calls, 0 writes, verified by mocking both client import points).

## Verification

- 45 new tests; **114 total pass** including the 59-video-test and 10-analytics canaries; existing scout suites (69) green.
- Built by a scout → dual-builders → verify → adversarial-review → fix Opus workflow. Review confirmed 1 major (the milestone-fabrication honesty bug) — fixed with corroboration gating + 3 regression tests.
- Import-safety proven: no `groq`/`openai` in `sys.modules` after importing the new services; the generate path is unreachable without an explicit admin POST with `dry_run=false`.

## Deploy notes

- After merge: `flask db upgrade` to `aw22` on prod (two new tables; additive). Cards remain inert until an admin runs compute + generate-cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBNsWRHccFp44PzYUiukhd