### PR TITLE
feat(harness): agent router CLAUDE.md + docs/agents playbooks + edit-time lint hook

### DIFF
--- a/.claude/hooks/lint_on_edit.sh
+++ b/.claude/hooks/lint_on_edit.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# PostToolUse(Edit|Write): auto-fix lint + format at edit time, mirroring the CI
+# gates exactly (ci.yml: `ruff check` + `ruff format --check` on
+# academy-watch-backend; `pnpm lint` (eslint) on academy-watch-frontend).
+# Always exits 0 — a formatter must never block an edit.
+
+FILE=$(jq -r '.tool_input.file_path // .tool_input.filePath // empty' 2>/dev/null)
+[ -n "$FILE" ] && [ -f "$FILE" ] || exit 0
+
+case "$FILE" in
+  */node_modules/*|*/dist/*) exit 0 ;;
+esac
+
+case "$FILE" in
+  "$CLAUDE_PROJECT_DIR"/academy-watch-backend/*.py)
+    command -v ruff >/dev/null 2>&1 || exit 0
+    cd "$CLAUDE_PROJECT_DIR/academy-watch-backend" || exit 0
+    ruff check --fix --quiet "$FILE" 2>/dev/null
+    ruff format --quiet "$FILE" 2>/dev/null
+    ;;
+
+  "$CLAUDE_PROJECT_DIR"/academy-watch-frontend/*.js | \
+  "$CLAUDE_PROJECT_DIR"/academy-watch-frontend/*.jsx | \
+  "$CLAUDE_PROJECT_DIR"/academy-watch-frontend/*.mjs)
+    cd "$CLAUDE_PROJECT_DIR/academy-watch-frontend" || exit 0
+    npx --no-install eslint --fix --quiet "$FILE" >/dev/null 2>&1
+    ;;
+esac
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/lint_on_edit.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,222 +1,77 @@
-# CLAUDE.md
+# The Academy Watch
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Football academy tracking platform: monitors academy players out on loan,
+generates AI newsletters, and lets journalists write about loaned players.
+React SPA + Flask API + PostgreSQL on Azure; integrates API-Football, Stripe,
+Mailgun. Two structural facts to hold at all times: (1) the player-tracking
+domain has strict semantics (`TrackedPlayer` = one row per player per parent
+academy club) that most data bugs trace back to, and (2) **every push to `main`
+deploys production**.
 
-## Project Overview
+## How to use this file
 
-**The Academy Watch** is a football (soccer) academy tracking platform that monitors academy players on loan, generates AI-powered newsletters, and enables journalists to write content about loaned players. It integrates with API-Football for player/fixture data, Stripe for payments, Mailgun for email delivery, and Reddit for social posting.
+This file is a router, not the manual. Deep context lives in `docs/agents/` —
+each doc encodes hard-won lessons; skipping them repeats old incidents.
+**Read the matching doc BEFORE starting work in its area:**
 
-## Development Commands
+| When you are... | Read first |
+|---|---|
+| Starting ANY task (ledger protocol — mandatory) | `AGENTS.md` + `CONTINUITY.md`, check `ledgers/` |
+| Touching player tracking, stats, journeys, classification | `docs/agents/data-model.md` |
+| Changing load-bearing mechanisms, or unsure if something is safe | `docs/agents/invariants.md` — permanent rules; each broke something once |
+| Debugging a live/prod issue | `docs/agents/debugging.md` |
+| Committing, pushing, merging, deploying, migrating | `docs/agents/workflow.md` |
+| Writing backend (Flask) code | `docs/agents/backend.md` |
+| Writing frontend (React) code | `docs/agents/frontend.md` |
+| Running Ralph, scheduled jobs, or sub-agent fan-outs | `docs/agents/loops.md` |
+| Needing the full system map / ops-job reference | `ARCHITECTURE.md` / `OPERATIONS.md` |
 
-### Backend (Flask)
+## Tech stack
+
+- **Frontend**: React 19 + Vite 6 + Tailwind 4 + Radix UI — `academy-watch-frontend/`, pnpm 9, Node 20
+- **Backend**: Flask 3.1 + SQLAlchemy 2.0 + Alembic — `academy-watch-backend/`, Python 3.12, venv at `.loan/`
+- **Data**: PostgreSQL (prod = Supabase)
+- **Infra**: Azure Container Apps (backend + 5 scheduled jobs), Azure Static Web App (frontend), ACR; GitHub Actions CI/CD
+- **Integrations**: API-Football, Stripe Connect, Mailgun, Reddit
+
+```
+React SPA (SWA) ──/api──▶ Flask (ACA: ca-loan-army-backend) ──▶ Supabase Postgres
+                            ▲ 5 scheduled ACA jobs (fixture/status/newsletter syncs)
+                            ◀▶ API-Football · Stripe · Mailgun
+```
+
+## Key commands
+
 ```bash
-cd academy-watch-backend
-
-# Run development server (port 5001)
-python src/main.py
-
-# Run with virtual environment
-../.loan/bin/python src/main.py
-
-# Database migrations
-flask db upgrade                    # Apply migrations
-flask db migrate -m "description"   # Create new migration
-flask db downgrade                  # Rollback one migration
+cd academy-watch-backend && python src/main.py     # backend dev server :5001
+cd academy-watch-frontend && pnpm dev              # frontend dev :5173 (proxies /api)
+pnpm lint && pnpm build                            # frontend CI gates (in frontend dir)
+ruff check academy-watch-backend && ruff format --check academy-watch-backend   # backend CI gates (repo root)
+pnpm exec playwright test tests/<file>.test.mjs    # one e2e file (in frontend dir)
+flask db upgrade                                   # apply migrations (backend dir)
 ```
 
-### Frontend (React/Vite)
-```bash
-cd academy-watch-frontend
+## Iron rules (always active — rationale in docs/agents/)
 
-pnpm install          # Install dependencies
-pnpm dev              # Dev server (port 5173, proxies /api to :5001)
-pnpm build            # Production build
-pnpm lint             # ESLint
-```
+- `main` deploys prod on push: never commit to `main` directly — branch → PR →
+  merge → **watch the deploy run finish**.
+- Stage by explicit path (`git add -A`/`.` are hook-blocked); never `--no-verify`;
+  never force-push `main`; cross-branch work via `git worktree add`.
+- CI-only gates to run before push: `ruff format --check academy-watch-backend`,
+  `pnpm build`; `pnpm-lock.yaml` must satisfy `--frozen-lockfile` — repair it
+  surgically, never regenerate wholesale.
+- Never reference the deleted models `AcademyPlayer` / `SupplementalLoan`; never
+  let a `Player NNNN` placeholder overwrite a real player name.
+- Prod DB connections: IPv4 pooler host + `postgresql+psycopg://` only. Never
+  rotate prod `SECRET_KEY` without a token-revocation plan. No bulk journey
+  re-syncs against the prod container.
+- Migration DDL must be idempotent via `migrations/_migration_helpers.py`.
+- Never print secrets or dump env vars. Never fabricate demo/social content —
+  real sources only. Destructive cloud ops need explicit user confirmation.
 
-### Testing
-```bash
-cd academy-watch-frontend
+## Commit convention
 
-# Run all Playwright E2E tests
-pnpm test:e2e
-
-# Run a single test file
-pnpm exec playwright test tests/admin-teams.test.mjs
-
-# Run tests with UI
-pnpm exec playwright test --ui
-```
-
-### Deployment
-```bash
-# CI auto-deploys on push to main (GitHub Actions → Azure Container Apps)
-# Manual deployment (rarely needed):
-./deploy_aca.sh
-```
-
-### Container Access
-```bash
-# Exec into production container
-az containerapp exec --name ca-loan-army-backend --resource-group rg-loan-army-westus2 --command /bin/sh
-
-# Run migrations in container
-FLASK_APP=src/main.py flask db upgrade
-
-# The Dockerfile only copies src/ and migrations/ — scripts at repo root are NOT in the image
-# Place runnable scripts in src/scripts/ to include them
-```
-
-### Alembic Migrations
-- All migrations use idempotent helpers from `migrations/_migration_helpers.py` (column_exists, table_exists, etc.)
-- Production DB has had columns/tables added out-of-band — always guard DDL operations
-- Current migration head: vid03 (chain … aw18 → cs01 → aw19 merges (cs01, vid02) → aw20 → vid03)
-
-## Architecture
-
-### Tech Stack
-- **Frontend**: React 19 + Vite 6 + Tailwind CSS 4 + Radix UI
-- **Backend**: Flask 3.1 + SQLAlchemy 2.0 + Alembic
-- **Database**: PostgreSQL
-- **Deployment**: Azure Container Apps (backend), Azure Static Web App (frontend)
-
-### Directory Structure
-```
-academy-watch-backend/src/
-├── main.py                 # Flask app init, blueprint registration
-├── routes/
-│   ├── api.py              # Admin + core API endpoints
-│   ├── players.py          # Public player endpoints (stats, profile, season-stats)
-│   ├── teams.py            # Team listings, loan data
-│   ├── journalist.py       # Writer/journalist endpoints
-│   ├── academy.py          # Academy league sync + stats
-│   ├── journey.py          # Player career journey/map
-│   └── ...                 # cohort, curator, gol, formation, feeder
-├── models/
-│   ├── league.py           # Core domain models (30+)
-│   ├── tracked_player.py   # TrackedPlayer model (primary player tracking)
-│   ├── journey.py          # PlayerJourney + PlayerJourneyEntry
-│   └── weekly.py           # Fixture/stats models
-├── services/
-│   ├── journey_sync.py     # Career data sync from API-Football
-│   ├── academy_sync_service.py  # Youth league fixture sync
-│   ├── radar_stats_service.py   # Per-90 stats + radar charts
-│   └── ...                 # email, reddit, stripe, gol
-├── agents/                 # AI newsletter generation
-├── admin/sandbox_tasks.py  # Admin diagnostic tasks
-└── utils/
-    ├── academy_classifier.py  # Player status classification
-    └── ...                    # team resolution, markdown, sanitization
-
-academy-watch-frontend/src/
-├── pages/
-│   ├── PlayerPage.jsx      # Player detail (stats, journey, academy stats)
-│   ├── TeamDetailPage.jsx  # Team page with squad listing
-│   ├── admin/              # Admin dashboard (14 pages)
-│   └── writer/             # Writer interface
-├── components/ui/          # Radix-based UI components
-└── lib/api.js              # API service wrapper (all endpoint methods)
-```
-
-### Blueprint Registration Order
-Blueprints are registered in `main.py` — order matters for route conflicts:
-- `players_bp` is registered BEFORE `api_bp` so `/players/*` routes in `players.py` take priority
-
-### Key Data Flow
-1. **Player Tracking**: API-Football → `TrackedPlayer` records (one per player per parent academy club)
-2. **Stats Sync**: Fixtures → `FixturePlayerStats` → `TrackedPlayer.compute_stats()` for aggregation
-3. **Academy Stats**: Youth league fixtures → `AcademyAppearance` records (U18/U21/U23 leagues)
-4. **Journey Sync**: API-Football transfers/seasons → `PlayerJourney` + `PlayerJourneyEntry` (full career history)
-5. **Newsletters**: Admin creates → Writers add commentaries → Email delivery via Mailgun
-6. **Payments**: Stripe Connect for writer monetization (10% platform fee)
-
-### API Proxy
-Frontend dev server proxies `/api/*` requests to `http://localhost:5001` (see `vite.config.js`).
-
-## Important Patterns
-
-### Database Models
-Core models in `academy-watch-backend/src/models/league.py`:
-- `Team`, `Newsletter`, `PlayerStatsCache` - core domain
-- `UserAccount`, `UserSubscription` - users and email subscriptions
-- `JournalistTeamAssignment` - writer assignments to teams
-- `StripeConnectedAccount`, `StripeSubscription` - payments
-- `AcademyLeague`, `AcademyAppearance` - youth league tracking
-
-Player tracking in `models/tracked_player.py`:
-- `TrackedPlayer` - one row per player per parent academy club, tracks pathway status (academy → on_loan → first_team → released → sold)
-- `compute_stats()` method aggregates from `FixturePlayerStats` (full coverage) or `PlayerStatsCache` (limited coverage)
-- `current_club_api_id` / `current_club_db_id` - where the player currently plays (loan destination or buying club)
-- `team_id` - parent academy club (origin)
-- `data_source='owning-club'` rows are **deprecated and auto-deactivated** — clubs only track players whose journey shows academy formation at that club (prior-senior-career rule in `JourneySyncService._compute_academy_club_ids`). The journey upsert never creates owning-club rows and deactivates any active row at the owning (buying) club unless it is pinned or manual
-- **Academy tracking window** (`utils/academy_window.py`): the platform only tracks players in an academy NOW or within the past `ACADEMY_WINDOW_YEARS` (default 4) seasons. `last_academy_season` on TrackedPlayer (and `academy_last_seasons` per-club map on PlayerJourney) record the evidence; the journey upsert, recompute-academy repair, rebuild stage 4, seed-team, and GOL lookup all enforce `is_within_academy_window()`. Older alumni rows are deactivated (pinned/manual survive)
-- `player_name` must always be a real name — placeholder `Player NNNN` names are resolved via `resolve_player_name()` in `utils/player_names.py` (CohortMember → AcademyPlayerSeasonStats → Player → PlayerJourney); a placeholder must never overwrite a real name
-
-Journey models in `models/journey.py`:
-- `PlayerJourney` - master career record per player
-- `PlayerJourneyEntry` - individual season/club/competition entries
-
-Weekly models in `models/weekly.py`:
-- `Fixture`, `FixturePlayerStats` - match and performance data
-
-### IMPORTANT: Deleted Models
-The `AcademyPlayer` (table `loaned_players`) and `SupplementalLoan` (table `supplemental_loans`) models have been **permanently deleted** and their tables dropped. Do NOT reference these anywhere in code. Use `TrackedPlayer` for all player tracking.
-
-### Team Name Resolution
-`resolve_team_name_and_logo()` in `api.py` handles team ID → name resolution with caching to `TeamProfile`.
-
-### Player Stats
-- **Full coverage** (top leagues): Aggregated from `FixturePlayerStats` via `TrackedPlayer.compute_stats()`
-- **Limited coverage** (lower leagues): Stored in `PlayerStatsCache`, read by `TrackedPlayer.compute_stats()`
-- **Academy stats** (youth leagues): Stored in `AcademyAppearance`, served by `/players/<id>/academy-stats`
-
-### Player Status Classification
-`classify_tracked_player()` in `utils/academy_classifier.py` determines player status:
-- Uses journey data + transfer history to classify as academy/on_loan/first_team/sold/released
-- For sold/released players, preserves `current_club_api_id` (destination club)
-- `owning-club` rows are deprecated and auto-deactivated: clubs only track players whose journey shows academy formation at that club (prior-senior-career rule). Active rows therefore need no owning-club ordering in queries; admin repair lives at `POST /api/admin/journeys/recompute-academy` (and `POST /api/admin/players/backfill-names` for placeholder names)
-
-### Journey Sync
-`JourneySyncService` in `services/journey_sync.py`:
-- `_correct_club_ids_from_transfers()` fixes API-Football returning current team for historical seasons
-- `_merge_corrected_duplicates()` deduplicates entries after club ID correction
-
-
-## Environment Variables
-
-Key variables (see `academy-watch-backend/env.template` for full list):
-- `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, `DB_NAME` - PostgreSQL
-- `API_FOOTBALL_KEY`, `API_FOOTBALL_MODE` - Football data API
-- `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` - Payments
-- `MAILGUN_API_KEY`, `MAILGUN_DOMAIN` - Email delivery
-- `ADMIN_API_KEY` - Admin endpoint authentication
-
-## Agent Protocol (MANDATORY)
-
-**CRITICAL: Before starting ANY work, you MUST:**
-
-1. **Read `AGENTS.md`** - Contains operating principles, ledger protocol, and task flow rules
-2. **Read `CONTINUITY.md`** - Master ledger with current project state and active tasks
-3. **Check for active planning ledgers** in `ledgers/` directory
-
-**This is not optional.** These files are the single source of truth for project state.
-
-### Key Rules from AGENTS.md
-
-- **Ledger-first:** Update CONTINUITY.md when state changes (goals, decisions, blockers)
-- **Task statuses:** `pending` → `ready` → `in-progress` → `complete`
-- **Quality bar:** Lint/typecheck must pass before marking work complete
-- **Trivial tasks** (<15 min, single file): Log one-liner in CONTINUITY.md's Trivial Log
-
-### Harness
-
-Run `~/bin/harness-check --project . --scope staged` before every commit. Pre-commit hooks enforce this automatically (ruff lint, ruff format, secret scan). See `rules/harness.md` for the full protocol. Auto-fix: `~/bin/harness-check --project . --scope staged --fix`. If hooks are missing: `~/bin/harness-install .`
-
-### Ralph Autonomous Mode
-
-When running via `./scripts/ralph/ralph.sh`:
-- Pick ONLY `ready` tasks from the active planning ledger
-- Complete ONE task per iteration
-- Update ledger status and commit after each task
-- Output `<ralph>COMPLETE</ralph>` when all tasks done
-- Output `<ralph>STOP</ralph>` when blocked
+`type(scope): summary` — feat / fix / chore / docs / refactor; message says why.
+Ledger-first: non-trivial work updates `CONTINUITY.md` / the active planning
+ledger in `ledgers/` (statuses: pending → ready → in-progress → complete);
+trivial tasks (<15 min, single file) get a one-liner in the Trivial Log.

--- a/docs/agents/backend.md
+++ b/docs/agents/backend.md
@@ -1,0 +1,28 @@
+# Backend — Flask patterns & gotchas
+
+- Run: `cd academy-watch-backend && python src/main.py` (port 5001). Venv lives
+  at repo root: `.loan/` (`../.loan/bin/python` from the backend dir).
+- The prod image is **python:3.11-slim** while CI lints on 3.12 — code and every
+  dependency must stay 3.11-compatible (this is why numpy is pinned <2.5).
+- **Blueprint registration order in `src/main.py` matters**: `players_bp` is
+  registered before `api_bp` so `/players/*` routes win conflicts. When adding a
+  blueprint, check for path overlap before picking a registration position.
+- Ruff config is `academy-watch-backend/pyproject.toml` (py312, line-length 120,
+  `E/F/I/UP/B/SIM` with a deliberate ignore list). The ignores are policy, not
+  debt to clean: don't mass-"fix" bare excepts, SIM readability rules, etc.
+- Sharp edge: `ruff check --fix` (run by the edit hook) deletes unused imports.
+  Add an import and its first usage **in the same edit**, or the autofixer strips
+  it before you use it.
+- Admin endpoints authenticate via `ADMIN_API_KEY` bearer token. Public
+  submission endpoints use Flask-Limiter rate limits + `bleach` sanitization —
+  follow that pattern for any new public write endpoint.
+- Team ID → name/logo resolution: `resolve_team_name_and_logo()` in
+  `src/routes/api.py`, caching to `TeamProfile`. Don't re-implement.
+- Environment: `env.template` lists the variables. Before concluding a credential
+  isn't configured, **read the actual `.env`** — grepping the source tree lies.
+- Newsletter emails embed images as base64 — newsletters rows are large by
+  design; don't "fix" that without checking the email-delivery path.
+- `api_cache` is purged daily by pg_cron in prod; don't build a second purge.
+- Timing/size debugging: when data "isn't showing", time the API call AND check
+  payload size — oversized/slow responses can prevent rendering even when the
+  data is correct (see `docs/agents/debugging.md`).

--- a/docs/agents/data-model.md
+++ b/docs/agents/data-model.md
@@ -1,0 +1,65 @@
+# Data model — player-tracking semantics
+
+Most data bugs here come from violating one of these semantics. Read before
+touching player tracking, stats, journeys, or status classification.
+
+## TrackedPlayer (`src/models/tracked_player.py`)
+
+- One row per player **per parent academy club**. `team_id` = parent academy
+  club (origin); `current_club_api_id` / `current_club_db_id` = where he plays
+  now (loan destination or buying club).
+- Pathway status (academy → on_loan → first_team → released/sold) is computed by
+  `classify_tracked_player()` in `src/utils/academy_classifier.py` from journey +
+  transfer history. For sold/released players the destination club is preserved
+  in `current_club_api_id`.
+- `data_source='owning-club'` rows are **deprecated and auto-deactivated**: a
+  club only tracks players whose journey shows academy formation there
+  (prior-senior-career rule in `JourneySyncService._compute_academy_club_ids`).
+  Repair endpoint: `POST /api/admin/journeys/recompute-academy`.
+- **Academy window** (`src/utils/academy_window.py`): only players in an academy
+  now or within the past `ACADEMY_WINDOW_YEARS` (default 4) seasons are tracked.
+  `last_academy_season` records the evidence; journey upsert, recompute repair,
+  rebuild stage 4, seed-team, and GOL all enforce `is_within_academy_window()`.
+  Older alumni rows are deactivated (pinned/manual rows survive).
+- `player_name` must be a real name. A placeholder `Player NNNN` must **never
+  overwrite a real name** — resolve via `resolve_player_name()` in
+  `src/utils/player_names.py`. Backfill: `POST /api/admin/players/backfill-names`.
+- `first_team` rows often have **NULL `current_club_api_id`** (internal
+  promotions have no transfer event) — consumers must degrade gracefully, never
+  assume the parent club. If a feature needs it populated, fix the classifier,
+  not the consumer.
+- **Two status axes**: `TrackedPlayer.status` is RELATIVE to the tracked academy
+  (sold/left = left *that* club). The player's ACTUAL situation lives in stored
+  `player_journeys.current_status` / `current_owner_*` (set by
+  `JourneySyncService._set_current_status`; backfill:
+  `POST /api/admin/journeys/backfill-current-status`). Player-page headline uses
+  the journey axis; team/academy views use the per-academy axis. A sixth status
+  `left` = at another club with no recorded parent departure. Affiliates
+  (Jong Ajax → Ajax etc.) resolve via `src/utils/affiliates.py`.
+
+## Stats — three sources; know which one you're reading
+
+- **Full coverage** (top leagues): aggregate `FixturePlayerStats`
+  (`src/models/weekly.py`) via `TrackedPlayer.compute_stats()`.
+- **Limited coverage** (lower leagues): `PlayerStatsCache` rows, read by the same
+  `compute_stats()`.
+- **Youth leagues**: `AcademyAppearance`, served by `/players/<id>/academy-stats`.
+
+When stats "look wrong", establish ground truth first: aggregate
+`FixturePlayerStats` per season for that player, then compare against what each
+serving path returns. Season values are the **start year** of a European season
+(2025 = 2025-26); mind the July/August rollover when defaulting "current season".
+
+## Journey (`src/models/journey.py`, `src/services/journey_sync.py`)
+
+- `PlayerJourney` + `PlayerJourneyEntry` = full career history from API-Football.
+- `_correct_club_ids_from_transfers()` fixes API-Football returning the *current*
+  team for historical seasons; `_merge_corrected_duplicates()` dedups afterwards.
+- Bulk journey re-syncs are expensive and have caused prod outages — see
+  `docs/agents/invariants.md` before running any bulk sync.
+
+## Deleted models — never reference
+
+`AcademyPlayer` (table `loaned_players`) and `SupplementalLoan` (table
+`supplemental_loans`) were permanently deleted and their tables dropped. Any code
+path referencing them is a bug. Use `TrackedPlayer`.

--- a/docs/agents/debugging.md
+++ b/docs/agents/debugging.md
@@ -1,0 +1,83 @@
+# Debugging — real failure modes
+
+One playbook per symptom that has actually occurred. Prod logs generally: the
+`production-logs` skill, or
+`az containerapp logs show -n ca-loan-army-backend -g rg-loan-army-westus2 --tail 100`.
+
+## Playbook: "Deploy Frontend" fails with 403 on an MCR image
+
+Symptom: the static-web-apps-deploy step dies pulling
+`mcr.microsoft.com/appsvc/staticappsclient:stable` → 403 Forbidden.
+Transient Microsoft registry flake, NOT a code/bundle bug.
+
+```bash
+gh run rerun <run_id> --failed
+```
+
+## Playbook: "data isn't showing" on a page, but the API has it
+
+Oversized/slow responses block rendering even when the data is correct.
+
+```bash
+curl -s <url> | head -c 2000          # 1. is the field even there?
+time curl -s <url> -o /tmp/x.json     # 2. >5s = serious
+wc -c /tmp/x.json                     # 3. >1MB for a LIST endpoint = suspicious;
+                                      #    >5MB = base64 images / duplicated blobs
+```
+
+Fix pattern: list endpoints return metadata + excerpts only, never full content.
+
+## Playbook: need admin/diagnostic access to prod from a local shell
+
+`az containerapp exec` needs a TTY; the direct DB host is IPv6-only. Use the
+prod HTTP admin endpoints — auth is two-factor: `Authorization: Bearer <token>`
+AND `X-API-Key: <admin key>`. Mint the Bearer locally with itsdangerous
+`URLSafeTimedSerializer(secret_key=<prod inline secret-key>, salt='user-auth')
+.dumps({'email': <admin email>, 'role': 'admin', 'iat': <now>})`.
+Read CURRENT inline secrets (Key Vault copies are stale):
+
+```bash
+az containerapp secret show -g rg-loan-army-westus2 -n ca-loan-army-backend \
+  --secret-name secret-key --query value -o tsv   # never echo into transcripts
+```
+
+Raw SQL: session pooler host + `PGOPTIONS='-c default_transaction_read_only=on'`
+for read-only work. Never print secret values into conversation output.
+
+## Playbook: prod /api/health flapping (000) during a bulk operation
+
+Cause is capacity, not code: 0.5 CPU / 1Gi / max 2 replicas; each force_full
+sync holds a worker ~7s and starves the probe.
+
+```bash
+az containerapp update -g rg-loan-army-westus2 -n ca-loan-army-backend \
+  --cpu 1.0 --memory 2Gi --min-replicas 2 --max-replicas 4   # scale UP first
+# run the bulk op in health-gated batches (abort on first 000), then scale back
+```
+
+Proven pattern: scale up → concurrency ~4 in batches of ~20 → scale down.
+
+## Playbook: POST 405s on theacademywatch.com but works elsewhere
+
+The SWA front door can 405 a POST at the custom domain. Test POSTs against the
+container-app FQDN directly (`https://ca-loan-army-backend.<env>.azurecontainerapps.io`),
+not `theacademywatch.com/api/*`, before debugging the backend.
+
+## Playbook: prod DB disk growth
+
+`api_cache` dominates. A pg_cron job `purge-expired-api-cache` (daily 03:30 UTC)
+is live — record at `migrations/maintenance/api_cache_purge_cron.sql`. Inspect:
+`select * from cron.job;` / `cron.job_run_details`. DELETE doesn't shrink disk
+(VACUUM FULL is one-time and manual — never schedule it). `newsletters` rows are
+~5MB each (base64-embedded images) — known TODO to externalize to Blob storage.
+Note: the default connected Supabase account may be a different org — prod is
+project ref `snqwamzutbcbjgusubsa`.
+
+## Playbook: exercising Film Room locally (no cloud GPU)
+
+Runs against the LOCAL DB (`soccer_newsletter`), never prod. Load real spike
+artifacts: `src/scripts/load_video_artifacts.py --match-id N --artifacts-dir
+spike/video-analysis/results/...`. Media routes need a match-scoped media token
+(`auth.py` `mint_media_token`, salt `video-media`). Known prod gaps: crop
+serving 501s (worker doesn't persist crops to blob); SWA CSP lacks
+`media-src blob:`.

--- a/docs/agents/frontend.md
+++ b/docs/agents/frontend.md
@@ -1,0 +1,20 @@
+# Frontend — React/Vite patterns & gotchas
+
+- pnpm only (v9, Node 20). `pnpm dev` (port 5173, proxies `/api` → :5001 via
+  `vite.config.js`), `pnpm lint`, `pnpm build`, `pnpm test:e2e`.
+- All API calls go through `src/lib/api.js` — add endpoint methods there; no
+  ad-hoc `fetch()` in components.
+- `VITE_API_BASE` is baked at **build** time. Locally leave it unset (the dev
+  proxy handles routing). Manual SWA deploys must set it (see workflow.md).
+- ESLint flat config (`eslint.config.js`): unused vars are errors unless prefixed
+  `A-Z`/`_` (vars/args) or `_` (caught errors). Node-context files (vite/playwright
+  config, `e2e/**`) get Node globals; everything else gets browser globals. The
+  edit hook runs `eslint --fix` for you.
+- E2E: Playwright. One file: `pnpm exec playwright test tests/<file>.test.mjs`;
+  interactive: `--ui`. Tests live in `tests/` and `e2e/`.
+- UI is Radix primitives (`src/components/ui/`) + Tailwind 4 — reuse the existing
+  `ui/` components before writing new ones.
+- `pnpm-lock.yaml` conflicts/breakage: repair surgically, never regenerate the
+  whole file (see `docs/agents/invariants.md` — Dependabot corruption incident).
+- Verify UI work **visually** (Playwright: load the page, screenshot, check for
+  console errors) — a green `pnpm build` proves nothing about rendering.

--- a/docs/agents/invariants.md
+++ b/docs/agents/invariants.md
@@ -1,0 +1,87 @@
+# Invariants — permanent platform rules
+
+Each rule exists because breaking it caused (or nearly caused) a real incident.
+If a task seems to require breaking one, stop and raise it with the user.
+
+## 1. `main` is production; the PR is the audit trail
+Never push directly to `main` — branch → PR → merge → watch the deploy run to
+completion. Deploy fires on ANY push to main, so the PR record is the only gate.
+
+## 2. Prod DB: IPv4 pooler host + psycopg driver — always
+Connection strings must use the Supabase **session pooler**
+(`aws-1-us-west-1.pooler.supabase.com:5432`, user `postgres.<ref>`) and the
+`postgresql+psycopg://` scheme. The direct `db.<ref>.supabase.co` host is
+IPv6-only ("Network is unreachable" from ACA); a bare `postgresql://` scheme
+selects psycopg2, which isn't installed → boot crash under gunicorn --preload.
+Both bit during the 2026-06-14 password-rotation outage. If
+`SQLALCHEMY_DATABASE_URI` is set it wins and must ALSO be pooler+psycopg;
+recovery: `az containerapp update --remove-env-vars SQLALCHEMY_DATABASE_URI`
+(falls back to DB_* components). Coercion helper: `src/main.py` `_coerce_psycopg_driver`.
+
+## 3. `VITE_API_BASE` must be set for any manual frontend build
+The `'/api'` fallback (`src/lib/api.js`) only works behind the vite dev proxy —
+on SWA every call 404s ("string did not match the expected pattern"). CI sets it
+from the backend FQDN; a manual `swa deploy` must too.
+
+## 4. Backend dependency changes are untested by CI — prove installability
+CI's backend job is ruff-only (no pip install); the ACR image build at deploy is
+the first real install. Before merging any `requirements.txt` change:
+`pip install --dry-run --ignore-installed -r academy-watch-backend/requirements.txt`.
+Batch backend Dependabot bumps into ONE PR. **Never merge a standalone
+pydantic_core bump** — pydantic pins it exactly. **numpy stays <2.5**: the image
+is `python:3.11-slim` (CI lints on 3.12) — all deps must stay py3.11-compatible.
+
+## 5. `pnpm-lock.yaml`: repair surgically, never regenerate
+2026-06-12 (PR #420): a Dependabot auto-merge left a duplicate YAML key →
+`ERR_PNPM_BROKEN_LOCKFILE` reddened EVERY open PR (CI runs the merge ref with
+main). A full regen re-resolves all `^` ranges and silently jumps versions.
+Delete the duplicated block by hand; verify with `pnpm install --frozen-lockfile`
+in a clean worktree.
+
+## 6. `recompute-academy` is attribution-only — status repair needs a journey RE-SYNC
+PR #512: recompute handed the classifier an empty transfer list; the
+empty-list→'left' rule overwrote statuses platform-wide (on_loan/sold → left).
+`POST /api/admin/journeys/recompute-academy` must never re-derive
+`TrackedPlayer.status`. Status flips → journey bulk re-sync (transfers
+required); names → `backfill-names`; journey current-status →
+`backfill-current-status`.
+
+## 7. Migrations don't run on deploy; all DDL must be idempotent
+The Dockerfile CMD is gunicorn only — no `flask db upgrade` anywhere in the
+pipeline, and prod schema has out-of-band DDL (the chain can't even replay on an
+empty DB). Guard everything with `migrations/_migration_helpers.py`; apply prod
+schema deliberately, then reconcile the migration.
+
+## 8. Prod `SECRET_KEY` is the literal string `kvref:http…` — do not "fix" it
+Every outstanding admin/user Bearer token is signed with that exact string
+(salt `user-auth`, `src/utils/auth.py`). Changing it 401s everyone instantly;
+rotation needs a token-revocation + re-login plan. KV copies of
+secret-key/admin-api-key are STALE — read inline values via
+`az containerapp secret show`.
+
+## 9. Bulk data ops never run against the live prod container
+Prod is 0.5 CPU / 1Gi / max 2 replicas: even sequential force_full journey
+syncs starve the health probe and cause outages. Scale up first, run
+health-gated batches, scale back — or run out-of-band against the pooler.
+Exact commands: `docs/agents/debugging.md`.
+
+## 10. API-Football quota: crawl scope is env-controlled, never code-widened
+`DEFAULT_CRAWL_LEAGUE_IDS` (`src/utils/supported_leagues.py`) = European top-5.
+Widen only via the `CRAWL_LEAGUE_IDS` env var after quota sign-off — past
+quota-exceeded incidents. Never hardcode league expansion.
+
+## 11. Never fabricate content attributed to real people or outlets
+28 invented "demo tweets" nearly shipped to a club stakeholder. Real
+integrations exist (`services/twitter_client.py`); fetch real content, ask the
+user, or flag the gap loudly. Corollary: curated stakeholder content must be
+analysed for VALUE, not just authenticity — drop opposition-perspective items,
+losses, in-passing mentions. Better empty than padded.
+
+## 12. Before declaring a credential missing, read `.env`
+A source-tree grep missed `TWITTER_BEARER_TOKEN` sitting in
+`academy-watch-backend/.env` — which cascaded into the fabrication incident.
+Check `.env`, `env.template`, AND `az containerapp secret show` first.
+
+## 13. Local dev: the login shell exports `ADMIN_API_KEY`, overriding `.env`
+Mismatched keys silently 401 local admin calls. Echo the effective env var
+before debugging admin auth. (Low-confidence/machine-specific — re-confirm.)

--- a/docs/agents/loops.md
+++ b/docs/agents/loops.md
@@ -1,0 +1,61 @@
+# Running loops safely here
+
+A **loop** is an agent repeating cycles of work until a stop condition is met.
+This repo runs them today: Ralph (`./scripts/ralph/ralph.sh`) executes ledger
+tasks autonomously, and five Azure Container App jobs run scheduled syncs
+(see `OPERATIONS.md`). `docs/agents/invariants.md` is the list of hard stops
+every loop must honor.
+
+## Ralph protocol
+
+- Ralph picks ONLY `ready` tasks from the active planning ledger (statuses:
+  pending / ready / in-progress / blocked / complete — see `AGENTS.md`).
+- One task per iteration; update the ledger and commit after each.
+- Sentinels: `<ralph>COMPLETE</ralph>` when all tasks done, `<ralph>STOP</ralph>`
+  when blocked. Review `scripts/ralph/progress.txt` and the commits afterwards.
+- Handing off: set `in-progress` → `ready`, make acceptance criteria explicit,
+  commit, then `./scripts/ralph/ralph.sh 25`.
+
+## 1. Stop conditions are safety gates, not just quality gates
+
+In an autonomous loop a wrong action *executes*. Hard-halt (raise to a human)
+before: prod schema migrations, bulk journey re-syncs against prod (they have
+flapped health probes and caused outages on the 0.5 CPU/1Gi container), sending
+email via Mailgun, Stripe changes, deleting Azure resources, anything touching
+prod secrets.
+
+## 2. Key "done" off the real end-state, not a proxy
+
+A MERGED badge ≠ `main` advanced (stacked PRs produce phantom merges — verify
+`git log origin/main`). CI green ≠ the page renders. "Job triggered" ≠ data
+landed — query the row or endpoint afterwards.
+
+## 3. Verify by DRIVING the change
+
+- Web UI: Playwright — load the page, interact, screenshot, zero new console errors.
+- API: curl the endpoint (prod or local) and read the payload; time it and check
+  its size — oversized responses break rendering with "correct" data.
+- Data jobs: SQL count/aggregate before vs after.
+
+## 4. Make the loop observe itself
+
+Sub-agents report through the ledgers (`CONTINUITY.md`, planning ledger status
+flips) — a structured channel. The orchestrator verifies each agent's *actual
+output* (commit exists, row written, screenshot taken), not that it "finished".
+
+## 5. Pilot the unit before you fan out
+
+Prove one instance end-to-end before scaling: one player before a full journey
+re-sync, one team before a full rebuild. Full rebuilds run for hours and burn
+API-Football quota — a flaw amplifies N times.
+
+## 6. When a result misses the bar, fix the SYSTEM
+
+Encode the miss as a new invariant, hook, or verify step so the next iteration
+can't repeat it. That flywheel is the point of the harness.
+
+## Token spend
+
+Mechanical work → cheap model; judgment → capable model. Prefer a deterministic
+script over re-reasoning. The scheduled ACA jobs + pg_cron already cover daily
+syncs and cache purges — don't build agent loops for what they already do.

--- a/docs/agents/workflow.md
+++ b/docs/agents/workflow.md
@@ -1,0 +1,85 @@
+# Workflow — git, CI, deploy, migrations
+
+Read before committing, pushing, merging, deploying, or migrating. Every push to
+`main` deploys to production — treat `main` as a deploy trigger, not a branch.
+
+## Branching & commits
+
+- Never commit directly to `main`. Branch → PR → merge → **watch the deploy finish**.
+  Unwatched deploys have shipped broken bundles; the loop closes only when you've
+  verified the run, not when you've merged.
+- Cross-branch work via `git worktree add`, never checkout-switching a dirty tree.
+- Stage files by explicit path. `git add -A` / `git add .` are blocked by a hook.
+- Conventional commits: `type(scope): summary` — e.g. `feat(pulse): …`, `fix(admin): …`.
+- Non-trivial work: update `CONTINUITY.md` / the active ledger per `AGENTS.md`.
+
+## Pre-push checklist (mirrors CI exactly)
+
+CI on every PR (`.github/workflows/ci.yml`) runs four gates:
+
+```bash
+# backend — from repo root; config lives in academy-watch-backend/pyproject.toml
+ruff check academy-watch-backend
+ruff format --check academy-watch-backend  # CI-only gate: plain `ruff check` misses format drift
+# frontend
+cd academy-watch-frontend && pnpm lint && pnpm build   # build is a gate too, not just lint
+```
+
+- Every CI job installs with `pnpm install --frozen-lockfile`: if you touch
+  `package.json`, update `pnpm-lock.yaml` with a normal `pnpm install`. **Never
+  regenerate the whole lockfile** — a full regen after a bad Dependabot auto-merge
+  once corrupted it and reddened CI on every open PR. Fix lockfile conflicts
+  surgically (see `docs/agents/invariants.md`).
+- Changing `academy-watch-backend/requirements.txt`? CI never installs backend
+  deps (lint-only) — the ACR build at deploy is the first real install. Dry-run
+  first: `pip install --dry-run --ignore-installed -r academy-watch-backend/requirements.txt`
+  (see `docs/agents/invariants.md` #4 for the pydantic_core / numpy rules).
+- The PostToolUse hook (`.claude/hooks/lint_on_edit.sh`) auto-fixes ruff + eslint
+  at edit time; this checklist is the backstop, not the first line.
+
+## Merging
+
+- Confirm the base first: `gh pr view <n> --json baseRefName` must be `main`.
+  Stacked PRs whose base branch was deleted produce **phantom merges** — the PR
+  shows MERGED but `main` never advanced.
+- After merging, verify: `git fetch origin && git log origin/main --oneline -1`.
+- Never pipe `gh pr checks --watch` / `gh run watch` through anything — the pipe
+  steals the exit code. Read the pass/fail output itself.
+
+## Deploy pipeline (push to main = deploy)
+
+- Backend or mixed changes → **Deploy** (`deploy.yml`, ~6 min): RLS security check
+  → ruff → ACR image build → Container App `ca-loan-army-backend` + 5 scheduled
+  jobs → frontend build + SWA upload.
+- Frontend-only changes → **Deploy Frontend (fast)** (`deploy-frontend.yml`,
+  ~1–2 min): SWA only. Temporary fast path — delete the file and remove
+  `paths-ignore` in `deploy.yml` to revert to full deploys.
+- Known flake: Deploy Frontend intermittently 403s pulling its MCR base image.
+  Not a code bug — `gh run rerun <id> --failed`.
+- `VITE_API_BASE` is baked into the bundle at build time by the workflow. A manual
+  `swa deploy` MUST set it explicitly or the frontend ships pointing at nothing.
+- RLS gate: every new table needs `ALTER TABLE <t> ENABLE ROW LEVEL SECURITY;`
+  (plus policies) or the Deploy workflow fails before building anything.
+
+## Verify the deploy (not the badge)
+
+Green Actions ≠ working product. Drive the user-facing symptom: load the affected
+page, hit the prod endpoint. Container logs via the `production-logs` skill or:
+
+```bash
+az containerapp logs show -n ca-loan-army-backend -g rg-loan-army-westus2 --tail 100
+```
+
+## Migrations
+
+- All DDL must be idempotent via `migrations/_migration_helpers.py`
+  (`column_exists`, `table_exists`, …) — prod has out-of-band schema drift.
+- Apply to prod inside the container:
+
+```bash
+az containerapp exec --name ca-loan-army-backend --resource-group rg-loan-army-westus2 --command /bin/sh
+FLASK_APP=src/main.py flask db upgrade
+```
+
+- The Dockerfile copies only `src/` and `migrations/` — runnable scripts must
+  live in `src/scripts/` to exist in the image.


### PR DESCRIPTION
## What

Rebuilds the repo's agent harness following the lean-router pattern:

- **`CLAUDE.md` → 77-line router** (was a 223-line manual). Identity, a read-first routing table into `docs/agents/`, compact stack + commands, iron rules, commit convention. The AGENTS.md/CONTINUITY.md ledger protocol stays mandatory and is the first routing row.
- **7 playbooks in `docs/agents/`** (all ≤120 lines): `workflow.md`, `invariants.md`, `debugging.md`, `data-model.md`, `backend.md`, `frontend.md`, `loops.md`.
- **Edit-time lint hook** `.claude/hooks/lint_on_edit.sh` + `.claude/settings.json`: mirrors CI exactly — `ruff check --fix`/`ruff format` for backend Python, `eslint --fix` for frontend JS. Verified by dry-run: reformats a deliberately bad file, exits 0 on non-source files, never blocks an edit.

## Stale content removed (verified missing before removal)

- CLAUDE.md "Harness" section: `~/bin/harness-check`, `~/bin/harness-install`, `rules/harness.md`, and the pre-commit hooks it described **do not exist** on this machine or in the repo.
- Migration-head claim ("vid03") — head has moved (aw22); the router no longer pins it.

## Promoted from per-project memory (each verified against the current tree)

Invariants now in-repo instead of one machine's memory: Supabase pooler+psycopg driver rule (2026-06-14 outage), surgical-lockfile-repair rule (PR #420 incident), recompute-academy attribution-only rule (PR #512 status clobber), backend-deps-untested-by-CI + pydantic_core/numpy<2.5 pins (python:3.11-slim image), SECRET_KEY kvref trap, bulk-ops capacity rule, VITE_API_BASE rule, no-fabrication + curation-quality rules, CRAWL_LEAGUE_IDS quota rule. Debugging playbooks: MCR 403 rerun, payload-size triage, prod admin access, health-flap scaling, SWA 405 quirk, pg_cron cache purge.

## CI gates the hook now mirrors

`ruff check academy-watch-backend`, `ruff format --check academy-watch-backend` (the CI-only gate local defaults miss), frontend eslint. `pnpm build` and `--frozen-lockfile` remain checklist items in `workflow.md`.

Docs-only + hooks; no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)