### PR TITLE
docs(harness): lean CLAUDE.md router + docs/agents playbooks + CI-mirroring hooks

### DIFF
--- a/.claude/hooks/lint_on_edit.sh
+++ b/.claude/hooks/lint_on_edit.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# PostToolUse(Edit|Write) — auto-fix lint AND format at edit time so drift is fixed
+# here, not at CI time. Mirrors both CI lint gates:
+#   backend  — `ruff check academy-watch-backend` + `ruff format --check academy-watch-backend`
+#   frontend — `pnpm lint` (eslint flat config) in academy-watch-frontend
+# Ruff is not in the .loan venv, so it uses the system `ruff` (as CI does). Always exit 0.
+# Sharp edge: `ruff check --fix` strips imports with no call site yet — add the import and
+# its first usage in the SAME edit (docs/agents/backend.md).
+
+FILE=$(jq -r '.tool_input.file_path // .tool_input.filePath // empty' 2>/dev/null)
+[ -n "$FILE" ] && [ -f "$FILE" ] || exit 0
+
+case "$FILE" in
+  # --- Backend Python: mirror `ruff check` + `ruff format --check` ---
+  *academy-watch-backend/*.py)
+    RUFF="$CLAUDE_PROJECT_DIR/.loan/bin/ruff"
+    [ -x "$RUFF" ] || RUFF=ruff
+    cd "$CLAUDE_PROJECT_DIR" || exit 0
+    "$RUFF" check --fix --quiet "$FILE" 2>/dev/null
+    "$RUFF" format --quiet "$FILE" 2>/dev/null
+    ;;
+
+  # --- Frontend JS/JSX/TS/TSX: mirror `pnpm lint` (eslint flat config) ---
+  *academy-watch-frontend/*.js|*academy-watch-frontend/*.jsx|*academy-watch-frontend/*.ts|*academy-watch-frontend/*.tsx)
+    cd "$CLAUDE_PROJECT_DIR/academy-watch-frontend" || exit 0
+    npx --no-install eslint --fix --quiet "$FILE" 2>/dev/null
+    ;;
+esac
+exit 0

--- a/.claude/hooks/migration_rls_reminder.sh
+++ b/.claude/hooks/migration_rls_reminder.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# PostToolUse(Edit|Write) — remind about the code↔deploy coupling on Alembic migrations:
+# the Deploy workflow's security-checks job FAILS the deploy if any new public table lacks
+# Row Level Security, and prod schema has drifted out-of-band so all DDL must be guarded.
+# Fires only when a migration version file is touched. See docs/agents/invariants.md §2, §8.
+
+FILE=$(jq -r '.tool_input.file_path // .tool_input.filePath // empty' 2>/dev/null)
+case "$FILE" in
+  *academy-watch-backend/migrations/versions/*.py)
+    cat <<'EOF'
+{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"REMINDER (hook): you edited an Alembic migration. (1) If it CREATE TABLEs in the public schema, add `ALTER TABLE <t> ENABLE ROW LEVEL SECURITY;` in the SAME migration — the Deploy security-checks job fails the deploy otherwise (invariants.md §2). (2) Guard every DDL with migrations/_migration_helpers.py (column_exists/table_exists) — prod schema drifted out-of-band, unguarded DDL crashes `flask db upgrade` on deploy (invariants.md §8). (3) Branch from the real tip: check `alembic heads` first."}}
+EOF
+    ;;
+esac
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/lint_on_edit.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/migration_rls_reminder.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,222 +1,66 @@
-# CLAUDE.md
+# The Academy Watch
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Football (soccer) academy-tracking platform: it follows academy players out on loan,
+syncs their career/stats from API-Football, and generates AI newsletters that
+journalists add commentary to. Monorepo — a Flask backend (`academy-watch-backend/`)
+serving a React/Vite SPA (`academy-watch-frontend/`), both deployed to Azure off a
+single Supabase Postgres. The load-bearing fact: the whole domain hangs off
+**`TrackedPlayer`** (one row per player per parent academy club) and the **journey
+sync** that classifies each player's pathway status — get those wrong and every
+page lies.
 
-## Project Overview
+## How to use this file
 
-**The Academy Watch** is a football (soccer) academy tracking platform that monitors academy players on loan, generates AI-powered newsletters, and enables journalists to write content about loaned players. It integrates with API-Football for player/fixture data, Stripe for payments, Mailgun for email delivery, and Reddit for social posting.
+This file is a router, not the manual. Deep context lives in `docs/agents/` —
+each doc encodes hard-won lessons, and skipping them repeats old mistakes.
+**Read the matching doc BEFORE starting work in its area:**
 
-## Development Commands
+| When you are... | Read first |
+|---|---|
+| Touching player tracking, journey sync, stats, or the data flow | `docs/agents/architecture.md` |
+| Changing models, migrations, journey/status logic, or the DB connection | `docs/agents/invariants.md` — permanent rules; each broke prod once |
+| Debugging a live issue (CI red, deploy fail, prod down, data missing) | `docs/agents/debugging.md` |
+| Committing, pushing, merging, deploying, migrating, or handling Dependabot | `docs/agents/workflow.md` |
+| Writing backend code (Flask / SQLAlchemy / Alembic) | `docs/agents/backend.md` |
+| Writing frontend code (React / Vite / Tailwind / Radix) | `docs/agents/frontend.md` |
 
-### Backend (Flask)
+**Ledger protocol (this repo's own system, still in force):** before ANY work read
+`AGENTS.md` + `CONTINUITY.md` and check `ledgers/` for an active planning ledger;
+update `CONTINUITY.md` when state changes. Autonomous runs go through `scripts/ralph/`.
+
+## Tech stack
+
+- **Backend**: Flask 3.1 + SQLAlchemy 2.0 + Alembic, Python **3.11** (Docker `python:3.11-slim`; ruff config targets py312, venv `.loan` is 3.11)
+- **Frontend**: React 19 + Vite 6 + Tailwind 4 + Radix UI, pnpm, ESLint flat config (`.jsx`)
+- **Data**: PostgreSQL on **Supabase** (`snqwamzutbcbjgusubsa`, us-west-1); RLS on all public tables
+- **Infra**: Azure Container Apps (backend `ca-loan-army-backend`) + Static Web App (frontend `swa-goonloan`), ACR `acrloanarmy`, RG `rg-loan-army-westus2`
+- **Integrations**: API-Football (all football data), Stripe Connect (writer payouts), Mailgun (email), Reddit, OpenAI (AI newsletters)
+
+```
+React/Vite SPA ──/api proxy──▶ Flask (13 blueprints) ──▶ Supabase Postgres (RLS + Alembic)
+                                     │
+                     API-Football · Stripe · Mailgun · Reddit · OpenAI
+```
+
+## Key commands
+
 ```bash
-cd academy-watch-backend
-
-# Run development server (port 5001)
-python src/main.py
-
-# Run with virtual environment
-../.loan/bin/python src/main.py
-
-# Database migrations
-flask db upgrade                    # Apply migrations
-flask db migrate -m "description"   # Create new migration
-flask db downgrade                  # Rollback one migration
+cd academy-watch-backend && python src/main.py        # backend dev (:5001)
+cd academy-watch-frontend && pnpm dev                 # frontend dev (:5173, proxies /api→:5001)
+ruff check academy-watch-backend && ruff format --check academy-watch-backend   # backend CI lint gates
+cd academy-watch-frontend && pnpm lint && pnpm build  # frontend CI gates (build failure blocks)
+cd academy-watch-backend && flask db upgrade          # apply migrations (head chain in backend.md)
+cd academy-watch-frontend && pnpm exec playwright test tests/<file>.mjs   # single E2E while iterating
 ```
 
-### Frontend (React/Vite)
-```bash
-cd academy-watch-frontend
+## Iron rules (always active — rationale in docs/agents/)
 
-pnpm install          # Install dependencies
-pnpm dev              # Dev server (port 5173, proxies /api to :5001)
-pnpm build            # Production build
-pnpm lint             # ESLint
-```
+- **PR flow, never push to main.** `main` is unprotected but the team runs PR → merge → watch-deploy on every change; branch (`feat/` `fix/` `chore/` `refactor/`), and use a worktree when the tree is dirty. Broad staging (`git add -A`/`.`), `--no-verify`, and force-push-main are blocked by the global git hook.
+- **CI gates local defaults miss:** `ruff format --check` is a separate gate from `ruff check`; frontend `pnpm build` must succeed (not just lint); `pnpm install --frozen-lockfile` fails on a stale lockfile; the Deploy job's RLS check **fails the deploy if any new public table lacks Row Level Security**. See `workflow.md`.
+- **Prod DB is reached via the IPv4 pooler + `postgresql+psycopg://` only** — the direct (IPv6) host is unreachable from ACA and a bare `postgresql://` loads the absent psycopg2. See `invariants.md`.
+- **Never reference the deleted `AcademyPlayer`/`SupplementalLoan` models** — use `TrackedPlayer`. **Alembic migrations guard every DDL** (prod schema drifted out-of-band). **Never bulk-sync/recompute against the live prod container** — it's tiny and falls over. See `invariants.md`.
+- **Secrets:** never print secrets or dump env; read live values via `az containerapp secret show`. Prod `SECRET_KEY` is a `kvref:` literal — do NOT "fix"/rotate it without a token-revocation plan (`invariants.md`).
 
-### Testing
-```bash
-cd academy-watch-frontend
+## Commit convention
 
-# Run all Playwright E2E tests
-pnpm test:e2e
-
-# Run a single test file
-pnpm exec playwright test tests/admin-teams.test.mjs
-
-# Run tests with UI
-pnpm exec playwright test --ui
-```
-
-### Deployment
-```bash
-# CI auto-deploys on push to main (GitHub Actions → Azure Container Apps)
-# Manual deployment (rarely needed):
-./deploy_aca.sh
-```
-
-### Container Access
-```bash
-# Exec into production container
-az containerapp exec --name ca-loan-army-backend --resource-group rg-loan-army-westus2 --command /bin/sh
-
-# Run migrations in container
-FLASK_APP=src/main.py flask db upgrade
-
-# The Dockerfile only copies src/ and migrations/ — scripts at repo root are NOT in the image
-# Place runnable scripts in src/scripts/ to include them
-```
-
-### Alembic Migrations
-- All migrations use idempotent helpers from `migrations/_migration_helpers.py` (column_exists, table_exists, etc.)
-- Production DB has had columns/tables added out-of-band — always guard DDL operations
-- Current migration head: vid03 (chain … aw18 → cs01 → aw19 merges (cs01, vid02) → aw20 → vid03)
-
-## Architecture
-
-### Tech Stack
-- **Frontend**: React 19 + Vite 6 + Tailwind CSS 4 + Radix UI
-- **Backend**: Flask 3.1 + SQLAlchemy 2.0 + Alembic
-- **Database**: PostgreSQL
-- **Deployment**: Azure Container Apps (backend), Azure Static Web App (frontend)
-
-### Directory Structure
-```
-academy-watch-backend/src/
-├── main.py                 # Flask app init, blueprint registration
-├── routes/
-│   ├── api.py              # Admin + core API endpoints
-│   ├── players.py          # Public player endpoints (stats, profile, season-stats)
-│   ├── teams.py            # Team listings, loan data
-│   ├── journalist.py       # Writer/journalist endpoints
-│   ├── academy.py          # Academy league sync + stats
-│   ├── journey.py          # Player career journey/map
-│   └── ...                 # cohort, curator, gol, formation, feeder
-├── models/
-│   ├── league.py           # Core domain models (30+)
-│   ├── tracked_player.py   # TrackedPlayer model (primary player tracking)
-│   ├── journey.py          # PlayerJourney + PlayerJourneyEntry
-│   └── weekly.py           # Fixture/stats models
-├── services/
-│   ├── journey_sync.py     # Career data sync from API-Football
-│   ├── academy_sync_service.py  # Youth league fixture sync
-│   ├── radar_stats_service.py   # Per-90 stats + radar charts
-│   └── ...                 # email, reddit, stripe, gol
-├── agents/                 # AI newsletter generation
-├── admin/sandbox_tasks.py  # Admin diagnostic tasks
-└── utils/
-    ├── academy_classifier.py  # Player status classification
-    └── ...                    # team resolution, markdown, sanitization
-
-academy-watch-frontend/src/
-├── pages/
-│   ├── PlayerPage.jsx      # Player detail (stats, journey, academy stats)
-│   ├── TeamDetailPage.jsx  # Team page with squad listing
-│   ├── admin/              # Admin dashboard (14 pages)
-│   └── writer/             # Writer interface
-├── components/ui/          # Radix-based UI components
-└── lib/api.js              # API service wrapper (all endpoint methods)
-```
-
-### Blueprint Registration Order
-Blueprints are registered in `main.py` — order matters for route conflicts:
-- `players_bp` is registered BEFORE `api_bp` so `/players/*` routes in `players.py` take priority
-
-### Key Data Flow
-1. **Player Tracking**: API-Football → `TrackedPlayer` records (one per player per parent academy club)
-2. **Stats Sync**: Fixtures → `FixturePlayerStats` → `TrackedPlayer.compute_stats()` for aggregation
-3. **Academy Stats**: Youth league fixtures → `AcademyAppearance` records (U18/U21/U23 leagues)
-4. **Journey Sync**: API-Football transfers/seasons → `PlayerJourney` + `PlayerJourneyEntry` (full career history)
-5. **Newsletters**: Admin creates → Writers add commentaries → Email delivery via Mailgun
-6. **Payments**: Stripe Connect for writer monetization (10% platform fee)
-
-### API Proxy
-Frontend dev server proxies `/api/*` requests to `http://localhost:5001` (see `vite.config.js`).
-
-## Important Patterns
-
-### Database Models
-Core models in `academy-watch-backend/src/models/league.py`:
-- `Team`, `Newsletter`, `PlayerStatsCache` - core domain
-- `UserAccount`, `UserSubscription` - users and email subscriptions
-- `JournalistTeamAssignment` - writer assignments to teams
-- `StripeConnectedAccount`, `StripeSubscription` - payments
-- `AcademyLeague`, `AcademyAppearance` - youth league tracking
-
-Player tracking in `models/tracked_player.py`:
-- `TrackedPlayer` - one row per player per parent academy club, tracks pathway status (academy → on_loan → first_team → released → sold)
-- `compute_stats()` method aggregates from `FixturePlayerStats` (full coverage) or `PlayerStatsCache` (limited coverage)
-- `current_club_api_id` / `current_club_db_id` - where the player currently plays (loan destination or buying club)
-- `team_id` - parent academy club (origin)
-- `data_source='owning-club'` rows are **deprecated and auto-deactivated** — clubs only track players whose journey shows academy formation at that club (prior-senior-career rule in `JourneySyncService._compute_academy_club_ids`). The journey upsert never creates owning-club rows and deactivates any active row at the owning (buying) club unless it is pinned or manual
-- **Academy tracking window** (`utils/academy_window.py`): the platform only tracks players in an academy NOW or within the past `ACADEMY_WINDOW_YEARS` (default 4) seasons. `last_academy_season` on TrackedPlayer (and `academy_last_seasons` per-club map on PlayerJourney) record the evidence; the journey upsert, recompute-academy repair, rebuild stage 4, seed-team, and GOL lookup all enforce `is_within_academy_window()`. Older alumni rows are deactivated (pinned/manual survive)
-- `player_name` must always be a real name — placeholder `Player NNNN` names are resolved via `resolve_player_name()` in `utils/player_names.py` (CohortMember → AcademyPlayerSeasonStats → Player → PlayerJourney); a placeholder must never overwrite a real name
-
-Journey models in `models/journey.py`:
-- `PlayerJourney` - master career record per player
-- `PlayerJourneyEntry` - individual season/club/competition entries
-
-Weekly models in `models/weekly.py`:
-- `Fixture`, `FixturePlayerStats` - match and performance data
-
-### IMPORTANT: Deleted Models
-The `AcademyPlayer` (table `loaned_players`) and `SupplementalLoan` (table `supplemental_loans`) models have been **permanently deleted** and their tables dropped. Do NOT reference these anywhere in code. Use `TrackedPlayer` for all player tracking.
-
-### Team Name Resolution
-`resolve_team_name_and_logo()` in `api.py` handles team ID → name resolution with caching to `TeamProfile`.
-
-### Player Stats
-- **Full coverage** (top leagues): Aggregated from `FixturePlayerStats` via `TrackedPlayer.compute_stats()`
-- **Limited coverage** (lower leagues): Stored in `PlayerStatsCache`, read by `TrackedPlayer.compute_stats()`
-- **Academy stats** (youth leagues): Stored in `AcademyAppearance`, served by `/players/<id>/academy-stats`
-
-### Player Status Classification
-`classify_tracked_player()` in `utils/academy_classifier.py` determines player status:
-- Uses journey data + transfer history to classify as academy/on_loan/first_team/sold/released
-- For sold/released players, preserves `current_club_api_id` (destination club)
-- `owning-club` rows are deprecated and auto-deactivated: clubs only track players whose journey shows academy formation at that club (prior-senior-career rule). Active rows therefore need no owning-club ordering in queries; admin repair lives at `POST /api/admin/journeys/recompute-academy` (and `POST /api/admin/players/backfill-names` for placeholder names)
-
-### Journey Sync
-`JourneySyncService` in `services/journey_sync.py`:
-- `_correct_club_ids_from_transfers()` fixes API-Football returning current team for historical seasons
-- `_merge_corrected_duplicates()` deduplicates entries after club ID correction
-
-
-## Environment Variables
-
-Key variables (see `academy-watch-backend/env.template` for full list):
-- `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, `DB_NAME` - PostgreSQL
-- `API_FOOTBALL_KEY`, `API_FOOTBALL_MODE` - Football data API
-- `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` - Payments
-- `MAILGUN_API_KEY`, `MAILGUN_DOMAIN` - Email delivery
-- `ADMIN_API_KEY` - Admin endpoint authentication
-
-## Agent Protocol (MANDATORY)
-
-**CRITICAL: Before starting ANY work, you MUST:**
-
-1. **Read `AGENTS.md`** - Contains operating principles, ledger protocol, and task flow rules
-2. **Read `CONTINUITY.md`** - Master ledger with current project state and active tasks
-3. **Check for active planning ledgers** in `ledgers/` directory
-
-**This is not optional.** These files are the single source of truth for project state.
-
-### Key Rules from AGENTS.md
-
-- **Ledger-first:** Update CONTINUITY.md when state changes (goals, decisions, blockers)
-- **Task statuses:** `pending` → `ready` → `in-progress` → `complete`
-- **Quality bar:** Lint/typecheck must pass before marking work complete
-- **Trivial tasks** (<15 min, single file): Log one-liner in CONTINUITY.md's Trivial Log
-
-### Harness
-
-Run `~/bin/harness-check --project . --scope staged` before every commit. Pre-commit hooks enforce this automatically (ruff lint, ruff format, secret scan). See `rules/harness.md` for the full protocol. Auto-fix: `~/bin/harness-check --project . --scope staged --fix`. If hooks are missing: `~/bin/harness-install .`
-
-### Ralph Autonomous Mode
-
-When running via `./scripts/ralph/ralph.sh`:
-- Pick ONLY `ready` tasks from the active planning ledger
-- Complete ONE task per iteration
-- Update ledger status and commit after each task
-- Output `<ralph>COMPLETE</ralph>` when all tasks done
-- Output `<ralph>STOP</ralph>` when blocked
+Scoped Conventional Commits: `feat(scope):` `fix(scope):` `chore(deps):` `refactor(scope):` `docs(scope):` — concise, focused on the why. Complex work gets a `ledgers/` planning ledger first (see `AGENTS.md`).

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -1,0 +1,73 @@
+# Architecture — system map + the player data model
+
+Read this before touching player tracking, journey sync, stats, or the pipelines
+that feed them. `ARCHITECTURE.md` at the repo root has the exhaustive wiring
+(API-Football modes, CSP/auth, every endpoint); this is the shape you must hold
+in your head so you don't optimize the wrong thing.
+
+## The planes
+
+```
+academy-watch-frontend/ (React 19 + Vite 6 + Tailwind 4 + Radix)
+  Admin dashboard (14 pages) · Writer interface · public Player/Team pages · journey maps
+        │  dev: Vite proxies /api/* → http://localhost:5001 (vite.config.js)
+        │  prod: VITE_API_BASE baked in at build time (Azure SWA has no proxy)
+        ▼
+academy-watch-backend/src/ (Flask 3.1 + SQLAlchemy 2.0)
+  main.py           app init, 19 blueprints (registration order matters — below)
+  routes/           api.py (admin+core, /health), players.py, teams.py, journalist.py,
+                    academy.py, journey.py, cohort/curator/gol/formation/feeder/showcase/…
+  services/         journey_sync.py, academy_sync_service.py, radar_stats_service.py, email/reddit/stripe/gol
+  models/           league.py (30+ core), tracked_player.py, journey.py, weekly.py
+  agents/           AI newsletter generation
+  utils/            academy_classifier.py, academy_window.py, player_names.py, team resolution
+        ▼
+Supabase Postgres (snqwamzutbcbjgusubsa, us-west-1) — RLS on all public tables, Alembic migrations
+        │  reached via IPv4 pooler + postgresql+psycopg:// (see invariants.md §1)
+External: API-Football (all football data) · Stripe Connect (10% platform fee) · Mailgun · Reddit · OpenAI
+```
+
+## Blueprint registration order (main.py) is load-bearing
+
+`players_bp`, `journey_bp`, `scout_bp`, `showcase_bp` are all registered **before**
+`api_bp` (all under `/api`). Flask resolves the first-registered match, so those
+specific `/api/players/*` etc. routes win over `api_bp`'s catch-alls. Adding a
+route to `api.py` that collides with a public path will silently never fire —
+register the specific blueprint earlier, don't reorder blindly.
+
+## The core object: `TrackedPlayer` (models/tracked_player.py)
+
+One row **per player per parent academy club**. This is the spine of the product.
+
+- `team_id` = the parent academy club (origin). `current_club_api_id` /
+  `current_club_db_id` = where the player plays now (loan destination or buying club).
+  First-team `TrackedPlayer`s often have **NULL `current_club_api_id`** — consumers
+  must degrade gracefully, never assume the parent club.
+- Pathway status (`academy → on_loan → first_team → released → sold`) is assigned by
+  `classify_tracked_player()` (utils/academy_classifier.py) from journey + transfer data.
+- `compute_stats()` aggregates from `FixturePlayerStats` (full coverage, top leagues)
+  or falls back to `PlayerStatsCache` (limited-coverage lower leagues). Academy/youth
+  stats live separately in `AcademyAppearance` (served by `/players/<id>/academy-stats`).
+- `player_name` must always be a real name — placeholder `Player NNNN` is resolved via
+  `resolve_player_name()` (utils/player_names.py) and a placeholder must NEVER overwrite
+  a real name (invariants.md §5).
+
+## The pipelines (all fed by API-Football)
+
+1. **Player tracking**: API-Football → `TrackedPlayer` records.
+2. **Stats sync**: fixtures → `FixturePlayerStats` → `TrackedPlayer.compute_stats()`.
+3. **Academy stats**: youth-league fixtures (U18/U21/U23) → `AcademyAppearance`.
+4. **Journey sync** (`services/journey_sync.py`): transfers/seasons →
+   `PlayerJourney` + `PlayerJourneyEntry` (full career). `_correct_club_ids_from_transfers()`
+   fixes API-Football returning the *current* team for historical seasons;
+   `_merge_corrected_duplicates()` dedupes afterward. This sync is what decides
+   academy-club membership and the academy window (invariants.md §3, §4).
+5. **Newsletters**: admin creates → writers add commentary → Mailgun delivery.
+6. **Payments**: Stripe Connect for writer monetization (10% platform fee).
+
+## Cost/shape you must respect
+
+Prod runs on **0.5 CPU / 1Gi / 1–2 replicas** — see invariants.md §7 before any
+bulk sync/recompute/backfill; the live container cannot absorb background work.
+The API-Football `api_cache` table dominates DB size; a pg_cron job purges it daily
+(debugging.md covers DB bloat).

--- a/docs/agents/backend.md
+++ b/docs/agents/backend.md
@@ -1,0 +1,66 @@
+# Backend — Flask / SQLAlchemy / Alembic gotchas
+
+Code-level notes for `academy-watch-backend/`. Architecture and the data model are in
+`architecture.md`; permanent rules in `invariants.md`.
+
+## Toolchain reality
+
+- The prod image is **`python:3.11-slim`** and the local venv `.loan/bin/python` is 3.11.
+  Ruff config (`academy-watch-backend/pyproject.toml`) targets **py312** and CI lints on 3.12.
+  So a `UP`/syntax feature that lints clean can still break the 3.11 runtime — mind the gap.
+- Ruff is **not** in the `.loan` venv; use the system `ruff` (the on-edit hook falls back to it).
+  Config: line-length 120, `select = E,F,I,UP,B,SIM` with a long `ignore` list (E501/E402/… —
+  E402 is ignored on purpose because Flask deferred imports are a pattern). Run gates from repo
+  root: `ruff check academy-watch-backend && ruff format --check academy-watch-backend`.
+- The on-edit lint hook runs `ruff check --fix` then `ruff format` on `.py` saves. `check --fix`
+  strips imports with **no call site yet** — when adding an import mid-refactor, add the import
+  and its first use in the **same** edit.
+
+## Migrations (Alembic)
+
+- **Always guard DDL** with `migrations/_migration_helpers.py` (`column_exists`, `table_exists`,
+  …) — prod schema has drifted out-of-band, so unguarded `op.add_column`/`op.create_table`
+  crashes `flask db upgrade` on deploy (invariants.md §8).
+- **New public table → enable RLS in the same migration** or the deploy's security-check fails
+  (invariants.md §2).
+- Generate migrations (`flask db migrate -m "..."`), review the autogen, then `flask db upgrade`.
+  The head is a long chain with merge nodes (e.g. `… aw18 → cs01 → aw19 (merge cs01,vid02) →
+  aw20 → vid03 → aw22`); check `alembic heads` before adding one so you branch from the real tip.
+- Maintenance SQL (non-schema, e.g. the api_cache pg_cron purge) lives in
+  `migrations/maintenance/`, not the version chain.
+
+## Database connection
+
+Prod reaches Supabase via the IPv4 pooler + `postgresql+psycopg://` (psycopg v3 only, no
+psycopg2) — see invariants.md §1. Locally the `DB_*` component vars or a `postgresql+psycopg://`
+URI both work; a bare `postgresql://` will fail the same way prod does.
+
+## Docker packaging trap
+
+The `Dockerfile` copies only `src/` and `migrations/` into the image — **scripts at the repo
+root are NOT in the container**. A runnable one-off (backfill, repair) must live in
+`src/scripts/` to be invokable in prod (`az containerapp exec ... python src/scripts/<x>.py`).
+The image also bundles Pango/Cairo/fonts for WeasyPrint PDF newsletters.
+
+## Blueprints & routing
+
+19 blueprints register under `/api` in `main.py`; **order matters** — specific public
+blueprints (`players_bp`, `journey_bp`, `scout_bp`, `showcase_bp`) register before `api_bp`
+so their routes win. A new `api.py` route that collides with a public path silently never
+fires (architecture.md). `/api/health` lives in `api.py`.
+
+## Player-data gotchas (the ones that bite)
+
+- First-team `TrackedPlayer`s frequently have **NULL `current_club_api_id`** — degrade
+  gracefully, never assume the parent club.
+- Stats have two coverage tiers: `FixturePlayerStats` (full) vs `PlayerStatsCache` (limited);
+  `TrackedPlayer.compute_stats()` reads both. Youth stats are separate (`AcademyAppearance`).
+- Never let a placeholder `Player NNNN` overwrite a real `player_name` (invariants.md §5); the
+  owning-club and academy-window rules (§3, §4) constrain what the journey sync may create.
+
+## Verify a backend change before shipping
+
+Don't rely on ruff alone — exercise the endpoint. Run locally (`python src/main.py`), mint an
+admin Bearer if the route needs it, and curl `/api/health` plus the changed route. For anything
+touching journey/stats, remember prod can't take a bulk run (invariants.md §7) — validate against
+local/spike data.

--- a/docs/agents/debugging.md
+++ b/docs/agents/debugging.md
@@ -1,0 +1,80 @@
+# Debugging — real failure modes, exact commands
+
+One playbook per symptom you'll actually see in logs, CI, or prod. Each was hit for real.
+
+## Playbook: frontend CI red at "Install dependencies" on an unrelated PR
+
+PR CI runs on the merge ref with `main`, so a broken **main** `pnpm-lock.yaml` reddens
+*every* PR regardless of its own changes. On 2026-06-12 sequential Dependabot auto-merges
+left a duplicated `@radix-ui/react-dialog` snapshot block → `ERR_PNPM_BROKEN_LOCKFILE:
+duplicated mapping key` on every run (fixed PR #420). Git merges YAML without detecting
+duplicate keys.
+
+```bash
+git worktree add /tmp/wt origin/main && cd /tmp/wt/academy-watch-frontend && pnpm install --frozen-lockfile
+```
+
+Fix the duplicate block **surgically** by hand. Do NOT run `pnpm install --lockfile-only`
+to regenerate — the broken file can't be parsed, so pnpm re-resolves every `^` range from
+scratch and silently jumps dep versions (this is how eslint-plugin-react-hooks 5→7 nearly
+snuck in; its v7 rules are pinned to `warn` in `eslint.config.js` pending a migration).
+
+## Playbook: "Deploy Frontend" job fails with MCR 403
+
+`Azure/static-web-apps-deploy@v1` intermittently can't pull *its own* base image:
+`mcr.microsoft.com/appsvc/staticappsclient:stable: ... 403 Forbidden`. Transient Microsoft
+Container Registry issue, NOT your code or bundle. The action's built-in 3× retry often
+isn't enough.
+
+```bash
+gh run rerun <run_id> --failed   # usually green on the next try
+```
+
+Don't chase it as a code bug; `Deploy Backend` is a separate job and succeeds independently,
+so don't block a backend-only change on it.
+
+## Playbook: prod `/api/health` returns 000 / site unresponsive
+
+Almost always **capacity saturation**, not a code crash — prod is 0.5 CPU / ~1–2 workers
+(invariants.md §7). Triggered by bulk journey syncs, recomputes, or even concurrent
+read-only roster fetches (`/api/teams/<id>/players` computes stats for ~80 players). Stop
+the load; prod self-heals ~1 min after. If you must run the op, scale up first or move it
+off-container. Check current scale:
+
+```bash
+az containerapp show -n ca-loan-army-backend -g rg-loan-army-westus2 \
+  --query 'properties.template.scale.{min:minReplicas,max:maxReplicas}' -o table
+```
+
+## Playbook: data "isn't showing" on a page
+
+Don't assume the data is wrong. Time the API call AND check the payload size — a slow or
+oversized response can block rendering even when the data is correct (season-stats endpoints
+time out under load for this reason — same root cause as §7, too few workers). Also: a
+manually-built frontend with no `VITE_API_BASE` falls back to `/api`, which 404s on Azure
+SWA (no proxy) and surfaces as "SyntaxError: The string did not match the expected pattern"
+— rebuild with the backend FQDN (workflow.md).
+
+## Playbook: `Deploy` fails at the Security Checks job
+
+A `public` table lacks Row Level Security (invariants.md §2). The job prints the offending
+`schema.table`. Add `ALTER TABLE <t> ENABLE ROW LEVEL SECURITY;` — ideally in the migration
+that created the table — and redeploy.
+
+## Playbook: deploy's pip install fails on a Dependabot bump
+
+`pydantic` pins `pydantic-core==X.Y.Z` exactly, but Dependabot opens standalone
+`pydantic_core` bump PRs — merging one alone fails the container build. Close it (needs a
+coordinated `pydantic` upgrade). Backend `Backend Lint` CI is **ruff only** — it doesn't
+install deps, so the deploy build is the first real install test. Dry-run first from a
+worktree: `pip install --dry-run --ignore-installed -r requirements.txt`. See workflow.md
+for the batching rule.
+
+## DB bloat (context, not usually an incident)
+
+`api_cache` (API-Football TTL cache) dominates DB size; a pg_cron job
+`purge-expired-api-cache` runs daily 03:30 UTC (`academy-watch-backend/migrations/maintenance/
+api_cache_purge_cron.sql`, PR #499). `DELETE` doesn't shrink disk (freed space is reused);
+`VACUUM FULL` is a one-time hand op, never a timer. Inspect: `select * from cron.job;`.
+Prod Supabase is `snqwamzutbcbjgusubsa` — a *different* account owns it than the default
+`nbhd-united` one, so connect the right account to manage it.

--- a/docs/agents/frontend.md
+++ b/docs/agents/frontend.md
@@ -1,0 +1,49 @@
+# Frontend — React / Vite / Tailwind / Radix gotchas
+
+Code-level notes for `academy-watch-frontend/`. Package manager is **pnpm** (not npm).
+
+## Stack
+
+React 19 + Vite 6 + Tailwind CSS 4 (`@tailwindcss/vite`) + Radix UI primitives, TipTap editor,
+Stripe.js, framer-motion, `d3-force-3d` for journey maps. Pages in `src/pages/` (admin dashboard
+= 14 pages under `admin/`, plus `writer/` and public Player/Team pages). Radix-based components in
+`src/components/ui/`. All API calls go through `src/lib/api.js`.
+
+## CI gates (mirror before pushing)
+
+- `pnpm lint` (ESLint flat config, `eslint.config.js`) **and** `pnpm build` (Vite) both run in
+  CI — a build/type error reddens CI even with clean lint. Run the build too.
+- `pnpm install --frozen-lockfile` — a `package.json` change without a matching
+  `pnpm-lock.yaml` fails install. The on-edit hook runs `eslint --fix` on `.js/.jsx/.ts/.tsx`
+  saves.
+
+## ESLint / lockfile traps
+
+- `eslint-plugin-react-hooks` v7's new rules are pinned to **`warn`** in `eslint.config.js`
+  pending a ~130-site migration (mostly `App.jsx`). Don't flip them to `error` casually.
+- A broken **main** `pnpm-lock.yaml` (duplicate YAML key from stacked Dependabot merges) reddens
+  every PR's install, not just the offending one. Fix the duplicate block **by hand** — never
+  `pnpm install --lockfile-only` to regen (it silently jumps `^` versions). Full playbook in
+  `debugging.md`.
+
+## The API base URL — the #1 frontend prod bug
+
+- **Dev**: Vite proxies `/api/*` → `http://localhost:5001` (`vite.config.js`). No env var needed.
+- **Prod / manual deploy**: Azure Static Web Apps has **no proxy**, so the app needs the absolute
+  backend URL baked in at build time via `VITE_API_BASE`. CI sets it from the backend FQDN; a
+  local `pnpm build` without it falls back to `/api` → every call 404s, surfacing as
+  "SyntaxError: The string did not match the expected pattern". Manual deploy:
+  `VITE_API_BASE="https://ca-loan-army-backend.<fqdn>/api" pnpm build`.
+
+## Deploy
+
+Push touching only `academy-watch-frontend/**` triggers the fast `Deploy Frontend (fast)`
+workflow (~1–2 min, no backend rebuild). The `Deploy Frontend` job can intermittently 403 on
+the MCR base image — just `gh run rerun <id> --failed` (debugging.md), not a code bug.
+
+## Verify a UI change
+
+Don't iterate blind. Run `pnpm dev`, drive the affected page (Playwright for anything
+interactive: `pnpm exec playwright test tests/<file>.mjs`), and confirm the change renders —
+especially data-heavy pages, where a slow/oversized payload can block render even when the data
+is correct (debugging.md).

--- a/docs/agents/invariants.md
+++ b/docs/agents/invariants.md
@@ -1,0 +1,86 @@
+# Invariants — permanent rules
+
+Each rule here exists because breaking it caused a real production incident or maps
+to a hard platform constraint. They are not style preferences. If a change needs to
+break one, stop and raise it with the user first.
+
+## 1. Prod DB: IPv4 pooler host + `postgresql+psycopg://` only
+
+Two hard requirements, both learned from a 2026-06-14 outage during a password rotation:
+- **Driver scheme**: the backend image ships **psycopg v3 only** (no psycopg2). A bare
+  `postgresql://` URI (Supabase's default copy string) routes SQLAlchemy to psycopg2 →
+  `ModuleNotFoundError` → the app crashes on boot under `gunicorn --preload`. Use
+  `postgresql+psycopg://`. `src/main.py::_coerce_psycopg_driver` (PR #434) auto-coerces
+  a bare scheme, but any `SQLALCHEMY_DATABASE_URI` override you set must already be right.
+- **Host = IPv4 pooler, NOT direct**: the direct host `db.<ref>.supabase.co:5432` resolves
+  to **IPv6**, and ACA has **no IPv6 egress** → "Network is unreachable". Use the pooler
+  `aws-1-us-west-1.pooler.supabase.com:5432`, user `postgres.<ref>`. The working prod
+  config is the `DB_*` component vars (secret `supabase-db-password`).
+- **Recovery**: `az containerapp update --remove-env-vars SQLALCHEMY_DATABASE_URI` falls
+  the app back to the DB_* pooler config. Password-free, reversible.
+
+## 2. Every public table needs Row Level Security — or the deploy fails
+
+The `Deploy` workflow's `security-checks` job queries `pg_tables` for any `public` table
+with `relrowsecurity = false` (excluding `alembic_version`, `schema_migrations`) and
+**fails the deploy** if one exists. A migration that `CREATE TABLE`s in `public` without
+`ALTER TABLE <t> ENABLE ROW LEVEL SECURITY;` will block prod for everyone. Enable RLS in
+the same migration that creates the table. (The check only runs when `SUPA_DB_PASSWORD`
+is set; treat it as always-on.)
+
+## 3. `owning-club` TrackedPlayer rows are deprecated and auto-deactivated
+
+Clubs only track players whose **journey shows academy formation at that club**
+(prior-senior-career rule in `JourneySyncService._compute_academy_club_ids`). The journey
+upsert never creates `data_source='owning-club'` rows and deactivates any active row at the
+owning (buying) club unless it is pinned or manual. Don't reintroduce owning-club ordering
+in queries or recreate these rows. Admin repair: `POST /api/admin/journeys/recompute-academy`.
+
+## 4. Academy tracking window: now or within `ACADEMY_WINDOW_YEARS` (default 4)
+
+The platform only tracks players in an academy **now or within the past N seasons**
+(`utils/academy_window.py::is_within_academy_window`). `last_academy_season` (and the
+per-club `academy_last_seasons` map on `PlayerJourney`) hold the evidence. The journey
+upsert, recompute-academy repair, rebuild stage 4, seed-team, and GOL lookup all enforce
+this; older alumni rows are deactivated (pinned/manual survive). Don't add a code path
+that tracks a player outside the window.
+
+## 5. A placeholder name must never overwrite a real `player_name`
+
+`Player NNNN` placeholders are resolved by `resolve_player_name()` (utils/player_names.py:
+CohortMember → AcademyPlayerSeasonStats → Player → PlayerJourney). Any write to
+`player_name` must guard against clobbering a real name with a placeholder.
+Backfill: `POST /api/admin/players/backfill-names`.
+
+## 6. The `AcademyPlayer` and `SupplementalLoan` models are permanently deleted
+
+Tables `loaned_players` and `supplemental_loans` were dropped. Do NOT reference these
+models anywhere in code — use `TrackedPlayer` for all player tracking. (Docstrings/scripts
+that mention the historical migration are fine; live model references are not.)
+
+## 7. Never run bulk data ops against the live prod container
+
+Prod (`ca-loan-army-backend`) runs on **0.5 CPU / 1Gi / minReplicas=1 / maxReplicas=2**
+(~1–2 gunicorn workers). On 2026-06-20 even a **single sequential** `force_full` journey
+re-sync flapped `/api/health` to `000` after ~2 players, and concurrent read-only roster
+fetches saturated it. Each `force_full` holds a worker ~7s (CPU + API-Football I/O),
+starving the health probe. For any re-sync/recompute/backfill: scale up first
+(`--cpu 1.0 --memory 2Gi --min-replicas 2 --max-replicas 4`), or run it as a separate ACA
+job / out-of-band script hitting the DB directly, then scale back. Health-gate and abort
+on the first `000`; prod self-heals once load stops.
+
+## 8. Every migration guards its DDL — prod schema drifted out-of-band
+
+Production has had columns/tables added outside Alembic. Migrations MUST use the idempotent
+helpers in `migrations/_migration_helpers.py` (`column_exists`, `table_exists`, …) so a
+re-applied or partially-applied DDL doesn't crash `flask db upgrade` on deploy. Never write
+a bare `op.add_column` / `op.create_table` without a guard.
+
+## 9. Prod `SECRET_KEY` is a `kvref:` literal — do not "fix" it casually
+
+The prod container's inline `secret-key` is the 61-char literal string `kvref:http...`
+(a failed Key Vault reference — ACA doesn't parse that syntax). Flask signs every admin/user
+Bearer token with it via `itsdangerous`. Changing it 401s **every outstanding token** the
+instant it changes. The KV copy `kv-loan-army/secret-key` is stale and differs — do not mint
+tokens from it. Rotation needs a planned window + user re-login. Read live truth via
+`az containerapp secret show`. Same inline-vs-KV divergence applies to `admin-api-key`.

--- a/docs/agents/workflow.md
+++ b/docs/agents/workflow.md
@@ -1,0 +1,85 @@
+# Git / CI / deploy workflow
+
+The rules and the traps for shipping. The user expects the full PR → merge →
+watch-deploy sequence on **every** change — never a direct push to main.
+
+## Branching
+
+- `main` is **unprotected** at the GitHub level, but the team runs strictly PR-based
+  (every commit on main is a `(#NNN)` merge). Branch from main: `feat/` `fix/` `chore/`
+  `refactor/` `docs/`.
+- **Dirty tree → use a worktree**: `git worktree add .claude/worktrees/<name> -b <branch> origin/main`.
+  Never `git checkout` away from a dirty tree.
+- Stage specific files by path. `git add -A` / `git add .`, `--no-verify`, and
+  force-push-main are blocked by the global git hook (`~/.claude/hooks/git_guard.sh`).
+- This repo also runs its own pre-commit harness: `~/bin/harness-check --project . --scope
+  staged` (ruff lint + format + secret scan); auto-fix with `--fix`. Install if missing:
+  `~/bin/harness-install .`.
+
+## Pre-push checklist (each maps to a CI gate a plain local run does NOT cover)
+
+1. **`ruff format --check academy-watch-backend`** — the `CI` and `Deploy` workflows run this
+   as a **separate, stricter gate** from `ruff check`. The on-edit hook auto-formats, but
+   verify before push. (`ruff check academy-watch-backend` is the other gate.)
+2. **`cd academy-watch-frontend && pnpm build`** — CI runs `pnpm lint` **and** `pnpm build`;
+   a build/type failure reddens CI even when lint is clean. Run the build, not just lint.
+3. **`pnpm install --frozen-lockfile`** — CI installs frozen; a `package.json` change without
+   a matching `pnpm-lock.yaml` update fails install. Never regen the whole lockfile to fix a
+   Dependabot break (debugging.md) — patch surgically.
+4. **Adding a migration that `CREATE TABLE`s?** Enable RLS in the same migration
+   (`ALTER TABLE <t> ENABLE ROW LEVEL SECURITY;`) — the Deploy `security-checks` job fails the
+   deploy otherwise (invariants.md §2). And guard all DDL with `_migration_helpers` (§8).
+5. **Changing `requirements.txt`?** `pip install --dry-run --ignore-installed -r requirements.txt`
+   from a worktree — `Backend Lint` CI is ruff-only and never installs deps, so the deploy
+   container build is otherwise the first install test.
+6. Local `.loan` venv is **Python 3.11** (matches the prod image) while CI lint runs on 3.12
+   and ruff config targets py312. When CI fails on something that passes locally, suspect the
+   version gap, not your diff.
+
+## Dependabot
+
+- **Backend** bumps all edit the one `requirements.txt` → merging individually triggers a
+  rebase cascade + one deploy each. Combine into a single hand-authored
+  `chore(deps): batch backend bumps` PR, then close the superseded ones (squash drops
+  `Closes #N` for all but the first). **Never merge a standalone `pydantic_core` bump**
+  (pydantic pins it exactly — breaks the deploy; debugging.md).
+- **Frontend** bumps (`package.json`/`pnpm-lock.yaml`) are independent — merge directly.
+- Dependabot PRs auto-merge (`dependabot-auto-merge.yml`, squash). The only red check is
+  usually the non-gating `auto-merge` job; real CI (Lint+Build) is green.
+
+## Merging & watching
+
+```bash
+gh pr create --fill                 # or with a why-focused body
+gh pr merge <n> --squash            # match the repo's squash-merge convention
+gh run watch                        # BARE — no pipe, no trailing `; echo` (steals the exit code)
+```
+
+Read the watch output, don't trust `$?` through a pipe.
+
+## Deploy pipeline (push to main)
+
+Two workflows split by path:
+- **`Deploy` (deploy.yml)** — backend or mixed changes. Jobs: `security-checks` (RLS on all
+  public tables) → `lint-backend` (ruff check + format) → `deploy-backend` (ACR build →
+  Container App single-revision update, tag `prod`, + updates the 5 scheduled jobs) →
+  `deploy-frontend` (builds with `VITE_API_BASE` from backend FQDN → Azure SWA).
+- **`Deploy Frontend (fast)` (deploy-frontend.yml)** — triggered by `academy-watch-frontend/**`
+  only. Skips the ~6-min backend rebuild + RLS check; deploys just the SPA (~1–2 min). It
+  fetches the backend FQDN for `VITE_API_BASE` and refuses to ship with an empty one.
+
+**Manual frontend deploy** must set `VITE_API_BASE` (the FQDN) or every API call 404s on SWA:
+`VITE_API_BASE="https://ca-loan-army-backend.<...>.azurecontainerapps.io/api" pnpm build`.
+
+## Verify a deploy is live
+
+`gh run watch` the run to completion, then hit `/api/health`:
+`curl -s https://ca-loan-army-backend.<fqdn>/api/health`. A `000`/timeout usually means
+capacity, not a bad deploy (debugging.md). Scheduled scaling toggles minReplicas 1↔0 at
+02:00/10:00 UTC — an off-peak cold start can mask as a deploy problem.
+
+## Commit convention
+
+Scoped Conventional Commits: `feat(scope):` `fix(scope):` `chore(deps):` `refactor(scope):`
+`docs(scope):`. Concise, focused on the why. Complex work gets a `ledgers/` planning ledger
+first and a `CONTINUITY.md` update (AGENTS.md).


### PR DESCRIPTION
## What

Refactors the ~250-line monolithic `CLAUDE.md` into a **~66-line router** that points into six on-demand playbooks under `docs/agents/`, plus PostToolUse hooks that fix lint/format drift at edit time the way CI would at merge time. The philosophy: keep every session's always-on context small, make deep context discoverable, and trace every rule to evidence. Generated via the `harness-init` skill, matching the nbhd-united reference implementation.

The repo's **existing ledger protocol** (`AGENTS.md` / `CONTINUITY.md` / `ledgers/` / Ralph autonomous mode) is preserved and surfaced as a router pointer — this change complements it, it doesn't replace it.

## docs/agents/ (each ≤120 lines, dense, every rule carries its why)

- **architecture.md** — planes, the load-bearing blueprint registration order, the `TrackedPlayer` model + journey/stats pipelines, and the prod capacity shape.
- **invariants.md** — 9 permanent rules, each tied to a real incident: pooler + `postgresql+psycopg://` DB driver, RLS-or-the-deploy-fails, deprecated owning-club rows, the academy window, the name-clobber guard, the deleted `AcademyPlayer`/`SupplementalLoan` models, no-bulk-ops-on-live-prod, guarded DDL, and the `kvref` `SECRET_KEY` literal.
- **debugging.md** — broken-`main` `pnpm-lock`, MCR-403 frontend deploy, `/api/health` 000 from capacity, payload-size render stalls, RLS deploy-gate failures, `pydantic_core` bumps.
- **workflow.md** — PR flow, a pre-push checklist for **the CI gates a plain local run misses**, Dependabot batching, the split deploy pipeline, and the verify-in-prod story.
- **backend.md / frontend.md** — Flask/Alembic and React/Vite code-level gotchas.

## Hooks (mirror CI; wired in `.claude/settings.json`)

- `lint_on_edit.sh` — `ruff check --fix` + `ruff format` on backend `.py`; `eslint --fix` on frontend `.js/.jsx/.ts/.tsx`. Mirrors the `ruff check` + separate `ruff format --check` gate and `pnpm lint`.
- `migration_rls_reminder.sh` — on Alembic version-file edits, reminds that a new public table needs RLS (or the Deploy `security-checks` job fails) and that all DDL must be guarded.
- **No repo-local git guard** — the global `~/.claude/hooks/git_guard.sh` already blocks broad staging / `--no-verify` / force-push-main.

### CI gates the hooks + checklist now cover (local defaults miss these)

- `ruff format --check` is a **separate** gate from `ruff check`.
- Frontend `pnpm build` must pass (not just `pnpm lint`).
- `pnpm install --frozen-lockfile` fails on a stale lockfile.
- The Deploy `security-checks` job **fails the deploy** if any `public` table lacks RLS.

## Promoted from per-project memory (verified against current code)

Supabase pooler + psycopg driver requirement, prod container capacity limits, the Dependabot lockfile/backend-batch traps, the `kvref` `SECRET_KEY`, and the `VITE_API_BASE` manual-deploy requirement.

## Verification

- Hook dry-runs pass: lint hook reformats a bad `.py` (`x=1`→`x = 1`, strips unused import) and exits 0; no-ops on non-source; migration reminder fires only on `migrations/versions/*.py`.
- `jq` validates `.claude/settings.json`; hooks are `chmod +x`; every doc named in `CLAUDE.md` exists; `CLAUDE.md` is 66 lines, all playbooks ≤120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)