### PR TITLE
fix(admin): unreachable API-key management + silent 403s on stale keys

### DIFF
--- a/academy-watch-frontend/src/components/layouts/AdminLayout.jsx
+++ b/academy-watch-frontend/src/components/layouts/AdminLayout.jsx
@@ -1,5 +1,5 @@
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Outlet } from 'react-router-dom'
 import { Navigate } from 'react-router-dom'
 import { AlertCircle, KeyRound, Menu, PanelLeftClose, PanelLeftOpen } from 'lucide-react'
@@ -31,11 +31,48 @@ export function AdminLayout() {
     const [keyInput, setKeyInput] = useState('')
     const [validatingKey, setValidatingKey] = useState(false)
     const [keyError, setKeyError] = useState(null)
+    // A stored key that the server rejects should not silently 403 every admin
+    // page — surface the key-entry screen (below) instead. Tracks the last key
+    // value we verified so we validate a given key only once per session.
+    const [keyRejected, setKeyRejected] = useState(false)
+    const validatedKeyRef = useRef(null)
 
     useEffect(() => {
         if (typeof localStorage === 'undefined') return
         localStorage.setItem(SIDEBAR_COLLAPSE_KEY, collapsed ? 'true' : 'false')
     }, [collapsed])
+
+    // Verify the stored admin key when entering the admin section. Presence of a
+    // key is not proof it is correct, so without this a stale/wrong key would let
+    // every page load and then 403 with no affordance to replace it. Only an
+    // explicit 401/403 flags the key invalid; transient/5xx failures are ignored
+    // so a backend blip never locks an admin out.
+    useEffect(() => {
+        if (!token || !isAdmin || !hasApiKey) return
+        const currentKey = APIService.adminKey
+        if (!currentKey || validatedKeyRef.current === currentKey) return
+        let cancelled = false
+        const verify = async () => {
+            try {
+                await APIService.validateAdminCredentials()
+                if (cancelled) return
+                validatedKeyRef.current = currentKey
+                setKeyRejected(false)
+            } catch (error) {
+                if (cancelled) return
+                if (error?.status === 401 || error?.status === 403) {
+                    validatedKeyRef.current = currentKey
+                    const baseError = error?.body?.error || error?.message || 'Access denied'
+                    setKeyError(`Stored admin key was rejected: ${baseError}. Paste a valid key to continue.`)
+                    setKeyRejected(true)
+                }
+            }
+        }
+        verify()
+        return () => {
+            cancelled = true
+        }
+    }, [token, isAdmin, hasApiKey])
 
     useEffect(() => {
         const closeOnResize = () => {
@@ -67,8 +104,12 @@ export function AdminLayout() {
         try {
             await APIService.validateAdminCredentials()
             setKeyInput('')
+            setKeyError(null)
+            setKeyRejected(false)
+            validatedKeyRef.current = trimmed
         } catch (error) {
             APIService.setAdminKey('')
+            validatedKeyRef.current = null
             const baseError = error?.body?.error || error?.message || 'Key rejected by server'
             const detail = error?.body?.detail || ''
             setKeyError(`Admin key not accepted: ${baseError}${detail ? ` — ${detail}` : ''}`)
@@ -77,7 +118,7 @@ export function AdminLayout() {
         }
     }
 
-    if (!hasApiKey || validatingKey) {
+    if (!hasApiKey || validatingKey || keyRejected) {
         return (
             <div className="min-h-screen bg-secondary flex items-center justify-center p-4">
                 <Card className="w-full max-w-md" data-testid="admin-api-key-bootstrap">
@@ -87,8 +128,9 @@ export function AdminLayout() {
                             Enter admin API key
                         </CardTitle>
                         <CardDescription>
-                            You are signed in as an admin, but no admin API key is stored on this
-                            device. It is kept in local storage and only sent with admin requests.
+                            {keyRejected
+                                ? 'The admin API key stored on this device was rejected by the server. Paste a current key to continue — it is kept in local storage and only sent with admin requests.'
+                                : 'You are signed in as an admin, but no admin API key is stored on this device. It is kept in local storage and only sent with admin requests.'}
                         </CardDescription>
                     </CardHeader>
                     <CardContent>

--- a/academy-watch-frontend/src/pages/admin/AdminSettings.jsx
+++ b/academy-watch-frontend/src/pages/admin/AdminSettings.jsx
@@ -9,8 +9,8 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import { KeyRound, LogIn, AlertCircle, CheckCircle2 } from 'lucide-react'
 
 export function AdminSettings() {
-    const { authToken, logout } = useAuth()
-    const { openLoginModal } = useAuthUI()
+    const { token } = useAuth()
+    const { openLoginModal, logout } = useAuthUI()
 
     // API Key state
     const [adminKey, setAdminKey] = useState(APIService.adminKey || '')
@@ -31,7 +31,7 @@ export function AdminSettings() {
     // Message state
     const [message, setMessage] = useState(null)
 
-    const hasAdminToken = Boolean(authToken && APIService.isAdmin())
+    const hasAdminToken = Boolean(token && APIService.isAdmin())
     const hasStoredKey = Boolean(adminKey)
     const adminReady = hasAdminToken && hasStoredKey
 
@@ -199,7 +199,7 @@ export function AdminSettings() {
                     {!adminReady && (
                         <div className="flex flex-wrap gap-2 pt-2">
                             {!hasAdminToken ? (
-                                authToken ? (
+                                token ? (
                                     <Button
                                         size="sm"
                                         variant="outline"


### PR DESCRIPTION
## The bug (reported by MJ, reproduced live)

A stale/wrong admin API key in localStorage (left by Playwright E2E state) made every admin page 403 "Invalid admin credential" — and there was **no reachable UI to replace the key**, even after logging out and re-authenticating.

## Root causes (file:line verified)

1. **`AdminSettings.jsx` destructured fields that don't exist**: `authToken`/`logout` from `useAuth()`, which exposes `token` (AuthContext.jsx:5) — `logout` lives on `useAuthUI()`. So `hasAdminToken` was **always false** and the API-key management card (Replace/Clear, gated at line 229) could never render — for anyone, ever.
2. **`AdminLayout.jsx` equated key presence with key validity**: the key-entry bootstrap screen only appeared when NO key was stored. A stored-but-rejected key passed straight through to a fully 403-poisoned admin section with no affordance to fix it.

## The fix

- AdminSettings reads `token` from `useAuth()` and `logout` from `useAuthUI()` — the key card now actually renders for signed-in admins.
- AdminLayout verifies the stored key on entering the admin section (once per key value, via the existing `validateAdminCredentials()`); an explicit 401/403 routes to the existing key-entry screen with a "stored key was rejected" message. Transient/5xx errors are deliberately ignored so a backend blip can't lock an admin out.

## Verification

- eslint 0 errors on both files; `pnpm build` green.
- Backend auth semantics reproduced live (Bearer-only → 401, Bearer+wrong key → 403 "Invalid admin credential", Bearer+correct key → 200) — unchanged by this PR (frontend-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBNsWRHccFp44PzYUiukhd