### PR TITLE
fix(heal): add 2026-27 and 2027-28 transfer windows — heal had no window data mid-window

### DIFF
--- a/academy-watch-backend/src/data/transfer_windows.py
+++ b/academy-watch-backend/src/data/transfer_windows.py
@@ -2,8 +2,14 @@
 Transfer window data for loan detection system.
 
 This module contains hard-coded transfer window boundaries for European football leagues
-from seasons 2022-23 through 2025-26. These dates are based on league-specific deadlines
+from seasons 2022-23 through 2027-28. These dates are based on league-specific deadlines
 and stored as ISO date strings for precise date filtering.
+
+Each season maps to two windows on the standard European convention: SUMMER runs
+Jun 1 – Sep 1 of the season-start year, WINTER runs Dec 1 – Feb 1. Keep future
+seasons ahead of the calendar so the nightly transfer heal always has window data
+for the window that is currently open (a missing season silently resolves every
+lookup to "out of window" — see api_football_client._in_window).
 
 Window Keys Format: "<YYYY-YY>::<SUMMER|WINTER|FULL>"
 - SUMMER: Summer transfer window
@@ -21,6 +27,8 @@ WINDOWS = {
         "SUMMER": ("2025-06-01", "2025-09-01"),
         "WINTER": ("2025-12-01", "2026-02-01"),
     },
+    "2026-27": {"SUMMER": ("2026-06-01", "2026-09-01"), "WINTER": ("2026-12-01", "2027-02-01")},
+    "2027-28": {"SUMMER": ("2027-06-01", "2027-09-01"), "WINTER": ("2027-12-01", "2028-02-01")},
 }
 
 

--- a/academy-watch-backend/tests/test_transfer_windows.py
+++ b/academy-watch-backend/tests/test_transfer_windows.py
@@ -1,0 +1,68 @@
+"""Transfer-window data coverage.
+
+Regression guard for the nightly transfer heal: the WINDOWS table must stay
+ahead of the calendar so the currently-open window always has data. A missing
+season does not raise — api_football_client._in_window catches the KeyError and
+silently returns False ("out of window"), so a gap degrades loan detection with
+no error. These tests pin that the seasons around today resolve, and that the
+summer 2026 window (season 2026-27), which is open on 2026-07-07, is covered.
+"""
+
+from datetime import date
+
+from src.api_football_client import APIFootballClient
+from src.data.transfer_windows import WINDOWS, get_supported_seasons, get_supported_window_keys
+
+
+def test_current_and_headroom_seasons_present():
+    seasons = get_supported_seasons()
+    # The season whose summer window is open right now (today is 2026-07-07)
+    # plus one season of headroom so a mid-window gap never recurs.
+    assert "2026-27" in seasons
+    assert "2027-28" in seasons
+
+
+def test_new_season_window_bounds_follow_convention():
+    # SUMMER: Jun 1 – Sep 1 of the season-start year; WINTER: Dec 1 – Feb 1.
+    assert WINDOWS["2026-27"]["SUMMER"] == ("2026-06-01", "2026-09-01")
+    assert WINDOWS["2026-27"]["WINTER"] == ("2026-12-01", "2027-02-01")
+    assert WINDOWS["2027-28"]["SUMMER"] == ("2027-06-01", "2027-09-01")
+    assert WINDOWS["2027-28"]["WINTER"] == ("2027-12-01", "2028-02-01")
+
+
+def test_supported_window_keys_include_new_seasons():
+    keys = get_supported_window_keys()
+    for key in (
+        "2026-27::SUMMER",
+        "2026-27::WINTER",
+        "2026-27::FULL",
+        "2027-28::SUMMER",
+        "2027-28::FULL",
+    ):
+        assert key in keys
+
+
+def test_parse_window_key_resolves_new_season():
+    client = APIFootballClient()
+    assert client._parse_window_key("2026-27::SUMMER") == (date(2026, 6, 1), date(2026, 9, 1))
+    # FULL spans the summer open through the winter close of the same season.
+    assert client._parse_window_key("2026-27::FULL") == (date(2026, 6, 1), date(2027, 2, 1))
+
+
+def test_today_maps_into_open_summer_window():
+    """2026-07-07 (today) is inside the summer 2026-27 window and, critically,
+    outside every 2025-26 window — the gap the heal hit before this fix."""
+    client = APIFootballClient()
+    assert client._in_window("2026-07-07", "2026-27::SUMMER") is True
+    assert client._in_window("2026-07-07", "2026-27::FULL") is True
+    # The pre-fix data (through 2025-26 only) could never place this date in a
+    # window: all 2025-26 windows closed by Feb 2026.
+    assert client._in_window("2026-07-07", "2025-26::SUMMER") is False
+    assert client._in_window("2026-07-07", "2025-26::FULL") is False
+
+
+def test_unknown_future_season_still_degrades_silently_not_crash():
+    """Behaviour contract: a season still absent from the table resolves to
+    False rather than raising, so callers never crash on a gap."""
+    client = APIFootballClient()
+    assert client._in_window("2030-07-01", "2030-31::SUMMER") is False


### PR DESCRIPTION
## What was missing

`academy-watch-backend/src/data/transfer_windows.py` (the `WINDOWS` table) stopped at season **2025-26**. There was **no window data for 2026-27** — and the **summer 2026 window belongs to season 2026-27 and is open right now** (today is 2026-07-07). So the nightly transfer heal has been running mid-window with no data for the window that is actually open.

## Current-behavior blast radius (verified in code)

The only consumer of `WINDOWS` is `api_football_client.py` via `_parse_window_key` / `_in_window`, which back the loan-detection helpers (`is_loan_transfer`, `get_current_loans_for_team`, and the loan-sweep/candidate loops).

- `_parse_window_key("2026-27::…")` raises `KeyError("Unknown season …")` for an absent season.
- **But every caller is shielded:** `_in_window` wraps the parse in `try/except (ValueError, KeyError)` and, on miss, **logs a warning and returns `False`**. The two direct `_parse_window_key` calls (client lines ~4017, ~5252) are debug-only and already inside guards.

**So there is no crash — the failure is silent.** A missing season resolves every lookup to *"transfer not in window" → not a new loan*. Concretely, a real summer-2026 loan dated `2026-07-xx` is invisible to loan detection:
- Today `current_stats_season` still returns **2025** (August rollover), so the default window key is `2025-26::…`, and a `2026-07` date is outside **all** 2025-26 windows (they close by Feb 2026) → `False`.
- After 1 Aug 2026 the default becomes `2026-27::…`, which was absent → `KeyError` → caught → `False` for everything.

Either way, new loans in the currently-open window degrade silently, with only a debug/warning log.

## What I added

- `2026-27` (currently open) and `2027-28` (headroom) to `WINDOWS`, following the **exact** existing convention: `SUMMER` = Jun 1 – Sep 1 of the season-start year, `WINTER` = Dec 1 – Feb 1.
- A module-docstring note (updated range to 2027-28) explaining why the table must stay ahead of the calendar and how a gap fails silently.
- No fallback/refactor added — step 4 was conditional on a hard crash, and there is none; the data addition is the fix.

## Test evidence

New `tests/test_transfer_windows.py` (6 tests, all pass) pins:
- `2026-27` / `2027-28` present in `get_supported_seasons()` and window keys.
- New-season bounds follow the convention; `_parse_window_key("2026-27::FULL")` → `(2026-06-01, 2027-02-01)`.
- **`_in_window("2026-07-07", "2026-27::SUMMER") is True`** and `…::FULL is True` — today maps into the open window.
- Regression guard: the pre-fix 2025-26-only data returns `False` for that same date (`2025-26::SUMMER`/`::FULL`).
- Absent-season contract still degrades to `False` (no crash).

Gates run green on the changed files: `ruff check` ✅, `ruff format --check` ✅, new tests 6 passed. Related suites `test_transfer_heal_orphans.py` and `test_season_regression.py` pass. One failure in `test_api_client_stats.py::test_get_player_season_context_includes_same_day_fixtures` is **pre-existing on `main`** (a date-dependent season-context test; reproduced with my change reverted) and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)