### PR TITLE
feat(season-api): D1 — ?season param, one resolver, provenance object, closed season ranges

### DIFF
--- a/academy-watch-backend/src/routes/players.py
+++ b/academy-watch-backend/src/routes/players.py
@@ -614,19 +614,24 @@ def get_public_player_season_stats(player_id: int):
 
         # Check for limited coverage
         if all_tracked and all_tracked[0].data_depth in ("events_only", "profile_only"):
-            from src.utils.academy_window import stats_season_with_data
+            from src.models.league import PlayerStatsCache
 
             tp = all_tracked[0]
-            # compute_stats() is pinned to stats_season_with_data() (plus its own
-            # latest-cached-season fallback), so it only ever speaks for ONE
-            # season. For the default (no ?season) request that IS the display
-            # season, so keep it verbatim (byte-compat). For an explicit ?season
-            # that differs, its numbers are another season's totals — serving
-            # them under the requested season label would contradict the
-            # (season-scoped) provenance object, so leave the zero baseline
-            # ("no data for this season"). Threading the season into the cache
-            # read waits for compute_stats(season=) in D4.
-            if requested_season is None or season_start_year == stats_season_with_data(db.session):
+            # PlayerStatsCache is season-keyed. compute_stats() can't yet take a
+            # season — it is pinned to stats_season_with_data() with its own
+            # latest-cached-season fallback, so it always reports whichever season
+            # that fallback lands on, which need NOT be the one the caller asked
+            # for. Gating it on stats_season_with_data() is doubly wrong: for a
+            # request that matches the display season but has no cache rows there,
+            # the fallback still serves an OLDER season's totals under the display
+            # label (mislabel); and for a request that matches the season the
+            # cache rows actually live in but differs from the display season, it
+            # zeroes real data. So: the default (no ?season) keeps calling
+            # compute_stats() verbatim (byte-compat, preserves the lower-league
+            # lag fallback), while an explicit ?season reads the cache DIRECTLY,
+            # scoped to that season — zeros only when no rows genuinely exist for
+            # it. (compute_stats(season=) lands in D4.)
+            if requested_season is None:
                 computed = tp.compute_stats()
                 result["appearances"] = computed["appearances"]
                 result["minutes"] = computed["minutes_played"]
@@ -634,6 +639,29 @@ def get_public_player_season_stats(player_id: int):
                 result["assists"] = computed["assists"]
                 result["yellows"] = computed["yellows"]
                 result["reds"] = computed["reds"]
+            else:
+                cache = (
+                    db.session.query(
+                        func.coalesce(func.sum(PlayerStatsCache.appearances), 0),
+                        func.coalesce(func.sum(PlayerStatsCache.minutes_played), 0),
+                        func.coalesce(func.sum(PlayerStatsCache.goals), 0),
+                        func.coalesce(func.sum(PlayerStatsCache.assists), 0),
+                        func.coalesce(func.sum(PlayerStatsCache.yellows), 0),
+                        func.coalesce(func.sum(PlayerStatsCache.reds), 0),
+                    )
+                    .filter(
+                        PlayerStatsCache.player_api_id == player_id,
+                        PlayerStatsCache.season == season_start_year,
+                    )
+                    .first()
+                )
+                apps, minutes, goals, assists, yellows, reds = (int(v or 0) for v in (cache or (0, 0, 0, 0, 0, 0)))
+                result["appearances"] = apps
+                result["minutes"] = minutes
+                result["goals"] = goals
+                result["assists"] = assists
+                result["yellows"] = yellows
+                result["reds"] = reds
             result["source"] = "limited-coverage"
             result["stats_coverage"] = "limited"
 

--- a/academy-watch-backend/src/routes/players.py
+++ b/academy-watch-backend/src/routes/players.py
@@ -8,7 +8,6 @@ This blueprint handles:
 """
 
 import logging
-from datetime import UTC, datetime
 
 from flask import Blueprint, jsonify, request
 from src.auth import _safe_error_payload
@@ -46,6 +45,81 @@ def _prefer_academy_origin():
     ).asc()
 
 
+def _season_provenance(player_id: int, season: int) -> dict:
+    """On-read provenance for a (player, season) SENIOR minutes figure.
+
+    Reconciles the two independent minute sources without ever silently mixing
+    them: per-match ``FixturePlayerStats`` (match-proven) vs the
+    ``PlayerJourneyEntry`` season totals (API season summary, cup-inclusive).
+
+    - ``fixtures_minutes``: SUM of the player's FixturePlayerStats minutes in
+      fixtures of this season.
+    - ``journey_minutes``: SUM of the player's SENIOR journey-entry minutes this
+      season — youth and international entries excluded.
+    - ``source``: which source wins the headline — the larger-minutes source
+      taken whole (journey wins ties / ``>=`` as the cup-inclusive convention).
+    - ``reconcile_flag``: ``cup-gap`` (journey > fixtures > 0) |
+      ``fixtures-invisible`` (fixtures == 0 < journey) | ``journey-under-sync``
+      (fixtures > journey) | ``None`` (agree, or both zero).
+    - ``delta_pct``: signed % gap ``(journey - fixtures) / max(both)``, 1 dp.
+
+    Two bounded aggregate queries (one FPS, one PJE) — cheap for a single
+    player, and pre-index acceptable per the D1 design.
+    """
+    from sqlalchemy import func
+    from src.models.journey import PlayerJourney, PlayerJourneyEntry
+    from src.models.weekly import Fixture, FixturePlayerStats
+
+    fixtures_minutes = int(
+        db.session.query(func.coalesce(func.sum(FixturePlayerStats.minutes), 0))
+        .join(Fixture, FixturePlayerStats.fixture_id == Fixture.id)
+        .filter(
+            FixturePlayerStats.player_api_id == player_id,
+            Fixture.season == season,
+        )
+        .scalar()
+    )
+
+    journey_minutes = int(
+        db.session.query(func.coalesce(func.sum(PlayerJourneyEntry.minutes), 0))
+        .join(PlayerJourney, PlayerJourneyEntry.journey_id == PlayerJourney.id)
+        .filter(
+            PlayerJourney.player_api_id == player_id,
+            PlayerJourneyEntry.season == season,
+            PlayerJourneyEntry.is_youth.is_(False),
+            PlayerJourneyEntry.is_international.is_(False),
+        )
+        .scalar()
+    )
+
+    if fixtures_minutes == 0 and journey_minutes == 0:
+        source = "none"
+    elif journey_minutes >= fixtures_minutes:
+        source = "journey"
+    else:
+        source = "fixtures"
+
+    if fixtures_minutes == 0 and journey_minutes > 0:
+        reconcile_flag = "fixtures-invisible"
+    elif journey_minutes > fixtures_minutes > 0:
+        reconcile_flag = "cup-gap"
+    elif fixtures_minutes > journey_minutes:
+        reconcile_flag = "journey-under-sync"
+    else:
+        reconcile_flag = None
+
+    larger = max(fixtures_minutes, journey_minutes)
+    delta_pct = round((journey_minutes - fixtures_minutes) / larger * 100, 1) if larger else 0.0
+
+    return {
+        "source": source,
+        "fixtures_minutes": fixtures_minutes,
+        "journey_minutes": journey_minutes,
+        "delta_pct": delta_pct,
+        "reconcile_flag": reconcile_flag,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Player stats endpoint
 # ---------------------------------------------------------------------------
@@ -68,21 +142,26 @@ def get_public_player_stats(player_id: int):
         resolve_team_name_and_logo = _get_resolve_team_name_and_logo()
         force_sync = request.args.get("force_sync", "").lower() == "true"
 
-        # Stats DISPLAY season: the current calendar season, but fall back to
-        # the latest season that actually has fixtures so a not-yet-started
-        # season never blanks the page (utils/academy_window docstrings).
-        from src.utils.academy_window import current_stats_season, stats_season_with_data
+        # Stats DISPLAY season. With no ?season this keeps today's behavior via
+        # the with-data fallback resolver (never blanks a not-yet-started season);
+        # an explicit ?season — validated to the fixture-data range — scopes every
+        # read below (club-set union, match log, freshness fetch) to it.
+        from src.utils.academy_window import current_stats_season, resolve_stats_season
 
-        season = stats_season_with_data(db.session)
+        requested_season = request.args.get("season") or None
+        try:
+            season = resolve_stats_season(db.session, requested=requested_season, surface="discovery")
+        except ValueError as ve:
+            return jsonify({"error": str(ve)}), 400
         season_prefix = f"{season}-{str(season + 1)[-2:]}"
-        # SYNC/FETCH season must be the pure calendar season, NOT the with-data
-        # fallback. During the Aug rollover `season` pins to the OLD season
-        # (no new fixtures yet); fetching/syncing that would re-pull completed
-        # fixtures and could never ingest the first new-season match, leaving the
-        # page permanently blank at the new club. current_stats_season() lets the
-        # view-driven sync land the new season and self-heal the fallback for all
-        # readers (mirrors journalist.get_player_stats' auto-sync).
-        sync_season = current_stats_season()
+        # SYNC/FETCH season. With no ?season it stays the pure calendar season
+        # (current_stats_season), NOT the with-data fallback: during the Aug
+        # rollover `season` pins to the OLD season, and fetching that could never
+        # ingest the first new-season match, leaving the page permanently blank at
+        # the new club. current_stats_season() lets the view-driven sync land the
+        # new season and self-heal the fallback for all readers. With an explicit
+        # ?season the freshness fetch targets exactly that requested season.
+        sync_season = season if requested_season is not None else current_stats_season()
 
         # Find ALL tracked players for this player (prefer academy-origin rows)
         tracked = (
@@ -174,7 +253,10 @@ def get_public_player_stats(player_id: int):
         stats_query = (
             db.session.query(FixturePlayerStats, Fixture)
             .join(Fixture, FixturePlayerStats.fixture_id == Fixture.id)
-            .filter(FixturePlayerStats.player_api_id == player_id)
+            .filter(
+                FixturePlayerStats.player_api_id == player_id,
+                Fixture.season == season,
+            )
         )
 
         if loan_team_api_ids:
@@ -213,7 +295,10 @@ def get_public_player_stats(player_id: int):
         stats_query = (
             db.session.query(FixturePlayerStats, Fixture)
             .join(Fixture, FixturePlayerStats.fixture_id == Fixture.id)
-            .filter(FixturePlayerStats.player_api_id == player_id)
+            .filter(
+                FixturePlayerStats.player_api_id == player_id,
+                Fixture.season == season,
+            )
         )
         if loan_team_api_ids:
             stats_query = stats_query.filter(FixturePlayerStats.team_api_id.in_(loan_team_api_ids))
@@ -472,12 +557,17 @@ def get_public_player_season_stats(player_id: int):
         from src.api_football_client import APIFootballClient
         from src.models.weekly import Fixture, FixturePlayerStats
 
-        # Stats DISPLAY season with latest-season-with-data fallback (see
-        # utils/academy_window.stats_season_with_data) — never blank on rollover.
-        from src.utils.academy_window import stats_season_with_data
+        # Stats DISPLAY season. Default (no ?season) is the with-data fallback so
+        # a not-yet-started season never blanks the page; an explicit ?season —
+        # validated to the fixture-data range — scopes every read below to it.
+        from src.utils.academy_window import resolve_stats_season
 
-        season_start_year = stats_season_with_data(db.session)
-        season_start = datetime(season_start_year, 8, 1, tzinfo=UTC)
+        try:
+            season_start_year = resolve_stats_season(
+                db.session, requested=request.args.get("season") or None, surface="discovery"
+            )
+        except ValueError as ve:
+            return jsonify({"error": str(ve)}), 400
         season_prefix = f"{season_start_year}-{str(season_start_year + 1)[-2:]}"
 
         result = {
@@ -497,6 +587,11 @@ def get_public_player_season_stats(player_id: int):
             "loan_clubs_only": True,
             "clubs": [],
         }
+
+        # On-read provenance for the resolved season — computed once here so every
+        # return path below (limited-coverage, shadow, main) carries it. Additive:
+        # the existing top-level `source` field is left exactly as-is.
+        result["provenance"] = _season_provenance(player_id, season_start_year)
 
         # Find tracked players (prefer academy-origin rows)
         all_tracked = (
@@ -610,7 +705,7 @@ def get_public_player_season_stats(player_id: int):
             )
             .filter(
                 FixturePlayerStats.player_api_id == player_id,
-                Fixture.date_utc >= season_start,
+                Fixture.season == season_start_year,
             )
             .distinct()
             .all()
@@ -727,7 +822,7 @@ def get_public_player_season_stats(player_id: int):
                 .filter(
                     FixturePlayerStats.player_api_id == player_id,
                     FixturePlayerStats.team_api_id.in_(loan_team_api_ids),
-                    Fixture.date_utc >= season_start,
+                    Fixture.season == season_start_year,
                 )
                 .first()
             )
@@ -759,7 +854,7 @@ def get_public_player_season_stats(player_id: int):
                 .filter(
                     FixturePlayerStats.player_api_id == player_id,
                     FixturePlayerStats.team_api_id.in_(loan_team_api_ids),
-                    Fixture.date_utc >= season_start,
+                    Fixture.season == season_start_year,
                     FixturePlayerStats.goals_conceded == 0,
                     FixturePlayerStats.minutes >= 45,
                 )

--- a/academy-watch-backend/src/routes/players.py
+++ b/academy-watch-backend/src/routes/players.py
@@ -562,10 +562,9 @@ def get_public_player_season_stats(player_id: int):
         # validated to the fixture-data range — scopes every read below to it.
         from src.utils.academy_window import resolve_stats_season
 
+        requested_season = request.args.get("season") or None
         try:
-            season_start_year = resolve_stats_season(
-                db.session, requested=request.args.get("season") or None, surface="discovery"
-            )
+            season_start_year = resolve_stats_season(db.session, requested=requested_season, surface="discovery")
         except ValueError as ve:
             return jsonify({"error": str(ve)}), 400
         season_prefix = f"{season_start_year}-{str(season_start_year + 1)[-2:]}"
@@ -615,14 +614,26 @@ def get_public_player_season_stats(player_id: int):
 
         # Check for limited coverage
         if all_tracked and all_tracked[0].data_depth in ("events_only", "profile_only"):
+            from src.utils.academy_window import stats_season_with_data
+
             tp = all_tracked[0]
-            computed = tp.compute_stats()
-            result["appearances"] = computed["appearances"]
-            result["minutes"] = computed["minutes_played"]
-            result["goals"] = computed["goals"]
-            result["assists"] = computed["assists"]
-            result["yellows"] = computed["yellows"]
-            result["reds"] = computed["reds"]
+            # compute_stats() is pinned to stats_season_with_data() (plus its own
+            # latest-cached-season fallback), so it only ever speaks for ONE
+            # season. For the default (no ?season) request that IS the display
+            # season, so keep it verbatim (byte-compat). For an explicit ?season
+            # that differs, its numbers are another season's totals — serving
+            # them under the requested season label would contradict the
+            # (season-scoped) provenance object, so leave the zero baseline
+            # ("no data for this season"). Threading the season into the cache
+            # read waits for compute_stats(season=) in D4.
+            if requested_season is None or season_start_year == stats_season_with_data(db.session):
+                computed = tp.compute_stats()
+                result["appearances"] = computed["appearances"]
+                result["minutes"] = computed["minutes_played"]
+                result["goals"] = computed["goals"]
+                result["assists"] = computed["assists"]
+                result["yellows"] = computed["yellows"]
+                result["reds"] = computed["reds"]
             result["source"] = "limited-coverage"
             result["stats_coverage"] = "limited"
 
@@ -632,9 +643,9 @@ def get_public_player_season_stats(player_id: int):
                     {
                         "team_name": tp.current_club.name,
                         "team_logo": tp.current_club.logo,
-                        "appearances": computed["appearances"],
-                        "goals": computed["goals"],
-                        "assists": computed["assists"],
+                        "appearances": result["appearances"],
+                        "goals": result["goals"],
+                        "assists": result["assists"],
                         "is_current": tp.is_active,
                     }
                 ]
@@ -643,18 +654,24 @@ def get_public_player_season_stats(player_id: int):
 
         if not all_tracked:
             # Shadow player fallback — no tracked rows, but a worldwide-followed
-            # PlayerShadow exists: serve its LATEST-season PlayerShadowStats as
-            # limited coverage so the profile's stats view renders. Latest-season
-            # (not wall-clock) is immune to API-Football client season drift.
+            # PlayerShadow exists: serve PlayerShadowStats as limited coverage so
+            # the profile's stats view renders. Default (no ?season) serves the
+            # LATEST season with shadow rows (not wall-clock) so it is immune to
+            # API-Football client season drift; an explicit ?season scopes to
+            # exactly that season (PlayerShadowStats is season-keyed) so the
+            # totals match the response's season label and the provenance object.
             from src.models.follow import PlayerShadow, PlayerShadowStats
 
             shadow = PlayerShadow.query.filter_by(player_api_id=player_id, is_active=True).first()
             if shadow:
-                latest_season = (
-                    db.session.query(func.max(PlayerShadowStats.season))
-                    .filter(PlayerShadowStats.player_api_id == player_id)
-                    .scalar()
-                )
+                if requested_season is not None:
+                    target_season = season_start_year
+                else:
+                    target_season = (
+                        db.session.query(func.max(PlayerShadowStats.season))
+                        .filter(PlayerShadowStats.player_api_id == player_id)
+                        .scalar()
+                    )
                 totals = (
                     db.session.query(
                         func.coalesce(func.sum(PlayerShadowStats.appearances), 0),
@@ -664,10 +681,10 @@ def get_public_player_season_stats(player_id: int):
                     )
                     .filter(
                         PlayerShadowStats.player_api_id == player_id,
-                        PlayerShadowStats.season == latest_season,
+                        PlayerShadowStats.season == target_season,
                     )
                     .first()
-                    if latest_season is not None
+                    if target_season is not None
                     else None
                 )
                 apps, goals, assists, minutes = (int(v or 0) for v in (totals or (0, 0, 0, 0)))

--- a/academy-watch-backend/src/utils/academy_window.py
+++ b/academy-watch-backend/src/utils/academy_window.py
@@ -83,6 +83,64 @@ def stats_season_with_data(db_session, today: date | datetime | None = None) -> 
     return latest if latest is not None else calendar_season
 
 
+def season_bounds(db_session, today: date | datetime | None = None) -> tuple[int, int]:
+    """Valid range for an explicit ``?season`` request: ``(low, high)`` inclusive.
+
+    - ``low`` = ``MIN(fixtures.season)`` — the platform only holds per-match
+      fixture data from 2025-26 onward, so an older season has no fixtures to
+      scope a stats read to. Falls back to ``current_stats_season`` when no
+      fixtures exist yet, so the range never inverts.
+    - ``high`` = ``current_stats_season() + 1`` — a caller may look one season
+      ahead (request the upcoming season before its fixtures land).
+
+    Season values are API-Football season-start years (2025 == 2025-26).
+    """
+    from sqlalchemy import func
+    from src.models.weekly import Fixture
+
+    high = current_stats_season(today) + 1
+    min_season = db_session.query(func.min(Fixture.season)).scalar()
+    low = int(min_season) if min_season is not None else current_stats_season(today)
+    return (low, high)
+
+
+def resolve_stats_season(
+    db_session,
+    requested=None,
+    surface: str = "discovery",
+    today: date | datetime | None = None,
+) -> int:
+    """The ONE season resolver every stats read routes through.
+
+    - ``requested`` given: validated against :func:`season_bounds`. A non-integer
+      value, or one outside the inclusive bounds, raises ``ValueError`` (routes
+      turn it into HTTP 400). The validated integer is returned verbatim — an
+      explicit request is honoured on every surface.
+    - ``requested`` omitted, ``surface="discovery"`` (default): the DISPLAY
+      default — :func:`stats_season_with_data`, which never points at a
+      not-yet-started season (fixtures-keyed fallback). Identical to the pre-param
+      behaviour of the single-player endpoints.
+    - ``requested`` omitted, ``surface="compare"``: the wall-clock
+      :func:`current_stats_season` with NO with-data fallback, so a compare
+      column for a season that has produced no fixtures renders empty ("season
+      not started") instead of silently borrowing the prior season's numbers.
+
+    Season values are API-Football season-start years (2025 == 2025-26).
+    """
+    if requested is not None:
+        try:
+            season = int(requested)
+        except (TypeError, ValueError):
+            raise ValueError(f"season must be an integer start-year, got {requested!r}") from None
+        low, high = season_bounds(db_session, today)
+        if season < low or season > high:
+            raise ValueError(f"season {season} is out of range [{low}, {high}]")
+        return season
+    if surface == "compare":
+        return current_stats_season(today)
+    return stats_season_with_data(db_session, today)
+
+
 def age_from_birth_date(birth_date, today: date | None = None) -> int | None:
     """Floor years between a 'YYYY-MM-DD...' birth date string and today.
 

--- a/academy-watch-backend/tests/test_season_api_d1.py
+++ b/academy-watch-backend/tests/test_season_api_d1.py
@@ -38,6 +38,10 @@ LIMITED_CLUB_API = 501
 SHADOW_PLAYER_API = 600600
 SHADOW_CLUB_API = 601
 GENERIC_OPP_API = 909
+# Limited player whose cache rows live in a season that is NOT the with-data
+# display season (exercises the season-scoped cache read, not compute_stats()).
+MISALIGNED_PLAYER_API = 500600
+MISALIGNED_CLUB_API = 502
 
 
 @pytest.fixture
@@ -298,6 +302,63 @@ def _seed_limited_player():
     db.session.commit()
 
 
+def _seed_limited_player_cache_off_with_data_season():
+    """events_only player whose PlayerStatsCache lives in a season that is NOT
+    the with-data display season. Cache rows exist ONLY for 2024 (30 apps, 2
+    goals, 2500 min); fixtures exist for BOTH 2024 and 2025, so season_bounds
+    span [2024, 2026] and stats_season_with_data()=2025. compute_stats() is
+    pinned to that display season (2025) and, finding no 2025 cache rows, falls
+    back to the latest cached season (2024) — so it serves the 2024 totals under
+    WHATEVER season label the caller asked for. The explicit ?season path must
+    instead read the cache season-scoped: ?season=2025 → zeros (no rows there),
+    ?season=2024 → the real 30/2500."""
+    from src.models.league import PlayerStatsCache, db
+    from src.models.tracked_player import TrackedPlayer
+    from src.models.weekly import Fixture
+
+    club = _team(MISALIGNED_CLUB_API, "Misaligned FC")
+    _team(GENERIC_OPP_API, "Opp FC")
+    for fx_id, season in ((8400, 2024), (8401, 2025)):
+        db.session.add(
+            Fixture(
+                fixture_id_api=fx_id,
+                season=season,
+                date_utc=datetime(season, 9, 1, tzinfo=UTC),
+                competition_name="League Two",
+                home_team_api_id=MISALIGNED_CLUB_API,
+                away_team_api_id=GENERIC_OPP_API,
+                home_goals=0,
+                away_goals=0,
+            )
+        )
+    tp = TrackedPlayer(
+        player_api_id=MISALIGNED_PLAYER_API,
+        player_name="Offset Guy",
+        position="Forward",
+        team_id=club.id,
+        status="on_loan",
+        current_club_api_id=MISALIGNED_CLUB_API,
+        current_club_db_id=club.id,
+        current_club_name="Misaligned FC",
+        data_depth="events_only",
+        is_active=True,
+    )
+    db.session.add(tp)
+    db.session.add(
+        PlayerStatsCache(
+            player_api_id=MISALIGNED_PLAYER_API,
+            team_api_id=MISALIGNED_CLUB_API,
+            season=2024,
+            stats_coverage="limited",
+            appearances=30,
+            goals=2,
+            assists=1,
+            minutes_played=2500,
+        )
+    )
+    db.session.commit()
+
+
 def _seed_shadow_player():
     """Worldwide-followed shadow (NO TrackedPlayer) with PlayerShadowStats only
     for season 2025 (15 apps, 6 goals, 1200 min). A lone 2025 fixture anchors
@@ -372,6 +433,32 @@ class TestLimitedCoverageSeasonScoping:
         # headline now AGREES with the season-scoped provenance (all-zero)
         assert data["provenance"]["fixtures_minutes"] == 0
         assert data["provenance"]["journey_minutes"] == 0
+
+    def test_explicit_cache_season_serves_data_even_off_display_season(self, app, client):
+        # Cache lives in 2024, display (with-data) season is 2025. An explicit
+        # request for the season the cache ACTUALLY holds must serve it — the
+        # old stats_season_with_data() gate wrongly zeroed this (regression).
+        _seed_limited_player_cache_off_with_data_season()
+        data = client.get(f"/api/players/{MISALIGNED_PLAYER_API}/season-stats?season=2024").get_json()
+        assert data["season"] == "2024/2025"
+        assert data["source"] == "limited-coverage"
+        assert data["appearances"] == 30
+        assert data["minutes"] == 2500
+        assert data["goals"] == 2
+        assert data["clubs"][0]["appearances"] == 30
+
+    def test_explicit_display_season_off_cache_returns_zeros(self, app, client):
+        # 2025 IS the with-data display season, but the cache only holds 2024.
+        # compute_stats()'s latest-cached fallback would mislabel the 2024
+        # totals under the 2025/26 label; the season-scoped read returns zeros.
+        _seed_limited_player_cache_off_with_data_season()
+        data = client.get(f"/api/players/{MISALIGNED_PLAYER_API}/season-stats?season=2025").get_json()
+        assert data["season"] == "2025/2026"
+        assert data["source"] == "limited-coverage"
+        assert data["appearances"] == 0
+        assert data["minutes"] == 0
+        assert data["goals"] == 0
+        assert data["clubs"][0]["appearances"] == 0
 
 
 class TestShadowSeasonScoping:

--- a/academy-watch-backend/tests/test_season_api_d1.py
+++ b/academy-watch-backend/tests/test_season_api_d1.py
@@ -1,0 +1,237 @@
+"""D1 zero-migration season-API contract (proposal §4 / §7 D1).
+
+Drives the two single-player endpoints end-to-end to lock in:
+
+1. ``?season=<int>`` scopes every read to that season; no param is unchanged.
+2. ``season_bounds`` validation → HTTP 400 on a non-int or out-of-range season.
+3. The on-read provenance object (FPS vs PlayerJourneyEntry senior minutes),
+   including the Gore-style ``cup-gap`` case (journey > fixtures) and the
+   youth/international/prior-season exclusions.
+"""
+
+import os
+from datetime import UTC, datetime
+
+import pytest
+from flask import Flask
+
+
+class _StubAPIClient:
+    """No-network stand-in: games_played=0 so the freshness-sync branch is inert."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def _fetch_player_team_season_totals_api(self, *args, **kwargs):
+        return {"games_played": 0}
+
+
+PLAYER_API = 303010  # Gore
+PARENT_API = 33
+LOAN_API = 777
+OPP_API = 999
+
+
+@pytest.fixture
+def app(monkeypatch):
+    os.environ.setdefault("SKIP_API_HANDSHAKE", "1")
+    os.environ.setdefault("API_USE_STUB_DATA", "true")
+
+    import src.api_football_client as apifc
+
+    monkeypatch.setattr(apifc, "APIFootballClient", _StubAPIClient)
+
+    # Import the models so their tables register on the metadata before
+    # create_all (players_bp imports them lazily, inside the endpoints).
+    from src.models import journey, tracked_player, weekly  # noqa: F401
+    from src.models.league import db
+    from src.routes.players import players_bp
+
+    application = Flask(__name__)
+    application.config.update(
+        TESTING=True,
+        SECRET_KEY="test-secret",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        RATELIMIT_ENABLED=False,
+    )
+    db.init_app(application)
+    application.register_blueprint(players_bp, url_prefix="/api")
+
+    ctx = application.app_context()
+    ctx.push()
+    db.create_all()
+    yield application
+    db.session.remove()
+    db.drop_all()
+    ctx.pop()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _team(api_id, name):
+    from src.models.league import Team, db
+
+    team = Team(team_id=api_id, name=name, country="England", season=2025, logo=f"{api_id}.png")
+    db.session.add(team)
+    db.session.flush()
+    return team
+
+
+def _seed_gore():
+    """FPS: two 90' league matches (season 2025) at the loan club = 180 min.
+    Journey (senior 2025): 300 min → cup-inclusive, so fixtures < journey =
+    ``cup-gap``. Decoys the provenance MUST ignore: a youth 2025 entry (500),
+    an international 2025 entry (200), and a prior-season 2024 senior entry
+    (1000). Only the single senior-2025 entry (300) may count."""
+    from src.models.journey import PlayerJourney, PlayerJourneyEntry
+    from src.models.league import db
+    from src.models.tracked_player import TrackedPlayer
+    from src.models.weekly import Fixture, FixturePlayerStats
+
+    parent = _team(PARENT_API, "Parent FC")
+    _team(LOAN_API, "Loan FC")
+    _team(OPP_API, "Opponent FC")
+
+    tp = TrackedPlayer(
+        player_api_id=PLAYER_API,
+        player_name="Daniel Gore",
+        position="Midfielder",
+        team_id=parent.id,
+        status="on_loan",
+        current_club_api_id=LOAN_API,
+        current_club_name="Loan FC",
+        data_depth="full_stats",
+        is_active=True,
+    )
+    db.session.add(tp)
+
+    for i in range(2):
+        fx = Fixture(
+            fixture_id_api=8100 + i,
+            season=2025,
+            date_utc=datetime(2025, 9, 1 + 7 * i, tzinfo=UTC),
+            competition_name="Championship",
+            home_team_api_id=LOAN_API,
+            away_team_api_id=OPP_API,
+            home_goals=1,
+            away_goals=0,
+        )
+        db.session.add(fx)
+        db.session.flush()
+        db.session.add(
+            FixturePlayerStats(
+                fixture_id=fx.id,
+                player_api_id=PLAYER_API,
+                team_api_id=LOAN_API,
+                minutes=90,
+                goals=1,
+                assists=0,
+                rating=7.5,
+            )
+        )
+
+    journey = PlayerJourney(player_api_id=PLAYER_API, player_name="Daniel Gore")
+    db.session.add(journey)
+    db.session.flush()
+    for season, minutes, is_youth, is_intl in [
+        (2025, 300, False, False),  # the only counting entry
+        (2025, 500, True, False),  # youth — excluded
+        (2025, 200, False, True),  # international — excluded
+        (2024, 1000, False, False),  # prior season — excluded
+    ]:
+        db.session.add(
+            PlayerJourneyEntry(
+                journey_id=journey.id,
+                season=season,
+                club_api_id=LOAN_API,
+                club_name="Loan FC",
+                minutes=minutes,
+                appearances=5,
+                goals=1,
+                assists=0,
+                is_youth=is_youth,
+                is_international=is_intl,
+            )
+        )
+    db.session.commit()
+
+
+class TestProvenanceObject:
+    def test_season_stats_carries_cup_gap_provenance(self, app, client):
+        _seed_gore()
+        res = client.get(f"/api/players/{PLAYER_API}/season-stats?season=2025")
+        assert res.status_code == 200
+        prov = res.get_json()["provenance"]
+        assert prov["fixtures_minutes"] == 180
+        assert prov["journey_minutes"] == 300  # senior-2025 only; decoys excluded
+        assert prov["source"] == "journey"
+        assert prov["reconcile_flag"] == "cup-gap"
+        assert prov["delta_pct"] == 40.0
+
+    def test_no_param_matches_explicit_current_season(self, app, client):
+        _seed_gore()
+        no_param = client.get(f"/api/players/{PLAYER_API}/season-stats").get_json()
+        explicit = client.get(f"/api/players/{PLAYER_API}/season-stats?season=2025").get_json()
+        # Discovery default resolves to MAX(fixtures.season)=2025 — identical.
+        assert no_param["provenance"] == explicit["provenance"]
+        assert no_param["season"] == explicit["season"]
+
+    def test_existing_source_field_untouched(self, app, client):
+        _seed_gore()
+        data = client.get(f"/api/players/{PLAYER_API}/season-stats").get_json()
+        # Local FPS rows exist → the existing top-level `source` stays "local-db",
+        # NOT overwritten by the provenance winner ("journey").
+        assert data["source"] == "local-db"
+        assert data["provenance"]["source"] == "journey"
+
+    def test_empty_season_provenance_is_none(self, app, client):
+        _seed_gore()
+        prov = client.get(f"/api/players/{PLAYER_API}/season-stats?season=2026").get_json()["provenance"]
+        assert prov == {
+            "source": "none",
+            "fixtures_minutes": 0,
+            "journey_minutes": 0,
+            "delta_pct": 0.0,
+            "reconcile_flag": None,
+        }
+
+
+class TestSeasonScoping:
+    def test_stats_scopes_match_log_to_requested_season(self, app, client):
+        _seed_gore()
+        rows_2025 = client.get(f"/api/players/{PLAYER_API}/stats?season=2025").get_json()
+        assert len(rows_2025) == 2
+        rows_2026 = client.get(f"/api/players/{PLAYER_API}/stats?season=2026").get_json()
+        assert rows_2026 == []
+
+    def test_stats_no_param_unchanged(self, app, client):
+        _seed_gore()
+        rows = client.get(f"/api/players/{PLAYER_API}/stats").get_json()
+        assert len(rows) == 2
+        assert {r["loan_team_name"] for r in rows} == {"Loan FC"}
+
+
+class TestSeasonBoundsValidation:
+    @pytest.mark.parametrize("endpoint", ["stats", "season-stats"])
+    def test_non_integer_season_is_400(self, app, client, endpoint):
+        _seed_gore()
+        res = client.get(f"/api/players/{PLAYER_API}/{endpoint}?season=abc")
+        assert res.status_code == 400
+        assert "error" in res.get_json()
+
+    @pytest.mark.parametrize("endpoint", ["stats", "season-stats"])
+    def test_out_of_range_season_is_400(self, app, client, endpoint):
+        _seed_gore()
+        # 2024 is below MIN(fixtures.season)=2025; 2099 is far above the horizon.
+        assert client.get(f"/api/players/{PLAYER_API}/{endpoint}?season=2024").status_code == 400
+        assert client.get(f"/api/players/{PLAYER_API}/{endpoint}?season=2099").status_code == 400
+
+    @pytest.mark.parametrize("endpoint", ["stats", "season-stats"])
+    def test_empty_season_param_treated_as_no_param(self, app, client, endpoint):
+        _seed_gore()
+        # `?season=` (present but empty) must not 400 — it means "no season".
+        assert client.get(f"/api/players/{PLAYER_API}/{endpoint}?season=").status_code == 200

--- a/academy-watch-backend/tests/test_season_api_d1.py
+++ b/academy-watch-backend/tests/test_season_api_d1.py
@@ -31,6 +31,14 @@ PARENT_API = 33
 LOAN_API = 777
 OPP_API = 999
 
+# Limited-coverage (PlayerStatsCache) and shadow (PlayerShadowStats) fixtures for
+# the ?season-scoping regressions below.
+LIMITED_PLAYER_API = 500500
+LIMITED_CLUB_API = 501
+SHADOW_PLAYER_API = 600600
+SHADOW_CLUB_API = 601
+GENERIC_OPP_API = 909
+
 
 @pytest.fixture
 def app(monkeypatch):
@@ -43,7 +51,7 @@ def app(monkeypatch):
 
     # Import the models so their tables register on the metadata before
     # create_all (players_bp imports them lazily, inside the endpoints).
-    from src.models import journey, tracked_player, weekly  # noqa: F401
+    from src.models import follow, journey, tracked_player, weekly  # noqa: F401
     from src.models.league import db
     from src.routes.players import players_bp
 
@@ -235,3 +243,160 @@ class TestSeasonBoundsValidation:
         _seed_gore()
         # `?season=` (present but empty) must not 400 — it means "no season".
         assert client.get(f"/api/players/{PLAYER_API}/{endpoint}?season=").status_code == 200
+
+
+def _seed_limited_player():
+    """events_only player with PlayerStatsCache ONLY for season 2025 (20 apps,
+    4 goals, 1700 min). A lone 2025 fixture anchors season_bounds and
+    stats_season_with_data to 2025, so ``compute_stats()`` — pinned to the
+    with-data season — speaks only for 2025. current_club is wired so the clubs
+    breakdown renders (guards the zero-path clubs block against a stray
+    ``computed`` reference)."""
+    from src.models.league import PlayerStatsCache, db
+    from src.models.tracked_player import TrackedPlayer
+    from src.models.weekly import Fixture
+
+    club = _team(LIMITED_CLUB_API, "Limited FC")
+    _team(GENERIC_OPP_API, "Opp FC")
+    db.session.add(
+        Fixture(
+            fixture_id_api=8200,
+            season=2025,
+            date_utc=datetime(2025, 9, 1, tzinfo=UTC),
+            competition_name="League Two",
+            home_team_api_id=LIMITED_CLUB_API,
+            away_team_api_id=GENERIC_OPP_API,
+            home_goals=0,
+            away_goals=0,
+        )
+    )
+    tp = TrackedPlayer(
+        player_api_id=LIMITED_PLAYER_API,
+        player_name="Limited Guy",
+        position="Forward",
+        team_id=club.id,
+        status="on_loan",
+        current_club_api_id=LIMITED_CLUB_API,
+        current_club_db_id=club.id,
+        current_club_name="Limited FC",
+        data_depth="events_only",
+        is_active=True,
+    )
+    db.session.add(tp)
+    db.session.add(
+        PlayerStatsCache(
+            player_api_id=LIMITED_PLAYER_API,
+            team_api_id=LIMITED_CLUB_API,
+            season=2025,
+            stats_coverage="limited",
+            appearances=20,
+            goals=4,
+            assists=3,
+            minutes_played=1700,
+        )
+    )
+    db.session.commit()
+
+
+def _seed_shadow_player():
+    """Worldwide-followed shadow (NO TrackedPlayer) with PlayerShadowStats only
+    for season 2025 (15 apps, 6 goals, 1200 min). A lone 2025 fixture anchors
+    the valid season range."""
+    from src.models.follow import PlayerShadow, PlayerShadowStats
+    from src.models.league import db
+    from src.models.weekly import Fixture
+
+    db.session.add(
+        Fixture(
+            fixture_id_api=8300,
+            season=2025,
+            date_utc=datetime(2025, 9, 1, tzinfo=UTC),
+            competition_name="Serie B",
+            home_team_api_id=SHADOW_CLUB_API,
+            away_team_api_id=GENERIC_OPP_API,
+            home_goals=0,
+            away_goals=0,
+        )
+    )
+    db.session.add(
+        PlayerShadow(
+            player_api_id=SHADOW_PLAYER_API,
+            player_name="Shadow Guy",
+            current_club_name="Shadow FC",
+            is_active=True,
+        )
+    )
+    db.session.add(
+        PlayerShadowStats(
+            player_api_id=SHADOW_PLAYER_API,
+            team_api_id=SHADOW_CLUB_API,
+            season=2025,
+            appearances=15,
+            goals=6,
+            assists=2,
+            minutes=1200,
+        )
+    )
+    db.session.commit()
+
+
+class TestLimitedCoverageSeasonScoping:
+    """The limited-coverage branch must not serve compute_stats()'s (single-season)
+    numbers under a DIFFERENT requested season label."""
+
+    def test_no_param_serves_with_data_season(self, app, client):
+        _seed_limited_player()
+        data = client.get(f"/api/players/{LIMITED_PLAYER_API}/season-stats").get_json()
+        assert data["source"] == "limited-coverage"
+        assert data["appearances"] == 20
+        assert data["goals"] == 4
+        assert data["clubs"][0]["appearances"] == 20  # breakdown mirrors headline
+
+    def test_explicit_matching_season_serves_data(self, app, client):
+        _seed_limited_player()
+        data = client.get(f"/api/players/{LIMITED_PLAYER_API}/season-stats?season=2025").get_json()
+        assert data["appearances"] == 20
+        assert data["goals"] == 4
+
+    def test_explicit_off_season_returns_zeros_not_mislabel(self, app, client):
+        _seed_limited_player()
+        data = client.get(f"/api/players/{LIMITED_PLAYER_API}/season-stats?season=2026").get_json()
+        # The 2025 cache numbers must NOT be served under the 2026/27 label.
+        assert data["season"] == "2026/2027"
+        assert data["source"] == "limited-coverage"
+        assert data["appearances"] == 0
+        assert data["minutes"] == 0
+        assert data["goals"] == 0
+        assert data["assists"] == 0
+        assert data["clubs"][0]["appearances"] == 0  # no stray `computed` ref → no 500
+        # headline now AGREES with the season-scoped provenance (all-zero)
+        assert data["provenance"]["fixtures_minutes"] == 0
+        assert data["provenance"]["journey_minutes"] == 0
+
+
+class TestShadowSeasonScoping:
+    """The shadow branch must scope to the requested season, not blanket-serve
+    MAX(PlayerShadowStats.season)."""
+
+    def test_no_param_serves_latest_shadow_season(self, app, client):
+        _seed_shadow_player()
+        data = client.get(f"/api/players/{SHADOW_PLAYER_API}/season-stats").get_json()
+        assert data["source"] == "shadow"
+        assert data["appearances"] == 15
+        assert data["goals"] == 6
+
+    def test_explicit_matching_season_serves_data(self, app, client):
+        _seed_shadow_player()
+        data = client.get(f"/api/players/{SHADOW_PLAYER_API}/season-stats?season=2025").get_json()
+        assert data["source"] == "shadow"
+        assert data["appearances"] == 15
+
+    def test_explicit_off_season_returns_zeros_not_latest(self, app, client):
+        _seed_shadow_player()
+        data = client.get(f"/api/players/{SHADOW_PLAYER_API}/season-stats?season=2026").get_json()
+        # 2025 shadow totals must NOT be served under the 2026/27 label.
+        assert data["season"] == "2026/2027"
+        assert data["source"] == "shadow"
+        assert data["appearances"] == 0
+        assert data["goals"] == 0
+        assert data["minutes"] == 0

--- a/academy-watch-backend/tests/test_season_d1_contract.py
+++ b/academy-watch-backend/tests/test_season_d1_contract.py
@@ -1,0 +1,550 @@
+"""D1 season-API CONTRACT pins (proposal §4 / §6 / §7 D1).
+
+Companion to ``test_season_api_d1.py`` (which drives the endpoint happy paths).
+This file locks the four contract surfaces the D1 design is judged on, filling
+the gaps the endpoint suite leaves open:
+
+1. **Resolver surfaces** (``academy_window.resolve_stats_season`` /
+   ``season_bounds``) as a direct unit: ``discovery`` falls back to the latest
+   season WITH fixtures; ``compare`` deliberately does NOT fall back and returns
+   the wall-clock season so a not-yet-started compare column renders empty
+   ("season not started"); an out-of-range / non-integer request raises
+   ``ValueError`` and the routes turn that into HTTP 400.
+2. **``?season`` contract** on ``/stats`` and ``/season-stats``: no param is
+   byte-identical to the pre-param behaviour (exact seeded field values); an
+   explicit PAST season returns that season only; out-of-bounds → 400.
+3. **Closed season ranges**: with fixtures seeded in TWO seasons, a single-season
+   read must NOT double-count. This is the regression that fires the day the
+   2026-27 fixtures land (the old open-ended ``date_utc >=`` filters summed every
+   season; the D1 fix scopes them to ``Fixture.season ==``).
+4. **Provenance buckets**: the on-read ``_season_provenance`` object routes the
+   FPS-vs-PJE senior-minutes reconciliation into exactly one of ``cup-gap``
+   (journey > fixtures > 0, the Gore case), ``fixtures-invisible`` (journey-only),
+   ``journey-under-sync`` (fixtures > journey), or ``None`` (agree / both zero) —
+   with youth / international / other-season journey entries excluded.
+
+Season values are API-Football season START years (2025 == 2025-26).
+"""
+
+import os
+from datetime import UTC, date, datetime
+
+import pytest
+from flask import Flask
+
+
+class _StubAPIClient:
+    """No-network stand-in: games_played=0 so the freshness-sync branch is inert
+    and the endpoints do zero I/O (mirrors test_season_api_d1.py)."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def _fetch_player_team_season_totals_api(self, *args, **kwargs):
+        return {"games_played": 0}
+
+
+# Distinct id spaces per concern so a stray cross-test collision would be loud.
+FULL_PLAYER_API = 700700
+PARENT_API = 33
+LOAN_API = 777
+OPP_API = 999
+
+PROV_PLAYER_API = 710710  # provenance-unit player (no TrackedPlayer needed)
+PROV_TEAM_API = 711
+
+
+@pytest.fixture
+def app(monkeypatch):
+    os.environ.setdefault("SKIP_API_HANDSHAKE", "1")
+    os.environ.setdefault("API_USE_STUB_DATA", "true")
+
+    import src.api_football_client as apifc
+
+    monkeypatch.setattr(apifc, "APIFootballClient", _StubAPIClient)
+
+    # Register the models on the metadata before create_all (players_bp imports
+    # them lazily inside the endpoints).
+    from src.models import follow, journey, tracked_player, weekly  # noqa: F401
+    from src.models.league import db
+    from src.routes.players import players_bp
+
+    application = Flask(__name__)
+    application.config.update(
+        TESTING=True,
+        SECRET_KEY="test-secret",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        RATELIMIT_ENABLED=False,
+    )
+    db.init_app(application)
+    application.register_blueprint(players_bp, url_prefix="/api")
+
+    ctx = application.app_context()
+    ctx.push()
+    db.create_all()
+    yield application
+    db.session.remove()
+    db.drop_all()
+    ctx.pop()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+
+def _team(api_id, name):
+    from src.models.league import Team, db
+
+    team = Team(team_id=api_id, name=name, country="England", season=2025, logo=f"{api_id}.png")
+    db.session.add(team)
+    db.session.flush()
+    return team
+
+
+def _add_fixture_stats(player_api_id, team_api_id, season, minutes_list, *, fx_base, goals=1, assists=0):
+    """Seed one Fixture + one FixturePlayerStats per entry in ``minutes_list``,
+    all in ``season`` at ``team_api_id``. ``fx_base`` keys unique fixture ids."""
+    from src.models.league import db
+    from src.models.weekly import Fixture, FixturePlayerStats
+
+    for i, minutes in enumerate(minutes_list):
+        fx = Fixture(
+            fixture_id_api=fx_base + i,
+            season=season,
+            date_utc=datetime(season, 9, 1 + i, tzinfo=UTC),
+            competition_name="Championship",
+            home_team_api_id=team_api_id,
+            away_team_api_id=OPP_API,
+            home_goals=1,
+            away_goals=0,
+        )
+        db.session.add(fx)
+        db.session.flush()
+        db.session.add(
+            FixturePlayerStats(
+                fixture_id=fx.id,
+                player_api_id=player_api_id,
+                team_api_id=team_api_id,
+                minutes=minutes,
+                goals=goals,
+                assists=assists,
+                rating=7.0,
+            )
+        )
+
+
+def _add_journey_entries(player_api_id, entries, *, player_name="Contract Player"):
+    """``entries`` = iterable of ``(season, minutes, is_youth, is_international)``."""
+    from src.models.journey import PlayerJourney, PlayerJourneyEntry
+    from src.models.league import db
+
+    journey = PlayerJourney(player_api_id=player_api_id, player_name=player_name)
+    db.session.add(journey)
+    db.session.flush()
+    for season, minutes, is_youth, is_intl in entries:
+        db.session.add(
+            PlayerJourneyEntry(
+                journey_id=journey.id,
+                season=season,
+                club_api_id=PROV_TEAM_API,
+                club_name="Prov FC",
+                minutes=minutes,
+                appearances=5,
+                goals=1,
+                assists=0,
+                is_youth=is_youth,
+                is_international=is_intl,
+            )
+        )
+
+
+def _seed_single_season_full_player():
+    """A full-coverage on-loan player with FPS ONLY in season 2025 (two 90'
+    matches = 180 min at the loan club). Discovery resolves to 2025 regardless
+    of wall clock (2025 either IS the calendar season or is MAX-with-data), so
+    the no-param assertions are deterministic across the Aug-2026 rollover."""
+    from src.models.league import db
+    from src.models.tracked_player import TrackedPlayer
+
+    parent = _team(PARENT_API, "Parent FC")
+    _team(LOAN_API, "Loan FC")
+    _team(OPP_API, "Opponent FC")
+    db.session.add(
+        TrackedPlayer(
+            player_api_id=FULL_PLAYER_API,
+            player_name="Single Season Guy",
+            position="Midfielder",
+            team_id=parent.id,
+            status="on_loan",
+            current_club_api_id=LOAN_API,
+            current_club_name="Loan FC",
+            data_depth="full_stats",
+            is_active=True,
+        )
+    )
+    _add_fixture_stats(FULL_PLAYER_API, LOAN_API, 2025, [90, 90], fx_base=9600, goals=1)
+    db.session.commit()
+
+
+def _seed_two_season_full_player():
+    """Same player, FPS in TWO seasons at the loan club: 2025 = two 90' matches
+    (180 min), 2026 = one 90' match (90 min). Cross-season total is 270; a
+    correctly season-scoped read never reports 270."""
+    from src.models.league import db
+    from src.models.tracked_player import TrackedPlayer
+
+    parent = _team(PARENT_API, "Parent FC")
+    _team(LOAN_API, "Loan FC")
+    _team(OPP_API, "Opponent FC")
+    db.session.add(
+        TrackedPlayer(
+            player_api_id=FULL_PLAYER_API,
+            player_name="Two Season Guy",
+            position="Midfielder",
+            team_id=parent.id,
+            status="on_loan",
+            current_club_api_id=LOAN_API,
+            current_club_name="Loan FC",
+            data_depth="full_stats",
+            is_active=True,
+        )
+    )
+    _add_fixture_stats(FULL_PLAYER_API, LOAN_API, 2025, [90, 90], fx_base=9700, goals=1)
+    _add_fixture_stats(FULL_PLAYER_API, LOAN_API, 2026, [90], fx_base=9750, goals=1)
+    db.session.commit()
+
+
+# ---------------------------------------------------------------------------
+# 1. Resolver surfaces (discovery fallback / compare no-fallback / bounds)
+# ---------------------------------------------------------------------------
+
+
+class TestResolverSurfaces:
+    """``resolve_stats_season`` + ``season_bounds`` as a direct unit. ``today`` is
+    passed explicitly so nothing hinges on the wall clock."""
+
+    def _seed_fixture(self, season, fx_id):
+        from src.models.league import db
+        from src.models.weekly import Fixture
+
+        db.session.add(
+            Fixture(
+                fixture_id_api=fx_id,
+                season=season,
+                date_utc=datetime(season, 9, 1, tzinfo=UTC),
+                home_team_api_id=1,
+                away_team_api_id=2,
+            )
+        )
+        db.session.commit()
+
+    def test_discovery_falls_back_to_latest_season_with_fixtures(self, app):
+        from src.models.league import db
+        from src.utils.academy_window import resolve_stats_season
+
+        # Only 2025 fixtures exist; wall clock frozen past the Aug-2026 rollover
+        # so the calendar season is 2026 but no 2026 fixtures exist yet.
+        self._seed_fixture(2025, 1)
+        got = resolve_stats_season(db.session, surface="discovery", today=date(2026, 8, 1))
+        assert got == 2025, "discovery must fall back to the latest season that HAS fixtures"
+
+    def test_compare_does_not_fall_back_and_signals_not_started(self, app):
+        from src.models.league import db
+        from src.utils.academy_window import resolve_stats_season
+
+        # Same seed: only 2025 fixtures, wall clock = 2026-08-01 (calendar 2026).
+        self._seed_fixture(2025, 1)
+        compare = resolve_stats_season(db.session, surface="compare", today=date(2026, 8, 1))
+        discovery = resolve_stats_season(db.session, surface="discovery", today=date(2026, 8, 1))
+        # compare returns the wall-clock season WITHOUT the with-data fallback, so
+        # a compare column for a season with no fixtures renders empty rather than
+        # borrowing 2025's numbers. It must diverge from discovery here.
+        assert compare == 2026
+        assert discovery == 2025
+        assert compare != discovery, "compare must NOT reuse discovery's with-data fallback"
+
+    def test_explicit_request_honored_verbatim_on_every_surface(self, app):
+        from src.models.league import db
+        from src.utils.academy_window import resolve_stats_season
+
+        self._seed_fixture(2025, 1)
+        # An explicit in-range request is returned as-is regardless of surface.
+        for surface in ("discovery", "compare"):
+            assert resolve_stats_season(db.session, requested=2025, surface=surface, today=date(2026, 8, 1)) == 2026 - 1
+        # String ints (what the route actually receives from request.args) coerce.
+        assert resolve_stats_season(db.session, requested="2025", today=date(2025, 9, 1)) == 2025
+
+    def test_season_bounds_span_min_fixture_to_next_season(self, app):
+        from src.models.league import db
+        from src.utils.academy_window import season_bounds
+
+        self._seed_fixture(2025, 1)
+        # low = MIN(fixtures.season) = 2025; high = current_stats_season + 1.
+        assert season_bounds(db.session, today=date(2025, 9, 1)) == (2025, 2026)
+
+    def test_season_bounds_low_is_min_fixture_season(self, app):
+        from src.models.league import db
+        from src.utils.academy_window import season_bounds
+
+        # Two fixture seasons: low tracks the MIN, not the MAX.
+        self._seed_fixture(2024, 1)
+        self._seed_fixture(2025, 2)
+        assert season_bounds(db.session, today=date(2025, 9, 1)) == (2024, 2026)
+
+    def test_season_bounds_falls_back_when_no_fixtures(self, app):
+        from src.models.league import db
+        from src.utils.academy_window import season_bounds
+
+        # No fixtures at all: low falls back to current_stats_season so the range
+        # never inverts (low <= high).
+        low, high = season_bounds(db.session, today=date(2025, 9, 1))
+        assert (low, high) == (2025, 2026)
+        assert low <= high
+
+    def test_out_of_range_request_raises_valueerror(self, app):
+        from src.models.league import db
+        from src.utils.academy_window import resolve_stats_season
+
+        self._seed_fixture(2025, 1)  # bounds = [2025, 2026]
+        with pytest.raises(ValueError):
+            resolve_stats_season(db.session, requested=2024, today=date(2025, 9, 1))  # below low
+        with pytest.raises(ValueError):
+            resolve_stats_season(db.session, requested=2099, today=date(2025, 9, 1))  # above high
+
+    def test_non_integer_request_raises_valueerror(self, app):
+        from src.models.league import db
+        from src.utils.academy_window import resolve_stats_season
+
+        self._seed_fixture(2025, 1)
+        with pytest.raises(ValueError):
+            resolve_stats_season(db.session, requested="abc", today=date(2025, 9, 1))
+
+
+# ---------------------------------------------------------------------------
+# 2. ?season contract on both endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestSeasonParamContract:
+    def test_stats_no_param_exact_field_values(self, app, client):
+        _seed_single_season_full_player()
+        rows = client.get(f"/api/players/{FULL_PLAYER_API}/stats").get_json()
+        assert isinstance(rows, list)
+        assert len(rows) == 2
+        assert {r["loan_team_name"] for r in rows} == {"Loan FC"}
+        assert sum(r["minutes"] for r in rows) == 180
+        assert sum(r["goals"] for r in rows) == 2
+
+    def test_season_stats_no_param_exact_field_values(self, app, client):
+        _seed_single_season_full_player()
+        data = client.get(f"/api/players/{FULL_PLAYER_API}/season-stats").get_json()
+        assert data["season"] == "2025/2026"
+        assert data["source"] == "local-db"
+        assert data["appearances"] == 2
+        assert data["minutes"] == 180
+        assert data["goals"] == 2
+        assert data["provenance"]["fixtures_minutes"] == 180
+
+    def test_no_param_byte_identical_to_explicit_current_season(self, app, client):
+        # The whole point of the additive ?season plumbing: with no param the
+        # response must equal what the resolved display season returns explicitly.
+        _seed_single_season_full_player()
+        stats_none = client.get(f"/api/players/{FULL_PLAYER_API}/stats").get_json()
+        stats_expl = client.get(f"/api/players/{FULL_PLAYER_API}/stats?season=2025").get_json()
+        assert stats_none == stats_expl
+
+        ss_none = client.get(f"/api/players/{FULL_PLAYER_API}/season-stats").get_json()
+        ss_expl = client.get(f"/api/players/{FULL_PLAYER_API}/season-stats?season=2025").get_json()
+        assert ss_none == ss_expl
+
+    def test_explicit_past_season_returns_that_season_only(self, app, client):
+        # Two seasons seeded; asking for the PAST season (2025) returns 2025's
+        # figures and nothing from 2026.
+        _seed_two_season_full_player()
+        rows = client.get(f"/api/players/{FULL_PLAYER_API}/stats?season=2025").get_json()
+        assert len(rows) == 2
+        assert sum(r["minutes"] for r in rows) == 180
+
+        ss = client.get(f"/api/players/{FULL_PLAYER_API}/season-stats?season=2025").get_json()
+        assert ss["season"] == "2025/2026"
+        assert ss["minutes"] == 180
+        assert ss["appearances"] == 2
+
+    @pytest.mark.parametrize("endpoint", ["stats", "season-stats"])
+    @pytest.mark.parametrize("bad", ["abc", "2024", "2099"])
+    def test_out_of_bounds_or_non_integer_is_400(self, app, client, endpoint, bad):
+        # 2024 is below MIN(fixtures.season)=2025; 2099 above the horizon; abc a
+        # non-int. The route maps the resolver's ValueError to HTTP 400.
+        _seed_single_season_full_player()
+        res = client.get(f"/api/players/{FULL_PLAYER_API}/{endpoint}?season={bad}")
+        assert res.status_code == 400
+        assert "error" in res.get_json()
+
+    @pytest.mark.parametrize("endpoint", ["stats", "season-stats"])
+    def test_empty_season_param_is_treated_as_no_param(self, app, client, endpoint):
+        # `?season=` (present but empty) is falsy → resolver default, not a 400.
+        _seed_single_season_full_player()
+        assert client.get(f"/api/players/{FULL_PLAYER_API}/{endpoint}?season=").status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# 3. Closed season ranges — single-season reads must not double-count
+# ---------------------------------------------------------------------------
+
+
+class TestClosedSeasonRanges:
+    """Fixtures in 2025 (180 min) AND 2026 (90 min); cross-season total = 270.
+    A season-scoped read never returns 270 — the pre-D1 open-ended ``date_utc >=``
+    filter would, the day 2026-27 fixtures land."""
+
+    def test_stats_match_log_scoped_per_season(self, app, client):
+        _seed_two_season_full_player()
+        rows_25 = client.get(f"/api/players/{FULL_PLAYER_API}/stats?season=2025").get_json()
+        rows_26 = client.get(f"/api/players/{FULL_PLAYER_API}/stats?season=2026").get_json()
+        assert len(rows_25) == 2 and sum(r["minutes"] for r in rows_25) == 180
+        assert len(rows_26) == 1 and sum(r["minutes"] for r in rows_26) == 90
+        # No season yields the union of both seasons' 3 matches / 270 minutes.
+        assert len(rows_25) + len(rows_26) == 3
+
+    def test_season_stats_aggregate_scoped_per_season(self, app, client):
+        _seed_two_season_full_player()
+        ss_25 = client.get(f"/api/players/{FULL_PLAYER_API}/season-stats?season=2025").get_json()
+        ss_26 = client.get(f"/api/players/{FULL_PLAYER_API}/season-stats?season=2026").get_json()
+        assert ss_25["minutes"] == 180 and ss_25["appearances"] == 2
+        assert ss_26["minutes"] == 90 and ss_26["appearances"] == 1
+        # Provenance minutes are season-scoped too — never the 270 cross-season sum.
+        assert ss_25["provenance"]["fixtures_minutes"] == 180
+        assert ss_26["provenance"]["fixtures_minutes"] == 90
+
+    def test_default_path_serves_a_single_season_not_the_sum(self, app, client):
+        # The no-param display path resolves to ONE season (which one depends on
+        # the wall clock relative to the Aug rollover); it must never fold both
+        # seasons together into 270.
+        _seed_two_season_full_player()
+        rows = client.get(f"/api/players/{FULL_PLAYER_API}/stats").get_json()
+        total = sum(r["minutes"] for r in rows)
+        assert total in (180, 90)
+        assert total != 270, "default path double-counted across seasons"
+
+        ss = client.get(f"/api/players/{FULL_PLAYER_API}/season-stats").get_json()
+        assert ss["minutes"] in (180, 90)
+        assert ss["minutes"] != 270
+
+
+# ---------------------------------------------------------------------------
+# 4. Provenance buckets (direct unit on _season_provenance)
+# ---------------------------------------------------------------------------
+
+
+class TestProvenanceBuckets:
+    """``_season_provenance(player, season)`` reconciles FPS senior minutes vs
+    PJE senior-season-total minutes into exactly one reconcile bucket."""
+
+    def test_cup_gap_gore_numbers(self, app):
+        # The real Gore 2025-26 shape: 2,583 league minutes from fixtures vs 2,936
+        # cup-inclusive minutes from the journey summary → journey wins, cup-gap.
+        from src.models.league import db
+        from src.routes.players import _season_provenance
+
+        _add_fixture_stats(PROV_PLAYER_API, PROV_TEAM_API, 2025, [900, 900, 783], fx_base=9800)
+        _add_journey_entries(PROV_PLAYER_API, [(2025, 2936, False, False)])
+        db.session.commit()
+
+        prov = _season_provenance(PROV_PLAYER_API, 2025)
+        assert prov["fixtures_minutes"] == 2583
+        assert prov["journey_minutes"] == 2936
+        assert prov["source"] == "journey"
+        assert prov["reconcile_flag"] == "cup-gap"
+        assert prov["delta_pct"] == 12.0  # (2936-2583)/2936*100, 1dp
+
+    def test_fixtures_invisible_journey_only(self, app):
+        # Journey has senior minutes but no per-match fixtures exist for the
+        # player this season → the whole season is fixtures-invisible.
+        from src.models.league import db
+        from src.routes.players import _season_provenance
+
+        _add_journey_entries(PROV_PLAYER_API, [(2025, 1500, False, False)])
+        db.session.commit()
+
+        prov = _season_provenance(PROV_PLAYER_API, 2025)
+        assert prov["fixtures_minutes"] == 0
+        assert prov["journey_minutes"] == 1500
+        assert prov["source"] == "journey"
+        assert prov["reconcile_flag"] == "fixtures-invisible"
+        assert prov["delta_pct"] == 100.0
+
+    def test_journey_under_sync_fixtures_gt_journey(self, app):
+        # Fixtures prove MORE minutes than the (lagging) journey summary knows →
+        # fixtures win the headline, journey flagged as under-sync.
+        from src.models.league import db
+        from src.routes.players import _season_provenance
+
+        _add_fixture_stats(PROV_PLAYER_API, PROV_TEAM_API, 2025, [900, 600], fx_base=9820)
+        _add_journey_entries(PROV_PLAYER_API, [(2025, 1000, False, False)])
+        db.session.commit()
+
+        prov = _season_provenance(PROV_PLAYER_API, 2025)
+        assert prov["fixtures_minutes"] == 1500
+        assert prov["journey_minutes"] == 1000
+        assert prov["source"] == "fixtures"
+        assert prov["reconcile_flag"] == "journey-under-sync"
+        assert prov["delta_pct"] == -33.3  # (1000-1500)/1500*100, 1dp
+
+    def test_sources_agree_no_flag(self, app):
+        # Equal minutes → journey wins the tie (cup-inclusive convention) but
+        # there is nothing to reconcile, so no flag and zero delta.
+        from src.models.league import db
+        from src.routes.players import _season_provenance
+
+        _add_fixture_stats(PROV_PLAYER_API, PROV_TEAM_API, 2025, [900], fx_base=9840)
+        _add_journey_entries(PROV_PLAYER_API, [(2025, 900, False, False)])
+        db.session.commit()
+
+        prov = _season_provenance(PROV_PLAYER_API, 2025)
+        assert prov["source"] == "journey"
+        assert prov["reconcile_flag"] is None
+        assert prov["delta_pct"] == 0.0
+
+    def test_both_zero_source_none(self, app):
+        # Nothing seeded for the season → source "none", no flag.
+        from src.routes.players import _season_provenance
+
+        prov = _season_provenance(PROV_PLAYER_API, 2025)
+        assert prov == {
+            "source": "none",
+            "fixtures_minutes": 0,
+            "journey_minutes": 0,
+            "delta_pct": 0.0,
+            "reconcile_flag": None,
+        }
+
+    def test_journey_minutes_exclude_youth_international_and_other_seasons(self, app):
+        # Only the senior, in-season entry (900) counts. Youth (500) and
+        # international (400) 2025 entries and a prior-season 2024 senior (1000)
+        # entry are all excluded — so journey=900, and with no fixtures the bucket
+        # is fixtures-invisible.
+        from src.models.league import db
+        from src.routes.players import _season_provenance
+
+        _add_journey_entries(
+            PROV_PLAYER_API,
+            [
+                (2025, 900, False, False),  # counts
+                (2025, 500, True, False),  # youth — excluded
+                (2025, 400, False, True),  # international — excluded
+                (2024, 1000, False, False),  # prior season — excluded
+            ],
+        )
+        db.session.commit()
+
+        prov = _season_provenance(PROV_PLAYER_API, 2025)
+        assert prov["journey_minutes"] == 900
+        assert prov["fixtures_minutes"] == 0
+        assert prov["reconcile_flag"] == "fixtures-invisible"

--- a/academy-watch-backend/tests/test_season_d1_contract.py
+++ b/academy-watch-backend/tests/test_season_d1_contract.py
@@ -46,8 +46,10 @@ class _StubAPIClient:
 
 # Distinct id spaces per concern so a stray cross-test collision would be loud.
 FULL_PLAYER_API = 700700
+GK_PLAYER_API = 700701  # goalkeeper spanning two clubs across two seasons
 PARENT_API = 33
 LOAN_API = 777
+LOAN2_API = 778  # a second, later-season-only loan club
 OPP_API = 999
 
 PROV_PLAYER_API = 710710  # provenance-unit player (no TrackedPlayer needed)
@@ -108,9 +110,14 @@ def _team(api_id, name):
     return team
 
 
-def _add_fixture_stats(player_api_id, team_api_id, season, minutes_list, *, fx_base, goals=1, assists=0):
+def _add_fixture_stats(
+    player_api_id, team_api_id, season, minutes_list, *, fx_base, goals=1, assists=0, goals_conceded=None
+):
     """Seed one Fixture + one FixturePlayerStats per entry in ``minutes_list``,
-    all in ``season`` at ``team_api_id``. ``fx_base`` keys unique fixture ids."""
+    all in ``season`` at ``team_api_id``. ``fx_base`` keys unique fixture ids.
+    ``goals_conceded`` defaults to ``None`` (NULL) so existing callers are
+    byte-identical; pass ``0`` to seed a GK clean sheet that the clean-sheets
+    read (``goals_conceded == 0``) will count."""
     from src.models.league import db
     from src.models.weekly import Fixture, FixturePlayerStats
 
@@ -135,6 +142,7 @@ def _add_fixture_stats(player_api_id, team_api_id, season, minutes_list, *, fx_b
                 minutes=minutes,
                 goals=goals,
                 assists=assists,
+                goals_conceded=goals_conceded,
                 rating=7.0,
             )
         )
@@ -218,6 +226,51 @@ def _seed_two_season_full_player():
     )
     _add_fixture_stats(FULL_PLAYER_API, LOAN_API, 2025, [90, 90], fx_base=9700, goals=1)
     _add_fixture_stats(FULL_PLAYER_API, LOAN_API, 2026, [90], fx_base=9750, goals=1)
+    db.session.commit()
+
+
+def _seed_gk_two_seasons_two_clubs():
+    """A full-coverage on-loan GOALKEEPER whose fixtures make BOTH open-range
+    Q12 sites REVEAL a season-filter regression that the single-club/no-clean-
+    sheet seeds above cannot (both mutations stay green against them):
+
+    - **Clean-sheets** (team-filtered to the resolved-season club list): club A
+      (``LOAN_API``) keeps a clean sheet in BOTH seasons — 2025: two 90' clean
+      sheets, 2026: one 90' clean sheet. A 2025 read scoped by ``Fixture.season``
+      counts 2; reverting that one site to an open ``date_utc >=`` filter folds
+      in A's 2026 clean sheet and reports 3. Club A must appear in both seasons
+      or the club-list filter would mask the leak on its own.
+    - **Distinct-teams club list**: club B (``LOAN2_API``) plays a SINGLE 2026
+      fixture (a goal conceded — not a clean sheet, but still a distinct club).
+      A 2025 read's club set is therefore ``{A}`` (``has_multiple_clubs`` False);
+      an open-range revert leaks B in and flips ``has_multiple_clubs`` / the
+      ``loan_team`` label.
+    """
+    from src.models.league import db
+    from src.models.tracked_player import TrackedPlayer
+
+    parent = _team(PARENT_API, "Parent FC")
+    _team(LOAN_API, "Loan FC")
+    _team(LOAN2_API, "Loan FC 2")
+    _team(OPP_API, "Opponent FC")
+    db.session.add(
+        TrackedPlayer(
+            player_api_id=GK_PLAYER_API,
+            player_name="Keeper Guy",
+            position="Goalkeeper",
+            team_id=parent.id,
+            status="on_loan",
+            current_club_api_id=LOAN_API,
+            current_club_name="Loan FC",
+            data_depth="full_stats",
+            is_active=True,
+        )
+    )
+    # Club A: clean sheets in BOTH seasons (2 in 2025, 1 in 2026).
+    _add_fixture_stats(GK_PLAYER_API, LOAN_API, 2025, [90, 90], fx_base=9900, goals=0, goals_conceded=0)
+    _add_fixture_stats(GK_PLAYER_API, LOAN_API, 2026, [90], fx_base=9950, goals=0, goals_conceded=0)
+    # Club B: one 2026 appearance, a goal conceded (a distinct 2026-only club).
+    _add_fixture_stats(GK_PLAYER_API, LOAN2_API, 2026, [90], fx_base=9980, goals=0, goals_conceded=1)
     db.session.commit()
 
 
@@ -436,6 +489,43 @@ class TestClosedSeasonRanges:
         ss = client.get(f"/api/players/{FULL_PLAYER_API}/season-stats").get_json()
         assert ss["minutes"] in (180, 90)
         assert ss["minutes"] != 270
+
+    def test_clean_sheets_scoped_per_season(self, app, client):
+        # The clean-sheets read is the third Q12 site and is team-filtered to the
+        # resolved-season club list, so a cross-season leak is only observable
+        # when the SAME club keeps clean sheets in a later season. Club A does
+        # (1 in 2026), so a 2025 read must count exactly its two 2025 clean
+        # sheets; an open-ended ``date_utc >=`` revert of THIS site alone would
+        # fold in A's 2026 clean sheet and report 3.
+        _seed_gk_two_seasons_two_clubs()
+        ss_25 = client.get(f"/api/players/{GK_PLAYER_API}/season-stats?season=2025").get_json()
+        ss_26 = client.get(f"/api/players/{GK_PLAYER_API}/season-stats?season=2026").get_json()
+        assert ss_25["clean_sheets"] == 2, "2025 clean sheets must exclude the club's 2026 clean sheet"
+        # 2026: club A's clean sheet + club B's goal-conceded appearance = 1.
+        assert ss_26["clean_sheets"] == 1
+
+    def test_distinct_club_list_scoped_per_season(self, app, client):
+        # The distinct-teams club list is the fourth Q12 site. Club B plays ONLY
+        # in 2026, so a 2025 read's club set is {A}: has_multiple_clubs False,
+        # loan_team "Loan FC". An open-range revert leaks B into 2025 and flips
+        # both. 2026 legitimately spans both clubs.
+        _seed_gk_two_seasons_two_clubs()
+        ss_25 = client.get(f"/api/players/{GK_PLAYER_API}/season-stats?season=2025").get_json()
+        assert ss_25["loan_team"] == "Loan FC"
+        assert ss_25["has_multiple_clubs"] is False, "the 2026-only club must not leak into the 2025 club set"
+
+        ss_26 = client.get(f"/api/players/{GK_PLAYER_API}/season-stats?season=2026").get_json()
+        assert ss_26["has_multiple_clubs"] is True
+
+        # The /stats match log for 2025 shows only club A's rows (season-scoped);
+        # 2026 spans two distinct clubs (club B's name resolves via the team
+        # resolver, so assert distinctness rather than pinning its label).
+        rows_25 = client.get(f"/api/players/{GK_PLAYER_API}/stats?season=2025").get_json()
+        assert {r["loan_team_name"] for r in rows_25} == {"Loan FC"}
+        rows_26 = client.get(f"/api/players/{GK_PLAYER_API}/stats?season=2026").get_json()
+        assert len(rows_26) == 2
+        assert len({r["loan_team_name"] for r in rows_26}) == 2
+        assert "Loan FC" in {r["loan_team_name"] for r in rows_26}
 
 
 # ---------------------------------------------------------------------------

--- a/ledgers/research/season-data-coverage.md
+++ b/ledgers/research/season-data-coverage.md
@@ -1,0 +1,150 @@
+# Season Data Coverage — Phase B synthesis (input to Phase C design panel)
+
+Written 2026-07-07 by season-discovery synthesis agent. Inputs: Sweep 1 (season assumptions),
+Sweep 2 (stats surfaces), Sweep 3 (API-Football capability), prod coverage audit (read-only
+SELECTs against snqwamzutbcbjgusubsa). Season values = START YEARS (2025 = 2025-26).
+`[UNIFY]` = already in Phase A scope (`feat/season-foundation`): `utils/academy_window.py`,
+`routes/players.py:75,:438`, `transfer_heal_service.py:265` + P0 read-path season-scoping.
+
+## 1. Data availability matrix (source × seasons × granularity × trust)
+
+| Source | Seasons (prod) | Granularity | Trust / caveats |
+|---|---|---|---|
+| `fixtures` + `FixturePlayerStats` | **2025 ONLY** (20,349 fx / 211 comps, 2025-08-01→2026-06-10; 98,565 FPS rows, 4,726 players, 4.75M min) | Per-match, rich fields | Best where covered, but: 34 comps ≥75% covered (77% of minutes), 43 partial (domestic cups: FA Cup 80/270 fx), **134 comps zero coverage** (all youth/reserve + lower/foreign divisions). `Fixture.season` column exists; almost no read path filters on it |
+| `PlayerStatsCache` | **0 rows (EMPTY)** | (per-player season cache, by design) | **Vestigial.** 100% of active tracked rows are `data_depth='full_stats'` → nothing routes to it. The 3-tier provenance model in code/docs is a 2-tier model in prod. Do NOT design around it being populated |
+| `PlayerJourneyEntry` | **2007–2027** (77,355 rows, 5,916 journeys; 2025 = 8,781 entries / 3,244 players / 3.58M min; 2026 = 740 pre-season noise) | Season totals per (club, league, season) — **4 fields only**: apps/goals/assists/minutes; `is_youth` flag | Sole pre-2025 source. Per covered player it is MORE complete than fixtures (cups + uncovered leagues) but **lags the just-ended season** (sync gap). Club IDs corrected from transfers at sync time |
+| `AcademyAppearance` | **0 rows (EMPTY)** | (per-youth-match, by design) | **Exclude from design.** CLAUDE.md/architecture.md still describe it as the youth-stats source — stale; `/players/<id>/academy-stats` actually reads APSS with AA as unused fallback |
+| `AcademyPlayerSeasonStats` | 2023 (2,640 rows/1,664p/1.13M min), 2024 (2,607/1,572/737k), **2025 near-empty** (363/728 min); table STALE (updated 2026-04-01/02) | Per-season/competition youth, rich extended fields (shots/passes/tackles) | Additive, not redundant (only 101 of its 2025 players overlap fixtures). Needs fresh 2025-26 sync before usable for current season |
+| `PlayerShadowStats` | Per-season (worldwide shadow) | Season totals | Latest-season picked via `max(season)`; digest + season-stats fallback |
+| **API-Football backfill options (unused/under-used)** | | | Rough call cost (Sweep 3; quota-gated by optional `API_FOOTBALL_DAILY_LIMIT`; cache hits free) |
+| — Wider extraction of `players?id&season` | any career season | Per (club, league, season): rating, position, shots, passes, tackles, duels, dribbles, cards, penalties, saves, GC | **ZERO new calls** — payload already fetched every journey sync; `_create_entry_from_stat` currently discards all but 4 fields |
+| — Journey re-sync / totals backfill | any career season | Season totals | **~N+2 live calls/player** (players/seasons + transfers + 1/season; N≈2–5 young, 8–15 senior). `api_cache` player TTL only 7 days + pg_cron purge → NOT a durable archive; durable store = PJE rows |
+| — Per-match historical crawl | any past season | Full FPS-grade per-match | **~40–60 calls per team-season** (`fixtures?team&season` + `fixtures/players` per fixture), amortized across roster; 10-yr immutable cache once fetched. Fixtures-2025-only is a coverage state, not a client limit |
+| — Never called (UNVERIFIED from docs knowledge) | | | `players/topscorers|topassists`, `sidelined`, `trophies`, `players/teams`. Discovery endpoints already in place: `players/seasons`, `teams/seasons`, `leagues?id&season` coverage flags — use to gate backfills |
+
+**Cross-input conflicts, stated explicitly:**
+- Docs (CLAUDE.md, architecture.md) vs prod: AcademyAppearance and PlayerStatsCache are described as live tiers; both are **empty**. Docs need correction; design is fixtures+journey (+APSS for youth).
+- Aggregate vs per-player 2025 completeness: headline says fixtures > journey for 2025 (4,726 vs 3,244 players) while Q4 says journey ≥ fixtures for most players — **both true, different scopes**: FPS includes non-tracked players and journey 2025 sync lags; per active-player-with-data, journey is usually the bigger, more complete number. Provenance must therefore be per-player-per-season, not global.
+
+## 2. What each product view can honestly show
+
+**25/26 vs 26/27 compare (fixtures-fed going forward).** Honest per-match comparison only once
+26/27 fixtures land (per-match sync continues). Requires `Fixture.season` filters (Phase A P0) +
+explicit `?season` params. The 25/26 side from fixtures **understates** ~40% of players (cup gap)
+and misses 375 players entirely (§3) — for season-total minutes the honest 25/26 number is journey
+(after re-sync). Before 26/27 fixtures exist, the compare must render "season not started", never
+blanks (Aug-1 bomb, Phase A P4 fallback = "latest season with fixtures", GOL `max(season)` pattern).
+
+**Past-X-years development (journey-fed).** Real depth among 3,544 distinct active tracked players
+(all have a journey): **≥2 seasons 3,121 (88%) · ≥3 2,575 (73%) · ≥4 1,956 (55%) · ≥5 1,266 (36%)**.
+(All journeys: 5,916 / 5,309 / 4,595 / 3,791 / 2,850.) Granularity is season totals, 4 fields; a
+richer development view (rating/shots/cards trends) costs zero extra API calls via wider extraction
+on re-sync. Per-match history pre-2025 exists only via team-season crawl (40–60 calls/team-season).
+Journey 2025 must be re-synced before it is authoritative for the season just ended (26 players
+currently have fixtures > journey = under-sync marker).
+
+**Youth overlay (AcademyAppearance reality).** AA is empty — the overlay CANNOT use it. Honest
+sources: (a) journey `is_youth` entries — broad, 2016–2024 substantial (2023=7,971, 2024=6,861,
+2025=1,920 entries so far), apps/goals/minutes per youth club-season; (b) APSS — deep stats but
+**2023 + 2024 only**, stale, 2025 near-zero pending fresh sync. Today's honest youth overlay =
+journey youth season totals for all years + deep APSS panels for 23/24 & 24/25 only, labeled.
+
+## 3. Consistency findings → provenance-labeling requirement
+
+Fixture-vs-journey minutes, season 2025, active players (journey club entries, internationals
+excluded). Of **1,071** active players with any 2025 senior minutes in either source:
+
+| Bucket | Players | Σ fixture min | Σ journey min |
+|---|---|---|---|
+| equal ±5% | 232 (22%) | 193,823 | 194,808 |
+| journey higher 5–25% (cup gap) | 215 | 297,401 | 355,317 |
+| journey higher >25% | 219 | 134,187 | 246,826 |
+| **journey-only (fixtures-invisible)** | **375 (35%)** | 0 | 225,169 |
+| fixture higher >5% (journey under-synced) | 26 | 29,042 | 21,933 |
+| fixture-only | 4 | 172 | 0 |
+
+Plus 2,473 active players both-zero (deep academy / departed; their only football is in
+zero-coverage youth leagues). Anchor case: Gore 303010 = 2,583 fixture min vs 2,936 journey
+(matches scout ledger exactly).
+
+**Requirement (non-negotiable for Phase C):** for **~78% of players-with-data the two sources
+materially disagree** — provenance is not cosmetic. Every season figure must carry a per-season,
+per-source provenance tag (`fixtures-full` | `journey-totals` | `apss-youth` | `shadow` |
+`cache-limited`), stored in the rollup and surfaced in the UI. `/players/<id>/season-stats`
+already returns a `source` field — extend that contract platform-wide. Never silently COALESCE
+(scout `_base_scout_query` does fps→cache today). Display policy: per-match views = fixtures;
+season-total minutes = journey where journey ≥ fixtures; fixtures>journey = re-sync flag, not a
+preference flip. Where both exist, consider surfacing the delta ("2,583 tracked / 2,936 incl. cups").
+
+## 4. Season-assumption debt (beyond the Phase A unification)
+
+From Sweep 1; semantics: AUG=`month>=8`, JUL=`month>=7`, RAWYR=`now().year` no guard, NONE=no scoping,
+MAX=implicit latest. Phase A already covers academy_window / players.py:75,:438 / transfer_heal:265 + P0.
+
+| Category | Sites | Semantic | Multi-season failure |
+|---|---|---|---|
+| Stat aggregation, no season filter | `tracked_player.py:132-147` compute_stats; `scout.py:160-174,301-315`; `teams.py:392-403` loans agg; `api.py:12373-12388,12438-12453` team-players agg; `journalist.py:2551-2557`; `graph_service.py` | NONE | Silent cross-season double-count the day 2026 fixtures land |
+| Latest-only cache reads | `tracked_player.py:104-114`; `scout.py:177-205` | MAX | No way to request a specific season |
+| Calendar/split-year league blindness | `supported_leagues.py:29-51` (no season_type field; Brazil 71, Argentina 128, MLS 253, Liga MX 262, J1 98); `api_football_client.py:356,366,378,2745`; `weekly_newsletter_agent.py:2454,2643,2918,1843`; `api.py:1511,5027,5434,6076` | AUG hardwired | Aug1–Jun30 window straddles two calendar-year seasons, misses Feb–Jul matches worldwide |
+| Jul-vs-Aug epoch split (~30 sites) | AUG: `api_football_client.py:348` (central default), `teams.py:506,963`, `journalist.py:2507`, `gol_service.py:441`, `player_shadow_service.py:57-62`, `weekly_agent.py:856`, `weekly_newsletter_agent.py:3497`, `api.py:4597,4998,5292,5999,11795,11903,12033`, `academy_sync_service.py:19-28` · JUL: `gameweeks.py:19-26`, `team_verify.py:37-40`, `radar_stats_service.py:580,712`, `journalist.py:1149,1886`, `api.py:3775` | AUG/JUL | June–Aug split-brain: profile vs radar vs chart vs academy disagree by one season |
+| Journey vs stats boundary | `journey_sync.py:508-531,514-515,732,1072` uses Jul 1; stats paths use Aug 1 | JUL vs AUG | July transfers/loans land in different seasons per code path |
+| Raw-year proxies | `journey_sync.py:189`; `academy_classifier.py:889` (feeds released-mislabel bug); `cohort_service.py:250`, `cohort.py:179`; `big6_seeding_service.py:328`, `api.py:10267,10291` | RAWYR | Off-by-one season Jan–Jul |
+| Implicit-latest Team/season resolution | `gol_dataframes.py:61,126`; `api.py:9734`; `players.py:518`, `scout_digest_service.py:83`; team_resolver/slug/gol_player_lookup/journey_sync latest-Team lookups; `rebuild_runner.py:179,270,294` | MAX | Hides older seasons; needs explicit-season variants |
+| Open-ended date ranges | `players.py:439,572,689,721` (`date_utc >= season_start`, no upper bound) `[UNIFY-adjacent]`; `weekly_newsletter_agent.py:2930` | AUG, one-sided | Sums 2025+2026 once new fixtures land — upper bound is a separate defect from P4 |
+| Hardcoded literals | `big6_seeding_service.py:38` SEASONS=[2020..2024]; `league.py:28` Team.season default=2024; `api_football_client.py:1799,1862,2061` season=2025 defaults; `api.py:5797,6812`; `data/transfer_windows.py:16-22` **stops at 2025-26** (26/27 heal has no window data); `backfill_tracked_player_stats.py:113` | literal | Caps the season horizon; must become data-driven |
+| Mutation-on-read | `academy_sync_service.py:42-52` overwrites `AcademyLeague.season` to current | AUG | Historical sync silently re-labels stored season |
+
+## 5. Surface inventory summary (endpoints/pages needing a season parameter)
+
+**Backend — must gain `?season` + season-scoped SQL:** `/players/<id>/stats` (players.py:54);
+`/players/<id>/season-stats` (:427 — cleanest template, currently hard-wired current);
+`/scout/players`, `/scout/leaderboards`, `/scout/compare`, `/scout/export.csv` (all all-time-at-CCAI);
+`/teams/<id>/players` (api.py:12323 — TeamDetailPage squad); `/teams/<id>/loans` (season param read
+but UNUSED for stats) + `/teams/<id>/loans/season/<season>` (slug only, never filters);
+`/journalists/chart-data` (date_range=season wall-clock only) + `/journalists/players/<id>/stats`;
+`/teams/<id>/trajectory` (has `?years` but no season anchor). Already parameterized (extend, don't
+break): teams.py:113,150,353,963; players.py:757 radar; availability :757; feeder (required);
+cohort :250; academy :75,256; several api.py admin routes. `journalist._get_season_stats:738-771`
+is the one internal helper already accepting a season — generalize it.
+
+**api.js:** only `getPlayerAvailability` forwards a season today. Need season args through:
+`getPublicPlayerStats`, `getPublicPlayerSeasonStats`, `getScoutPlayers/Leaderboards`,
+`compareScoutPlayers`, `downloadScoutCsv`, `getChartData`, `getPlayerStats`, `getTeamPlayers`,
+`getTeamLoans`, `getPlayerAcademyStats`.
+
+**Frontend pages needing a season selector / provenance labels:** PlayerPage (seasonTotals mixes
+season-scoped + all-time fallback under one heading), ScoutPage (compare section **labeled
+"Season", is all-time-at-CCAI**), TeamDetailPage (squad stats all-time; `?season` only reaches the
+constellation), WatchlistPage, GOL PlayerPreviewDrawer (**"Season stats" heading over all-time
+array**), writer PlayerStatsDrawer ("Season Totals" over all-time log), newsletter chart chain.
+Eight "lying" surfaces enumerated in Sweep 2 Part 4 — fixing the label is part of the season work,
+not polish. Season-native already (build on): journey map/SeasonStatsPanel, cohort pages, GOL
+dataframes (`f.season` joined — the only natively season-aware analytics).
+
+## 6. Open questions for the Phase C design panel
+
+1. **Rollup grain:** per (player, team, season) or (player, team, season, competition)? Journey is
+   per-league already; cup-vs-league splits are where provenance diverges.
+2. **Provenance precedence & display:** when fixtures and journey disagree for the same
+   player-season, which is primary, and is the delta shown? Per-surface policy (per-match vs totals)?
+3. **Canonical boundary:** Jul 1 vs Aug 1 vs per-league `season_start_month`? What migrates the
+   Jul-journey/Aug-stats split, and do we ship Euro-only first with calendar-year leagues
+   (Brazil/MLS/Argentina/Liga MX/J1) explicitly deferred or modeled now?
+4. **Current-season resolution:** wall-clock vs "latest season with fixtures" fallback — one global
+   policy or per-surface (e.g., compare wants wall-clock, scout wants latest-with-data)?
+5. **Season API contract:** `?season=<int start-year>` everywhere — how do split-season leagues
+   (Apertura/Clausura) and the `YYYY-YY::WINDOW` transfer-key format fit?
+6. **Journey 2025 re-sync:** required before journey is authoritative for 25/26 (fixtures currently
+   richer; 26 players fixtures>journey). Sequence vs rollup backfill? Off-container prod op — MJ gate.
+7. **Wider extraction:** add rich per-season fields to PJE columns vs a new rollup table fed from
+   the same `players?id&season` payload? (Zero extra calls either way; schema choice matters.)
+8. **Per-match historical backfill:** wanted at all (~40–60 calls/team-season, durable 10-yr cache)?
+   If so, which teams/seasons (e.g., tracked-club top leagues 2022–2024)?
+9. **PlayerStatsCache tier:** delete from the design (empty, nothing routes to it) or keep as a
+   future limited-league ingest path? Same question for reviving vs removing AcademyAppearance.
+10. **Youth in the rollup:** unified table with `is_youth`/level, or separate youth rollup? Fresh
+    APSS 2025-26 sync is a prerequisite for deep youth stats either way.
+11. **Hardcoded horizon debt:** who owns making SEASONS lists, Team.season default, season=2025
+    defaults, and `transfer_windows` (missing 2026-27) data-driven — Phase C schema or Phase D chores?
+12. **Open-ended `date_utc >=` upper bounds** (players.py:439 etc.): fold into Phase A P0 or track
+    as separate Phase D items? They double-count the moment 26/27 fixtures land even if labeled.

--- a/ledgers/research/seasons-design-proposal.md
+++ b/ledgers/research/seasons-design-proposal.md
@@ -1,0 +1,249 @@
+# Seasons System — Final Design Proposal (Phase C synthesis)
+
+Written 2026-07-07 by the season-design-panel SYNTHESIS agent. Inputs: 3 competing designs
+(rollup-first / compute-on-read / journey-canon) × 3 judge lenses (correctness / operations /
+product). Season values = START YEARS (2025 = 2025-26). Verified against main: Alembic head
+= **aw23** (vid03 → aw21 → aw22 → aw23), PJE grain = `uq_journey_entry (journey_id, season,
+club_api_id, league_api_id)`, `fixture_player_stats.player_api_id` has NO standalone index.
+
+## 1. Chosen architecture and why
+
+**Winner: the rollup-first skeleton** — a precomputed, provenance-tagged per-player-per-season
+read surface (fine source-cells table + coarse totals table), written only by sync hooks and
+rebuild jobs, read by every hot path. It won on fatal-flaw asymmetry, not averages. Its judged
+flaws are all graftable fixes: the wrong migration head (real head is aw23), upsert-only feeders
+that orphan cells after journey club-ID corrections, a precedence rule that headlined stale
+journey numbers mid-season, an Aug-1 resolver keyed on noisy rollup seasons, and a cup-fold
+cross-source double-count. The losers' fatal flaws are structural to their theses: compute-on-read
+leaves the Scout Desk fixtures-only forever (375 fixtures-invisible players — 35% of players with
+2025 data, 225k real minutes — rank at ZERO, with the fix gated behind a performance condition a
+coverage defect never triggers), and journey-canon rebuilds its rollup only inside journey sync,
+so every totals surface freezes for the whole live season and the new season starts empty each
+August (fixable only by quota-prohibitive weekly re-syncs). On a 0.5 CPU box with a documented
+read-saturation incident, "every hot surface is one indexed row" is the only shape that stays
+cheap as FPS grows ~100k rows/season — and it is the only design where fixtures-invisible players,
+cup-inclusive totals, and historical seasons all work on list surfaces.
+
+**Grafted onto the skeleton** (every judge-flagged flaw resolved): (a) journey-canon's
+DELETE+INSERT per-(player, source) rebuild inside the same transaction as the source write, plus
+an admin rebuild-all endpoint — the rollup is a reconstructable cache, never a second truth;
+(b) compute-on-read's display rule — when fixtures > journey the HEADLINE is the larger
+per-match-proven fixtures figure + a visible `journey-under-sync` flag (rollup-first's rule 3 is
+rejected: never show a number our own match data disproves); (c) a **never-cross-source-sum**
+aggregation rule (per-source totals, larger source wins whole) that eliminates the cup-fold
+double-count by construction; (d) the season default resolver stays keyed on FIXTURES via Phase
+A's `stats_season_with_data` — never on MAX(rollup.season), which PJE pre-season noise (740
+season-2026 stub rows) would poison; (e) PJE is widened with the free rich fields (durable
+archive; api_cache TTL is 7 days) and the extraction code ships BEFORE the MJ-gated 2025 re-sync;
+(f) journey-canon's `league_season_config` + `level_group` axis and semantic reconcile-flag enum;
+(g) compute-on-read's zero-migration PR1 (?season plumbing + Q12 date fixes + `ix_fps_player`)
+ships first so users get season-scoped, provenance-labeled data before any new table exists;
+(h) rollup-first's own keepers: fixtures-fed incremental refresh (centralized at ONE choke point
+— FPS is written from ≥4 code paths), the dual-number provenance columns, and the
+`SEASON_ROLLUP_READS` env-flag per-surface cutover with Phase-A paths as instant rollback.
+
+## 2. Data model (DDL sketch — all guarded via `migrations/_migration_helpers`, RLS in-migration)
+
+**Migration `sea01`** (`down_revision = "aw23"`) — widen PJE + missing indexes. No new tables.
+```
+ALTER player_journey_entries ADD (all nullable; add_column_safe):
+  player_api_id INT,                      -- denormalized from journey; backfilled off-path
+  rating FLOAT, position VARCHAR(10), lineups INT,
+  shots_total INT, shots_on INT, passes_total INT, passes_key INT, passes_accuracy INT,
+  tackles_total INT, tackles_blocks INT, tackles_interceptions INT,
+  duels_total INT, duels_won INT, dribbles_attempts INT, dribbles_success INT,
+  fouls_drawn INT, fouls_committed INT, cards_yellow INT, cards_red INT,
+  penalty_scored INT, penalty_missed INT, penalty_saved INT, goals_conceded INT, saves INT,
+  stats_source VARCHAR(24) DEFAULT 'legacy-basic',  -- 'journey-api'|'legacy-basic'|'manual'
+  stats_synced_at TIMESTAMPTZ, season_phase VARCHAR(12)  -- dormant Apertura/Clausura hook
+CREATE INDEX ix_fps_player ON fixture_player_stats (player_api_id);   -- verified missing
+CREATE INDEX ix_pje_player_season ON player_journey_entries (player_api_id, season);
+```
+`player_api_id` backfill (77k rows) runs as a batched admin endpoint post-deploy, NOT inside the
+migration (ops-judge requirement). PJE already has RLS; ADD COLUMN doesn't touch it.
+
+**Migration `sea02`** (`down_revision = "sea01"`) — the rollup pair + league config.
+```
+player_season_cells                       -- fine grain: one row per SOURCE-contributed cell
+  id BIGINT PK, player_api_id INT NOT NULL, season INT NOT NULL,
+  source VARCHAR(12) NOT NULL,            -- 'fixtures'|'journey'|'apss'|'shadow'|'cache'
+  club_api_id INT NOT NULL, club_name VARCHAR(200),
+  competition_tier VARCHAR(20) NOT NULL,  -- league|domestic_cup|league_cup|continental|other|youth
+  level_group VARCHAR(13) NOT NULL,       -- 'senior'|'youth'|'international'
+  appearances INT, goals INT, assists INT, minutes INT, yellows INT, reds INT,
+  saves INT, goals_conceded INT,
+  avg_rating NUMERIC(4,2),                -- minutes-weighted WITHIN this source only
+  detail JSONB,                           -- shots/passes/tackles/duels/dribbles (rich fields)
+  synced_at TIMESTAMPTZ NOT NULL,
+  UNIQUE (player_api_id, season, source, club_api_id, competition_tier),
+  INDEX ix_psc_player_season (player_api_id, season); RLS ENABLED
+
+player_season_totals                      -- coarse grain: the single hot-read row
+  id BIGINT PK, player_api_id INT NOT NULL, season INT NOT NULL,
+  level_group VARCHAR(13) NOT NULL,       -- senior|youth|international (Q10)
+  appearances INT, goals INT, assists INT, minutes INT, yellows INT, reds INT,
+  saves INT, goals_conceded INT,
+  avg_rating NUMERIC(4,2),                -- ALWAYS fixtures-sourced, minutes-weighted
+  primary_source VARCHAR(12) NOT NULL,    -- source whose totals won the headline
+  fixtures_minutes INT, journey_minutes INT,   -- both raw values, always
+  reconcile_flag VARCHAR(20),             -- NULL|'cup-gap'|'journey-under-sync'|'fixtures-invisible'
+  source_breakdown JSONB, clubs JSONB,    -- per-source minutes; compact per-club render array
+  computed_at TIMESTAMPTZ NOT NULL,
+  UNIQUE (player_api_id, season, level_group),
+  INDEX ix_pst_season_group (season, level_group), INDEX ix_pst_player (player_api_id, season);
+  RLS ENABLED
+
+league_season_config                      -- "what season is NOW" per league (Q3)
+  league_api_id INT PK, season_type VARCHAR(12), rollover_month INT; RLS ENABLED
+  seed: (71,'calendar',1),(128,'calendar',1),(253,'calendar',1),(262,'calendar',1),(98,'calendar',1)
+```
+**Aggregation rule (the double-count guard, non-negotiable):** totals NEVER sum across sources.
+Per (player, season, level_group): compute each source's own total; headline = the source with
+larger minutes, taken WHOLE (journey wins ties/≥ — cup-inclusive convention; fixtures wins when
+strictly larger → `journey-under-sync`). Flags: journey > fixtures > 0 → `cup-gap`; fixtures = 0 →
+`fixtures-invisible`. Rich fields + per-90s always pair fixtures numerators with fixtures_minutes.
+**Noise filter:** feeders skip source rows with 0 apps AND 0 minutes AND 0 goals (kills the 740
+PJE 2026 pre-season stubs); selectors list only seasons with an active totals row.
+Anchor test (gates everything): Gore 303010 season 2025 senior → minutes 2,936, primary_source
+journey, fixtures_minutes 2,583, flag cup-gap; per-match log unchanged.
+
+## 3. Sync / backfill plan (write path + sequencing of MJ-gated ops)
+
+**Steady state — two hooks + one safety net, all pure-DB per-player (sub-second, container-safe):**
+1. `season_rollup_service.refresh_player(player_api_id, season=None)` — DELETE+INSERT that
+   player's cells per source, then re-resolve totals, in one transaction. Called from:
+   (a) **one FPS choke point**: a single function every FixturePlayerStats writer calls
+   (api_football_client, stats_parser, weekly_newsletter_agent, api.py routes all route through
+   it) — this is what keeps 26/27 fresh weekly at zero API cost and creates new-season rows the
+   moment fixtures land; (b) **end of `JourneySyncService.sync_player`** (after
+   `_merge_corrected_duplicates`), same transaction — club-ID corrections can never orphan cells.
+2. `_create_entry_from_stat` widened to persist the rich fields + `stats_source='journey-api'` +
+   `stats_synced_at` (zero extra API calls — payload already fetched, currently discarded).
+3. Safety net: `POST /api/admin/season-rollup/rebuild?scope=stale|player|season|all` (batched,
+   idempotent) + a rows-behind gauge (MAX(source.updated_at) vs totals.computed_at) on the admin
+   sandbox. Nightly stale-only sweep scheduled against the admin endpoint — drift is measurable
+   and one rebuild from fixed, because every derived row is a pure function of FPS+PJE+APSS.
+
+**Backfill sequencing (value before spend; each step gated as marked):**
+- **B0** (deploy): sea01+sea02 migrations; batched PJE `player_api_id` backfill endpoint. No API.
+- **B1** (pure DB, off-container or scaled per invariants §7, no MJ quota gate): cold-build —
+  journey cells from all 77k PJE rows (basic 4 fields), fixtures cells from 98,565 FPS rows
+  (season 2025, rich detail + rating), shadow cells; resolve all totals. Platform-wide multi-season
+  data goes live HERE, before any API spend. Then the 20-player pilot validation (incl. Gore).
+- **B2 [MJ-GATED, off-container]**: journey 2025-26 re-sync (~3,544 active players × ~N+2 live
+  calls). MUST run after the wider-extraction code is deployed so one pass banks corrected 25/26
+  totals AND rich fields AND the P3 status repair (invariants §7 playbook: scale to 1.0 CPU/2Gi/
+  min-2 or ACA job direct-to-DB; health-gate, abort on first `000`). Rollup self-updates via hook.
+  Until B2 lands, the 26 under-synced players display their (larger) fixtures figure + flag — the
+  system is honest without the re-sync; B2 upgrades it.
+- **B3 [MJ-GATED, off-container]**: APSS 2025-26 sync → apss cells → deep youth panels. Parallel
+  to / independent of B2; blocks only the deep-youth overlay, nothing senior.
+- **B4 (deferred, not designed in)**: per-match historical crawl (~40–60 calls/team-season). The
+  resolver auto-upgrades a season's provenance to fixtures if its FPS ever lands — zero code change.
+
+## 4. API contract
+
+- `?season=<int start-year>` on: `/players/<id>/stats`, `/players/<id>/season-stats`,
+  `/scout/players|leaderboards|compare|export.csv`, `/teams/<id>/players|loans|trajectory`,
+  `/journalists/chart-data`, `/journalists/players/<id>/stats`. Validation via new
+  `academy_window.season_bounds()` → 400 outside [min season with data, current_stats_season()+1].
+- Defaults via ONE resolver `resolve_stats_season(db, requested=None, surface="discovery")`:
+  `discovery` → `stats_season_with_data` (fixtures-keyed — the graft; never rollup/PJE-keyed);
+  `compare` → `current_stats_season` wall-clock, NO fallback (UI renders "season not started");
+  sync paths keep `current_stats_season`. Aug 1: discovery stays on 25/26 until real 26/27
+  fixtures land; the fixtures hook then creates 2026 totals rows the same week.
+- New: `GET /players/<id>/seasons` → `{seasons:[{season, sources:[], has_senior, has_youth}]}`
+  (noise-filtered); `GET /players/<id>/season-history?from&to&level_group=` → totals rows desc
+  (development view, one indexed scan); `?seasons=2025,2026` on compare endpoints.
+- Every season figure carries the provenance object (extends the existing `/season-stats`
+  `source` field): `{source, fixtures_minutes, journey_minutes, delta_pct, reconcile_flag,
+  breakdown}`. Never silently COALESCE — scout's fps→cache COALESCE is retired at cutover.
+- Split-season leagues: one API-Football season int (correct today); dormant `season_phase` for a
+  future `&phase=`. `YYYY-YY::WINDOW` transfer keys are a transfer-axis concern — untouched.
+
+## 5. UI plan
+
+- **SeasonSelector** (shared component; PlayerPage, ScoutPage, TeamDetailPage, WatchlistPage, GOL
+  drawer, writer drawer): fed by `/players/<id>/seasons` (or DISTINCT totals seasons for lists),
+  labels "2025/26" (calendar leagues "2025" via `league_season_config`), default = resolver.
+  **URL-bound (`?season=`)** — shareable, back-button-safe (compute-on-read graft).
+- **Provenance badges everywhere a figure renders**: "2,583 in league · 2,936 incl. cups" when
+  `cup-gap`; chips map 1:1 to `reconcile_flag` (`journey-under-sync` → "re-sync pending", visible
+  to all, not admin-only); tooltip shows `breakdown`. This retires the 8 "lying" surfaces —
+  relabeling is in-scope work, not polish.
+- **Compare card** (PlayerPage, ScoutPage): two columns via `?seasons=`, per-metric delta arrows,
+  empty side renders "Season not started" (never blanks).
+- **Development view** (PlayerPage): per-season strip from `/season-history` — minutes bars +
+  goal-contribution + rating sparkline (post-B2), youth track muted (level_group), APSS deep
+  panels expandable where 23/24–25/26 data exists, "rich stats syncing" hint where PJE rich = NULL.
+- `api.js`: thread `season` through the 10 methods in coverage map §5; add `getPlayerSeasons`,
+  `getPlayerSeasonHistory`, compare variants.
+
+## 6. Answers to the 12 coverage-map questions
+
+1. **Grain:** cells = (player, season, SOURCE, club, competition_tier); totals = (player, season,
+   level_group). Source in the unique key means feeders never collide; PJE stays the durable
+   per-(club,league) archive underneath.
+2. **Precedence/display:** never cross-source sum. Larger-minutes source wins the headline whole
+   (journey on ≥ — cup-inclusive; fixtures when > — with visible `journey-under-sync` flag, never
+   an understated headline). Rich/per-match fields always fixtures-sourced with fixtures
+   denominators. Both raw values + delta always in the provenance object.
+3. **Boundary:** no third epoch. Academy window stays Jul; stats display stays Aug via the one
+   resolver; storage is boundary-immune (API-Football labels). Calendar-year leagues modeled NOW
+   via `league_season_config` (labels + per-league "current" resolution); Euro-first behavior.
+4. **Current-season resolution:** one resolver, per-surface policy — discovery = fixtures-keyed
+   latest-with-data; compare = wall-clock, no fallback; sync = wall-clock. Never rollup-keyed.
+5. **API contract:** `?season=<int>` pass-through + `season_bounds()` validation; `?seasons=` for
+   compare; `/seasons` + `/season-history` for multi-season. Apertura/Clausura = one int +
+   dormant `season_phase`; transfer `YYYY-YY::WINDOW` keys untouched.
+6. **Journey 2025 re-sync:** NOT a shipping blocker (fixtures-wins rule keeps display honest);
+   sequenced first among API ops (B2), after B1 cold-build, after wider-extraction deploys.
+   Off-container, MJ-gated.
+7. **Wider extraction:** into PJE columns (the durable archive — api_cache purges in 7 days);
+   rollup cells derive from them. Code ships before B2 so one API pass banks everything.
+8. **Per-match historical backfill:** deferred (B4). Resolver auto-upgrades provenance if FPS for
+   a past season ever lands — zero code change.
+9. **PSC / AcademyAppearance:** demoted, not dropped. PSC stays a dormant `cache` feeder branch;
+   AA excluded (youth = PJE is_youth + APSS). Docs corrected in Phase D. No schema work.
+10. **Youth:** unified via `level_group` senior|youth|international (international stays visible
+    in development view). APSS 2025-26 sync (B3) gates deep current-season youth panels only.
+11. **Horizon debt:** this phase ships the data-driven source (`season_bounds()`,
+    `league_season_config`, selector fed from totals). Literal sites (big6 SEASONS, Team.season
+    default, client 2025 defaults) = Phase D chores. `transfer_windows` missing 26/27 is flagged
+    as a BLOCKER for the 26/27 transfer heal — separate subsystem, raise with MJ.
+12. **Open-ended `date_utc >=`:** fixed in PR1 with the `?season` plumbing (players.py:439/572/
+    613/689/721/730 → `Fixture.season ==`), not deferred — they double-count the day 26/27 lands.
+
+## 7. Rollout phases (mapped to seasons-ledger Phase D / E)
+
+- **D1** — PR1, zero-migration: `?season` + provenance object on single-player endpoints (direct
+  FPS/PJE reads), Q12 date fixes, `season_bounds()`. Verify Gore via real endpoints.
+- **D2** — PR2: `sea01` (PJE widen + `ix_fps_player` + PJE indexes) + wider extraction +
+  `player_api_id` backfill endpoint.
+- **D3** — PR3: `sea02` (cells/totals/config, RLS) + rollup service (feeders, resolver, hooks,
+  FPS choke point, noise filter) + admin rebuild + rows-behind gauge + Gore-anchored unit tests.
+- **D4** — B1 cold-build + 20-player pilot → flip `SEASON_ROLLUP_READS` per surface:
+  `compute_stats(season=)` → scout `_base_scout_query` (drop both subqueries + COALESCE) →
+  players → teams/journalist. Rollback = flag flip.
+- **D5** — PR4/5, frontend: SeasonSelector, badges, compare, development view; relabel the 8
+  lying surfaces; Playwright drives PlayerPage/ScoutPage.
+- **E1 [MJ gate]** — B2 journey 2025-26 re-sync (P1/P3 status repair rides along, per ledger).
+- **E2 [MJ gate]** — B3 APSS 2025-26 sync → youth overlay complete.
+- **E3** — nightly stale-reconcile schedule live; verification targets: Gore 2,936/2,583/cup-gap,
+  zero-at-tracked-club gauge → ~0, rows-behind gauge ≈ 0; Phase D chores + doc corrections.
+
+## 8. Decision points requiring MJ sign-off
+
+1. **Schema** (irreversible-ish): sea01 (25 nullable PJE columns) + sea02 (2 rollup tables +
+   `league_season_config`). Confirm the never-cross-source-sum totals rule and cells grain.
+2. **Display flip**: headline season totals become the larger cup-inclusive figure for ~78% of
+   players-with-data (e.g. Gore 2,583 → 2,936 "incl. cups"). User-visible numbers change.
+3. **B1 cold-build scope**: all players × all seasons, pure DB, off-container. Cheap but
+   platform-wide; pilot (20 players incl. Gore) gates the read cutover.
+4. **B2 journey 2025-26 re-sync**: ~3,544 players × ~N+2 live API calls, off-container scale-up
+   per invariants §7. Quota sign-off. Wider extraction MUST be deployed first (one-pass banking).
+5. **B3 APSS 2025-26 sync**: off-container, MJ-gated (stale since 2026-04).
+6. **Deliberately deferred** (sign off on NOT doing): per-match historical crawl (B4);
+   Apertura/Clausura behavior (dormant column only); PSC/AA table drops (demote only).
+7. **Flagged escalation**: `data/transfer_windows.py` stops at 2025-26 — blocks the 26/27
+   transfer heal independently of this design; needs its own small data PR.


### PR DESCRIPTION
## What

Phase D1 of the approved seasons design (`ledgers/research/seasons-design-proposal.md` §7, committed here) — the zero-migration slice. Built by a 14-agent workflow (impl + two adversarial reviewers per stage with fix loops), then independently reviewed + gate-verified by the orchestrating session.

- **One season resolver**: `resolve_stats_season(db, requested, surface)` + `season_bounds()` in `utils/academy_window.py`. `discovery` surface falls back to latest-season-with-fixtures; `compare` is wall-clock with no fallback; explicit requests validated → HTTP 400 out of bounds.
- **`?season=<start-year>`** on `/players/<id>/stats` and `/players/<id>/season-stats`. No param → byte-compatible with current behavior (pinned by tests asserting exact field values). Explicit season scopes every internal read — including the limited-coverage `PlayerStatsCache` branch, where review flushed out and fixed a pre-existing mislabel (cache totals from season N-1 served under season N's label).
- **Provenance object** on both endpoints: `{source, fixtures_minutes, journey_minutes, delta_pct, reconcile_flag}` with the coverage-map buckets (`cup-gap` / `journey-under-sync` / `fixtures-invisible`). Extends the existing `source` field, additive only.
- **Q12 closed ranges**: all four `Fixture.date_utc >=` one-sided filters in players.py → `Fixture.season ==` equality. These would double-count the day 26/27 fixtures land; mutation-tested (each site reverted individually fails exactly one pin).
- **Docs**: commits the Phase B coverage map + approved design proposal under `ledgers/research/`.

## Verification

- ruff check + format --check: clean.
- Suite: 775 passed / 23 failed / 12 collection errors — failure and error **sets byte-identical to main** (pre-existing); +51 new tests (`test_season_api_d1.py`, `test_season_d1_contract.py`), including the Gore-shaped provenance anchor (journey 2936 vs fixtures 2583 → cup-gap).
- Post-merge live checks: Gore `/players/303010/season-stats` unchanged (2,936, source api-football) + new provenance fields; `?season=2025` explicit; out-of-bounds → 400.

Next: D2 (`sea01` PJE widening + rich-field extraction) per the proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)