### PR TITLE
docs(harness): refresh — verified memory promotions, stale-ref fixes, loops playbook

### DIFF
--- a/.claude/hooks/lint_on_edit.sh
+++ b/.claude/hooks/lint_on_edit.sh
@@ -21,7 +21,7 @@ case "$FILE" in
     ;;
 
   # --- Frontend JS/JSX/TS/TSX: mirror `pnpm lint` (eslint flat config) ---
-  *academy-watch-frontend/*.js|*academy-watch-frontend/*.jsx|*academy-watch-frontend/*.ts|*academy-watch-frontend/*.tsx)
+  *academy-watch-frontend/*.js|*academy-watch-frontend/*.mjs|*academy-watch-frontend/*.jsx|*academy-watch-frontend/*.ts|*academy-watch-frontend/*.tsx)
     cd "$CLAUDE_PROJECT_DIR/academy-watch-frontend" || exit 0
     npx --no-install eslint --fix --quiet "$FILE" 2>/dev/null
     ;;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ each doc encodes hard-won lessons, and skipping them repeats old mistakes.
 | Committing, pushing, merging, deploying, migrating, or handling Dependabot | `docs/agents/workflow.md` |
 | Writing backend code (Flask / SQLAlchemy / Alembic) | `docs/agents/backend.md` |
 | Writing frontend code (React / Vite / Tailwind / Radix) | `docs/agents/frontend.md` |
+| Running Ralph, scheduled/autonomous loops, or sub-agent fan-outs | `docs/agents/loops.md` |
 
 **Ledger protocol (this repo's own system, still in force):** before ANY work read
 `AGENTS.md` + `CONTINUITY.md` and check `ledgers/` for an active planning ledger;
@@ -60,6 +61,7 @@ cd academy-watch-frontend && pnpm exec playwright test tests/<file>.mjs   # sing
 - **Prod DB is reached via the IPv4 pooler + `postgresql+psycopg://` only** — the direct (IPv6) host is unreachable from ACA and a bare `postgresql://` loads the absent psycopg2. See `invariants.md`.
 - **Never reference the deleted `AcademyPlayer`/`SupplementalLoan` models** — use `TrackedPlayer`. **Alembic migrations guard every DDL** (prod schema drifted out-of-band). **Never bulk-sync/recompute against the live prod container** — it's tiny and falls over. See `invariants.md`.
 - **Secrets:** never print secrets or dump env; read live values via `az containerapp secret show`. Prod `SECRET_KEY` is a `kvref:` literal — do NOT "fix"/rotate it without a token-revocation plan (`invariants.md`).
+- **Real sources only:** never fabricate content attributed to real people/outlets (tweets, quotes, articles) — not even as "demo" data. And keep the API-Football crawl scope env-gated (`CRAWL_LEAGUE_IDS`). See `invariants.md`.
 
 ## Commit convention
 

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -52,6 +52,20 @@ One row **per player per parent academy club**. This is the spine of the product
   `resolve_player_name()` (utils/player_names.py) and a placeholder must NEVER overwrite
   a real name (invariants.md §5).
 
+## Status is two axes; seasons are start-years
+
+- `TrackedPlayer.status` is RELATIVE to the tracked academy (`sold`/`left` = left THAT
+  club; the 6th status `left` = at another club with no recorded parent departure). The
+  player's ACTUAL situation lives on the journey: `player_journeys.current_status` /
+  `current_owner_*` (set by `JourneySyncService._set_current_status`; repair:
+  `POST /api/admin/journeys/backfill-current-status`). Player-page headlines read the
+  journey axis; team/academy views read the per-academy axis. Affiliates
+  (Jong Ajax → Ajax, …) resolve via `utils/affiliates.py`.
+- A season value is the START YEAR (2025 = the 2025-26 season). Rollover is
+  inconsistent by design-accident: profile endpoints flip in **August**
+  (`routes/players.py`, month >= 8) while the academy window flips in **July**
+  (`utils/academy_window.py`, month >= 7) — mind the gap in June–August work.
+
 ## The pipelines (all fed by API-Football)
 
 1. **Player tracking**: API-Football → `TrackedPlayer` records.

--- a/docs/agents/debugging.md
+++ b/docs/agents/debugging.md
@@ -70,6 +70,37 @@ install deps, so the deploy build is the first real install test. Dry-run first 
 worktree: `pip install --dry-run --ignore-installed -r requirements.txt`. See workflow.md
 for the batching rule.
 
+## Playbook: need an admin/diagnostic op against prod from a local shell
+
+`az containerapp exec` needs a TTY, and the direct DB host is IPv6-only (no local route).
+Use the prod HTTP admin endpoints — auth is two-factor: `Authorization: Bearer <token>`
+AND `X-API-Key`. Mint the Bearer locally with itsdangerous:
+`URLSafeTimedSerializer(secret_key=<inline secret-key>, salt='user-auth').dumps({'email': <admin email>, 'role': 'admin', 'iat': <now>})`.
+Read CURRENT inline secrets — the Key Vault copies are stale (invariants.md §9) — and
+never echo the values into the transcript:
+
+```bash
+az containerapp secret show -g rg-loan-army-westus2 -n ca-loan-army-backend \
+  --secret-name secret-key --query value -o tsv
+```
+
+Raw SQL: the pooler host, with `PGOPTIONS='-c default_transaction_read_only=on'` for
+read-only work.
+
+## Playbook: a POST 405s on theacademywatch.com but the route looks right
+
+The SWA front door can 405 POSTs at the custom domain. Test against the container-app
+FQDN (`https://ca-loan-army-backend.<env>.azurecontainerapps.io/api/...`) before
+debugging the backend.
+
+## Playbook: exercising Film Room locally (no cloud GPU)
+
+Runs against the LOCAL DB (`soccer_newsletter`), never prod. Load real spike artifacts:
+`python src/scripts/load_video_artifacts.py --match-id N --artifacts-dir spike/video-analysis/results/...`.
+Media routes need a match-scoped token (`utils/auth.py::mint_media_token`, salt
+`video-media`). Known prod gaps: crop serving 501s (no blob persistence yet); SWA CSP
+lacks `media-src blob:`.
+
 ## DB bloat (context, not usually an incident)
 
 `api_cache` (API-Football TTL cache) dominates DB size; a pg_cron job

--- a/docs/agents/invariants.md
+++ b/docs/agents/invariants.md
@@ -84,3 +84,37 @@ Bearer token with it via `itsdangerous`. Changing it 401s **every outstanding to
 instant it changes. The KV copy `kv-loan-army/secret-key` is stale and differs — do not mint
 tokens from it. Rotation needs a planned window + user re-login. Read live truth via
 `az containerapp secret show`. Same inline-vs-KV divergence applies to `admin-api-key`.
+
+## 10. `recompute-academy` is attribution-only — it must never re-derive `status`
+
+PR #512: the recompute repair handed `classify_tracked_player()` an **empty transfer
+list**; the empty-list→'left' rule fired and unconditionally overwrote statuses
+platform-wide (on_loan 188→0, sold 688→0). Status flips (on_loan→sold/released/…)
+require a journey RE-SYNC with real transfer data. `recompute-academy` repairs
+attribution only; `backfill-names` repairs names; `backfill-current-status` repairs the
+journey's current-status axis. Never wire status derivation into a transfers-less path.
+
+## 11. API-Football crawl scope is env-gated — never widen it in code
+
+`DEFAULT_CRAWL_LEAGUE_IDS` (`src/utils/supported_leagues.py`) pins the expensive
+crawl/loan-sweep to the European top-5. Quota-exceeded incidents made this a hard
+requirement: widening scope is a `CRAWL_LEAGUE_IDS` env decision after quota sign-off,
+never a code side-effect. (Related: `League.is_european_top_league` deliberately kept
+its name — it now means "supported league" — because prod DDL drifted out-of-band.)
+
+## 12. Never fabricate content attributed to real people or outlets
+
+28 invented "demo tweets" with fake handles nearly shipped to a club stakeholder. Real
+integrations exist (`services/twitter_client.py`); fetch real content, ask the user, or
+flag the gap loudly. Corollary: curated stakeholder content is judged on VALUE, not just
+authenticity — drop opposition-perspective items, losses, and in-passing mentions.
+Better empty than padded.
+
+## 13. Before declaring a credential missing, read `.env`
+
+A source-tree grep missed `TWITTER_BEARER_TOKEN` sitting unused in
+`academy-watch-backend/.env` — that wrong conclusion cascaded into the fabrication
+incident above. Check `.env`, `env.template`, AND `az containerapp secret show` before
+concluding a secret is absent. (Local quirk: the login shell exports its own
+`ADMIN_API_KEY` that overrides `.env` — echo the effective value when local admin auth
+401s unexpectedly.)

--- a/docs/agents/loops.md
+++ b/docs/agents/loops.md
@@ -1,0 +1,60 @@
+# Running loops safely here
+
+A **loop** is an agent repeating cycles of work until a stop condition is met.
+This repo runs them today: Ralph (`./scripts/ralph/ralph.sh`) executes ledger
+tasks autonomously, and five Azure Container App jobs run scheduled syncs
+(see `OPERATIONS.md`). `docs/agents/invariants.md` is the list of hard stops
+every loop must honor.
+
+## Ralph protocol
+
+- Ralph picks ONLY `ready` tasks from the active planning ledger (statuses:
+  pending / ready / in-progress / blocked / complete — see `AGENTS.md`).
+- One task per iteration; update the ledger and commit after each.
+- Sentinels: `<ralph>COMPLETE</ralph>` when all tasks done, `<ralph>STOP</ralph>`
+  when blocked. Review `scripts/ralph/progress.txt` and the commits afterwards.
+- Handing off: set `in-progress` → `ready`, make acceptance criteria explicit,
+  commit, then `./scripts/ralph/ralph.sh 25`.
+
+## 1. Stop conditions are safety gates, not just quality gates
+
+In an autonomous loop a wrong action *executes*. Hard-halt (raise to a human)
+before: prod schema migrations, bulk journey re-syncs against prod (they starve
+the health probe and have caused outages — invariants.md §7), sending email via
+Mailgun, Stripe changes, deleting Azure resources, anything touching prod secrets.
+
+## 2. Key "done" off the real end-state, not a proxy
+
+A MERGED badge ≠ `main` advanced (stacked PRs produce phantom merges — verify
+`git log origin/main`). CI green ≠ the page renders. "Job triggered" ≠ data
+landed — query the row or endpoint afterwards.
+
+## 3. Verify by DRIVING the change
+
+- Web UI: Playwright — load the page, interact, screenshot, zero new console errors.
+- API: curl the endpoint (prod or local) and read the payload; time it and check
+  its size — oversized responses break rendering with "correct" data (debugging.md).
+- Data jobs: SQL count/aggregate before vs after.
+
+## 4. Make the loop observe itself
+
+Sub-agents report through the ledgers (`CONTINUITY.md`, planning-ledger status
+flips) — a structured channel. The orchestrator verifies each agent's *actual
+output* (commit exists, row written, screenshot taken), not that it "finished".
+
+## 5. Pilot the unit before you fan out
+
+Prove one instance end-to-end before scaling: one player before a full journey
+re-sync, one team before a full rebuild. Full rebuilds run for hours and burn
+API-Football quota (invariants.md §11) — a flaw amplifies N times.
+
+## 6. When a result misses the bar, fix the SYSTEM
+
+Encode the miss as a new invariant, hook, or verify step so the next iteration
+can't repeat it. That flywheel is the point of the harness.
+
+## Token spend
+
+Mechanical work → cheap model; judgment → capable model. Prefer a deterministic
+script over re-reasoning. The scheduled ACA jobs + pg_cron already cover daily
+syncs and cache purges — don't build agent loops for what they already do.

--- a/docs/agents/workflow.md
+++ b/docs/agents/workflow.md
@@ -12,9 +12,6 @@ watch-deploy sequence on **every** change — never a direct push to main.
   Never `git checkout` away from a dirty tree.
 - Stage specific files by path. `git add -A` / `git add .`, `--no-verify`, and
   force-push-main are blocked by the global git hook (`~/.claude/hooks/git_guard.sh`).
-- This repo also runs its own pre-commit harness: `~/bin/harness-check --project . --scope
-  staged` (ruff lint + format + secret scan); auto-fix with `--fix`. Install if missing:
-  `~/bin/harness-install .`.
 
 ## Pre-push checklist (each maps to a CI gate a plain local run does NOT cover)
 
@@ -42,7 +39,8 @@ watch-deploy sequence on **every** change — never a direct push to main.
   rebase cascade + one deploy each. Combine into a single hand-authored
   `chore(deps): batch backend bumps` PR, then close the superseded ones (squash drops
   `Closes #N` for all but the first). **Never merge a standalone `pydantic_core` bump**
-  (pydantic pins it exactly — breaks the deploy; debugging.md).
+  (pydantic pins it exactly — breaks the deploy; debugging.md). **numpy stays <2.5**
+  (needs py≥3.12; the image is 3.11) — `dependabot.yml` already ignores it, don't override.
 - **Frontend** bumps (`package.json`/`pnpm-lock.yaml`) are independent — merge directly.
 - Dependabot PRs auto-merge (`dependabot-auto-merge.yml`, squash). The only red check is
   usually the non-gating `auto-merge` job; real CI (Lint+Build) is green.


### PR DESCRIPTION
## What

Refresh pass on the harness that landed in #580. Every addition traces to a memory-mining audit in which each candidate rule was **verified against the current tree** before promotion. (Replaces #587, which was a parallel bootstrap that #580 superseded — rebuilt here as a clean delta on main.)

### Corrections
- **workflow.md**: removed the `~/bin/harness-check` / `~/bin/harness-install` pre-commit paragraph — verified those scripts and hooks **do not exist**; the real gates are CI + the on-edit lint hook.

### New incident-backed invariants (#10–13)
- `recompute-academy` is attribution-only — never re-derives `status` (PR #512 platform-wide status clobber)
- API-Football crawl scope stays env-gated via `CRAWL_LEAGUE_IDS` (quota incidents)
- Never fabricate content attributed to real people/outlets + curation-value corollary (Forest demo incident)
- Read `.env` before declaring a credential missing (+ shell `ADMIN_API_KEY` override quirk)

### New debugging playbooks
- Prod admin/diagnostic access from a local shell (two-factor auth, minting the Bearer, stale-KV warning, read-only PGOPTIONS)
- SWA front-door 405 on POST → test against the container FQDN
- Film Room local validation (local DB, artifact loader, media tokens, known prod gaps)

### New content
- **loops.md**: Ralph protocol + safety gates for autonomous/scheduled loops — hard stops, real-end-state vs proxy signals, verify-by-driving, pilot-before-fan-out. Routed from CLAUDE.md.
- **architecture.md**: two-axes status model (per-academy `TrackedPlayer.status` vs journey `current_status`/`current_owner_*`) and season start-year semantics incl. the **July-vs-August rollover inconsistency** (`players.py` month≥8 vs `academy_window.py` month≥7) — directly relevant to the scout-page data investigation running in parallel.
- **workflow.md**: numpy<2.5 Dependabot rule (py3.11 image); **lint hook**: also match `.mjs`.

Docs + hook only; no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)