### PR TITLE
feat(season): foundation — canonical season service, season-scoped stat reads, orphan guards

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -77,11 +77,25 @@ How the automated maintenance jobs work and when to use them.
 Bought players (owning-club rows) are excluded from academy views but exist in the DB so the GOL bot can show correct parent clubs for loan display.
 
 ### TrackedPlayer Row Types
-Each player can have multiple rows:
-- **Academy-origin** (`data_source: journey-sync`): Links player to their youth academy. This is how they appear on the academy's Teams page.
-- **Owning-club** (`data_source: owning-club`): Links player to their current contract holder. Used for GOL bot parent club display.
+The **academy-origin** row (`data_source: journey-sync`) is canonical. It links a
+player to the youth academy that formed him and is how he surfaces on that
+academy's Teams page, in Scout Desk, and in newsletters. Clubs only track players
+formed in their OWN academy (see the academy provenance rule).
 
-The stale row cleanup (runs automatically in transfer-heal) deactivates academy-origin rows when they're superseded by an owning-club row.
+Legacy **owning-club** rows (`data_source: owning-club`) linked a player to his
+current contract holder. These are **deprecated and auto-deactivated** — the
+journey upsert never creates them, and academy/Scout/Teams surfaces exclude them
+entirely.
+
+The stale row cleanup (runs automatically in transfer-heal) enforces
+academy-canonical precedence: it deactivates the **owning-club** duplicate
+whenever an active **academy-origin** sibling exists, so the academy row always
+wins. (The previous direction — retiring the academy row in favour of an
+owning-club row — would make the player invisible everywhere.)
+
+The nightly heal also **requeues orphaned in-window academy rows** (`is_active=false`,
+non-manual, non-pinned) so a transfers-fed journey re-sync can reactivate them,
+recovering rows that an earlier transient sync wrongly deactivated.
 
 ### Transfer Classification
 - `"Loan"` → player is on loan, status = `on_loan`

--- a/academy-watch-backend/migrations/versions/aw23_index_fixtures_season.py
+++ b/academy-watch-backend/migrations/versions/aw23_index_fixtures_season.py
@@ -1,0 +1,31 @@
+"""Index fixtures.season
+
+Revision ID: aw23
+Revises: aw22
+Create Date: 2026-07-07
+
+stats_season_with_data() runs `SELECT id FROM fixtures WHERE season = :s LIMIT 1`
+(plus a MAX(season) fallback in the rollover gap), and every season-scoped stats,
+chart, and radar query filters `Fixture.season == season`. fixtures.season was
+unindexed, so each of those was a near-full seq scan of ~20k rows — worse for the
+current season whose rows sit at the heap tail. On the 0.5 CPU prod container this
+cost tens of ms per request and seconds per newsletter render (many players x
+multiple chart calls). Guarded so it is a no-op if the index was added out-of-band.
+"""
+
+from alembic import op
+from migrations._migration_helpers import create_index_safe, index_exists
+
+revision = "aw23"
+down_revision = "aw22"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    create_index_safe("ix_fixtures_season", "fixtures", ["season"])
+
+
+def downgrade():
+    if index_exists("ix_fixtures_season"):
+        op.drop_index("ix_fixtures_season", table_name="fixtures")

--- a/academy-watch-backend/src/agents/weekly_agent.py
+++ b/academy-watch-backend/src/agents/weekly_agent.py
@@ -853,7 +853,9 @@ async def fetch_weekly_report(ctx, args) -> dict[str, Any]:
         raise ValueError(f"Team DB id {parent_team_db_id} not found")
 
     # Sync season to target date's season (European season starts Aug 1)
-    season_start_year = tdate.year if tdate.month >= 8 else tdate.year - 1
+    from src.utils.academy_window import current_stats_season
+
+    season_start_year = current_stats_season(tdate)
     api_client.set_season_year(season_start_year)
     api_client._prime_team_cache(season_start_year)
 

--- a/academy-watch-backend/src/agents/weekly_newsletter_agent.py
+++ b/academy-watch-backend/src/agents/weekly_newsletter_agent.py
@@ -3494,7 +3494,9 @@ def compose_team_weekly_newsletter(
     week_start, week_end = _monday_range(target_date)
 
     # Derive season from the week we are processing (European season starts Aug 1)
-    season_start_year = week_start.year if week_start.month >= 8 else week_start.year - 1
+    from src.utils.academy_window import current_stats_season
+
+    season_start_year = current_stats_season(week_start)
 
     if force_refresh:
         api_client.clear_stats_cache(season=season_start_year)

--- a/academy-watch-backend/src/api_football_client.py
+++ b/academy-watch-backend/src/api_football_client.py
@@ -340,17 +340,12 @@ class APIFootballClient:
 
     def _set_default_season_from_date(self):
         """Set default season based on current date."""
-        current_year = self.current_date.year
+        # European football season runs Aug→May/June: the shared stats/fixture
+        # season rule (August rollover) selects the start year.
+        from src.utils.academy_window import current_stats_season
 
-        # European football season typically runs from August to May/June
-        # If it's January-July, we're in the second half of the season
-        # If it's August-December, we're in the first half of the season
-        if self.current_date.month >= 8:  # August or later
-            self.current_season_start_year = current_year
-            self.current_season_end_year = current_year + 1
-        else:  # January to July
-            self.current_season_start_year = current_year - 1
-            self.current_season_end_year = current_year
+        self.current_season_start_year = current_stats_season(self.current_date)
+        self.current_season_end_year = self.current_season_start_year + 1
 
         self.current_season = f"{self.current_season_start_year}-{self.current_season_end_year}"
         self.season_start_date = date(self.current_season_start_year, 8, 1)

--- a/academy-watch-backend/src/jobs/run_status_refresh.py
+++ b/academy-watch-backend/src/jobs/run_status_refresh.py
@@ -21,7 +21,7 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(mess
 
 
 def run(dry_run=False):
-    from src.services.transfer_heal_service import refresh_and_heal
+    from src.services.transfer_heal_service import MAX_ORPHAN_REQUEUE, refresh_and_heal
 
     try:
         db.session.rollback()
@@ -41,6 +41,12 @@ def run(dry_run=False):
     team_ids = teams_with_active_tracked_players()
     logger.info("Processing %d teams", len(team_ids))
 
+    # Orphan requeue budget is JOB-GLOBAL, not per-team: refresh_and_heal runs
+    # once per team, so a per-call cap would multiply into cap×len(teams)
+    # force_full re-syncs a night. Decrement a shared budget across teams so the
+    # nightly ceiling is MAX_ORPHAN_REQUEUE.
+    orphan_budget_remaining = MAX_ORPHAN_REQUEUE
+
     results = []
     total_changed = 0
     for team_db_id in team_ids:
@@ -58,7 +64,9 @@ def run(dry_run=False):
                 resync_journeys=True,
                 dry_run=dry_run,
                 cascade_fixtures=True,
+                orphan_budget=orphan_budget_remaining,
             )
+            orphan_budget_remaining = max(0, orphan_budget_remaining - result.get("orphans_requeued", 0))
             changed = len(result.get("players_changed", []))
             total_changed += changed
             results.append({"team_id": team_db_id, **result})

--- a/academy-watch-backend/src/jobs/run_transfer_window_heal.py
+++ b/academy-watch-backend/src/jobs/run_transfer_window_heal.py
@@ -41,7 +41,7 @@ def is_transfer_window() -> bool:
 
 
 def run(dry_run=False):
-    from src.services.transfer_heal_service import refresh_and_heal
+    from src.services.transfer_heal_service import MAX_ORPHAN_REQUEUE, refresh_and_heal
 
     # Clean transaction state
     try:
@@ -72,6 +72,12 @@ def run(dry_run=False):
     team_ids = teams_with_active_tracked_players()
     logger.info("Processing %d teams", len(team_ids))
 
+    # Orphan requeue budget is JOB-GLOBAL, not per-team: refresh_and_heal is
+    # called once per team, so a per-call cap would multiply into cap×len(teams)
+    # force_full re-syncs a night (API-Football quota + 3AM runtime). Decrement
+    # a shared budget across teams so the nightly ceiling is MAX_ORPHAN_REQUEUE.
+    orphan_budget_remaining = MAX_ORPHAN_REQUEUE
+
     results = []
     for team_db_id in team_ids:
         if is_job_paused("transfer_heal_paused"):
@@ -89,7 +95,9 @@ def run(dry_run=False):
                 resync_journeys=resync,
                 dry_run=dry_run,
                 cascade_fixtures=True,
+                orphan_budget=orphan_budget_remaining,
             )
+            orphan_budget_remaining = max(0, orphan_budget_remaining - result.get("orphans_requeued", 0))
             results.append({"team_id": team_db_id, **result})
             logger.info(
                 "Team %d: %d/%d updated, %d changed, %d fixture syncs",

--- a/academy-watch-backend/src/models/tracked_player.py
+++ b/academy-watch-backend/src/models/tracked_player.py
@@ -81,11 +81,24 @@ class TrackedPlayer(db.Model):
         return age_from_birth_date(self.birth_date) or self.age
 
     def compute_stats(self):
-        """Compute stats independently of AcademyPlayer.
+        """Compute a player's CURRENT-SEASON stats.
 
-        - full_stats: aggregate from FixturePlayerStats
-        - events_only / limited: read from PlayerStatsCache
+        - full_stats: aggregate FixturePlayerStats for the current stats season
+          across EVERY club the player actually appeared for.
+        - events_only / profile_only: sum PlayerStatsCache across the player's
+          clubs for that season (limited-coverage leagues).
+
+        The season's clubs are derived from the stat rows themselves rather than
+        keyed on ``current_club_api_id``. Two failure modes that keying created:
+        a returned loanee's journey flips his current club back to the parent, so
+        his whole loan season was dropped; and first-team rows commonly have a
+        NULL current club, which returned zeros outright. A player who moved
+        mid-season (sold/released) now reports the season total across both
+        clubs, matching /players/<id>/season-stats.
         """
+        from sqlalchemy import func
+        from src.utils.academy_window import stats_season_with_data
+
         default_stats = {
             "appearances": 0,
             "goals": 0,
@@ -97,41 +110,67 @@ class TrackedPlayer(db.Model):
             "stats_coverage": self.data_depth or "full_stats",
         }
 
-        if not self.current_club_api_id:
-            return default_stats
+        # Stats DISPLAY season, with the latest-season-with-fixtures fallback so a
+        # not-yet-started calendar season never zeroes every player (see
+        # utils/academy_window.stats_season_with_data).
+        season = stats_season_with_data(db.session)
 
-        # Limited / events-only coverage → read from PlayerStatsCache
+        # Limited / events-only coverage → read from PlayerStatsCache.
         if self.data_depth in ("events_only", "profile_only"):
             from src.models.league import PlayerStatsCache
 
-            cache = (
-                PlayerStatsCache.query.filter_by(
-                    player_api_id=self.player_api_id,
-                    team_api_id=self.current_club_api_id,
+            def _cache_totals(season_value):
+                return (
+                    db.session.query(
+                        func.count(PlayerStatsCache.id).label("n"),
+                        func.coalesce(func.sum(PlayerStatsCache.appearances), 0).label("appearances"),
+                        func.coalesce(func.sum(PlayerStatsCache.goals), 0).label("goals"),
+                        func.coalesce(func.sum(PlayerStatsCache.assists), 0).label("assists"),
+                        func.coalesce(func.sum(PlayerStatsCache.minutes_played), 0).label("minutes_played"),
+                        func.coalesce(func.sum(PlayerStatsCache.saves), 0).label("saves"),
+                        func.coalesce(func.sum(PlayerStatsCache.yellows), 0).label("yellows"),
+                        func.coalesce(func.sum(PlayerStatsCache.reds), 0).label("reds"),
+                        func.max(PlayerStatsCache.stats_coverage).label("stats_coverage"),
+                    )
+                    .filter(
+                        PlayerStatsCache.player_api_id == self.player_api_id,
+                        PlayerStatsCache.season == season_value,
+                    )
+                    .first()
                 )
-                .order_by(PlayerStatsCache.season.desc())
-                .first()
-            )
-            if cache:
+
+            cache = _cache_totals(season)
+            if not cache or not cache.n:
+                # Lower-league feeds lag; fall back to the player's most recent
+                # cached season so a limited player doesn't blank on rollover.
+                latest = (
+                    db.session.query(func.max(PlayerStatsCache.season))
+                    .filter(PlayerStatsCache.player_api_id == self.player_api_id)
+                    .scalar()
+                )
+                if latest is not None and latest != season:
+                    cache = _cache_totals(latest)
+            if cache and cache.n:
                 return {
-                    "appearances": cache.appearances or 0,
-                    "goals": cache.goals or 0,
-                    "assists": cache.assists or 0,
-                    "minutes_played": cache.minutes_played or 0,
-                    "saves": cache.saves or 0,
-                    "yellows": cache.yellows or 0,
-                    "reds": cache.reds or 0,
+                    "appearances": int(cache.appearances or 0),
+                    "goals": int(cache.goals or 0),
+                    "assists": int(cache.assists or 0),
+                    "minutes_played": int(cache.minutes_played or 0),
+                    "saves": int(cache.saves or 0),
+                    "yellows": int(cache.yellows or 0),
+                    "reds": int(cache.reds or 0),
                     "stats_coverage": cache.stats_coverage or "limited",
                 }
             return default_stats
 
-        # Full stats → aggregate from FixturePlayerStats
-        from sqlalchemy import func
-        from src.models.weekly import FixturePlayerStats
+        # Full stats → aggregate FixturePlayerStats across ALL clubs the player
+        # appeared for this season (join Fixture to season-scope; the
+        # fixtures.season index keeps this a single cheap grouped scan).
+        from src.models.weekly import Fixture, FixturePlayerStats
 
         stats = (
             db.session.query(
-                func.count().label("appearances"),
+                func.count(FixturePlayerStats.id).label("appearances"),
                 func.coalesce(func.sum(FixturePlayerStats.goals), 0).label("goals"),
                 func.coalesce(func.sum(FixturePlayerStats.assists), 0).label("assists"),
                 func.coalesce(func.sum(FixturePlayerStats.minutes), 0).label("minutes_played"),
@@ -139,9 +178,10 @@ class TrackedPlayer(db.Model):
                 func.coalesce(func.sum(FixturePlayerStats.yellows), 0).label("yellows"),
                 func.coalesce(func.sum(FixturePlayerStats.reds), 0).label("reds"),
             )
+            .join(Fixture, FixturePlayerStats.fixture_id == Fixture.id)
             .filter(
                 FixturePlayerStats.player_api_id == self.player_api_id,
-                FixturePlayerStats.team_api_id == self.current_club_api_id,
+                Fixture.season == season,
             )
             .first()
         )

--- a/academy-watch-backend/src/models/weekly.py
+++ b/academy-watch-backend/src/models/weekly.py
@@ -28,7 +28,10 @@ class Fixture(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     fixture_id_api = db.Column(db.Integer, unique=True, nullable=False)
     date_utc = db.Column(db.DateTime)
-    season = db.Column(db.Integer, nullable=False)
+    # Indexed: stats_season_with_data() and every season-scoped stats/radar query
+    # filter on season; without this the current-season rows (heap tail) force a
+    # near-full seq scan on the 0.5 CPU prod container. See migration aw23.
+    season = db.Column(db.Integer, nullable=False, index=True)
     competition_name = db.Column(db.String(100))
     home_team_api_id = db.Column(db.Integer)
     away_team_api_id = db.Column(db.Integer)

--- a/academy-watch-backend/src/routes/api.py
+++ b/academy-watch-backend/src/routes/api.py
@@ -3769,7 +3769,12 @@ def _build_squad_watch(items: list[dict], n: Newsletter) -> list[dict]:
     injury_budget = _INJURY_LOOKUP_CAP
     week_start = getattr(n, "week_start_date", None)
     week_end = getattr(n, "week_end_date", None)
-    # Season the newsletter week falls in (European seasons start in July).
+    # Season the SPECIFIC newsletter week falls in (for the API-Football injury
+    # lookup below) — a per-date mapping of week_start, NOT a "current season"
+    # default, so the current_stats_season / stats_season_with_data helpers do not
+    # apply. The July hinge is intentional and matches current_academy_season's
+    # cutoff: a preseason July fixture already belongs to the upcoming season, so
+    # month>=7 maps July friendly weeks to the right (upcoming) API-Football season.
     season = None
     if week_start:
         season = week_start.year if week_start.month >= 7 else week_start.year - 1

--- a/academy-watch-backend/src/routes/api.py
+++ b/academy-watch-backend/src/routes/api.py
@@ -4594,7 +4594,9 @@ def generate_weekly_mcp_team():
 
         # Resolve DB id if only API id provided (use inferred season from date)
         if not team_db_id and api_team_id:
-            season = tdate.year if tdate.month >= 8 else tdate.year - 1
+            from src.utils.academy_window import current_stats_season
+
+            season = current_stats_season(tdate)
             row = Team.query.filter_by(team_id=int(api_team_id), season=season).first()
             if not row:
                 return jsonify({"error": f"Team api_id={api_team_id} not found for season {season}"}), 404
@@ -4991,11 +4993,9 @@ def admin_sync_player_fixtures(player_id: int):
         data = request.get_json() or {}
         dry_run = data.get("dry_run", False)
 
-        # Get current season
-        now_utc = datetime.now(UTC)
-        current_year = now_utc.year
-        current_month = now_utc.month
-        season = data.get("season", current_year if current_month >= 8 else current_year - 1)
+        from src.utils.academy_window import current_stats_season
+
+        season = data.get("season", current_stats_season())
 
         # Try TrackedPlayer first (newer model)
         tp = TrackedPlayer.query.filter_by(
@@ -5286,10 +5286,10 @@ def _run_batch_fixture_sync(data: dict, job_id: str = None) -> dict:
     dry_run = bool(data.get("dry_run", False))
     delay = float(data.get("delay", 0.1))
 
+    from src.utils.academy_window import current_stats_season
+
     now_utc = datetime.now(UTC)
-    current_year = now_utc.year
-    current_month = now_utc.month
-    season = data.get("season", current_year if current_month >= 8 else current_year - 1)
+    season = data.get("season", current_stats_season())
 
     # ── 1. Gather all players grouped by current team API ID ──
     team_players = defaultdict(list)  # {team_api_id: [(player_api_id, player_name), ...]}
@@ -5992,11 +5992,9 @@ def _run_team_fixtures_sync(team_id: int, data: dict, job_id: str = None) -> dic
     try:
         dry_run = data.get("dry_run", False)
 
-        # Get current season
-        now_utc = datetime.now(UTC)
-        current_year = now_utc.year
-        current_month = now_utc.month
-        season = data.get("season", current_year if current_month >= 8 else current_year - 1)
+        from src.utils.academy_window import current_stats_season
+
+        season = data.get("season", current_stats_season())
 
         team = Team.query.get(team_id)
         if not team:
@@ -11790,9 +11788,9 @@ def _run_seed_team_process(job_id, team_id, max_age=30, sync_journeys=True, year
             # Phase 1: Cohort discovery (youth league data)
             try:
                 from src.services.big6_seeding_service import run_big6_seed
+                from src.utils.academy_window import current_stats_season
 
-                now = datetime.now()
-                current_season = now.year if now.month >= 8 else now.year - 1
+                current_season = current_stats_season()
                 run_big6_seed(job_id, seasons=[current_season], team_ids=[team.team_id])
             except Exception as cohort_err:
                 logger.warning("Cohort discovery for %s failed (continuing with squad seed): %s", team.name, cohort_err)
@@ -11898,9 +11896,9 @@ def _run_seed_teams_process(job_id, team_db_ids, max_age=30, sync_journeys=True,
             # Phase 1: Cohort discovery for all target teams
             try:
                 from src.services.big6_seeding_service import run_big6_seed
+                from src.utils.academy_window import current_stats_season
 
-                now = datetime.now()
-                current_season = now.year if now.month >= 8 else now.year - 1
+                current_season = current_stats_season()
                 team_api_ids = [t.team_id for t in target_teams]
                 update_job(job_id, current_player="Discovering cohorts...")
                 run_big6_seed(job_id, seasons=[current_season], team_ids=team_api_ids)
@@ -12028,9 +12026,9 @@ def _run_seed_all_tracked_process(job_id, max_age=30, sync_journeys=True, years=
             # Phase 1: Cohort discovery for all empty teams
             try:
                 from src.services.big6_seeding_service import run_big6_seed
+                from src.utils.academy_window import current_stats_season
 
-                now = datetime.now()
-                current_season = now.year if now.month >= 8 else now.year - 1
+                current_season = current_stats_season()
                 team_api_ids = [t.team_id for t in empty_teams]
                 update_job(job_id, current_player="Discovering cohorts for all teams...")
                 run_big6_seed(job_id, seasons=[current_season], team_ids=team_api_ids)

--- a/academy-watch-backend/src/routes/journalist.py
+++ b/academy-watch-backend/src/routes/journalist.py
@@ -2493,7 +2493,6 @@ def get_player_stats(player_id):
             return jsonify({"error": "Not authorized as a writer"}), 403
 
         # Import models here to avoid circular imports if any
-        from datetime import datetime
 
         from src.api_football_client import APIFootballClient
         from src.models.league import Team
@@ -2501,10 +2500,9 @@ def get_player_stats(player_id):
         from src.routes.api import _sync_player_club_fixtures, resolve_team_name_and_logo
 
         # Get current season
-        now_utc = datetime.now(UTC)
-        current_year = now_utc.year
-        current_month = now_utc.month
-        season = current_year if current_month >= 8 else current_year - 1
+        from src.utils.academy_window import current_stats_season
+
+        season = current_stats_season()
 
         # Auto-sync: Check if we're missing fixtures compared to API-Football
         loaned = TrackedPlayer.query.filter_by(player_api_id=player_id, is_active=True).first()

--- a/academy-watch-backend/src/routes/journalist.py
+++ b/academy-watch-backend/src/routes/journalist.py
@@ -1142,11 +1142,14 @@ def get_chart_data():
             )
 
         elif date_range == "season":
-            # Get current season (assume July-June cycle)
-            now_utc = datetime.now(UTC)
-            current_year = now_utc.year
-            current_month = now_utc.month
-            season = current_year if current_month >= 7 else current_year - 1
+            # Stats DISPLAY season. _get_season_stats filters Fixture.season == season,
+            # so an inline July hinge blanks the chart all summer (fixtures roll over in
+            # Aug, not July) and again on any rollover before new fixtures land. Route
+            # through the shared helper with the latest-season-with-data fallback so
+            # "current season" has one source of truth (utils/academy_window).
+            from src.utils.academy_window import stats_season_with_data
+
+            season = stats_season_with_data(db.session)
             fixtures_data = _get_season_stats(player_id, season, current_club_api_id=current_club_api_id)
 
         # Get player info
@@ -1880,10 +1883,11 @@ def _fetch_chart_data_for_rendering(
                 player_id, start_date, end_date, current_club_api_id=current_club_api_id
             )
         elif date_range == "season":
-            now_utc = datetime.now(UTC)
-            current_year = now_utc.year
-            current_month = now_utc.month
-            season = current_year if current_month >= 7 else current_year - 1
+            # Stats DISPLAY season with latest-season-with-data fallback — same rationale
+            # as the get_chart_data path above (never blank on the July/Aug rollover gap).
+            from src.utils.academy_window import stats_season_with_data
+
+            season = stats_season_with_data(db.session)
             fixtures_data = _get_season_stats(player_id, season, current_club_api_id=current_club_api_id)
         else:
             # Default to last 30 days if no specific range

--- a/academy-watch-backend/src/routes/journalist.py
+++ b/academy-watch-backend/src/routes/journalist.py
@@ -1114,6 +1114,11 @@ def get_chart_data():
 
         # Get fixtures data based on date range
         fixtures_data = []
+        # Only the "season" range computes a DISPLAY season; hand it to the radar
+        # builder so it isn't recomputed there (stats_season_with_data is an
+        # uncached DB query). None for week/month ranges → radar uses its own
+        # season-scoped default for the league overlay.
+        season: int | None = None
 
         if date_range == "week":
             week_start = request.args.get("week_start")
@@ -1187,7 +1192,7 @@ def get_chart_data():
 
             # Let the service auto-select axes unless caller explicitly provided stat_keys
             explicit_keys = stat_keys if stat_keys_param else None
-            radar = get_radar_chart_data(player_id, fixtures_data, stat_keys=explicit_keys)
+            radar = get_radar_chart_data(player_id, fixtures_data, stat_keys=explicit_keys, season=season)
 
             response.update(radar)
             response["player"] = player_info
@@ -1865,6 +1870,10 @@ def _fetch_chart_data_for_rendering(
 
         # Get fixtures data based on date range
         fixtures_data = []
+        # Only the "season" range computes a DISPLAY season; pass it to the radar
+        # builder to avoid recomputing stats_season_with_data (an uncached DB
+        # query) there. None for other ranges → radar uses its own default.
+        season: int | None = None
 
         if date_range == "week" and week_start and week_end:
             try:
@@ -1931,7 +1940,7 @@ def _fetch_chart_data_for_rendering(
         elif chart_type == "radar":
             from src.services.radar_stats_service import get_radar_chart_data
 
-            radar = get_radar_chart_data(player_id, fixtures_data, stat_keys=stat_keys or None)
+            radar = get_radar_chart_data(player_id, fixtures_data, stat_keys=stat_keys or None, season=season)
             response.update(radar)
             response["player"] = player_info
 

--- a/academy-watch-backend/src/routes/players.py
+++ b/academy-watch-backend/src/routes/players.py
@@ -139,6 +139,35 @@ def get_public_player_stats(player_id: int):
                     },
                 )
 
+        # UNION in every club the player actually appeared for THIS stats season,
+        # taken straight from FixturePlayerStats (the source of truth for where a
+        # player played). A returned loanee's tracked row points current_club back
+        # at the parent club, so his loan club is absent from the sets above and
+        # the match log renders empty even though the fixture rows exist — this is
+        # exactly how /season-stats stays correct (it derives its club list from
+        # FixturePlayerStats). Season-scoped via the fixtures.season index so a
+        # prior-season-only club doesn't leak into the current club set.
+        fixture_team_rows = (
+            db.session.query(FixturePlayerStats.team_api_id)
+            .join(Fixture, FixturePlayerStats.fixture_id == Fixture.id)
+            .filter(
+                FixturePlayerStats.player_api_id == player_id,
+                Fixture.season == season,
+            )
+            .distinct()
+            .all()
+        )
+        for (fixture_team_api_id,) in fixture_team_rows:
+            if not fixture_team_api_id or fixture_team_api_id in loan_teams_info:
+                continue
+            fixture_team_name, fixture_team_logo = resolve_team_name_and_logo(fixture_team_api_id, season)
+            loan_teams_info[fixture_team_api_id] = {
+                "name": fixture_team_name or "Unknown",
+                "logo": fixture_team_logo,
+                "window_type": "Summer",
+                "is_active": True,
+            }
+
         loan_team_api_ids = list(loan_teams_info.keys())
 
         # Query local stats for ALL loan teams

--- a/academy-watch-backend/src/routes/players.py
+++ b/academy-watch-backend/src/routes/players.py
@@ -71,10 +71,18 @@ def get_public_player_stats(player_id: int):
         # Stats DISPLAY season: the current calendar season, but fall back to
         # the latest season that actually has fixtures so a not-yet-started
         # season never blanks the page (utils/academy_window docstrings).
-        from src.utils.academy_window import stats_season_with_data
+        from src.utils.academy_window import current_stats_season, stats_season_with_data
 
         season = stats_season_with_data(db.session)
         season_prefix = f"{season}-{str(season + 1)[-2:]}"
+        # SYNC/FETCH season must be the pure calendar season, NOT the with-data
+        # fallback. During the Aug rollover `season` pins to the OLD season
+        # (no new fixtures yet); fetching/syncing that would re-pull completed
+        # fixtures and could never ingest the first new-season match, leaving the
+        # page permanently blank at the new club. current_stats_season() lets the
+        # view-driven sync land the new season and self-heal the fallback for all
+        # readers (mirrors journalist.get_player_stats' auto-sync).
+        sync_season = current_stats_season()
 
         # Find ALL tracked players for this player (prefer academy-origin rows)
         tracked = (
@@ -155,7 +163,7 @@ def get_public_player_stats(player_id: int):
                 api_totals = api_client._fetch_player_team_season_totals_api(
                     player_id=player_id,
                     team_id=loan_team_api_id,
-                    season=season,
+                    season=sync_season,
                 )
                 api_appearances = api_totals.get("games_played", 0)
                 api_totals_failed = not api_totals  # empty dict = API call failed
@@ -166,7 +174,9 @@ def get_public_player_stats(player_id: int):
                     )
                     from src.routes.api import _sync_player_club_fixtures
 
-                    _sync_player_club_fixtures(player_id, loan_team_api_id, season, player_name=player_name_for_sync)
+                    _sync_player_club_fixtures(
+                        player_id, loan_team_api_id, sync_season, player_name=player_name_for_sync
+                    )
             except Exception as e:
                 logger.warning(f"Failed to sync for player {player_id} at team {loan_team_api_id}: {e}")
 

--- a/academy-watch-backend/src/routes/players.py
+++ b/academy-watch-backend/src/routes/players.py
@@ -68,11 +68,12 @@ def get_public_player_stats(player_id: int):
         resolve_team_name_and_logo = _get_resolve_team_name_and_logo()
         force_sync = request.args.get("force_sync", "").lower() == "true"
 
-        # Get current season
-        now_utc = datetime.now(UTC)
-        current_year = now_utc.year
-        current_month = now_utc.month
-        season = current_year if current_month >= 8 else current_year - 1
+        # Stats DISPLAY season: the current calendar season, but fall back to
+        # the latest season that actually has fixtures so a not-yet-started
+        # season never blanks the page (utils/academy_window docstrings).
+        from src.utils.academy_window import stats_season_with_data
+
+        season = stats_season_with_data(db.session)
         season_prefix = f"{season}-{str(season + 1)[-2:]}"
 
         # Find ALL tracked players for this player (prefer academy-origin rows)
@@ -432,10 +433,11 @@ def get_public_player_season_stats(player_id: int):
         from src.api_football_client import APIFootballClient
         from src.models.weekly import Fixture, FixturePlayerStats
 
-        now_utc = datetime.now(UTC)
-        current_year = now_utc.year
-        current_month = now_utc.month
-        season_start_year = current_year if current_month >= 8 else current_year - 1
+        # Stats DISPLAY season with latest-season-with-data fallback (see
+        # utils/academy_window.stats_season_with_data) — never blank on rollover.
+        from src.utils.academy_window import stats_season_with_data
+
+        season_start_year = stats_season_with_data(db.session)
         season_start = datetime(season_start_year, 8, 1, tzinfo=UTC)
         season_prefix = f"{season_start_year}-{str(season_start_year + 1)[-2:]}"
 

--- a/academy-watch-backend/src/routes/scout.py
+++ b/academy-watch-backend/src/routes/scout.py
@@ -157,51 +157,65 @@ def _attach_recent_form(player_dicts):
         p["recent_form"] = form_by_pair.get((p["player_id"], p.get("loan_team_api_id")), [])
 
 
-def _fixture_stats_subquery():
-    """Aggregate FixturePlayerStats per (player, team)."""
+def _fixture_stats_subquery(season):
+    """Aggregate FixturePlayerStats per player for one stats season.
+
+    Grouped per player (NOT per (player, team)) and season-scoped: the Scout Desk
+    shows a single season figure per player, summed across every club they played
+    for. The old (player, team) grain forced the base query to join on
+    ``current_club_api_id``, which hid a returned loanee's whole season once his
+    tracked row pointed the current club back at the parent. ``avg_rating`` is now
+    a cross-club season average, which is the intended cross-club view.
+    """
     return (
         db.session.query(
             FixturePlayerStats.player_api_id.label("player_api_id"),
-            FixturePlayerStats.team_api_id.label("team_api_id"),
             func.count(FixturePlayerStats.id).label("appearances"),
             func.coalesce(func.sum(FixturePlayerStats.goals), 0).label("goals"),
             func.coalesce(func.sum(FixturePlayerStats.assists), 0).label("assists"),
             func.coalesce(func.sum(FixturePlayerStats.minutes), 0).label("minutes_played"),
             func.avg(FixturePlayerStats.rating).label("avg_rating"),
         )
-        .group_by(FixturePlayerStats.player_api_id, FixturePlayerStats.team_api_id)
+        .join(Fixture, Fixture.id == FixturePlayerStats.fixture_id)
+        .filter(Fixture.season == season)
+        .group_by(FixturePlayerStats.player_api_id)
         .subquery()
     )
 
 
 def _cache_stats_subquery():
-    """Latest-season PlayerStatsCache row per (player, team)."""
+    """Latest-cached-season PlayerStatsCache summed per player.
+
+    Limited-coverage players have no fixture rows; their stats live in
+    PlayerStatsCache. Per player, take their most recent cached season and sum
+    across every club in it — dropping the old per-(player, team) grain and the
+    base query's join on current_club_api_id, so one season figure lands per
+    player regardless of which club the tracked row points at.
+    """
     latest = (
         db.session.query(
             PlayerStatsCache.player_api_id.label("player_api_id"),
-            PlayerStatsCache.team_api_id.label("team_api_id"),
             func.max(PlayerStatsCache.season).label("season"),
         )
-        .group_by(PlayerStatsCache.player_api_id, PlayerStatsCache.team_api_id)
+        .group_by(PlayerStatsCache.player_api_id)
         .subquery()
     )
     return (
         db.session.query(
             PlayerStatsCache.player_api_id.label("player_api_id"),
-            PlayerStatsCache.team_api_id.label("team_api_id"),
-            PlayerStatsCache.appearances.label("appearances"),
-            PlayerStatsCache.goals.label("goals"),
-            PlayerStatsCache.assists.label("assists"),
-            PlayerStatsCache.minutes_played.label("minutes_played"),
+            func.coalesce(func.sum(PlayerStatsCache.appearances), 0).label("appearances"),
+            func.coalesce(func.sum(PlayerStatsCache.goals), 0).label("goals"),
+            func.coalesce(func.sum(PlayerStatsCache.assists), 0).label("assists"),
+            func.coalesce(func.sum(PlayerStatsCache.minutes_played), 0).label("minutes_played"),
         )
         .join(
             latest,
             and_(
                 PlayerStatsCache.player_api_id == latest.c.player_api_id,
-                PlayerStatsCache.team_api_id == latest.c.team_api_id,
                 PlayerStatsCache.season == latest.c.season,
             ),
         )
+        .group_by(PlayerStatsCache.player_api_id)
         .subquery()
     )
 
@@ -264,7 +278,13 @@ def _preferred_row_filter():
 
 def _base_scout_query():
     """TrackedPlayer rows joined to aggregated stats, deduped per player."""
-    fps = _fixture_stats_subquery()
+    from src.utils.academy_window import stats_season_with_data
+
+    # Season-scope the fixture aggregate to the current stats season (latest with
+    # data on rollover). One grouped join over the fixture rows, resolved once as
+    # a subquery and outer-joined per player — no per-row N+1.
+    season = stats_season_with_data(db.session)
+    fps = _fixture_stats_subquery(season)
     cache = _cache_stats_subquery()
 
     goals = func.coalesce(fps.c.goals, cache.c.goals, 0).label("goals")
@@ -298,20 +318,11 @@ def _base_scout_query():
             journey_owner_name,
         )
         .outerjoin(PlayerJourney, PlayerJourney.player_api_id == TrackedPlayer.player_api_id)
-        .outerjoin(
-            fps,
-            and_(
-                fps.c.player_api_id == TrackedPlayer.player_api_id,
-                fps.c.team_api_id == TrackedPlayer.current_club_api_id,
-            ),
-        )
-        .outerjoin(
-            cache,
-            and_(
-                cache.c.player_api_id == TrackedPlayer.player_api_id,
-                cache.c.team_api_id == TrackedPlayer.current_club_api_id,
-            ),
-        )
+        # Stats join per player (not per current club): the aggregates are now
+        # one season figure per player, so a returned loanee whose current club
+        # points back at the parent still gets his loan-club season attributed.
+        .outerjoin(fps, fps.c.player_api_id == TrackedPlayer.player_api_id)
+        .outerjoin(cache, cache.c.player_api_id == TrackedPlayer.player_api_id)
         .filter(TrackedPlayer.is_active.is_(True))
         # owning-club rows are deprecated (senior signings, not academy
         # products) — never surface them even before a data repair runs.

--- a/academy-watch-backend/src/routes/scout.py
+++ b/academy-watch-backend/src/routes/scout.py
@@ -552,6 +552,16 @@ def scout_compare():
         except ValueError:
             return jsonify({"error": "ids must be integers"}), 400
 
+        from src.utils.academy_window import stats_season_with_data
+
+        # One season figure per player, summed across EVERY club the player
+        # appeared for — mirrors the season-scoped /scout/players list and
+        # /players/<id>/season-stats. Keying this on current_club_api_id (as it
+        # was) both hid a returned loanee's whole loan season and let a stray
+        # parent-club cup cameo masquerade as his season, so the compare panel
+        # contradicted the list on the same Scout Desk page.
+        season = stats_season_with_data(db.session)
+
         players = []
         for player_id in player_ids:
             tracked_player = (
@@ -564,64 +574,66 @@ def scout_compare():
                 continue
 
             totals = None
-            if tracked_player.current_club_api_id:
-                row = (
-                    db.session.query(
-                        func.count(FixturePlayerStats.id).label("appearances"),
-                        func.coalesce(func.sum(FixturePlayerStats.goals), 0).label("goals"),
-                        func.coalesce(func.sum(FixturePlayerStats.assists), 0).label("assists"),
-                        func.coalesce(func.sum(FixturePlayerStats.minutes), 0).label("minutes"),
-                        func.avg(FixturePlayerStats.rating).label("avg_rating"),
-                        func.coalesce(func.sum(FixturePlayerStats.shots_total), 0).label("shots_total"),
-                        func.coalesce(func.sum(FixturePlayerStats.shots_on), 0).label("shots_on"),
-                        func.coalesce(func.sum(FixturePlayerStats.passes_total), 0).label("passes_total"),
-                        func.coalesce(func.sum(FixturePlayerStats.passes_key), 0).label("key_passes"),
-                        func.coalesce(func.sum(FixturePlayerStats.dribbles_attempts), 0).label("dribbles_attempts"),
-                        func.coalesce(func.sum(FixturePlayerStats.dribbles_success), 0).label("dribbles_success"),
-                        func.coalesce(func.sum(FixturePlayerStats.tackles_total), 0).label("tackles"),
-                        func.coalesce(func.sum(FixturePlayerStats.tackles_interceptions), 0).label("interceptions"),
-                        func.coalesce(func.sum(FixturePlayerStats.duels_total), 0).label("duels_total"),
-                        func.coalesce(func.sum(FixturePlayerStats.duels_won), 0).label("duels_won"),
-                        func.coalesce(func.sum(FixturePlayerStats.fouls_drawn), 0).label("fouls_drawn"),
-                        func.coalesce(func.sum(FixturePlayerStats.yellows), 0).label("yellows"),
-                        func.coalesce(func.sum(FixturePlayerStats.reds), 0).label("reds"),
-                        func.coalesce(func.sum(FixturePlayerStats.saves), 0).label("saves"),
-                        func.coalesce(func.sum(FixturePlayerStats.goals_conceded), 0).label("goals_conceded"),
-                    )
-                    .filter(
-                        FixturePlayerStats.player_api_id == player_id,
-                        FixturePlayerStats.team_api_id == tracked_player.current_club_api_id,
-                    )
-                    .first()
+            row = (
+                db.session.query(
+                    func.count(FixturePlayerStats.id).label("appearances"),
+                    func.coalesce(func.sum(FixturePlayerStats.goals), 0).label("goals"),
+                    func.coalesce(func.sum(FixturePlayerStats.assists), 0).label("assists"),
+                    func.coalesce(func.sum(FixturePlayerStats.minutes), 0).label("minutes"),
+                    func.avg(FixturePlayerStats.rating).label("avg_rating"),
+                    func.coalesce(func.sum(FixturePlayerStats.shots_total), 0).label("shots_total"),
+                    func.coalesce(func.sum(FixturePlayerStats.shots_on), 0).label("shots_on"),
+                    func.coalesce(func.sum(FixturePlayerStats.passes_total), 0).label("passes_total"),
+                    func.coalesce(func.sum(FixturePlayerStats.passes_key), 0).label("key_passes"),
+                    func.coalesce(func.sum(FixturePlayerStats.dribbles_attempts), 0).label("dribbles_attempts"),
+                    func.coalesce(func.sum(FixturePlayerStats.dribbles_success), 0).label("dribbles_success"),
+                    func.coalesce(func.sum(FixturePlayerStats.tackles_total), 0).label("tackles"),
+                    func.coalesce(func.sum(FixturePlayerStats.tackles_interceptions), 0).label("interceptions"),
+                    func.coalesce(func.sum(FixturePlayerStats.duels_total), 0).label("duels_total"),
+                    func.coalesce(func.sum(FixturePlayerStats.duels_won), 0).label("duels_won"),
+                    func.coalesce(func.sum(FixturePlayerStats.fouls_drawn), 0).label("fouls_drawn"),
+                    func.coalesce(func.sum(FixturePlayerStats.yellows), 0).label("yellows"),
+                    func.coalesce(func.sum(FixturePlayerStats.reds), 0).label("reds"),
+                    func.coalesce(func.sum(FixturePlayerStats.saves), 0).label("saves"),
+                    func.coalesce(func.sum(FixturePlayerStats.goals_conceded), 0).label("goals_conceded"),
                 )
-                if row and row.appearances:
-                    minutes = int(row.minutes or 0)
-                    totals = {
-                        "appearances": int(row.appearances),
-                        "goals": int(row.goals),
-                        "assists": int(row.assists),
-                        "minutes_played": minutes,
-                        "avg_rating": round(float(row.avg_rating), 2) if row.avg_rating else None,
-                        "shots_total": int(row.shots_total),
-                        "shots_on": int(row.shots_on),
-                        "passes_total": int(row.passes_total),
-                        "key_passes": int(row.key_passes),
-                        "dribbles_attempts": int(row.dribbles_attempts),
-                        "dribbles_success": int(row.dribbles_success),
-                        "tackles": int(row.tackles),
-                        "interceptions": int(row.interceptions),
-                        "duels_total": int(row.duels_total),
-                        "duels_won": int(row.duels_won),
-                        "fouls_drawn": int(row.fouls_drawn),
-                        "yellows": int(row.yellows),
-                        "reds": int(row.reds),
-                        "saves": int(row.saves),
-                        "goals_conceded": int(row.goals_conceded),
-                        "stats_coverage": "full",
-                    }
+                .join(Fixture, Fixture.id == FixturePlayerStats.fixture_id)
+                .filter(
+                    FixturePlayerStats.player_api_id == player_id,
+                    Fixture.season == season,
+                )
+                .first()
+            )
+            if row and row.appearances:
+                minutes = int(row.minutes or 0)
+                totals = {
+                    "appearances": int(row.appearances),
+                    "goals": int(row.goals),
+                    "assists": int(row.assists),
+                    "minutes_played": minutes,
+                    "avg_rating": round(float(row.avg_rating), 2) if row.avg_rating else None,
+                    "shots_total": int(row.shots_total),
+                    "shots_on": int(row.shots_on),
+                    "passes_total": int(row.passes_total),
+                    "key_passes": int(row.key_passes),
+                    "dribbles_attempts": int(row.dribbles_attempts),
+                    "dribbles_success": int(row.dribbles_success),
+                    "tackles": int(row.tackles),
+                    "interceptions": int(row.interceptions),
+                    "duels_total": int(row.duels_total),
+                    "duels_won": int(row.duels_won),
+                    "fouls_drawn": int(row.fouls_drawn),
+                    "yellows": int(row.yellows),
+                    "reds": int(row.reds),
+                    "saves": int(row.saves),
+                    "goals_conceded": int(row.goals_conceded),
+                    "stats_coverage": "full",
+                }
 
             if totals is None:
-                # Fall back to basic limited-coverage stats
+                # No fixture rows this season (limited-coverage / no-data) — fall
+                # back to basic totals. This keeps the detailed shot/duel/per-90
+                # panel for full-coverage players while degrading gracefully.
                 basic = tracked_player.compute_stats()
                 totals = {**basic, "minutes_played": basic.get("minutes_played", 0)}
 

--- a/academy-watch-backend/src/routes/teams.py
+++ b/academy-watch-backend/src/routes/teams.py
@@ -383,11 +383,18 @@ def get_team_loans(team_identifier):
 
         # Batch-fetch stats for all TrackedPlayers
         from sqlalchemy import func as sa_func
-        from src.models.weekly import FixturePlayerStats
+        from src.models.weekly import Fixture, FixturePlayerStats
+        from src.utils.academy_window import stats_season_with_data
 
         tp_api_ids = [tp.player_api_id for tp in tracked]
         stats_by_player = {}
         if tp_api_ids:
+            # Season-scope the aggregate to the current stats season (latest with
+            # data on rollover) so team-roster numbers match the season-scoped
+            # profile / Scout Desk figures. Without this, once next-season
+            # fixtures land the roster would show career-summed apps/minutes while
+            # the profile shows the season total — contradictory one click apart.
+            season = stats_season_with_data(db.session)
             stats_rows = (
                 db.session.query(
                     FixturePlayerStats.player_api_id,
@@ -396,7 +403,11 @@ def get_team_loans(team_identifier):
                     sa_func.coalesce(sa_func.sum(FixturePlayerStats.assists), 0).label("assists"),
                     sa_func.coalesce(sa_func.sum(FixturePlayerStats.minutes), 0).label("minutes_played"),
                 )
-                .filter(FixturePlayerStats.player_api_id.in_(tp_api_ids))
+                .join(Fixture, FixturePlayerStats.fixture_id == Fixture.id)
+                .filter(
+                    FixturePlayerStats.player_api_id.in_(tp_api_ids),
+                    Fixture.season == season,
+                )
                 .group_by(FixturePlayerStats.player_api_id)
                 .all()
             )

--- a/academy-watch-backend/src/routes/teams.py
+++ b/academy-watch-backend/src/routes/teams.py
@@ -382,12 +382,15 @@ def get_team_loans(team_identifier):
         tracked = tp_query.order_by(TrackedPlayer.updated_at.desc()).all()
 
         # Batch-fetch stats for all TrackedPlayers
+        from sqlalchemy import and_ as sa_and
         from sqlalchemy import func as sa_func
+        from src.models.league import PlayerStatsCache
         from src.models.weekly import Fixture, FixturePlayerStats
         from src.utils.academy_window import stats_season_with_data
 
         tp_api_ids = [tp.player_api_id for tp in tracked]
         stats_by_player = {}
+        cache_by_player = {}
         if tp_api_ids:
             # Season-scope the aggregate to the current stats season (latest with
             # data on rollover) so team-roster numbers match the season-scoped
@@ -419,10 +422,64 @@ def get_team_loans(team_identifier):
                     "minutes_played": int(row.minutes_played),
                 }
 
+            # Limited-coverage rows (events_only / profile_only) have no
+            # FixturePlayerStats — their season lives in PlayerStatsCache. Mirror
+            # compute_stats and the Scout Desk _cache_stats_subquery (latest cached
+            # season per player, summed) so these players show their real
+            # apps/mins on the roster instead of zeros, matching the season-scoped
+            # profile / Scout figures rather than contradicting them one click away.
+            limited_ids = [tp.player_api_id for tp in tracked if tp.data_depth in ("events_only", "profile_only")]
+            if limited_ids:
+                latest_cached = (
+                    db.session.query(
+                        PlayerStatsCache.player_api_id.label("player_api_id"),
+                        sa_func.max(PlayerStatsCache.season).label("season"),
+                    )
+                    .filter(PlayerStatsCache.player_api_id.in_(limited_ids))
+                    .group_by(PlayerStatsCache.player_api_id)
+                    .subquery()
+                )
+                cache_rows = (
+                    db.session.query(
+                        PlayerStatsCache.player_api_id,
+                        sa_func.coalesce(sa_func.sum(PlayerStatsCache.appearances), 0).label("appearances"),
+                        sa_func.coalesce(sa_func.sum(PlayerStatsCache.goals), 0).label("goals"),
+                        sa_func.coalesce(sa_func.sum(PlayerStatsCache.assists), 0).label("assists"),
+                        sa_func.coalesce(sa_func.sum(PlayerStatsCache.minutes_played), 0).label("minutes_played"),
+                        sa_func.coalesce(sa_func.sum(PlayerStatsCache.saves), 0).label("saves"),
+                        sa_func.coalesce(sa_func.sum(PlayerStatsCache.yellows), 0).label("yellows"),
+                        sa_func.coalesce(sa_func.sum(PlayerStatsCache.reds), 0).label("reds"),
+                    )
+                    .join(
+                        latest_cached,
+                        sa_and(
+                            PlayerStatsCache.player_api_id == latest_cached.c.player_api_id,
+                            PlayerStatsCache.season == latest_cached.c.season,
+                        ),
+                    )
+                    .group_by(PlayerStatsCache.player_api_id)
+                    .all()
+                )
+                for row in cache_rows:
+                    cache_by_player[row.player_api_id] = {
+                        "appearances": int(row.appearances),
+                        "goals": int(row.goals),
+                        "assists": int(row.assists),
+                        "minutes_played": int(row.minutes_played),
+                        "saves": int(row.saves),
+                        "yellows": int(row.yellows),
+                        "reds": int(row.reds),
+                    }
+
         result = []
         for tp in tracked:
             tp_dict = tp.to_public_dict()
-            if tp.player_api_id in stats_by_player:
+            # Route stats by coverage tier exactly like compute_stats: limited
+            # rows read from the cache, everyone else from the fixture aggregate.
+            if tp.data_depth in ("events_only", "profile_only"):
+                if tp.player_api_id in cache_by_player:
+                    tp_dict.update(cache_by_player[tp.player_api_id])
+            elif tp.player_api_id in stats_by_player:
                 tp_dict.update(stats_by_player[tp.player_api_id])
             result.append(tp_dict)
 

--- a/academy-watch-backend/src/routes/teams.py
+++ b/academy-watch-backend/src/routes/teams.py
@@ -9,7 +9,6 @@ This blueprint handles:
 """
 
 import logging
-from datetime import UTC, datetime
 
 from flask import Blueprint, jsonify, request
 from sqlalchemy import cast
@@ -502,8 +501,9 @@ def get_academy_network(team_identifier):
 
         years = request.args.get("years", 4, type=int)
         limit = request.args.get("limit", 200, type=int)
-        now = datetime.now(UTC)
-        current_season = now.year if now.month >= 8 else now.year - 1
+        from src.utils.academy_window import current_stats_season
+
+        current_season = current_stats_season()
         min_season = current_season - years + 1
 
         # Find the parent team for name/logo

--- a/academy-watch-backend/src/services/gol_service.py
+++ b/academy-watch-backend/src/services/gol_service.py
@@ -437,8 +437,10 @@ class GolService:
             # Inject current date and season into system prompt
             from datetime import datetime
 
+            from src.utils.academy_window import current_stats_season
+
             now = datetime.now(UTC)
-            season_int = now.year if now.month >= 8 else now.year - 1
+            season_int = current_stats_season(now)
             season_label = f"{season_int}/{str(season_int + 1)[-2:]}"
             system_content = SYSTEM_PROMPT.format(
                 today=now.strftime("%d %B %Y"),

--- a/academy-watch-backend/src/services/journey_sync.py
+++ b/academy-watch-backend/src/services/journey_sync.py
@@ -1242,6 +1242,16 @@ class JourneySyncService:
         if entries is None:
             entries = PlayerJourneyEntry.query.filter_by(journey_id=journey.id).all()
 
+        # Capture the journey's PERSISTED academy attribution BEFORE this run
+        # overwrites it below. A transient run (API youth-coverage gap or a
+        # tenure-gate flicker) can compute an EMPTY academy set even for an
+        # established academy product; the stored-attribution floor in
+        # _upsert_tracked_players uses these prior values so a transient empty
+        # computation never orphans an in-window academy row (the Gore-class
+        # orphan trap).
+        prior_academy_ids = set(journey.academy_club_ids or [])
+        prior_last_seasons = dict(journey.academy_last_seasons or {})
+
         youth_entries = [
             e
             for e in entries
@@ -1254,7 +1264,13 @@ class JourneySyncService:
             journey.academy_club_ids = []
             journey.academy_last_seasons = {}
             # Deactivate any stale tracked-player rows from prior runs
-            self._upsert_tracked_players(journey, set(), transfers=transfers)
+            self._upsert_tracked_players(
+                journey,
+                set(),
+                transfers=transfers,
+                prior_academy_ids=prior_academy_ids,
+                prior_last_seasons=prior_last_seasons,
+            )
             return
 
         # ── Development-only noise filter ──
@@ -1324,7 +1340,13 @@ class JourneySyncService:
         if not youth_entries:
             journey.academy_club_ids = []
             journey.academy_last_seasons = {}
-            self._upsert_tracked_players(journey, set(), transfers=transfers)
+            self._upsert_tracked_players(
+                journey,
+                set(),
+                transfers=transfers,
+                prior_academy_ids=prior_academy_ids,
+                prior_last_seasons=prior_last_seasons,
+            )
             return
 
         # ── Academy tenure gate ──
@@ -1371,7 +1393,13 @@ class JourneySyncService:
             journey.academy_club_ids = []
             journey.academy_last_seasons = {}
             # Deactivate any stale tracked-player rows from prior runs
-            self._upsert_tracked_players(journey, set(), transfers=transfers)
+            self._upsert_tracked_players(
+                journey,
+                set(),
+                transfers=transfers,
+                prior_academy_ids=prior_academy_ids,
+                prior_last_seasons=prior_last_seasons,
+            )
             return
 
         # Build lookup: base_name -> api_id from non-youth, non-international entries
@@ -1484,12 +1512,27 @@ class JourneySyncService:
 
         # Auto-upsert TrackedPlayer rows for each academy connection
         try:
-            self._upsert_tracked_players(journey, academy_ids, transfers=transfers, last_seasons=last_seasons)
+            self._upsert_tracked_players(
+                journey,
+                academy_ids,
+                transfers=transfers,
+                last_seasons=last_seasons,
+                prior_academy_ids=prior_academy_ids,
+                prior_last_seasons=prior_last_seasons,
+            )
         except Exception as e:
             logger.error(f"_upsert_tracked_players failed for player {journey.player_api_id}: {e}")
             db.session.rollback()
 
-    def _upsert_tracked_players(self, journey: PlayerJourney, academy_ids: set, transfers=None, last_seasons=None):
+    def _upsert_tracked_players(
+        self,
+        journey: PlayerJourney,
+        academy_ids: set,
+        transfers=None,
+        last_seasons=None,
+        prior_academy_ids=None,
+        prior_last_seasons=None,
+    ):
         """Create or update TrackedPlayer rows for discovered academy connections.
 
         Clubs may only track players formed in their OWN academy, and only
@@ -1497,6 +1540,13 @@ class JourneySyncService:
         academy now, or within the past ACADEMY_WINDOW_YEARS seasons).
         The owning (buying) club never gets a row — legacy 'owning-club'
         rows are deactivated.
+
+        ``prior_academy_ids`` / ``prior_last_seasons`` carry the journey's
+        PERSISTED attribution from BEFORE this run overwrote it. They power the
+        stored-attribution floor: when this run resolved no academy evidence
+        for a club (transient API coverage gap / tenure-gate flicker) but the
+        stored attribution still lists it inside the window, the row is spared
+        rather than orphaned.
         """
         from src.models.journey import YOUTH_LEVELS
         from src.models.tracked_player import TrackedPlayer
@@ -1504,6 +1554,8 @@ class JourneySyncService:
         from src.utils.academy_window import is_within_academy_window
 
         last_seasons = last_seasons or {}
+        prior_academy_ids = prior_academy_ids or set()
+        prior_last_seasons = prior_last_seasons or {}
 
         # Status (on_loan/sold/released/left) is transfer-driven, so it can only
         # be derived when transfers were actually fetched. Callers that pass
@@ -1533,6 +1585,29 @@ class JourneySyncService:
         }
         aged_out = academy_ids - keep_ids
 
+        def _stored_attribution_floor(club_id: int) -> bool:
+            """Should ``club_id`` be spared deactivation this run?
+
+            True when this run produced NO fresh academy evidence for the club
+            (it is not in the just-computed ``academy_ids``) yet the journey's
+            PERSISTED attribution still lists it AND its last youth season there
+            is inside the tracking window. A transient empty computation (API
+            youth-coverage gap / tenure-gate flicker) must never orphan an
+            established in-window academy row — leave it for the next sync that
+            actually has evidence. Keys on stored SEASON evidence, so a merely
+            stale ``academy_club_ids`` value without an in-window season does
+            NOT trip it (that still deactivates, as it should).
+            """
+            return (
+                club_id not in academy_ids
+                and club_id in prior_academy_ids
+                and is_within_academy_window(
+                    prior_last_seasons.get(str(club_id)),
+                    status=window_status,
+                    birth_date=journey.birth_date,
+                )
+            )
+
         # Deactivate journey-sync and legacy owning-club rows whose academy
         # connection no longer holds. Skip pinned rows — manual corrections
         # must persist.
@@ -1548,6 +1623,13 @@ class JourneySyncService:
                 if tp.team.team_id in aged_out and tp.status == "academy":
                     # The row itself says the player is currently in this
                     # academy — never window-deactivate current kids.
+                    continue
+                if _stored_attribution_floor(tp.team.team_id):
+                    logger.info(
+                        f"Stored-attribution floor kept {tp.data_source} TrackedPlayer "
+                        f"{tp.id} for player {journey.player_api_id} at {tp.team.name} "
+                        f"(no fresh academy evidence this run; established in-window academy row)"
+                    )
                     continue
                 tp.is_active = False
                 why = "outside the academy tracking window" if tp.team.team_id in aged_out else "not an academy origin"
@@ -1568,6 +1650,18 @@ class JourneySyncService:
                 if tp.pinned_parent or tp.data_source == "manual":
                     continue
                 if tp.team and tp.team.team_id == owning_api_id:
+                    if _stored_attribution_floor(owning_api_id):
+                        # The "owning" club is also this player's established
+                        # in-window academy origin (a homegrown player still
+                        # owned by his academy club, e.g. an academy product on
+                        # loan) and this run produced no fresh evidence — keep
+                        # the academy row instead of nuking it as a buyer.
+                        logger.info(
+                            f"Stored-attribution floor kept TrackedPlayer {tp.id} for player "
+                            f"{journey.player_api_id} at {tp.team.name} "
+                            f"(owning club is an established in-window academy origin)"
+                        )
+                        continue
                     tp.is_active = False
                     logger.info(
                         f"Deactivated TrackedPlayer {tp.id} for player {journey.player_api_id} "

--- a/academy-watch-backend/src/services/journey_sync.py
+++ b/academy-watch-backend/src/services/journey_sync.py
@@ -1242,19 +1242,59 @@ class JourneySyncService:
         regardless of season — so the floor survives consecutive empty runs.
         Genuinely aged-out and season-less stale clubs are dropped, so they
         still deactivate as before.
+
+        Row-local evidence counts too: the journey's per-club season map can be
+        empty (legacy pre-aw18 maps, or youth entries whose seasons are NULL)
+        while an ACTIVE tracked row still carries an in-window
+        ``last_academy_season`` or a current-kid ``status='academy'``. Keying
+        retention on the journey map alone would then drop the club here and
+        strand the row (the floor and the transfer-heal requeue gate both read
+        the journey map) — so an in-window row-local season / academy status is
+        honoured, and the recovered season is written back into the map so the
+        floor's SEASON key holds on subsequent empty runs.
         """
+        from src.models.tracked_player import TrackedPlayer
         from src.utils.academy_window import academy_window_start
 
         window_start = academy_window_start()
         current_kid = (journey.current_level or "") in YOUTH_LEVELS
+
+        # Collect row-local evidence keyed by the parent club's API id.
+        row_season_by_club: dict[int, int] = {}
+        row_academy_clubs: set[int] = set()
+        if prior_academy_ids:
+            for tp in TrackedPlayer.query.filter(
+                TrackedPlayer.player_api_id == journey.player_api_id,
+                TrackedPlayer.is_active.is_(True),
+            ).all():
+                club_id = tp.team.team_id if tp.team else None
+                if club_id is None:
+                    continue
+                if tp.last_academy_season is not None:
+                    prev = row_season_by_club.get(club_id)
+                    if prev is None or tp.last_academy_season > prev:
+                        row_season_by_club[club_id] = tp.last_academy_season
+                if tp.status == "academy":
+                    row_academy_clubs.add(club_id)
+
         retained_ids: list[int] = []
         retained_seasons: dict[str, int] = {}
         for cid in prior_academy_ids:
             season = prior_last_seasons.get(str(cid))
-            if current_kid or (season is not None and season >= window_start):
-                retained_ids.append(cid)
-                if season is not None:
-                    retained_seasons[str(cid)] = season
+            row_season = row_season_by_club.get(cid)
+            season_in_window = season is not None and season >= window_start
+            row_season_in_window = row_season is not None and row_season >= window_start
+            if not (current_kid or cid in row_academy_clubs or season_in_window or row_season_in_window):
+                continue
+            retained_ids.append(cid)
+            # Persist the best in-window season so the floor's SEASON key holds
+            # on later empty runs; prefer the journey map, fall back to the row.
+            if season_in_window:
+                retained_seasons[str(cid)] = season
+            elif row_season_in_window:
+                retained_seasons[str(cid)] = row_season
+            elif season is not None:
+                retained_seasons[str(cid)] = season
         return sorted(retained_ids), retained_seasons
 
     def _compute_academy_club_ids(self, journey: PlayerJourney, entries: list | None = None, transfers=None):
@@ -1634,7 +1674,7 @@ class JourneySyncService:
         }
         aged_out = academy_ids - keep_ids
 
-        def _stored_attribution_floor(club_id: int) -> bool:
+        def _stored_attribution_floor(club_id: int, row_last_season=None, row_status=None) -> bool:
             """Should ``club_id`` be spared deactivation this run?
 
             True when this run produced NO fresh academy evidence for the club
@@ -1652,16 +1692,28 @@ class JourneySyncService:
             every U21 with a birth date — the entire academy-tracker demographic
             — would have season-less stale attributions spared, silently
             defeating that guarantee and stalling one-shot recompute repairs.
+
+            Callers pass the tracked ROW's own evidence (``row_last_season`` /
+            ``row_status``) because the journey's per-club season map can lag
+            the row (legacy pre-aw18 maps / NULL-season youth entries). A row
+            that says ``status='academy'`` is a current kid even when the
+            journey's ``current_level`` is stale (mirroring the aged-out branch);
+            an in-window row-local season is real SEASON evidence, so honouring
+            it does not reopen the season-less-stale hole.
             """
             if club_id in academy_ids or club_id not in prior_academy_ids:
                 return False
-            # Current academy kid (journey current level is a youth level):
-            # protected even without a stored season, so patchy youth-league
-            # coverage can't age out a player who is in an academy right now.
-            if window_status == "academy":
+            # Current academy kid — protected even without a stored season, so
+            # patchy youth-league coverage can't age out a player who is in an
+            # academy right now. The journey's current level OR the row's own
+            # status can attest this.
+            if window_status == "academy" or row_status == "academy":
                 return True
+            window_start = academy_window_start()
             prior_season = prior_last_seasons.get(str(club_id))
-            return prior_season is not None and prior_season >= academy_window_start()
+            if prior_season is not None and prior_season >= window_start:
+                return True
+            return row_last_season is not None and row_last_season >= window_start
 
         # Deactivate journey-sync and legacy owning-club rows whose academy
         # connection no longer holds. Skip pinned rows — manual corrections
@@ -1679,7 +1731,9 @@ class JourneySyncService:
                     # The row itself says the player is currently in this
                     # academy — never window-deactivate current kids.
                     continue
-                if _stored_attribution_floor(tp.team.team_id):
+                if _stored_attribution_floor(
+                    tp.team.team_id, row_last_season=tp.last_academy_season, row_status=tp.status
+                ):
                     logger.info(
                         f"Stored-attribution floor kept {tp.data_source} TrackedPlayer "
                         f"{tp.id} for player {journey.player_api_id} at {tp.team.name} "
@@ -1705,7 +1759,9 @@ class JourneySyncService:
                 if tp.pinned_parent or tp.data_source == "manual":
                     continue
                 if tp.team and tp.team.team_id == owning_api_id:
-                    if _stored_attribution_floor(owning_api_id):
+                    if _stored_attribution_floor(
+                        owning_api_id, row_last_season=tp.last_academy_season, row_status=tp.status
+                    ):
                         # The "owning" club is also this player's established
                         # in-window academy origin (a homegrown player still
                         # owned by his academy club, e.g. an academy product on

--- a/academy-watch-backend/src/services/journey_sync.py
+++ b/academy-watch-backend/src/services/journey_sync.py
@@ -1227,6 +1227,36 @@ class JourneySyncService:
 
         return None
 
+    def _retained_empty_run_attribution(self, journey, prior_academy_ids, prior_last_seasons):
+        """Journey attribution to KEEP when this run resolved no academy evidence.
+
+        An empty computation (API youth-coverage gap, or all youth entries
+        filtered out) is "no evidence THIS run", not "evidence the player was
+        never an academy product". Zeroing the journey's stored attribution
+        outright makes the stored-attribution floor one-run-deep: a coverage
+        gap spanning two nightly syncs still orphans the row on run 2, because
+        ``prior_academy_ids`` (re-read from the journey) is empty by then.
+
+        Retain exactly the SUBSET the floor would spare — clubs still inside
+        the window by stored SEASON evidence, or (for a current academy kid)
+        regardless of season — so the floor survives consecutive empty runs.
+        Genuinely aged-out and season-less stale clubs are dropped, so they
+        still deactivate as before.
+        """
+        from src.utils.academy_window import academy_window_start
+
+        window_start = academy_window_start()
+        current_kid = (journey.current_level or "") in YOUTH_LEVELS
+        retained_ids: list[int] = []
+        retained_seasons: dict[str, int] = {}
+        for cid in prior_academy_ids:
+            season = prior_last_seasons.get(str(cid))
+            if current_kid or (season is not None and season >= window_start):
+                retained_ids.append(cid)
+                if season is not None:
+                    retained_seasons[str(cid)] = season
+        return sorted(retained_ids), retained_seasons
+
     def _compute_academy_club_ids(self, journey: PlayerJourney, entries: list | None = None, transfers=None):
         """
         Derive academy parent club IDs from youth journey entries.
@@ -1261,8 +1291,15 @@ class JourneySyncService:
             and not is_national_team(e.club_name)
         ]
         if not youth_entries:
-            journey.academy_club_ids = []
-            journey.academy_last_seasons = {}
+            # Empty computation = "no evidence NOW", not "never an academy
+            # product". Retain the stored attribution the floor would still
+            # spare (in-window by SEASON, or a current kid) so the floor
+            # survives consecutive empty runs instead of being zeroed after one;
+            # genuinely aged-out / season-less stale clubs are dropped and their
+            # rows deactivate as before.
+            journey.academy_club_ids, journey.academy_last_seasons = self._retained_empty_run_attribution(
+                journey, prior_academy_ids, prior_last_seasons
+            )
             # Deactivate any stale tracked-player rows from prior runs
             self._upsert_tracked_players(
                 journey,
@@ -1338,8 +1375,13 @@ class JourneySyncService:
             )
         ]
         if not youth_entries:
-            journey.academy_club_ids = []
-            journey.academy_last_seasons = {}
+            # Empty computation = "no evidence NOW", not "never an academy
+            # product". Retain the stored attribution the floor would still
+            # spare (see _retained_empty_run_attribution) so the floor survives
+            # consecutive empty runs instead of being zeroed after one.
+            journey.academy_club_ids, journey.academy_last_seasons = self._retained_empty_run_attribution(
+                journey, prior_academy_ids, prior_last_seasons
+            )
             self._upsert_tracked_players(
                 journey,
                 set(),
@@ -1390,8 +1432,15 @@ class JourneySyncService:
             or self._strip_youth_suffix(e.club_name) == top_base
         ]
         if not youth_entries:
-            journey.academy_club_ids = []
-            journey.academy_last_seasons = {}
+            # Empty computation = "no evidence NOW", not "never an academy
+            # product". Retain the stored attribution the floor would still
+            # spare (in-window by SEASON, or a current kid) so the floor
+            # survives consecutive empty runs instead of being zeroed after one;
+            # genuinely aged-out / season-less stale clubs are dropped and their
+            # rows deactivate as before.
+            journey.academy_club_ids, journey.academy_last_seasons = self._retained_empty_run_attribution(
+                journey, prior_academy_ids, prior_last_seasons
+            )
             # Deactivate any stale tracked-player rows from prior runs
             self._upsert_tracked_players(
                 journey,
@@ -1551,7 +1600,7 @@ class JourneySyncService:
         from src.models.journey import YOUTH_LEVELS
         from src.models.tracked_player import TrackedPlayer
         from src.utils.academy_classifier import _get_latest_season, classify_tracked_player
-        from src.utils.academy_window import is_within_academy_window
+        from src.utils.academy_window import academy_window_start, is_within_academy_window
 
         last_seasons = last_seasons or {}
         prior_academy_ids = prior_academy_ids or set()
@@ -1590,23 +1639,29 @@ class JourneySyncService:
 
             True when this run produced NO fresh academy evidence for the club
             (it is not in the just-computed ``academy_ids``) yet the journey's
-            PERSISTED attribution still lists it AND its last youth season there
-            is inside the tracking window. A transient empty computation (API
-            youth-coverage gap / tenure-gate flicker) must never orphan an
-            established in-window academy row — leave it for the next sync that
-            actually has evidence. Keys on stored SEASON evidence, so a merely
-            stale ``academy_club_ids`` value without an in-window season does
-            NOT trip it (that still deactivates, as it should).
+            PERSISTED attribution still lists it AND either the player is a
+            current academy kid or its stored last youth season there is inside
+            the tracking window. A transient empty computation (API youth-
+            coverage gap / tenure-gate flicker) must never orphan an established
+            in-window academy row — leave it for the next sync that actually has
+            evidence.
+
+            Keys on stored SEASON evidence (NOT the birth-date development-age
+            fallback in ``is_within_academy_window``): a merely-stale, season-
+            less ``academy_club_ids`` value must still deactivate. Otherwise
+            every U21 with a birth date — the entire academy-tracker demographic
+            — would have season-less stale attributions spared, silently
+            defeating that guarantee and stalling one-shot recompute repairs.
             """
-            return (
-                club_id not in academy_ids
-                and club_id in prior_academy_ids
-                and is_within_academy_window(
-                    prior_last_seasons.get(str(club_id)),
-                    status=window_status,
-                    birth_date=journey.birth_date,
-                )
-            )
+            if club_id in academy_ids or club_id not in prior_academy_ids:
+                return False
+            # Current academy kid (journey current level is a youth level):
+            # protected even without a stored season, so patchy youth-league
+            # coverage can't age out a player who is in an academy right now.
+            if window_status == "academy":
+                return True
+            prior_season = prior_last_seasons.get(str(club_id))
+            return prior_season is not None and prior_season >= academy_window_start()
 
         # Deactivate journey-sync and legacy owning-club rows whose academy
         # connection no longer holds. Skip pinned rows — manual corrections
@@ -1724,6 +1779,14 @@ class JourneySyncService:
                 # retired academy rows in favour of owning-club duplicates).
                 if existing.is_active is False and existing.data_source != "manual":
                     existing.is_active = True
+                    # Provenance is now journey-verified (club is in keep_ids), so
+                    # a legacy 'owning-club' label is both wrong and — critically —
+                    # keeps the reactivated row INVISIBLE: Scout Desk and Teams all
+                    # filter out data_source='owning-club' (invariant #3). Convert
+                    # it to the canonical academy source so the row is actually
+                    # surfaced instead of being healed-but-hidden (the Gore case).
+                    if existing.data_source == "owning-club":
+                        existing.data_source = "journey-sync"
                     logger.info(
                         f"Reactivated TrackedPlayer {existing.id} for player "
                         f"{journey.player_api_id} at {team.name} (academy origin inside tracking window)"

--- a/academy-watch-backend/src/services/player_shadow_service.py
+++ b/academy-watch-backend/src/services/player_shadow_service.py
@@ -58,8 +58,9 @@ def _current_season_start_year(client=None) -> int:
     year = getattr(client, "current_season_start_year", None)
     if isinstance(year, int):
         return year
-    now = datetime.now(UTC)
-    return now.year if now.month >= 8 else now.year - 1
+    from src.utils.academy_window import current_stats_season
+
+    return current_stats_season()
 
 
 # --------------------------------------------------------------------------- #

--- a/academy-watch-backend/src/services/radar_stats_service.py
+++ b/academy-watch-backend/src/services/radar_stats_service.py
@@ -9,7 +9,6 @@ import logging
 import os
 import time
 from collections import Counter
-from datetime import UTC
 from typing import Any
 
 from src.models.league import db
@@ -574,10 +573,14 @@ def resolve_player_league(
     from src.models.tracked_player import TrackedPlayer
 
     if season is None:
-        from datetime import datetime
+        # Radar league comparison is a request-scoped DISPLAY. Default to the
+        # current stats season with the latest-season-with-data fallback so the
+        # senior-minutes gate (Fixture.season == season, below) and league
+        # averages never blank during the July/Aug rollover. One source of
+        # truth — utils/academy_window. Callers may still pass an explicit season.
+        from src.utils.academy_window import stats_season_with_data
 
-        now = datetime.now(UTC)
-        season = now.year if now.month >= 7 else now.year - 1
+        season = stats_season_with_data(db.session)
 
     def _league_from_team(team: "Team") -> tuple[int, str] | None:
         if not team or not team.league_id:
@@ -705,11 +708,12 @@ def get_radar_chart_data(
     average. Both values are normalized to 0-100 where 100 = the best
     performer at that position in the league.
     """
-    from datetime import datetime
-
     if season is None:
-        now = datetime.now(UTC)
-        season = now.year if now.month >= 7 else now.year - 1
+        # DISPLAY default (see resolve_player_league) — latest-season-with-data
+        # fallback keeps the radar populated across the July/Aug rollover.
+        from src.utils.academy_window import stats_season_with_data
+
+        season = stats_season_with_data(db.session)
 
     # Determine primary position
     primary_fp, fp_count, fp_total = get_primary_formation_position(fixtures_data)

--- a/academy-watch-backend/src/services/scout_digest_service.py
+++ b/academy-watch-backend/src/services/scout_digest_service.py
@@ -31,6 +31,16 @@ MAX_DIGEST_USERS = 200
 # One run touches at most this many entries across all users — keeps a
 # synchronous admin request bounded; callers page with `cursor`.
 MAX_DIGEST_ENTRIES = 2000
+# A single digest window (weekly cadence, occasionally longer) can plausibly add
+# only a handful of appearances / minutes. A delta far beyond that is not real
+# activity but a SHIFTED BASELINE — e.g. a one-off stats re-keying that makes a
+# returned loanee's stored season jump from 0 to a full season in one step. When
+# a delta looks like a baseline shift we suppress the "since last digest" chips
+# and let the accurate season line stand, so a re-keying/backfill deploy can't
+# email "+30 apps / +2,583 mins" as if it happened this week. The fresh snapshot
+# is still written, so the next digest self-heals to real deltas.
+MAX_PLAUSIBLE_WINDOW_APPS = 15
+MAX_PLAUSIBLE_WINDOW_MINUTES = 1000
 # Full rendered HTML only for the first few dry-run previews; at 200 users
 # the response would otherwise be a multi-megabyte JSON blob.
 MAX_PREVIEW_HTML = 5
@@ -240,14 +250,19 @@ def _entry_update(entry, cache: dict, api_client=None) -> dict | None:
         new_goals = int(stats.get("goals") or 0) - int(previous.get("goals") or 0)
         new_assists = int(stats.get("assists") or 0) - int(previous.get("assists") or 0)
         new_minutes = int(stats.get("minutes_played") or 0) - int(previous.get("minutes_played") or 0)
-        if new_goals > 0:
-            chips.append(f"+{_plural(new_goals, 'goal')}")
-        if new_assists > 0:
-            chips.append(f"+{_plural(new_assists, 'assist')}")
-        if new_apps > 0:
-            chips.append(f"+{_plural(new_apps, 'app')}")
-        if new_minutes > 0:
-            chips.append(f"+{new_minutes} mins")
+        # A baseline shift (a re-keying/backfill that moved the stored totals, not
+        # real match activity) produces implausibly large deltas — suppress ALL
+        # numeric chips for it and let the season line carry the truth.
+        baseline_shift = new_apps > MAX_PLAUSIBLE_WINDOW_APPS or new_minutes > MAX_PLAUSIBLE_WINDOW_MINUTES
+        if not baseline_shift:
+            if new_goals > 0:
+                chips.append(f"+{_plural(new_goals, 'goal')}")
+            if new_assists > 0:
+                chips.append(f"+{_plural(new_assists, 'assist')}")
+            if new_apps > 0:
+                chips.append(f"+{_plural(new_apps, 'app')}")
+            if new_minutes > 0:
+                chips.append(f"+{new_minutes} mins")
 
         # Status headlines only apply to tracked players (shadows have no status).
         previous_status = previous.get("status")

--- a/academy-watch-backend/src/services/team_verify.py
+++ b/academy-watch-backend/src/services/team_verify.py
@@ -25,7 +25,6 @@ Usage:
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime
 from typing import Any
 
 from src.models.league import Team, db
@@ -35,9 +34,16 @@ logger = logging.getLogger(__name__)
 
 
 def _current_season() -> int:
-    """European season cycle: Aug-Jul. Mirrors get_radar_chart_data."""
-    now = datetime.now(UTC)
-    return now.year if now.month >= 7 else now.year - 1
+    """Current stats season (European Aug rollover) for the API-Football league
+    lookup that drives parent_league_drift detection.
+
+    This is a data-FETCH/audit path, so it uses the pure calendar helper
+    (utils/academy_window.current_stats_season) — one source of truth. (The old
+    inline month>=7 hinge disagreed with its own "Aug-Jul" docstring.)
+    """
+    from src.utils.academy_window import current_stats_season
+
+    return current_stats_season()
 
 
 def audit_team_consistency(team_db_id: int) -> dict[str, Any]:

--- a/academy-watch-backend/src/services/transfer_heal_service.py
+++ b/academy-watch-backend/src/services/transfer_heal_service.py
@@ -9,6 +9,7 @@ directly, without depending on AcademyPlayer rows.
 """
 
 import logging
+from datetime import UTC, datetime
 
 from sqlalchemy import text
 from src.api_football_client import APIFootballClient
@@ -24,15 +25,27 @@ from src.utils.academy_classifier import (
 
 logger = logging.getLogger(__name__)
 
-# Cap on how many orphaned rows a single heal run may requeue for a force_full
-# journey re-sync. Each requeued row costs ~7s + several API-Football calls, so
-# an unbounded requeue (e.g. after a mass-orphaning incident) would blow the
-# nightly job's runtime and API quota. Genuinely-healable orphans reactivate and
-# leave the pool, so the backlog drains across runs (oldest-touched first).
+# Budget on how many orphaned rows may be requeued for a force_full journey
+# re-sync. Each requeued row costs ~7s + several API-Football calls, so an
+# unbounded requeue (e.g. after a mass-orphaning incident) would blow the
+# nightly job's runtime and API quota.
+#
+# This is the DEFAULT per-call cap. The nightly job runners iterate ~137 teams
+# and call refresh_and_heal once per team, so a per-call cap would multiply into
+# 50×137 re-syncs a night — the exact quota/runtime blow-up the cap is meant to
+# prevent. Those runners therefore pass an ``orphan_budget`` that they DECREMENT
+# across teams, making the ceiling job-global (this constant) rather than
+# per-team. Callers that fire a single refresh (admin endpoint, team-verify,
+# newsletter pre-refresh) omit ``orphan_budget`` and get this cap for that call.
+#
+# Genuinely-healable orphans reactivate and leave the pool; non-healable rows
+# have their updated_at touched on the skipped requeue so the oldest-touched
+# ordering ROUND-ROBINS through the backlog instead of pinning the same stuck
+# tail every night — so the budget rotates fairly and the backlog drains.
 MAX_ORPHAN_REQUEUE = 50
 
 
-def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False, cascade_fixtures=True):
+def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False, cascade_fixtures=True, orphan_budget=None):
     """Re-derive statuses for tracked players, detecting loan club changes.
 
     Args:
@@ -41,14 +54,20 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False, cascade_
         dry_run: If True, do not commit changes or cascade fixture syncs.
         cascade_fixtures: If True, sync fixtures for players whose loan club
             changed. Set False for admin endpoint (preserves old behavior).
+        orphan_budget: Max orphan rows this call may requeue for a force_full
+            journey re-sync. None → the per-call default MAX_ORPHAN_REQUEUE.
+            The nightly per-team job loops pass a shrinking budget so the
+            ceiling stays job-global (see MAX_ORPHAN_REQUEUE) rather than
+            multiplying by the team count.
 
     Returns:
         dict with keys: total, updated, journeys_resynced, players_changed,
-        fixture_syncs_triggered.
+        fixture_syncs_triggered, orphans_requeued.
 
     Note: Fixture syncs are independent — status changes persist even if
     a fixture sync fails for an individual player.
     """
+    orphan_cap = MAX_ORPHAN_REQUEUE if orphan_budget is None else max(int(orphan_budget), 0)
     query = TrackedPlayer.query.filter_by(is_active=True)
     if team_id:
         query = query.filter_by(team_id=team_id)
@@ -78,7 +97,7 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False, cascade_
     # Reactivation requires a journey re-sync, so this is gated on resync_journeys;
     # scoped by team_id like the active set.
     orphans = []
-    if resync_journeys:
+    if resync_journeys and orphan_cap > 0:
         from src.utils.academy_window import academy_window_start, is_within_academy_window
 
         window_start = academy_window_start()
@@ -109,7 +128,7 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False, cascade_
                 for j in PlayerJourney.query.filter(PlayerJourney.player_api_id.in_(cand_api_ids)).all()
             }
             for tp in candidates:
-                if len(orphans) >= MAX_ORPHAN_REQUEUE:
+                if len(orphans) >= orphan_cap:
                     break
                 parent = teams_by_id.get(tp.team_id)
                 journey = journeys_by_api.get(tp.player_api_id)
@@ -124,10 +143,9 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False, cascade_
 
         if orphans:
             logger.info(
-                "transfer-heal: requeuing %d journey-attributed in-window orphan row(s) "
-                "for reactivation (capped at %d)",
+                "transfer-heal: requeuing %d journey-attributed in-window orphan row(s) for reactivation (budget %d)",
                 len(orphans),
-                MAX_ORPHAN_REQUEUE,
+                orphan_cap,
             )
             players = players + orphans
 
@@ -232,6 +250,13 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False, cascade_
         # would fire a fixture sync for a hidden player. Leave it for a future
         # run where the re-sync actually has evidence to revive it.
         if was_inactive and not tp.is_active:
+            # Rotate the queue: this row keeps its old updated_at otherwise, so
+            # the oldest-touched candidate ordering (ORDER BY updated_at ASC)
+            # would re-select the SAME never-healable rows first every night —
+            # perpetual force_full churn that starves healable orphans behind
+            # them once a team accumulates a budget's worth of stuck rows. Touch
+            # updated_at so the backlog round-robins and drains instead.
+            tp.updated_at = datetime.now(UTC)
             continue
 
         if not journey:
@@ -419,4 +444,5 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False, cascade_
         "fixture_syncs_triggered": fixture_syncs_triggered,
         "skipped_by_failed_prefetch": skipped_by_failed_prefetch,
         "failed_squad_clubs": sorted(failed_squad_clubs),
+        "orphans_requeued": len(orphans),
     }

--- a/academy-watch-backend/src/services/transfer_heal_service.py
+++ b/academy-watch-backend/src/services/transfer_heal_service.py
@@ -9,7 +9,6 @@ directly, without depending on AcademyPlayer rows.
 """
 
 import logging
-from datetime import UTC, datetime
 
 from sqlalchemy import text
 from src.api_football_client import APIFootballClient
@@ -260,9 +259,12 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False, cascade_
     fixture_syncs_triggered = 0
     if not dry_run and cascade_fixtures and players_changed:
         from src.routes.api import _sync_player_club_fixtures
+        from src.utils.academy_window import current_stats_season
 
-        now = datetime.now(UTC)
-        season = now.year if now.month >= 8 else now.year - 1
+        # Transfer heal fetches fixtures for the UPCOMING season — use the pure
+        # calendar season (NO latest-with-data fallback) so a newly-started
+        # season actually gets synced instead of being pinned to old data.
+        season = current_stats_season()
 
         for pc in players_changed:
             try:

--- a/academy-watch-backend/src/services/transfer_heal_service.py
+++ b/academy-watch-backend/src/services/transfer_heal_service.py
@@ -24,6 +24,13 @@ from src.utils.academy_classifier import (
 
 logger = logging.getLogger(__name__)
 
+# Cap on how many orphaned rows a single heal run may requeue for a force_full
+# journey re-sync. Each requeued row costs ~7s + several API-Football calls, so
+# an unbounded requeue (e.g. after a mass-orphaning incident) would blow the
+# nightly job's runtime and API quota. Genuinely-healable orphans reactivate and
+# leave the pool, so the backlog drains across runs (oldest-touched first).
+MAX_ORPHAN_REQUEUE = 50
+
 
 def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False, cascade_fixtures=True):
     """Re-derive statuses for tracked players, detecting loan club changes.
@@ -49,22 +56,33 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False, cascade_
     players = query.all()
 
     # ── Orphan self-heal ──
-    # Requeue is_active=false journey-attributed academy rows that are still
-    # inside the tracking window so they can reactivate themselves. The journey
-    # upsert's reactivation branch only fires during a full journey re-sync, and
-    # the heal historically looked at ACTIVE rows only — so a row orphaned by an
-    # earlier transient empty computation (before the stored-attribution floor
-    # landed) was never revisited. Adding these to the queue lets a transfers-fed
-    # re-sync flip them back on via the existing upsert path, respecting
-    # invariant #10 (status changes only through the transfers-fed sync).
-    # Reactivation requires a journey re-sync, so this is gated on
-    # resync_journeys; scoped by team_id like the active set, so the scheduled
-    # per-team jobs stay bounded and orphans just join the existing batch.
+    # Requeue is_active=false rows that were orphaned by an earlier transient
+    # empty computation so a transfers-fed journey re-sync can reactivate them
+    # via the upsert's reactivation branch (invariant #10 — status only changes
+    # through the transfers-fed sync). The journey upsert's reactivation branch
+    # only fires during a full journey re-sync, and the heal historically looked
+    # at ACTIVE rows only, so orphans were never revisited.
+    #
+    # Bounded and TERMINAL by construction, so the nightly job doesn't force_full
+    # re-sync a never-healable tail forever (API-Football quota + runtime):
+    #   1. Journey-attribution gate — only requeue a row whose LINKED journey
+    #      STILL attributes the row's academy club IN-WINDOW. Those are the only
+    #      rows the upsert can actually reactivate; graveyard rows (no journey /
+    #      journey no longer attributes the club / aged-out season) are excluded,
+    #      and once an evidenced re-sync overwrites the attribution or the season
+    #      ages out, a row drops out of the set (terminal). This also catches the
+    #      legacy owning-club orphans (the canonical Gore row) that carry NO row-
+    #      local season, which the old row-local filter silently missed.
+    #   2. MAX_ORPHAN_REQUEUE cap, oldest-touched first, so a mass orphaning
+    #      can't blow up a single run.
+    # Reactivation requires a journey re-sync, so this is gated on resync_journeys;
+    # scoped by team_id like the active set.
+    orphans = []
     if resync_journeys:
-        from src.utils.academy_window import academy_window_start
+        from src.utils.academy_window import academy_window_start, is_within_academy_window
 
         window_start = academy_window_start()
-        orphan_query = TrackedPlayer.query.filter(
+        candidate_q = TrackedPlayer.query.filter(
             TrackedPlayer.is_active.is_(False),
             TrackedPlayer.pinned_parent.isnot(True),
             TrackedPlayer.data_source != "manual",
@@ -72,15 +90,44 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False, cascade_
             db.or_(
                 TrackedPlayer.last_academy_season >= window_start,
                 TrackedPlayer.status == "academy",
+                # Legacy owning-club orphans were created without row-local season
+                # evidence; keep them in the candidate net and let the journey
+                # gate below decide.
+                TrackedPlayer.data_source == "owning-club",
             ),
-        )
+        ).order_by(TrackedPlayer.updated_at.asc())
         if team_id:
-            orphan_query = orphan_query.filter(TrackedPlayer.team_id == team_id)
-        orphans = orphan_query.all()
+            candidate_q = candidate_q.filter(TrackedPlayer.team_id == team_id)
+        candidates = candidate_q.all()
+
+        if candidates:
+            cand_team_ids = {tp.team_id for tp in candidates}
+            teams_by_id = {t.id: t for t in Team.query.filter(Team.id.in_(cand_team_ids)).all()}
+            cand_api_ids = {tp.player_api_id for tp in candidates}
+            journeys_by_api = {
+                j.player_api_id: j
+                for j in PlayerJourney.query.filter(PlayerJourney.player_api_id.in_(cand_api_ids)).all()
+            }
+            for tp in candidates:
+                if len(orphans) >= MAX_ORPHAN_REQUEUE:
+                    break
+                parent = teams_by_id.get(tp.team_id)
+                journey = journeys_by_api.get(tp.player_api_id)
+                if not parent or not journey:
+                    continue
+                if parent.team_id not in set(journey.academy_club_ids or []):
+                    continue
+                season = (journey.academy_last_seasons or {}).get(str(parent.team_id))
+                window_status = "academy" if tp.status == "academy" else None
+                if is_within_academy_window(season, status=window_status, birth_date=journey.birth_date):
+                    orphans.append(tp)
+
         if orphans:
             logger.info(
-                "transfer-heal: requeuing %d orphaned in-window academy row(s) for journey-driven reactivation",
+                "transfer-heal: requeuing %d journey-attributed in-window orphan row(s) "
+                "for reactivation (capped at %d)",
                 len(orphans),
+                MAX_ORPHAN_REQUEUE,
             )
             players = players + orphans
 
@@ -161,6 +208,7 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False, cascade_
     skipped_by_failed_prefetch = 0
     for tp in players:
         journey = None
+        was_inactive = not tp.is_active
 
         # Re-sync journey from API-Football if requested
         if resync_journeys and journey_svc and tp.player_api_id:
@@ -176,6 +224,15 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False, cascade_
                     tp.player_api_id,
                     sync_err,
                 )
+
+        # Orphan requeue that the re-sync could NOT reactivate (still inactive
+        # after the journey upsert ran — e.g. the API coverage gap persists) must
+        # not have its status rewritten or its fixtures cascaded: it is not
+        # displayed anywhere. Writing to it and appending it to players_changed
+        # would fire a fixture sync for a hidden player. Leave it for a future
+        # run where the re-sync actually has evidence to revive it.
+        if was_inactive and not tp.is_active:
+            continue
 
         if not journey:
             if tp.journey_id:

--- a/academy-watch-backend/src/services/transfer_heal_service.py
+++ b/academy-watch-backend/src/services/transfer_heal_service.py
@@ -48,6 +48,42 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False, cascade_
 
     players = query.all()
 
+    # ── Orphan self-heal ──
+    # Requeue is_active=false journey-attributed academy rows that are still
+    # inside the tracking window so they can reactivate themselves. The journey
+    # upsert's reactivation branch only fires during a full journey re-sync, and
+    # the heal historically looked at ACTIVE rows only — so a row orphaned by an
+    # earlier transient empty computation (before the stored-attribution floor
+    # landed) was never revisited. Adding these to the queue lets a transfers-fed
+    # re-sync flip them back on via the existing upsert path, respecting
+    # invariant #10 (status changes only through the transfers-fed sync).
+    # Reactivation requires a journey re-sync, so this is gated on
+    # resync_journeys; scoped by team_id like the active set, so the scheduled
+    # per-team jobs stay bounded and orphans just join the existing batch.
+    if resync_journeys:
+        from src.utils.academy_window import academy_window_start
+
+        window_start = academy_window_start()
+        orphan_query = TrackedPlayer.query.filter(
+            TrackedPlayer.is_active.is_(False),
+            TrackedPlayer.pinned_parent.isnot(True),
+            TrackedPlayer.data_source != "manual",
+            TrackedPlayer.player_api_id.isnot(None),
+            db.or_(
+                TrackedPlayer.last_academy_season >= window_start,
+                TrackedPlayer.status == "academy",
+            ),
+        )
+        if team_id:
+            orphan_query = orphan_query.filter(TrackedPlayer.team_id == team_id)
+        orphans = orphan_query.all()
+        if orphans:
+            logger.info(
+                "transfer-heal: requeuing %d orphaned in-window academy row(s) for journey-driven reactivation",
+                len(orphans),
+            )
+            players = players + orphans
+
     updated = 0
     journeys_resynced = 0
     players_changed = []

--- a/academy-watch-backend/src/utils/academy_window.py
+++ b/academy-watch-backend/src/utils/academy_window.py
@@ -36,6 +36,53 @@ def academy_window_start(today: date | None = None) -> int:
     return current_academy_season(today) - _window_years()
 
 
+def current_stats_season(today: date | datetime | None = None) -> int:
+    """Season-start year for STATS DISPLAY / fixture data (August rollover).
+
+    Two "current season" rules exist on purpose — do NOT collapse them:
+
+    - ``current_academy_season`` rolls over on **1 July** because it gates the
+      ACADEMY TRACKING WINDOW: when the youth calendar turns over in summer a
+      player's academy eligibility should advance immediately, so July is the
+      right hinge for who is still "in window".
+    - ``current_stats_season`` rolls over on **1 August** because it selects
+      which SEASON'S FIXTURES to show. European league football starts in
+      August; rolling in July would point at a season that has no matches yet
+      and blank every stats page for a month.
+
+    Callers that display or sync fixture/stats data want THIS helper; callers
+    that gate academy eligibility want ``current_academy_season``.
+    """
+    if isinstance(today, datetime):
+        today = today.date()
+    today = today or date.today()
+    return today.year if today.month >= 8 else today.year - 1
+
+
+def stats_season_with_data(db_session, today: date | datetime | None = None) -> int:
+    """``current_stats_season`` but never point at a season with no fixtures.
+
+    The calendar season (e.g. 2026 on 1 Aug 2026) can roll over before any
+    fixtures for it have been ingested. Using it directly would blank every
+    stats page platform-wide until the new season's fixtures land. When the
+    calendar season has zero fixture rows this falls back to the latest season
+    that actually HAS fixtures (``MAX(fixtures.season)``).
+
+    DISPLAY paths only. Data-fetching / sync paths (transfer heal, newsletter
+    generation, API-Football season priming) must use ``current_stats_season``
+    so they fetch the real upcoming season instead of being pinned to old data.
+    """
+    from sqlalchemy import func
+    from src.models.weekly import Fixture
+
+    calendar_season = current_stats_season(today)
+    has_current = db_session.query(Fixture.id).filter(Fixture.season == calendar_season).first() is not None
+    if has_current:
+        return calendar_season
+    latest = db_session.query(func.max(Fixture.season)).scalar()
+    return latest if latest is not None else calendar_season
+
+
 def age_from_birth_date(birth_date, today: date | None = None) -> int | None:
     """Floor years between a 'YYYY-MM-DD...' birth date string and today.
 

--- a/academy-watch-backend/tests/test_academy_provenance.py
+++ b/academy-watch-backend/tests/test_academy_provenance.py
@@ -811,6 +811,26 @@ class TestUpsertReactivatesOrphanedAcademyRows:
 
         assert row.is_active is False
 
+    def test_reactivated_owning_club_row_becomes_visible_journey_sync(self, app, sync_service):
+        # The Gore heal: an inactive 'owning-club' row whose club IS the academy
+        # origin (in keep_ids). Reactivation must also flip data_source to
+        # 'journey-sync' — otherwise the row comes back ACTIVE but still invisible
+        # on Scout Desk / Teams (which exclude data_source='owning-club',
+        # invariant #3), i.e. healed-but-hidden.
+        from src.utils.academy_window import current_academy_season
+
+        recent = current_academy_season()
+        league = _seed_league()
+        team = _seed_team(league, 100, "Feyenoord")
+        journey = _academy_alumnus_journey(434, [recent])
+        row = _tracked(434, team, data_source="owning-club", journey_id=journey.id, active=False)
+        db.session.commit()
+
+        sync_service._compute_academy_club_ids(journey)
+
+        assert row.is_active is True
+        assert row.data_source == "journey-sync"
+
 
 class TestStoredAttributionFloor:
     """A transient sync that resolves NO academy evidence (API youth-coverage
@@ -904,3 +924,54 @@ class TestStoredAttributionFloor:
         sync_service._compute_academy_club_ids(journey)
 
         assert row.is_active is False
+
+    def test_floor_ignores_season_less_stale_ids_even_for_u21(self, app, sync_service):
+        # Same season-less stale shape, but now the player is a U21 WITH a birth
+        # date. The floor must key on stored SEASON evidence only — the birth-date
+        # development-age fallback in is_within_academy_window must NOT stand in
+        # for it, or every young player's season-less stale attribution would be
+        # spared (defeating the one-shot recompute repair).
+        from datetime import date
+
+        league = _seed_league()
+        team = _seed_team(league, 100, "Feyenoord")
+        nineteen = date.today().year - 19
+        journey = PlayerJourney(
+            player_api_id=504,
+            player_name="Test Player 504",
+            academy_club_ids=[100],
+            academy_last_seasons={},
+            birth_date=f"{nineteen}-01-15",
+        )
+        db.session.add(journey)
+        db.session.flush()
+        row = _tracked(504, team, data_source="journey-sync", journey_id=journey.id)
+        db.session.commit()
+
+        sync_service._compute_academy_club_ids(journey)
+
+        assert row.is_active is False
+
+    def test_floor_survives_two_consecutive_empty_runs(self, app, sync_service):
+        # An API coverage gap that lasts two nightly syncs must not orphan the
+        # row on run 2. Run 1 spares it AND retains the stored attribution the
+        # floor depends on (instead of zeroing it), so run 2 still fires.
+        from src.utils.academy_window import current_academy_season
+
+        recent = current_academy_season()
+        league = _seed_league()
+        team = _seed_team(league, 100, "Feyenoord")
+        journey = self._stored_journey(505, stored_last_seasons={100: recent})
+        row = _tracked(505, team, data_source="journey-sync", journey_id=journey.id)
+        db.session.commit()
+
+        # Run 1: empty computation spares the row and keeps the attribution.
+        sync_service._compute_academy_club_ids(journey)
+        assert row.is_active is True
+        assert (journey.academy_club_ids or []) == [100]
+        assert (journey.academy_last_seasons or {}) == {"100": recent}
+        db.session.commit()
+
+        # Run 2: gap persists — the floor must still protect the row.
+        sync_service._compute_academy_club_ids(journey)
+        assert row.is_active is True

--- a/academy-watch-backend/tests/test_academy_provenance.py
+++ b/academy-watch-backend/tests/test_academy_provenance.py
@@ -975,3 +975,70 @@ class TestStoredAttributionFloor:
         # Run 2: gap persists — the floor must still protect the row.
         sync_service._compute_academy_club_ids(journey)
         assert row.is_active is True
+
+    def test_floor_honours_in_window_row_local_season(self, app, sync_service):
+        # The journey's per-club season map is EMPTY (legacy pre-aw18 map, or
+        # youth entries whose seasons are NULL) but the tracked ROW carries an
+        # in-window last_academy_season. Keying the floor on the journey map
+        # alone would orphan it on a single empty run (and, since retention
+        # would zero academy_club_ids, put it beyond the transfer-heal requeue
+        # gate too). Row-local season evidence must spare it AND be recovered
+        # into the journey map so the floor survives a second empty run.
+        from src.utils.academy_window import current_academy_season
+
+        recent = current_academy_season()
+        league = _seed_league()
+        team = _seed_team(league, 100, "Feyenoord")
+        journey = PlayerJourney(
+            player_api_id=510,
+            player_name="Test Player 510",
+            academy_club_ids=[100],
+            academy_last_seasons={},
+        )
+        db.session.add(journey)
+        db.session.flush()
+        row = _tracked(510, team, data_source="journey-sync", journey_id=journey.id)
+        row.last_academy_season = recent
+        db.session.commit()
+
+        # Run 1: empty computation, but the row's own season spares it and the
+        # attribution is recovered into the journey map.
+        sync_service._compute_academy_club_ids(journey)
+        assert row.is_active is True
+        assert (journey.academy_club_ids or []) == [100]
+        assert (journey.academy_last_seasons or {}) == {"100": recent}
+        db.session.commit()
+
+        # Run 2: gap persists — the recovered attribution keeps the floor firing.
+        sync_service._compute_academy_club_ids(journey)
+        assert row.is_active is True
+
+    def test_floor_honours_row_status_academy_when_journey_level_lags(self, app, sync_service):
+        # Row says status='academy' (a current academy kid) but the journey's
+        # current_level lags (First Team / legacy) and the season map is empty.
+        # The aged-out branch already spares status='academy' rows, but only on
+        # runs with evidence; on a NO-evidence run academy_ids (and aged_out) are
+        # empty, so the floor must itself honour the row's status.
+        league = _seed_league()
+        team = _seed_team(league, 100, "Feyenoord")
+        journey = PlayerJourney(
+            player_api_id=511,
+            player_name="Test Player 511",
+            academy_club_ids=[100],
+            academy_last_seasons={},
+            current_level="First Team",
+        )
+        db.session.add(journey)
+        db.session.flush()
+        row = _tracked(511, team, data_source="journey-sync", journey_id=journey.id)
+        row.status = "academy"
+        db.session.commit()
+
+        sync_service._compute_academy_club_ids(journey)
+        assert row.is_active is True
+        # Retained via the row's status so the requeue gate could still see it.
+        assert (journey.academy_club_ids or []) == [100]
+        db.session.commit()
+
+        sync_service._compute_academy_club_ids(journey)
+        assert row.is_active is True

--- a/academy-watch-backend/tests/test_academy_provenance.py
+++ b/academy-watch-backend/tests/test_academy_provenance.py
@@ -810,3 +810,97 @@ class TestUpsertReactivatesOrphanedAcademyRows:
         sync_service._compute_academy_club_ids(journey)
 
         assert row.is_active is False
+
+
+class TestStoredAttributionFloor:
+    """A transient sync that resolves NO academy evidence (API youth-coverage
+    gap / tenure-gate flicker → empty academy_ids) must never orphan an
+    established in-window academy row. Canonical case: Daniel Gore."""
+
+    def _stored_journey(self, player_api_id, *, stored_last_seasons, senior_entry=None):
+        """Journey with a PERSISTED academy attribution but NO youth entries
+        this run — so _compute takes an empty-computation path and the floor
+        must lean on the stored attribution to spare the row."""
+        journey = PlayerJourney(
+            player_api_id=player_api_id,
+            player_name=f"Test Player {player_api_id}",
+            academy_club_ids=sorted(int(k) for k in stored_last_seasons),
+            academy_last_seasons={str(k): v for k, v in stored_last_seasons.items()},
+        )
+        db.session.add(journey)
+        db.session.flush()
+        if senior_entry is not None:
+            season, club_api_id, club_name = senior_entry
+            db.session.add(_entry(journey.id, season, club_api_id, club_name, entry_type="first_team", appearances=20))
+            db.session.flush()
+        return journey
+
+    def test_empty_computation_spares_in_window_row(self, app, sync_service):
+        from src.utils.academy_window import current_academy_season
+
+        recent = current_academy_season()
+        league = _seed_league()
+        team = _seed_team(league, 100, "Feyenoord")
+        journey = self._stored_journey(500, stored_last_seasons={100: recent})
+        row = _tracked(500, team, data_source="journey-sync", journey_id=journey.id)
+        db.session.commit()
+
+        sync_service._compute_academy_club_ids(journey)
+
+        assert row.is_active is True
+
+    def test_homegrown_owned_row_spared_from_owning_block(self, app, sync_service):
+        # Gore-shaped: the owning club IS the academy club (a homegrown player
+        # still owned by his academy, e.g. on loan). A transient empty run would
+        # otherwise nuke the row via BOTH the stale sweep and the owning-club
+        # block; the floor must protect it in both.
+        from src.utils.academy_window import current_academy_season
+
+        recent = current_academy_season()
+        league = _seed_league()
+        team = _seed_team(league, 100, "Feyenoord")
+        journey = self._stored_journey(501, stored_last_seasons={100: recent}, senior_entry=(recent, 100, "Feyenoord"))
+        # owning-club data_source mirrors the real orphaned Gore row.
+        row = _tracked(501, team, data_source="owning-club", journey_id=journey.id)
+        db.session.commit()
+
+        sync_service._compute_academy_club_ids(journey)
+
+        assert row.is_active is True
+
+    def test_floor_does_not_protect_out_of_window_stored_row(self, app, sync_service):
+        # Stored attribution present but its last youth season is OUT of window
+        # → a genuine aged-out alumnus; the floor must NOT keep it alive.
+        from src.utils.academy_window import academy_window_start
+
+        old = academy_window_start() - 2
+        league = _seed_league()
+        team = _seed_team(league, 100, "Feyenoord")
+        journey = self._stored_journey(502, stored_last_seasons={100: old})
+        row = _tracked(502, team, data_source="journey-sync", journey_id=journey.id)
+        db.session.commit()
+
+        sync_service._compute_academy_club_ids(journey)
+
+        assert row.is_active is False
+
+    def test_floor_ignores_stale_ids_without_season_evidence(self, app, sync_service):
+        # academy_club_ids lists the club but there is NO season evidence
+        # (academy_last_seasons empty) — a merely-stale stored value. This is the
+        # recompute contradiction shape; the floor must NOT protect it.
+        league = _seed_league()
+        team = _seed_team(league, 100, "Feyenoord")
+        journey = PlayerJourney(
+            player_api_id=503,
+            player_name="Test Player 503",
+            academy_club_ids=[100],
+            academy_last_seasons={},
+        )
+        db.session.add(journey)
+        db.session.flush()
+        row = _tracked(503, team, data_source="journey-sync", journey_id=journey.id)
+        db.session.commit()
+
+        sync_service._compute_academy_club_ids(journey)
+
+        assert row.is_active is False

--- a/academy-watch-backend/tests/test_radar_stats_service.py
+++ b/academy-watch-backend/tests/test_radar_stats_service.py
@@ -207,7 +207,12 @@ class TestGetRadarChartData:
             },
         ]
 
-        result = get_radar_chart_data(player_id=123, fixtures_data=fixtures)
+        # Pass an explicit season: resolve_player_league and
+        # fetch_league_position_averages are mocked, so season is a passthrough
+        # here. Supplying it keeps the test deterministic and avoids the
+        # season default, which now reads db.session (stats_season_with_data)
+        # and would require a Flask app context this pure unit test doesn't set up.
+        result = get_radar_chart_data(player_id=123, fixtures_data=fixtures, season=2025)
 
         assert result["chart_type"] == "radar"
         assert result["position_group"] == "FB"
@@ -229,7 +234,9 @@ class TestGetRadarChartData:
         fixtures = [
             {"stats": {"minutes": 90, "position": "D", "formation_position": "CB"}},
         ]
-        result = get_radar_chart_data(player_id=456, fixtures_data=fixtures)
+        # Explicit season (passthrough while resolve/fetch are mocked) — see
+        # test_response_shape_with_league for why the default is avoided here.
+        result = get_radar_chart_data(player_id=456, fixtures_data=fixtures, season=2025)
         assert result["league_name"] is None
         assert result["league_peers"] == 0
         # Should still have data items

--- a/academy-watch-backend/tests/test_scout_blueprint.py
+++ b/academy-watch-backend/tests/test_scout_blueprint.py
@@ -378,6 +378,81 @@ class TestScoutCompare:
         assert scout_client.get("/api/scout/compare?ids=1,2,3,4,5").status_code == 400
 
 
+@pytest.fixture
+def returned_loanee(scout_app):
+    """A returned loanee: the journey flipped his current club back to the
+    parent (current_club_api_id == parent), but his real season is a full loan
+    spell at ANOTHER club plus one parent cup cameo. Reproduces the Gore-class
+    stat-attribution bug that keying /scout/compare on current_club_api_id hid."""
+    with scout_app.app_context():
+        league = League(
+            league_id=39, name="Premier League", country="England", season=2025, is_european_top_league=True
+        )
+        db.session.add(league)
+        db.session.flush()
+        parent = Team(
+            team_id=33, name="Manchester United", country="England", season=2025, league_id=league.id, is_active=True
+        )
+        db.session.add(parent)
+        db.session.flush()
+
+        player = TrackedPlayer(
+            player_api_id=2001,
+            player_name="Danny Returnee",
+            position="Midfielder",
+            nationality="England",
+            age=20,
+            team_id=parent.id,
+            status="first_team",
+            current_club_api_id=33,  # journey flipped current club back to the parent
+            current_club_name="Manchester United",
+            data_depth="full_stats",
+            is_active=True,
+        )
+        db.session.add(player)
+
+        # One parent-club cameo (team 33) + three loan-club league apps (team 777).
+        fixtures = []
+        for i in range(4):
+            fixtures.append(
+                Fixture(
+                    fixture_id_api=7000 + i,
+                    season=2025,
+                    home_team_api_id=33 if i == 0 else 777,
+                    away_team_api_id=999,
+                    date_utc=datetime(2025, 9, 1 + 7 * i),
+                )
+            )
+        db.session.add_all(fixtures)
+        db.session.flush()
+        db.session.add(
+            FixturePlayerStats(
+                fixture_id=fixtures[0].id, player_api_id=2001, team_api_id=33, minutes=10, goals=0, rating=6.5
+            )
+        )
+        for i in range(1, 4):
+            db.session.add(
+                FixturePlayerStats(
+                    fixture_id=fixtures[i].id, player_api_id=2001, team_api_id=777, minutes=90, goals=1, rating=7.5
+                )
+            )
+        db.session.commit()
+
+
+class TestScoutCompareReturnedLoanee:
+    def test_compare_reports_full_season_not_current_club_cameo(self, scout_client, returned_loanee):
+        # Keyed on current_club_api_id (the bug), compare returned only the single
+        # parent cameo (1 app / 10 min / 0 goals). Season-scoped and de-keyed it
+        # reports the whole season across both clubs, matching /scout/players.
+        resp = scout_client.get("/api/scout/compare?ids=2001")
+        assert resp.status_code == 200
+        totals = resp.get_json()["players"][0]["totals"]
+        assert totals["appearances"] == 4
+        assert totals["minutes_played"] == 280
+        assert totals["goals"] == 3
+        assert totals["stats_coverage"] == "full"
+
+
 class TestRecentForm:
     def test_browse_includes_recent_form_newest_first(self, scout_client, seeded_players):
         resp = scout_client.get("/api/scout/players?position=Attacker")

--- a/academy-watch-backend/tests/test_scout_watchlist.py
+++ b/academy-watch-backend/tests/test_scout_watchlist.py
@@ -549,6 +549,33 @@ class TestDigests:
         assert self._post(client, {"cursor": -1}).status_code == 400
         assert self._post(client, {"cursor": "abc"}).status_code == 400
 
+    def test_baseline_shift_suppresses_implausible_delta_chips(self, client, seeded):
+        """A re-keying/backfill can move a stored snapshot from ~0 to a full
+        season in one step. The digest must NOT advertise that as huge weekly
+        deltas — it suppresses the delta chips and lets the season line stand."""
+        from src.services.scout_digest_service import build_user_digest
+
+        user = _make_user("shift@example.com")
+        # Keeper 1003: current season is 12 apps / 1080 mins (PlayerStatsCache).
+        # Stale baseline of ~0 → a +1080-minute delta, far beyond one window.
+        stale = json.dumps(
+            {"appearances": 0, "goals": 0, "assists": 0, "minutes_played": 0, "status": "on_loan", "absences": 0}
+        )
+        entry = ScoutWatchlistEntry(user_account_id=user.id, player_api_id=1003, last_snapshot=stale)
+        db.session.add(entry)
+        db.session.commit()
+
+        digest = build_user_digest(user, [entry], api_client=None)
+        assert digest is not None
+        text = digest["text"]
+        # Accurate season total is still shown...
+        assert "12 apps" in text
+        assert "1080 mins" in text
+        # ...but the implausible "since last digest" delta chips are suppressed.
+        assert "+12 apps" not in text
+        assert "+1080 mins" not in text
+        assert "+1 assist" not in text
+
 
 class TestCsvInjectionEscaping:
     def test_formula_prefixed_names_are_neutralised(self, client, seeded, watchlist_app):

--- a/academy-watch-backend/tests/test_season_regression.py
+++ b/academy-watch-backend/tests/test_season_regression.py
@@ -313,12 +313,19 @@ class TestLimitedCoverageComputeStats:
         from src.models.league import db
         from src.models.tracked_player import TrackedPlayer
 
-        # Two cache rows in the display season at DIFFERENT clubs, neither of them
-        # the tracked row's current club (parent / NULL).
+        # Two cache rows in the DISPLAY season (2025) at DIFFERENT clubs, neither of
+        # them the tracked row's current club (parent / NULL), PLUS a prior-season
+        # (2024) decoy at one of those clubs. Correct season-scoped code sums only
+        # the two 2025 rows (12 apps / 1080 min); a regression that drops the
+        # ``season == season_value`` filter — or re-keys onto a player-wide "sum
+        # every cached season" — folds the 2024 row's 30 apps / 2700 min / 9 goals
+        # in and blows past the assertions below, so this pins season scoping and
+        # display-season preference alongside the cross-club sum.
         tp_id = _seed_limited_loanee(
             current_club,
             depth=depth,
             cache_rows=[
+                (LOAN_API, 2024, {"appearances": 30, "minutes_played": 2700, "goals": 9, "assists": 7, "saves": 60}),
                 (LOAN_API, 2025, {"appearances": 8, "minutes_played": 720, "goals": 1, "assists": 2, "saves": 20}),
                 (
                     SECOND_LOAN_API,
@@ -332,7 +339,8 @@ class TestLimitedCoverageComputeStats:
         stats = tp.compute_stats()
 
         # Keyed on current_club_api_id (the pre-A1 bug) this returned zeros; keyed
-        # on the player and summed across clubs it returns the whole loan season.
+        # on the player and summed across clubs for the display season it returns
+        # the whole 2025 loan season — and excludes the 2024 decoy.
         assert stats["appearances"] == 12
         assert stats["minutes_played"] == 1080
         assert stats["goals"] == 1

--- a/academy-watch-backend/tests/test_season_regression.py
+++ b/academy-watch-backend/tests/test_season_regression.py
@@ -12,6 +12,12 @@ a future refactor can't silently reintroduce them:
    fixture data itself. This file asserts ``compute_stats``,
    ``GET /players/<id>/stats`` and the Scout base query (``GET /scout/players``)
    all surface the loan-club season regardless of where the tracked row points.
+   The same read-path hardening rewrote the limited-coverage
+   (``PlayerStatsCache``) branch of ``compute_stats`` to sum across every club
+   per season keyed on the player — not ``current_club_api_id`` + ``MAX(season)``
+   — with a latest-cached-season fallback for lagging lower-league feeds; that
+   branch is pinned here too so the Gore bug class can't return for the
+   lower-league tier.
 
 2. **Orphan guard (stored-attribution floor).** A transient journey sync that
    resolves NO academy evidence (API youth-coverage gap / tenure-gate flicker →
@@ -104,7 +110,9 @@ def sync_service(app):
 PARENT_API = 33
 LOAN_API = 777
 OPP_API = 999
+SECOND_LOAN_API = 888  # a second loan club, for cross-club cache summing
 PLAYER_API = 303010  # Daniel Gore's real API id, kept for provenance
+LIMITED_PLAYER_API = 404040  # limited-coverage (PlayerStatsCache) player
 
 
 def _team(api_id, name):
@@ -224,6 +232,137 @@ class TestReturnedLoaneeAttribution:
         assert row["minutes_played"] == 270
         assert row["appearances"] == 3
         assert row["goals"] == 3
+
+
+# ---------------------------------------------------------------------------
+# 1b. Limited-coverage (PlayerStatsCache) compute_stats attribution (A1)
+# ---------------------------------------------------------------------------
+
+
+def _seed_limited_loanee(current_club_api_id, *, depth="events_only", cache_rows, anchor_season=2025):
+    """A limited-coverage (lower-league) player whose season stats live in
+    ``PlayerStatsCache``, not ``FixturePlayerStats``. Tracked at the parent
+    academy club with the current club flipped back to the parent (or NULL),
+    while the cache rows sit at OTHER clubs — the same shape that dropped a
+    returned loanee's season when the read keyed on ``current_club_api_id``.
+
+    ``cache_rows`` is an iterable of ``(team_api_id, season, {field: value})``.
+    A bare fixture at ``anchor_season`` pins the DISPLAY season deterministically
+    (``stats_season_with_data`` == ``MAX(fixtures.season)``) so the assertions
+    don't hinge on the wall-clock August rollover.
+    """
+    from src.models.league import PlayerStatsCache, db
+    from src.models.tracked_player import TrackedPlayer
+    from src.models.weekly import Fixture
+
+    parent = _team(PARENT_API, "Parent FC")
+    _team(LOAN_API, "Loan FC")
+    _team(SECOND_LOAN_API, "Other Loan FC")
+
+    db.session.add(
+        Fixture(
+            fixture_id_api=9100,
+            season=anchor_season,
+            date_utc=datetime(anchor_season, 9, 1, tzinfo=UTC),
+            competition_name="League Two",
+            home_team_api_id=PARENT_API,
+            away_team_api_id=SECOND_LOAN_API,
+            home_goals=0,
+            away_goals=0,
+        )
+    )
+
+    tp = TrackedPlayer(
+        player_api_id=LIMITED_PLAYER_API,
+        player_name="Limited Loanee",
+        position="Goalkeeper",
+        team_id=parent.id,
+        status="first_team",
+        current_club_api_id=current_club_api_id,  # parent id OR None — the bug trigger
+        current_club_name="Parent FC" if current_club_api_id else None,
+        data_depth=depth,
+        is_active=True,
+    )
+    db.session.add(tp)
+    db.session.flush()
+
+    for team_api_id, season, vals in cache_rows:
+        db.session.add(
+            PlayerStatsCache(
+                player_api_id=LIMITED_PLAYER_API,
+                team_api_id=team_api_id,
+                season=season,
+                stats_coverage="limited",
+                **vals,
+            )
+        )
+    db.session.commit()
+    return tp.id
+
+
+class TestLimitedCoverageComputeStats:
+    """``data_depth`` events_only/profile_only reads ``PlayerStatsCache``. The A1
+    rewrite keys that read on ``player_api_id`` + the display season and SUMS
+    across every club — not ``current_club_api_id`` + ``MAX(season)`` (the pre-A1
+    shape that dropped a returned loanee's cached loan season). A latest-cached-
+    season fallback keeps a lagging lower-league feed from blanking on rollover."""
+
+    @pytest.mark.parametrize("depth", ["events_only", "profile_only"])
+    @pytest.mark.parametrize("current_club", [PARENT_API, None], ids=["current=parent", "current=NULL"])
+    def test_cache_totals_sum_across_clubs(self, app, current_club, depth):
+        from src.models.league import db
+        from src.models.tracked_player import TrackedPlayer
+
+        # Two cache rows in the display season at DIFFERENT clubs, neither of them
+        # the tracked row's current club (parent / NULL).
+        tp_id = _seed_limited_loanee(
+            current_club,
+            depth=depth,
+            cache_rows=[
+                (LOAN_API, 2025, {"appearances": 8, "minutes_played": 720, "goals": 1, "assists": 2, "saves": 20}),
+                (
+                    SECOND_LOAN_API,
+                    2025,
+                    {"appearances": 4, "minutes_played": 360, "saves": 10, "yellows": 3, "reds": 1},
+                ),
+            ],
+        )
+        tp = db.session.get(TrackedPlayer, tp_id)
+
+        stats = tp.compute_stats()
+
+        # Keyed on current_club_api_id (the pre-A1 bug) this returned zeros; keyed
+        # on the player and summed across clubs it returns the whole loan season.
+        assert stats["appearances"] == 12
+        assert stats["minutes_played"] == 1080
+        assert stats["goals"] == 1
+        assert stats["assists"] == 2
+        assert stats["saves"] == 30
+        assert stats["yellows"] == 3
+        assert stats["reds"] == 1
+        assert stats["stats_coverage"] == "limited"
+
+    def test_latest_cached_season_fallback(self, app):
+        from src.models.league import db
+        from src.models.tracked_player import TrackedPlayer
+
+        # Display season anchors to 2025 (the fixture), but the lower-league feed
+        # only has a 2024 cache row — the fallback must surface it, not blank.
+        tp_id = _seed_limited_loanee(
+            None,
+            cache_rows=[
+                (LOAN_API, 2024, {"appearances": 10, "minutes_played": 900, "saves": 30, "goals": 0}),
+            ],
+            anchor_season=2025,
+        )
+        tp = db.session.get(TrackedPlayer, tp_id)
+
+        stats = tp.compute_stats()
+
+        assert stats["appearances"] == 10
+        assert stats["minutes_played"] == 900
+        assert stats["saves"] == 30
+        assert stats["stats_coverage"] == "limited"
 
 
 # ---------------------------------------------------------------------------

--- a/academy-watch-backend/tests/test_season_regression.py
+++ b/academy-watch-backend/tests/test_season_regression.py
@@ -1,0 +1,385 @@
+"""Regression coverage for the season-foundation branch (A1-A3).
+
+Locks in the three defects the ``feat/season-foundation`` remediation fixed, so
+a future refactor can't silently reintroduce them:
+
+1. **Returned-loanee stat attribution.** Every season stat read used to key on
+   ``TrackedPlayer.current_club_api_id``. When a loan-return transfer flips a
+   player's current club back to the parent (or leaves it NULL, common for
+   first-team rows), his whole loan season vanished — 0 minutes on the profile
+   match log, absent from Scout Desk — even though the ``FixturePlayerStats``
+   rows exist at the loan club. Fixed by deriving the season's clubs from the
+   fixture data itself. This file asserts ``compute_stats``,
+   ``GET /players/<id>/stats`` and the Scout base query (``GET /scout/players``)
+   all surface the loan-club season regardless of where the tracked row points.
+
+2. **Orphan guard (stored-attribution floor).** A transient journey sync that
+   resolves NO academy evidence (API youth-coverage gap / tenure-gate flicker →
+   empty ``academy_ids``) must NOT deactivate an established in-window academy
+   row whose stored journey attribution still lists the club. A genuinely
+   out-of-window alumnus row must still deactivate.
+
+3. **August rollover.** ``current_stats_season`` rolls the DISPLAY season over
+   on 1 August, but the calendar season can turn before any of its fixtures are
+   ingested. ``stats_season_with_data`` falls back to the latest season that
+   actually HAS fixtures so a not-yet-started season never blanks the platform.
+   Frozen to 2026-08-01 with fixtures only for 2025: the service returns 2026 as
+   the calendar season but 2025 as the with-data season, and the display paths
+   keep rendering the 2025 numbers instead of zeros.
+"""
+
+import os
+from datetime import UTC, date, datetime
+
+import pytest
+from flask import Flask
+
+
+class _StubAPIClient:
+    """No-network stand-in. Returns a non-empty dict so ``api_totals_failed`` is
+    False and ``games_played=0`` so the freshness-sync branch never fires — the
+    player-stats endpoint therefore does zero network I/O in tests."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def _fetch_player_team_season_totals_api(self, *args, **kwargs):
+        return {"games_played": 0}
+
+
+@pytest.fixture
+def app(monkeypatch):
+    os.environ.setdefault("SKIP_API_HANDSHAKE", "1")
+    os.environ.setdefault("API_USE_STUB_DATA", "true")
+
+    import src.api_football_client as apifc
+
+    monkeypatch.setattr(apifc, "APIFootballClient", _StubAPIClient)
+
+    from src.models.league import db
+    from src.routes.players import players_bp
+    from src.routes.scout import scout_bp
+    from src.routes.teams import teams_bp
+
+    application = Flask(__name__)
+    application.config.update(
+        TESTING=True,
+        SECRET_KEY="test-secret",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        RATELIMIT_ENABLED=False,
+    )
+    db.init_app(application)
+    # scout_bp / players_bp register before any api_bp catch-all would (not
+    # registered here) — mirrors main.py's load-bearing order.
+    application.register_blueprint(scout_bp, url_prefix="/api")
+    application.register_blueprint(players_bp, url_prefix="/api")
+    application.register_blueprint(teams_bp, url_prefix="/api")
+
+    ctx = application.app_context()
+    ctx.push()
+    db.create_all()
+    yield application
+    db.session.remove()
+    db.drop_all()
+    ctx.pop()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def sync_service(app):
+    from src.services.journey_sync import JourneySyncService
+
+    return JourneySyncService()
+
+
+# ---------------------------------------------------------------------------
+# Shared seed helpers (assume an active app context — the `app` fixture pushes one)
+# ---------------------------------------------------------------------------
+
+PARENT_API = 33
+LOAN_API = 777
+OPP_API = 999
+PLAYER_API = 303010  # Daniel Gore's real API id, kept for provenance
+
+
+def _team(api_id, name):
+    from src.models.league import Team, db
+
+    team = Team(team_id=api_id, name=name, country="England", season=2025, logo=f"{api_id}.png")
+    db.session.add(team)
+    db.session.flush()
+    return team
+
+
+def _seed_returned_loanee(current_club_api_id, *, loan_minutes=90, loan_apps=3, season=2025):
+    """A returned loanee: tracked at the parent academy club, current club flipped
+    back to the parent (or NULL), but the real season is a full loan spell at
+    another club recorded in FixturePlayerStats. Returns the parent Team + the id.
+    """
+    from src.models.tracked_player import TrackedPlayer
+    from src.models.weekly import Fixture, FixturePlayerStats, db
+
+    parent = _team(PARENT_API, "Parent FC")
+    _team(LOAN_API, "Loan FC")
+    _team(OPP_API, "Opponent FC")
+
+    tp = TrackedPlayer(
+        player_api_id=PLAYER_API,
+        player_name="Gore Regression",
+        position="Midfielder",
+        team_id=parent.id,
+        status="first_team",
+        current_club_api_id=current_club_api_id,  # parent id OR None — the bug trigger
+        current_club_name="Parent FC" if current_club_api_id else None,
+        data_depth="full_stats",
+        is_active=True,
+    )
+    db.session.add(tp)
+
+    for i in range(loan_apps):
+        fx = Fixture(
+            fixture_id_api=8000 + i,
+            season=season,
+            date_utc=datetime(season, 9, 1 + 7 * i, tzinfo=UTC),
+            competition_name="Championship",
+            home_team_api_id=LOAN_API,
+            away_team_api_id=OPP_API,
+            home_goals=1,
+            away_goals=0,
+        )
+        db.session.add(fx)
+        db.session.flush()
+        db.session.add(
+            FixturePlayerStats(
+                fixture_id=fx.id,
+                player_api_id=PLAYER_API,
+                team_api_id=LOAN_API,
+                minutes=loan_minutes,
+                goals=1,
+                assists=0,
+                rating=7.5,
+            )
+        )
+    db.session.commit()
+    return parent, tp.id
+
+
+# ---------------------------------------------------------------------------
+# 1. Returned-loanee stat attribution (A1 read-path hardening)
+# ---------------------------------------------------------------------------
+
+
+class TestReturnedLoaneeAttribution:
+    """current_club points at the parent / NULL, but the season lives at the loan
+    club — all three season-stat reads must attribute it anyway."""
+
+    @pytest.mark.parametrize("current_club", [PARENT_API, None], ids=["current=parent", "current=NULL"])
+    def test_compute_stats_returns_loan_minutes(self, app, current_club):
+        from src.models.league import db
+        from src.models.tracked_player import TrackedPlayer
+
+        _, tp_id = _seed_returned_loanee(current_club, loan_minutes=90, loan_apps=3)
+        tp = db.session.get(TrackedPlayer, tp_id)
+
+        stats = tp.compute_stats()
+
+        # Keyed on current_club_api_id (the bug) this returned zeros; season-scoped
+        # across the clubs actually played it returns the loan spell.
+        assert stats["minutes_played"] == 270
+        assert stats["appearances"] == 3
+        assert stats["goals"] == 3
+        assert stats["stats_coverage"] == "full"
+
+    @pytest.mark.parametrize("current_club", [PARENT_API, None], ids=["current=parent", "current=NULL"])
+    def test_players_stats_endpoint_includes_loan_club(self, app, client, current_club):
+        _seed_returned_loanee(current_club, loan_minutes=90, loan_apps=3)
+
+        res = client.get(f"/api/players/{PLAYER_API}/stats")
+        assert res.status_code == 200
+        rows = res.get_json()
+        assert isinstance(rows, list)
+        # The loan club's three match rows render even though no tracked-row field
+        # points at it — they come from the FixturePlayerStats UNION.
+        assert len(rows) == 3
+        assert {r["loan_team_name"] for r in rows} == {"Loan FC"}
+        assert sum(r["minutes"] for r in rows) == 270
+
+    @pytest.mark.parametrize("current_club", [PARENT_API, None], ids=["current=parent", "current=NULL"])
+    def test_scout_base_query_surfaces_season_minutes(self, app, client, current_club):
+        _seed_returned_loanee(current_club, loan_minutes=90, loan_apps=3)
+
+        res = client.get("/api/scout/players?search=gore")
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["total"] == 1
+        row = data["players"][0]
+        assert row["player_id"] == PLAYER_API
+        # Scout Desk shows one season figure per player, summed across clubs — the
+        # loan season, not a zero-at-current-club blank.
+        assert row["minutes_played"] == 270
+        assert row["appearances"] == 3
+        assert row["goals"] == 3
+
+
+# ---------------------------------------------------------------------------
+# 2. Orphan guard: stored-attribution floor (A2/A3 write guard)
+# ---------------------------------------------------------------------------
+
+
+class TestOrphanGuard:
+    """An empty-evidence sync must not orphan an in-window academy row that the
+    journey still attributes to the club; a genuine aged-out row still deactivates."""
+
+    def _journey_with_stored_attribution(self, player_api_id, club_api_id, last_season):
+        """Journey carrying a PERSISTED academy attribution but NO youth entries
+        this run, so _compute_academy_club_ids takes an empty-computation path and
+        must lean on the stored attribution (the floor) to decide."""
+        from src.models.journey import PlayerJourney
+        from src.models.league import db
+
+        journey = PlayerJourney(
+            player_api_id=player_api_id,
+            player_name=f"Orphan {player_api_id}",
+            academy_club_ids=[club_api_id],
+            academy_last_seasons={str(club_api_id): last_season},
+        )
+        db.session.add(journey)
+        db.session.flush()
+        return journey
+
+    def _tracked_at(self, player_api_id, team, journey):
+        from src.models.league import db
+        from src.models.tracked_player import TrackedPlayer
+
+        tp = TrackedPlayer(
+            player_api_id=player_api_id,
+            player_name=f"Orphan {player_api_id}",
+            team_id=team.id,
+            status="first_team",
+            data_source="journey-sync",
+            journey_id=journey.id,
+            is_active=True,
+        )
+        db.session.add(tp)
+        db.session.flush()
+        return tp
+
+    def test_empty_sync_does_not_deactivate_in_window_row(self, app, sync_service):
+        from src.models.league import db
+        from src.utils.academy_window import current_academy_season
+
+        recent = current_academy_season()  # in window
+        club = _team(100, "Feyenoord")
+        journey = self._journey_with_stored_attribution(600, 100, recent)
+        row = self._tracked_at(600, club, journey)
+        db.session.commit()
+
+        # This run resolves no fresh academy evidence (no youth entries).
+        sync_service._compute_academy_club_ids(journey)
+
+        assert row.is_active is True, "the stored-attribution floor must spare an in-window orphan"
+
+    def test_out_of_window_row_still_deactivates(self, app, sync_service):
+        from src.models.league import db
+        from src.utils.academy_window import academy_window_start
+
+        old = academy_window_start() - 2  # aged out of the tracking window
+        club = _team(100, "Feyenoord")
+        journey = self._journey_with_stored_attribution(601, 100, old)
+        row = self._tracked_at(601, club, journey)
+        db.session.commit()
+
+        sync_service._compute_academy_club_ids(journey)
+
+        assert row.is_active is False, "a genuinely out-of-window alumnus must still deactivate"
+
+
+# ---------------------------------------------------------------------------
+# 3. August rollover: with-data fallback keeps the platform from blanking (A1/P4)
+# ---------------------------------------------------------------------------
+
+
+class _FrozenDate(date):
+    """date subclass whose today() is pinned to 2026-08-01 — past the 1 Aug stats
+    rollover while fixtures still only exist for season 2025."""
+
+    _frozen = date(2026, 8, 1)
+
+    @classmethod
+    def today(cls):
+        return cls._frozen
+
+
+class TestAugustRollover:
+    def test_current_stats_season_rolls_over_on_august(self):
+        from src.utils.academy_window import current_stats_season
+
+        # August hinge (distinct from the academy window's July hinge).
+        assert current_stats_season(date(2026, 7, 31)) == 2025
+        assert current_stats_season(date(2026, 8, 1)) == 2026
+
+    def test_with_data_falls_back_to_latest_season_with_fixtures(self, app):
+        from src.models.league import db
+        from src.models.weekly import Fixture
+        from src.utils.academy_window import current_stats_season, stats_season_with_data
+
+        # Only season-2025 fixtures exist.
+        db.session.add(
+            Fixture(
+                fixture_id_api=1,
+                season=2025,
+                date_utc=datetime(2025, 9, 1, tzinfo=UTC),
+                home_team_api_id=1,
+                away_team_api_id=2,
+            )
+        )
+        db.session.commit()
+
+        aug_first = date(2026, 8, 1)
+        # Calendar season has already rolled to 2026 ...
+        assert current_stats_season(aug_first) == 2026
+        # ... but with no 2026 fixtures the with-data season stays on 2025 rather
+        # than pointing at an empty season and blanking every stats page.
+        assert stats_season_with_data(db.session, aug_first) == 2025
+
+        # Once a 2026 fixture lands the fallback self-heals to the calendar season.
+        db.session.add(
+            Fixture(
+                fixture_id_api=2,
+                season=2026,
+                date_utc=datetime(2026, 8, 20, tzinfo=UTC),
+                home_team_api_id=1,
+                away_team_api_id=2,
+            )
+        )
+        db.session.commit()
+        assert stats_season_with_data(db.session, aug_first) == 2026
+
+    def test_display_paths_do_not_blank_on_august_first(self, app, client, monkeypatch):
+        """Frozen to 2026-08-01 with only 2025 fixtures, both compute_stats and the
+        player-stats endpoint keep rendering the 2025 season instead of zeros."""
+        import src.utils.academy_window as aw
+        from src.models.league import db
+        from src.models.tracked_player import TrackedPlayer
+
+        _, tp_id = _seed_returned_loanee(PARENT_API, loan_minutes=90, loan_apps=3, season=2025)
+
+        # Pin "today" to the day after the August rollover.
+        monkeypatch.setattr(aw, "date", _FrozenDate)
+        assert aw.current_stats_season() == 2026  # calendar rolled ...
+        assert aw.stats_season_with_data(db.session) == 2025  # ... display falls back
+
+        tp = db.session.get(TrackedPlayer, tp_id)
+        stats = tp.compute_stats()
+        assert stats["minutes_played"] == 270, "compute_stats blanked on the Aug rollover"
+
+        res = client.get(f"/api/players/{PLAYER_API}/stats")
+        assert res.status_code == 200
+        rows = res.get_json()
+        assert len(rows) == 3, "player-stats endpoint blanked on the Aug rollover"
+        assert sum(r["minutes"] for r in rows) == 270

--- a/academy-watch-backend/tests/test_team_loans_stats.py
+++ b/academy-watch-backend/tests/test_team_loans_stats.py
@@ -1,0 +1,156 @@
+"""Regression tests for GET /teams/<id>/loans roster stat attribution.
+
+Covers the fix that makes the team roster read limited-coverage players'
+(``data_depth`` events_only / profile_only) stats from ``PlayerStatsCache`` —
+the same source the season-scoped profile (``compute_stats``) and Scout Desk
+(``_cache_stats_subquery``) use. Before the fix these players rendered
+0 apps / 0 mins on the roster while the profile and Scout showed their real
+cache totals — a contradiction one click apart.
+"""
+
+import os
+from datetime import datetime
+
+import pytest
+from flask import Flask
+from src.models.league import League, PlayerStatsCache, Team, db
+from src.models.tracked_player import TrackedPlayer
+from src.models.weekly import Fixture, FixturePlayerStats
+
+
+@pytest.fixture
+def teams_app():
+    os.environ.setdefault("SKIP_API_HANDSHAKE", "1")
+    os.environ.setdefault("API_USE_STUB_DATA", "true")
+
+    from src.routes.teams import teams_bp
+
+    app = Flask(__name__)
+    app.config.update(
+        TESTING=True,
+        SECRET_KEY="test-secret-key",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        RATELIMIT_ENABLED=False,
+    )
+    db.init_app(app)
+    app.register_blueprint(teams_bp, url_prefix="/api")
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def teams_client(teams_app):
+    return teams_app.test_client()
+
+
+@pytest.fixture
+def roster_seeded(teams_app):
+    """One full-coverage loanee (fixtures) + one limited-coverage loanee (cache)."""
+    with teams_app.app_context():
+        league = League(
+            league_id=39, name="Premier League", country="England", season=2025, is_european_top_league=True
+        )
+        db.session.add(league)
+        db.session.flush()
+
+        parent = Team(
+            team_id=33, name="Manchester United", country="England", season=2025, league_id=league.id, is_active=True
+        )
+        db.session.add(parent)
+        db.session.flush()
+
+        full = TrackedPlayer(
+            player_api_id=1001,
+            player_name="Freddie Fixtures",
+            position="Attacker",
+            team_id=parent.id,
+            status="on_loan",
+            current_club_api_id=901,
+            current_club_name="Loan FC",
+            data_depth="full_stats",
+            is_active=True,
+        )
+        limited = TrackedPlayer(
+            player_api_id=1003,
+            player_name="Charlie Gloves",
+            position="Goalkeeper",
+            team_id=parent.id,
+            status="on_loan",
+            current_club_api_id=902,
+            current_club_name="Far FC",
+            data_depth="events_only",
+            is_active=True,
+        )
+        db.session.add_all([full, limited])
+
+        fixtures = []
+        for i in range(2):
+            fixtures.append(
+                Fixture(
+                    fixture_id_api=5000 + i,
+                    season=2025,
+                    home_team_api_id=901,
+                    away_team_api_id=950 + i,
+                    date_utc=datetime(2025, 9, 1 + 7 * i),
+                )
+            )
+        db.session.add_all(fixtures)
+        db.session.flush()
+        db.session.add_all(
+            [
+                FixturePlayerStats(
+                    fixture_id=fixtures[0].id, player_api_id=1001, team_api_id=901, minutes=90, goals=2, assists=1
+                ),
+                FixturePlayerStats(
+                    fixture_id=fixtures[1].id, player_api_id=1001, team_api_id=901, minutes=80, goals=1, assists=0
+                ),
+            ]
+        )
+
+        # Limited-coverage keeper: two cached seasons, the latest must win.
+        db.session.add_all(
+            [
+                PlayerStatsCache(
+                    player_api_id=1003, team_api_id=902, season=2024, appearances=10, minutes_played=900, saves=30
+                ),
+                PlayerStatsCache(
+                    player_api_id=1003,
+                    team_api_id=902,
+                    season=2025,
+                    appearances=12,
+                    assists=1,
+                    minutes_played=1080,
+                    saves=41,
+                ),
+            ]
+        )
+        db.session.commit()
+        return parent.id
+
+
+def _by_id(rows, player_id):
+    return next(r for r in rows if r["player_id"] == player_id)
+
+
+class TestTeamRosterStatAttribution:
+    def test_full_coverage_player_reads_fixture_totals(self, teams_client, roster_seeded):
+        rows = teams_client.get(f"/api/teams/{roster_seeded}/loans").get_json()
+        full = _by_id(rows, 1001)
+        assert full["appearances"] == 2
+        assert full["minutes_played"] == 170
+        assert full["goals"] == 3
+        assert full["assists"] == 1
+
+    def test_limited_coverage_player_reads_cache_latest_season(self, teams_client, roster_seeded):
+        # Regression: previously 0/0 because the roster only read FixturePlayerStats.
+        rows = teams_client.get(f"/api/teams/{roster_seeded}/loans").get_json()
+        keeper = _by_id(rows, 1003)
+        assert keeper["appearances"] == 12
+        assert keeper["minutes_played"] == 1080
+        assert keeper["assists"] == 1
+        assert keeper["saves"] == 41

--- a/academy-watch-backend/tests/test_transfer_heal_orphans.py
+++ b/academy-watch-backend/tests/test_transfer_heal_orphans.py
@@ -1,0 +1,148 @@
+"""Transfer-heal orphan self-heal scope.
+
+Orphaned in-window academy rows (is_active=false, journey-attributed,
+non-manual, non-pinned) must be requeued into the heal so a transfers-fed
+journey re-sync can reactivate them via the journey upsert. Out-of-window,
+manual, and pinned orphans must stay out of the queue. Reactivation needs a
+journey re-sync, so orphans are only requeued when resync_journeys=True.
+"""
+
+import pytest
+from flask import Flask
+from src.models.league import League, Team, db
+from src.models.tracked_player import TrackedPlayer
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("SKIP_API_HANDSHAKE", "1")
+    monkeypatch.setenv("API_USE_STUB_DATA", "true")
+
+    flask_app = Flask(__name__)
+    flask_app.config.update(
+        TESTING=True,
+        SECRET_KEY="test-secret-key",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+    db.init_app(flask_app)
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+        db.drop_all()
+
+
+def _seed_team():
+    league = League(league_id=39, name="Premier League", country="England", season=2025)
+    db.session.add(league)
+    db.session.flush()
+    team = Team(team_id=100, name="Feyenoord", country="England", season=2025, league_id=league.id, is_active=True)
+    db.session.add(team)
+    db.session.flush()
+    return team
+
+
+def _tracked(
+    player_api_id, team, *, active, data_source="journey-sync", last_season=None, status="on_loan", pinned=False
+):
+    tp = TrackedPlayer(
+        player_api_id=player_api_id,
+        player_name=f"Test Player {player_api_id}",
+        team_id=team.id,
+        status=status,
+        data_source=data_source,
+        last_academy_season=last_season,
+        pinned_parent=pinned,
+        is_active=active,
+    )
+    db.session.add(tp)
+    db.session.flush()
+    return tp
+
+
+def _patch_api_and_journey(monkeypatch):
+    """Stub every network call and record which players get a journey re-sync."""
+    from src.api_football_client import APIFootballClient
+    from src.services.journey_sync import JourneySyncService
+
+    monkeypatch.setattr(APIFootballClient, "batch_get_player_transfers", lambda self, ids, **kw: {})
+    monkeypatch.setattr(APIFootballClient, "get_team_players", lambda self, club_id, season=None: [])
+
+    resynced: list[int] = []
+
+    def _record_sync(self, player_api_id, force_full=False):
+        resynced.append(player_api_id)
+        return None  # no journey → the heal loop skips further processing
+
+    monkeypatch.setattr(JourneySyncService, "sync_player", _record_sync)
+    return resynced
+
+
+class TestOrphanRequeueScope:
+    def test_in_window_orphan_requeued_others_excluded(self, app, monkeypatch):
+        from src.services.transfer_heal_service import refresh_and_heal
+        from src.utils.academy_window import academy_window_start, current_academy_season
+
+        recent = current_academy_season()
+        old = academy_window_start() - 2
+        team = _seed_team()
+
+        active_row = _tracked(600, team, active=True, last_season=recent)
+        orphan_in_window = _tracked(601, team, active=False, last_season=recent)
+        orphan_out_window = _tracked(602, team, active=False, last_season=old)
+        orphan_manual = _tracked(603, team, active=False, data_source="manual", last_season=recent)
+        orphan_pinned = _tracked(604, team, active=False, last_season=recent, pinned=True)
+        db.session.commit()
+        ids = {
+            "active": active_row.player_api_id,
+            "in_window": orphan_in_window.player_api_id,
+            "out_window": orphan_out_window.player_api_id,
+            "manual": orphan_manual.player_api_id,
+            "pinned": orphan_pinned.player_api_id,
+        }
+
+        resynced = _patch_api_and_journey(monkeypatch)
+        result = refresh_and_heal(resync_journeys=True, dry_run=True, cascade_fixtures=False)
+
+        # Only the active row + the in-window orphan are in the queue.
+        assert result["total"] == 2
+        assert ids["active"] in resynced
+        assert ids["in_window"] in resynced
+        assert ids["out_window"] not in resynced
+        assert ids["manual"] not in resynced
+        assert ids["pinned"] not in resynced
+
+    def test_status_academy_orphan_requeued_without_season(self, app, monkeypatch):
+        from src.services.transfer_heal_service import refresh_and_heal
+
+        team = _seed_team()
+        # No last_academy_season, but the row says the player is in the academy
+        # right now — a current kid that got orphaned must still self-heal.
+        orphan = _tracked(605, team, active=False, last_season=None, status="academy")
+        db.session.commit()
+        orphan_id = orphan.player_api_id
+
+        resynced = _patch_api_and_journey(monkeypatch)
+        result = refresh_and_heal(resync_journeys=True, dry_run=True, cascade_fixtures=False)
+
+        assert result["total"] == 1
+        assert orphan_id in resynced
+
+    def test_orphans_not_requeued_without_resync(self, app, monkeypatch):
+        # Without a journey re-sync there is nothing to reactivate the row, so
+        # orphans must NOT be pulled in (they can't self-heal via cached data).
+        from src.services.transfer_heal_service import refresh_and_heal
+        from src.utils.academy_window import current_academy_season
+
+        recent = current_academy_season()
+        team = _seed_team()
+        _tracked(600, team, active=True, last_season=recent)
+        _tracked(601, team, active=False, last_season=recent)
+        db.session.commit()
+
+        _patch_api_and_journey(monkeypatch)
+        result = refresh_and_heal(resync_journeys=False, dry_run=True, cascade_fixtures=False)
+
+        # Only the active row is in the queue; the orphan is left alone.
+        assert result["total"] == 1

--- a/academy-watch-backend/tests/test_transfer_heal_orphans.py
+++ b/academy-watch-backend/tests/test_transfer_heal_orphans.py
@@ -1,14 +1,17 @@
 """Transfer-heal orphan self-heal scope.
 
-Orphaned in-window academy rows (is_active=false, journey-attributed,
-non-manual, non-pinned) must be requeued into the heal so a transfers-fed
-journey re-sync can reactivate them via the journey upsert. Out-of-window,
-manual, and pinned orphans must stay out of the queue. Reactivation needs a
-journey re-sync, so orphans are only requeued when resync_journeys=True.
+Orphaned rows are requeued into the heal so a transfers-fed journey re-sync can
+reactivate them via the journey upsert. The requeue is BOUNDED and TERMINAL:
+only rows whose linked PlayerJourney still attributes the row's academy club
+IN-WINDOW are requeued (those are the only rows the upsert can reactivate), so
+graveyard rows are not force_full re-synced forever. Manual and pinned orphans
+stay out of the queue. Reactivation needs a journey re-sync, so orphans are only
+requeued when resync_journeys=True.
 """
 
 import pytest
 from flask import Flask
+from src.models.journey import PlayerJourney
 from src.models.league import League, Team, db
 from src.models.tracked_player import TrackedPlayer
 
@@ -41,6 +44,24 @@ def _seed_team():
     db.session.add(team)
     db.session.flush()
     return team
+
+
+def _journey(player_api_id, *, academy_club_ids=None, academy_last_seasons=None, birth_date=None):
+    """A PlayerJourney carrying the academy attribution the requeue gate reads.
+
+    The gate keys on the journey, not the tracked row's own fields, so a legacy
+    owning-club orphan with NO row-local season is still requeued when its
+    journey attributes the club in-window (the Gore case)."""
+    j = PlayerJourney(
+        player_api_id=player_api_id,
+        player_name=f"Test Player {player_api_id}",
+        academy_club_ids=academy_club_ids if academy_club_ids is not None else [],
+        academy_last_seasons=academy_last_seasons if academy_last_seasons is not None else {},
+        birth_date=birth_date,
+    )
+    db.session.add(j)
+    db.session.flush()
+    return j
 
 
 def _tracked(
@@ -89,10 +110,16 @@ class TestOrphanRequeueScope:
         team = _seed_team()
 
         active_row = _tracked(600, team, active=True, last_season=recent)
+        # In-window orphan whose journey still attributes club 100 in-window.
         orphan_in_window = _tracked(601, team, active=False, last_season=recent)
+        _journey(601, academy_club_ids=[100], academy_last_seasons={"100": recent})
+        # Journey attributes 100 but OUT of window → not requeued.
         orphan_out_window = _tracked(602, team, active=False, last_season=old)
+        _journey(602, academy_club_ids=[100], academy_last_seasons={"100": old})
         orphan_manual = _tracked(603, team, active=False, data_source="manual", last_season=recent)
+        _journey(603, academy_club_ids=[100], academy_last_seasons={"100": recent})
         orphan_pinned = _tracked(604, team, active=False, last_season=recent, pinned=True)
+        _journey(604, academy_club_ids=[100], academy_last_seasons={"100": recent})
         db.session.commit()
         ids = {
             "active": active_row.player_api_id,
@@ -117,9 +144,11 @@ class TestOrphanRequeueScope:
         from src.services.transfer_heal_service import refresh_and_heal
 
         team = _seed_team()
-        # No last_academy_season, but the row says the player is in the academy
-        # right now — a current kid that got orphaned must still self-heal.
+        # No last_academy_season and the journey has no stored season either, but
+        # the row says the player is in the academy right now — a current kid that
+        # got orphaned must still self-heal (journey attributes the club).
         orphan = _tracked(605, team, active=False, last_season=None, status="academy")
+        _journey(605, academy_club_ids=[100], academy_last_seasons={})
         db.session.commit()
         orphan_id = orphan.player_api_id
 
@@ -128,6 +157,65 @@ class TestOrphanRequeueScope:
 
         assert result["total"] == 1
         assert orphan_id in resynced
+
+    def test_owning_club_null_season_orphan_requeued(self, app, monkeypatch):
+        # The canonical Gore row: data_source='owning-club', NO row-local season,
+        # but the journey attributes the club in-window. The old row-local filter
+        # missed it entirely; the journey-attribution gate must catch it.
+        from src.services.transfer_heal_service import refresh_and_heal
+        from src.utils.academy_window import current_academy_season
+
+        recent = current_academy_season()
+        team = _seed_team()
+        orphan = _tracked(606, team, active=False, data_source="owning-club", last_season=None, status="first_team")
+        _journey(606, academy_club_ids=[100], academy_last_seasons={"100": recent})
+        db.session.commit()
+        orphan_id = orphan.player_api_id
+
+        resynced = _patch_api_and_journey(monkeypatch)
+        result = refresh_and_heal(resync_journeys=True, dry_run=True, cascade_fixtures=False)
+
+        assert result["total"] == 1
+        assert orphan_id in resynced
+
+    def test_journey_unattributed_orphan_not_requeued(self, app, monkeypatch):
+        # Row passes the coarse row-local filter (in-window last_academy_season)
+        # but its journey NO LONGER attributes the club — a genuinely-departed
+        # row the upsert cannot reactivate. It must NOT be force_full re-synced
+        # (terminal state; no fruitless nightly retries).
+        from src.services.transfer_heal_service import refresh_and_heal
+        from src.utils.academy_window import current_academy_season
+
+        recent = current_academy_season()
+        team = _seed_team()
+        orphan = _tracked(607, team, active=False, last_season=recent)
+        _journey(607, academy_club_ids=[999], academy_last_seasons={"999": recent})
+        db.session.commit()
+        orphan_id = orphan.player_api_id
+
+        resynced = _patch_api_and_journey(monkeypatch)
+        result = refresh_and_heal(resync_journeys=True, dry_run=True, cascade_fixtures=False)
+
+        assert result["total"] == 0
+        assert orphan_id not in resynced
+
+    def test_orphan_without_journey_not_requeued(self, app, monkeypatch):
+        # A row-local in-window orphan with NO journey at all cannot be
+        # reactivated by the journey upsert, so it must stay out of the queue.
+        from src.services.transfer_heal_service import refresh_and_heal
+        from src.utils.academy_window import current_academy_season
+
+        recent = current_academy_season()
+        team = _seed_team()
+        orphan = _tracked(608, team, active=False, last_season=recent)
+        db.session.commit()
+        orphan_id = orphan.player_api_id
+
+        resynced = _patch_api_and_journey(monkeypatch)
+        result = refresh_and_heal(resync_journeys=True, dry_run=True, cascade_fixtures=False)
+
+        assert result["total"] == 0
+        assert orphan_id not in resynced
 
     def test_orphans_not_requeued_without_resync(self, app, monkeypatch):
         # Without a journey re-sync there is nothing to reactivate the row, so
@@ -138,7 +226,8 @@ class TestOrphanRequeueScope:
         recent = current_academy_season()
         team = _seed_team()
         _tracked(600, team, active=True, last_season=recent)
-        _tracked(601, team, active=False, last_season=recent)
+        orphan = _tracked(601, team, active=False, last_season=recent)
+        _journey(601, academy_club_ids=[100], academy_last_seasons={"100": recent})
         db.session.commit()
 
         _patch_api_and_journey(monkeypatch)

--- a/academy-watch-backend/tests/test_transfer_heal_orphans.py
+++ b/academy-watch-backend/tests/test_transfer_heal_orphans.py
@@ -235,3 +235,85 @@ class TestOrphanRequeueScope:
 
         # Only the active row is in the queue; the orphan is left alone.
         assert result["total"] == 1
+
+
+class TestOrphanRequeueBudgetAndRotation:
+    def test_orphan_budget_caps_requeue(self, app, monkeypatch):
+        # A single call may requeue at most `orphan_budget` orphans, so the
+        # per-team nightly job can keep the ceiling job-global.
+        from src.services.transfer_heal_service import refresh_and_heal
+        from src.utils.academy_window import current_academy_season
+
+        recent = current_academy_season()
+        team = _seed_team()
+        for pid in (711, 712, 713):
+            _tracked(pid, team, active=False, last_season=recent)
+            _journey(pid, academy_club_ids=[100], academy_last_seasons={"100": recent})
+        db.session.commit()
+
+        resynced = _patch_api_and_journey(monkeypatch)
+        result = refresh_and_heal(resync_journeys=True, dry_run=True, cascade_fixtures=False, orphan_budget=2)
+
+        assert result["orphans_requeued"] == 2
+        assert len([p for p in (711, 712, 713) if p in resynced]) == 2
+
+    def test_zero_orphan_budget_requeues_nothing(self, app, monkeypatch):
+        # A depleted job-global budget (0) must requeue no orphans, while active
+        # rows still get processed normally.
+        from src.services.transfer_heal_service import refresh_and_heal
+        from src.utils.academy_window import current_academy_season
+
+        recent = current_academy_season()
+        team = _seed_team()
+        _tracked(720, team, active=True, last_season=recent)
+        orphan = _tracked(721, team, active=False, last_season=recent)
+        _journey(721, academy_club_ids=[100], academy_last_seasons={"100": recent})
+        db.session.commit()
+        orphan_id = orphan.player_api_id
+
+        resynced = _patch_api_and_journey(monkeypatch)
+        result = refresh_and_heal(resync_journeys=True, dry_run=True, cascade_fixtures=False, orphan_budget=0)
+
+        assert result["orphans_requeued"] == 0
+        assert result["total"] == 1  # only the active row
+        assert orphan_id not in resynced
+
+    def test_stuck_orphan_rotates_to_back_of_queue(self, app, monkeypatch):
+        # An orphan the re-sync cannot reactivate keeps churning force_full
+        # re-syncs. Its updated_at must be bumped on the skipped requeue so the
+        # oldest-touched ordering round-robins instead of re-selecting the same
+        # stuck rows first every night (starving healable orphans behind them).
+        from datetime import UTC, datetime, timedelta
+
+        from src.services.transfer_heal_service import refresh_and_heal
+        from src.utils.academy_window import current_academy_season
+
+        recent = current_academy_season()
+        team = _seed_team()
+        older = _tracked(701, team, active=False, last_season=recent)
+        newer = _tracked(702, team, active=False, last_season=recent)
+        _journey(701, academy_club_ids=[100], academy_last_seasons={"100": recent})
+        _journey(702, academy_club_ids=[100], academy_last_seasons={"100": recent})
+        # Deterministic queue order: 701 is the oldest-touched candidate.
+        t0 = datetime(2026, 6, 1, tzinfo=UTC)
+        older.updated_at = t0
+        newer.updated_at = t0 + timedelta(hours=1)
+        db.session.commit()
+
+        # sync_player returns None → the row stays inactive (never healable).
+        resynced = _patch_api_and_journey(monkeypatch)
+
+        # Budget 1 → run 1 requeues only the oldest (701).
+        r1 = refresh_and_heal(resync_journeys=True, dry_run=False, cascade_fixtures=False, orphan_budget=1)
+        assert r1["orphans_requeued"] == 1
+        assert 701 in resynced
+        assert 702 not in resynced
+
+        # 701's updated_at was bumped past 702, so run 2 rotates to 702 —
+        # the previously-starved row is now reached.
+        db.session.expire_all()
+        resynced.clear()
+        r2 = refresh_and_heal(resync_journeys=True, dry_run=False, cascade_fixtures=False, orphan_budget=1)
+        assert r2["orphans_requeued"] == 1
+        assert 702 in resynced
+        assert 701 not in resynced


### PR DESCRIPTION
## What

Phase A of the seasons initiative (`ledgers/CONTINUITY_seasons-system.md`) — implements remediation P0 + P4 + P2 from `ledgers/CONTINUITY_scout-data-attribution.md`. Built by a 29-agent workflow (sequential impl stages, each gated by two adversarial reviewers with fix loops), then independently reviewed + gate-verified by the orchestrating session.

### P4 — canonical season service (`utils/academy_window.py`)
- `current_stats_season()` (August rollover, for fixture display/sync) vs `current_academy_season()` (July, tracking window) — both intentional, documented in-code.
- `stats_season_with_data()` — display paths fall back to the latest season that HAS fixtures, so Aug 1 no longer blanks every stats page while 26/27 fixtures haven't landed. All inline `month>=8` stats derivations routed through the helpers.

### P0 — season-scoped stat reads (the Daniel Gore fix)
- `/players/<id>/stats` unions in every club the player actually has fixture stats for in the current season (mirrors `/season-stats`).
- `TrackedPlayer.compute_stats()` no longer zeroes on NULL/wrong `current_club_api_id` — aggregates the season across clubs actually played; `PlayerStatsCache` fallback preserved (incl. a reviewer-caught team-roster regression fix).
- Scout Desk queries aggregate per player, season-scoped via `Fixture.season ==` equality (bounded — no open date ranges); compare panel same treatment.
- `perf`: guarded migration `aw23` indexes `fixtures.season` (previously every season filter seq-scanned ~20k rows). **Not auto-applied** — needs the out-of-band `CREATE INDEX` / `flask db upgrade` per invariants §7 (will apply post-deploy).

### P2 — write guards (stop re-orphaning rows nightly)
- Stored-attribution floor in the journey upsert: a transient empty `academy_ids` computation can no longer deactivate an established in-window academy row (keyed on stored season evidence, deliberately NOT the birth-date fallback).
- Transfer heal now requeues inactive in-window academy orphans (bounded by a job-global budget, rotating so the backlog round-robins) so Gore-class rows self-heal. `OPERATIONS.md` stale cleanup description corrected.

### Tests
`test_season_regression.py` + 4 more suites (~900 lines): returned-loanee end-to-end (stats/compute/scout), orphan-floor invariants, Aug-1 frozen-clock rollover, limited-coverage cache branch, heal budget rotation. Full suite: 724 passed; the 23 failures + 12 collection errors are byte-identical to main (pre-existing, e.g. deleted-model imports).

### Expected effect after merge
Gore (`/players/303010/stats`) and the ~126 zeroed players render real minutes on the profile immediately. Scout visibility for orphaned rows additionally needs the P1 prod reactivation run (MJ-gated). Verification: Gore prod endpoint + the zero-at-tracked-club gauge (SQL in the scout ledger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)