### PR TITLE
feat(season-data): D2 — sea01 widens journey entries, rich-field extraction, player_api_id backfill

### DIFF
--- a/academy-watch-backend/migrations/versions/sea01_widen_journey_entries.py
+++ b/academy-watch-backend/migrations/versions/sea01_widen_journey_entries.py
@@ -21,6 +21,20 @@ Also adds two indexes the seasons work needs on every hot path:
 
 ADD COLUMN does not touch RLS, and player_journey_entries already has RLS
 enabled, so no RLS statement is needed here.
+
+DEPLOY ORDERING (migrations do NOT auto-run — deploy.yml only runs the RLS
+security-check; the container CMD is gunicorn, nothing runs `flask db upgrade`).
+The shipped ORM model declares these 28 columns, so the moment the new image takes
+traffic every read of PlayerJourneyEntry SELECTs them; if the DDL is not yet applied
+that is psycopg UndefinedColumn -> 500 on all journey / D1-provenance surfaces.
+Chosen sequence: PRE-APPLY this migration out-of-band against prod BEFORE merging —
+from a local checkout with the prod DB env (IPv4 pooler + `postgresql+psycopg://`,
+invariants #1) run `FLASK_APP=src/main.py flask db upgrade`. ADD COLUMN is a
+metadata-only instant op in Postgres; the two CREATE INDEXes are the only real work.
+Then merge: when CI deploys the image the columns already exist -> zero 500 window,
+and the manual in-container `flask db upgrade` is a pure no-op stamp (all DDL guarded
+via *_safe / index_exists). Fallback if pre-apply is skipped: run `flask db upgrade`
+in the container immediately after the deploy goes green and accept the brief window.
 """
 
 import sqlalchemy as sa

--- a/academy-watch-backend/migrations/versions/sea01_widen_journey_entries.py
+++ b/academy-watch-backend/migrations/versions/sea01_widen_journey_entries.py
@@ -1,0 +1,97 @@
+"""Widen player_journey_entries with rich per-season stats + missing indexes
+
+Revision ID: sea01
+Revises: aw23
+Create Date: 2026-07-07
+
+The journey sync already fetches the full API-Football `players?id&season`
+statistics block per season but persists only 4 fields (appearances, goals,
+assists, minutes). This widens player_journey_entries so that same free payload
+can be banked as a durable per-season archive (api_cache TTL is only 7 days, so
+the raw response is otherwise lost). All columns are nullable and guarded via
+add_column_safe — prod schema has drifted out-of-band, and a re-applied or
+partially-applied DDL must never crash `flask db upgrade` on deploy.
+
+Also adds two indexes the seasons work needs on every hot path:
+  ix_fps_player            — fixture_player_stats(player_api_id) was unindexed;
+                             every per-player season aggregation seq-scanned FPS
+                             (~100k rows/season on a 0.5 CPU box).
+  ix_pje_player_season     — player_journey_entries(player_api_id, season) for
+                             the denormalized per-player-per-season reads.
+
+ADD COLUMN does not touch RLS, and player_journey_entries already has RLS
+enabled, so no RLS statement is needed here.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from migrations._migration_helpers import (
+    add_column_safe,
+    column_exists,
+    create_index_safe,
+    index_exists,
+)
+
+revision = "sea01"
+down_revision = "aw23"
+branch_labels = None
+depends_on = None
+
+
+# (name, SQLAlchemy type) for every column added to player_journey_entries.
+# All nullable; stats_source carries a server default so pre-existing rows read
+# as 'legacy-basic' (they predate the wider extraction).
+_COLUMNS = [
+    ("player_api_id", sa.Integer()),
+    ("rating", sa.Float()),
+    ("position", sa.String(length=10)),
+    ("lineups", sa.Integer()),
+    ("shots_total", sa.Integer()),
+    ("shots_on", sa.Integer()),
+    ("passes_total", sa.Integer()),
+    ("passes_key", sa.Integer()),
+    ("passes_accuracy", sa.Integer()),
+    ("tackles_total", sa.Integer()),
+    ("tackles_blocks", sa.Integer()),
+    ("tackles_interceptions", sa.Integer()),
+    ("duels_total", sa.Integer()),
+    ("duels_won", sa.Integer()),
+    ("dribbles_attempts", sa.Integer()),
+    ("dribbles_success", sa.Integer()),
+    ("fouls_drawn", sa.Integer()),
+    ("fouls_committed", sa.Integer()),
+    ("cards_yellow", sa.Integer()),
+    ("cards_red", sa.Integer()),
+    ("penalty_scored", sa.Integer()),
+    ("penalty_missed", sa.Integer()),
+    ("penalty_saved", sa.Integer()),
+    ("goals_conceded", sa.Integer()),
+    ("saves", sa.Integer()),
+    ("season_phase", sa.String(length=12)),
+    ("stats_synced_at", sa.TIMESTAMP(timezone=True)),
+]
+
+
+def upgrade():
+    for name, col_type in _COLUMNS:
+        add_column_safe("player_journey_entries", sa.Column(name, col_type, nullable=True))
+
+    # stats_source has a server default so existing rows backfill to 'legacy-basic'.
+    add_column_safe(
+        "player_journey_entries",
+        sa.Column("stats_source", sa.String(length=24), nullable=True, server_default="legacy-basic"),
+    )
+
+    create_index_safe("ix_fps_player", "fixture_player_stats", ["player_api_id"])
+    create_index_safe("ix_pje_player_season", "player_journey_entries", ["player_api_id", "season"])
+
+
+def downgrade():
+    if index_exists("ix_pje_player_season"):
+        op.drop_index("ix_pje_player_season", table_name="player_journey_entries")
+    if index_exists("ix_fps_player"):
+        op.drop_index("ix_fps_player", table_name="fixture_player_stats")
+
+    for name, _ in [*_COLUMNS, ("stats_source", None)]:
+        if column_exists("player_journey_entries", name):
+            op.drop_column("player_journey_entries", name)

--- a/academy-watch-backend/migrations/versions/sea01_widen_journey_entries.py
+++ b/academy-watch-backend/migrations/versions/sea01_widen_journey_entries.py
@@ -1,4 +1,4 @@
-"""Widen player_journey_entries with rich per-season stats + missing indexes
+"""Widen player_journey_entries with rich per-season stats + read-path index
 
 Revision ID: sea01
 Revises: aw23
@@ -12,12 +12,14 @@ the raw response is otherwise lost). All columns are nullable and guarded via
 add_column_safe — prod schema has drifted out-of-band, and a re-applied or
 partially-applied DDL must never crash `flask db upgrade` on deploy.
 
-Also adds two indexes the seasons work needs on every hot path:
-  ix_fps_player            — fixture_player_stats(player_api_id) was unindexed;
-                             every per-player season aggregation seq-scanned FPS
-                             (~100k rows/season on a 0.5 CPU box).
+Also adds one index the seasons work needs on the denormalized read path:
   ix_pje_player_season     — player_journey_entries(player_api_id, season) for
-                             the denormalized per-player-per-season reads.
+                             the per-player-per-season reads.
+
+fixture_player_stats(player_api_id) is deliberately NOT indexed separately here:
+aw15's composite ix_fps_player_team already leads on player_api_id, so every
+per-player FPS scan is index-served. A single-column duplicate would only add
+write overhead on the hottest write table.
 
 ADD COLUMN does not touch RLS, and player_journey_entries already has RLS
 enabled, so no RLS statement is needed here.
@@ -30,7 +32,8 @@ that is psycopg UndefinedColumn -> 500 on all journey / D1-provenance surfaces.
 Chosen sequence: PRE-APPLY this migration out-of-band against prod BEFORE merging —
 from a local checkout with the prod DB env (IPv4 pooler + `postgresql+psycopg://`,
 invariants #1) run `FLASK_APP=src/main.py flask db upgrade`. ADD COLUMN is a
-metadata-only instant op in Postgres; the two CREATE INDEXes are the only real work.
+metadata-only instant op in Postgres; the single CREATE INDEX (ix_pje_player_season)
+is the only real work.
 Then merge: when CI deploys the image the columns already exist -> zero 500 window,
 and the manual in-container `flask db upgrade` is a pure no-op stamp (all DDL guarded
 via *_safe / index_exists). Fallback if pre-apply is skipped: run `flask db upgrade`
@@ -96,15 +99,14 @@ def upgrade():
         sa.Column("stats_source", sa.String(length=24), nullable=True, server_default="legacy-basic"),
     )
 
-    create_index_safe("ix_fps_player", "fixture_player_stats", ["player_api_id"])
+    # fixture_player_stats(player_api_id) needs no index here — aw15's
+    # ix_fps_player_team (player_api_id, team_api_id) already covers player-only scans.
     create_index_safe("ix_pje_player_season", "player_journey_entries", ["player_api_id", "season"])
 
 
 def downgrade():
     if index_exists("ix_pje_player_season"):
         op.drop_index("ix_pje_player_season", table_name="player_journey_entries")
-    if index_exists("ix_fps_player"):
-        op.drop_index("ix_fps_player", table_name="fixture_player_stats")
 
     for name, _ in [*_COLUMNS, ("stats_source", None)]:
         if column_exists("player_journey_entries", name):

--- a/academy-watch-backend/src/models/journey.py
+++ b/academy-watch-backend/src/models/journey.py
@@ -343,6 +343,10 @@ class PlayerJourneyEntry(db.Model):
 
     __table_args__ = (
         db.Index("ix_journey_entry_lookup", "journey_id", "season", "club_api_id", "league_api_id"),
+        # Denormalized per-player-per-season read path (D1 provenance / D2 aggregation).
+        # Named to match migration sea01's create_index_safe so `flask db migrate`
+        # autogenerate sees no diff and never proposes dropping it.
+        db.Index("ix_pje_player_season", "player_api_id", "season"),
         db.UniqueConstraint("journey_id", "season", "club_api_id", "league_api_id", name="uq_journey_entry"),
     )
 

--- a/academy-watch-backend/src/models/journey.py
+++ b/academy-watch-backend/src/models/journey.py
@@ -260,7 +260,10 @@ class PlayerJourneyEntry(db.Model):
     __tablename__ = "player_journey_entries"
 
     id = db.Column(db.Integer, primary_key=True)
-    journey_id = db.Column(db.Integer, db.ForeignKey("player_journeys.id"), nullable=False, index=True)
+    # No index=True here — the journey_id index is declared by name in __table_args__
+    # below to match the migration-created ix_journey_entry_journey_id (index=True would
+    # mint the default ix_player_journey_entries_journey_id and churn autogenerate).
+    journey_id = db.Column(db.Integer, db.ForeignKey("player_journeys.id"), nullable=False)
 
     # Season
     season = db.Column(db.Integer, nullable=False)  # e.g., 2021
@@ -342,12 +345,21 @@ class PlayerJourneyEntry(db.Model):
     created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
 
     __table_args__ = (
+        # journey_id FK lookups. x2y3z4a5b6c7 created this as ix_journey_entry_journey_id;
+        # declared here by that exact name (see journey_id column note) so autogenerate
+        # does not churn an add/drop rename pair against prod.
+        db.Index("ix_journey_entry_journey_id", "journey_id"),
         db.Index("ix_journey_entry_lookup", "journey_id", "season", "club_api_id", "league_api_id"),
         # Denormalized per-player-per-season read path (D1 provenance / D2 aggregation).
-        # Named to match migration sea01's create_index_safe so `flask db migrate`
-        # autogenerate sees no diff and never proposes dropping it.
+        # Named to match migration sea01's create_index_safe so autogenerate keeps it.
         db.Index("ix_pje_player_season", "player_api_id", "season"),
-        db.UniqueConstraint("journey_id", "season", "club_api_id", "league_api_id", name="uq_journey_entry"),
+        # NB: intentionally no uq_journey_entry UniqueConstraint. x2y3z4a5b6c7 created
+        # only the NON-unique ix_journey_entry_lookup on these four columns — the DB has
+        # never held a unique constraint here. Dedup is enforced in application code
+        # (JourneySyncService._merge_corrected_duplicates), and declaring the constraint
+        # in metadata would make autogenerate emit a create_unique_constraint that could
+        # ABORT on pre-existing duplicate rows. Omitting it keeps autogenerate a true
+        # no-op on this table.
     )
 
     def to_dict(self):

--- a/academy-watch-backend/src/models/journey.py
+++ b/academy-watch-backend/src/models/journey.py
@@ -289,6 +289,45 @@ class PlayerJourneyEntry(db.Model):
     assists = db.Column(db.Integer, default=0)
     minutes = db.Column(db.Integer, default=0)
 
+    # Denormalized player id (copied from the parent PlayerJourney) so this
+    # table can be read per-player-per-season without joining player_journeys.
+    # Set on new entries at create time; backfilled for legacy rows off-path
+    # via POST /api/admin/journeys/backfill-entry-player-ids.
+    player_api_id = db.Column(db.Integer)
+
+    # Rich per-season stats (sea01) — banked from the API-Football
+    # players?id&season statistics block the sync already fetches. All nullable
+    # (payload fields are frequently null/absent) and durable (api_cache TTL is
+    # 7 days). stats_source distinguishes 'journey-api' (rich) from the
+    # 'legacy-basic' rows written before this extraction existed.
+    rating = db.Column(db.Float)
+    position = db.Column(db.String(10))
+    lineups = db.Column(db.Integer)
+    shots_total = db.Column(db.Integer)
+    shots_on = db.Column(db.Integer)
+    passes_total = db.Column(db.Integer)
+    passes_key = db.Column(db.Integer)
+    passes_accuracy = db.Column(db.Integer)
+    tackles_total = db.Column(db.Integer)
+    tackles_blocks = db.Column(db.Integer)
+    tackles_interceptions = db.Column(db.Integer)
+    duels_total = db.Column(db.Integer)
+    duels_won = db.Column(db.Integer)
+    dribbles_attempts = db.Column(db.Integer)
+    dribbles_success = db.Column(db.Integer)
+    fouls_drawn = db.Column(db.Integer)
+    fouls_committed = db.Column(db.Integer)
+    cards_yellow = db.Column(db.Integer)
+    cards_red = db.Column(db.Integer)
+    penalty_scored = db.Column(db.Integer)
+    penalty_missed = db.Column(db.Integer)
+    penalty_saved = db.Column(db.Integer)
+    goals_conceded = db.Column(db.Integer)
+    saves = db.Column(db.Integer)
+    stats_source = db.Column(db.String(24), default="legacy-basic")  # journey-api|legacy-basic|manual
+    stats_synced_at = db.Column(db.DateTime(timezone=True))
+    season_phase = db.Column(db.String(12))  # dormant Apertura/Clausura hook
+
     # Transfer date (YYYY-MM-DD) — when the player moved to this club
     # Populated from transfer API for loan entries; used as tiebreaker
     # when multiple clubs share the same season and sort_priority.

--- a/academy-watch-backend/src/models/weekly.py
+++ b/academy-watch-backend/src/models/weekly.py
@@ -120,11 +120,13 @@ class FixturePlayerStats(db.Model):
     raw_json = db.Column(db.Text)
 
     __table_args__ = (
-        # Per-player season aggregation scans FPS by player_api_id; without this
-        # it seq-scans ~100k rows/season on the 0.5-CPU prod box. Named to match
-        # migration sea01's create_index_safe so `flask db migrate` autogenerate
-        # sees no diff and never proposes dropping it.
-        db.Index("ix_fps_player", "player_api_id"),
+        # aw15 created this composite on (player_api_id, team_api_id). Its leading
+        # column already index-serves every per-player FPS scan (compute_stats,
+        # recent-form, season aggregation), so a separate single-column player index
+        # would be a redundant duplicate — pure write overhead on the hottest write
+        # table. Declared here with aw15's exact name so `flask db migrate`
+        # autogenerate does NOT propose dropping the index prod has relied on since aw15.
+        db.Index("ix_fps_player_team", "player_api_id", "team_api_id"),
         db.UniqueConstraint("fixture_id", "player_api_id", name="uq_fixture_player"),
     )
 

--- a/academy-watch-backend/src/models/weekly.py
+++ b/academy-watch-backend/src/models/weekly.py
@@ -119,7 +119,14 @@ class FixturePlayerStats(db.Model):
     # Raw JSON for future expansion
     raw_json = db.Column(db.Text)
 
-    __table_args__ = (db.UniqueConstraint("fixture_id", "player_api_id", name="uq_fixture_player"),)
+    __table_args__ = (
+        # Per-player season aggregation scans FPS by player_api_id; without this
+        # it seq-scans ~100k rows/season on the 0.5-CPU prod box. Named to match
+        # migration sea01's create_index_safe so `flask db migrate` autogenerate
+        # sees no diff and never proposes dropping it.
+        db.Index("ix_fps_player", "player_api_id"),
+        db.UniqueConstraint("fixture_id", "player_api_id", name="uq_fixture_player"),
+    )
 
     def to_dict(self):
         """Convert player stats to dictionary for API responses."""

--- a/academy-watch-backend/src/routes/journey.py
+++ b/academy-watch-backend/src/routes/journey.py
@@ -352,6 +352,58 @@ def admin_backfill_current_status():
     )
 
 
+@journey_bp.route("/admin/journeys/backfill-entry-player-ids", methods=["POST"])
+@require_api_key
+def admin_backfill_entry_player_ids():
+    """Backfill player_journey_entries.player_api_id (sea01) from the parent
+    player_journeys row, for NULL rows only. No API calls.
+
+    New entries get player_api_id at create time; this fills the ~77k legacy
+    rows that predate the column. Batched, idempotent and restartable — it only
+    touches rows where player_api_id IS NULL, so each call strictly shrinks the
+    remaining set and re-running after completion is a no-op.
+
+    Query: ?batch_size=<int, default 5000, max 50000>
+    Returns: {"updated": <this call>, "remaining": <still NULL>, "batch_size"}
+    """
+    from sqlalchemy import text
+
+    batch_size = request.args.get("batch_size", 5000, type=int)
+    if not isinstance(batch_size, int) or batch_size < 1:
+        batch_size = 5000
+    batch_size = min(batch_size, 50000)
+
+    # Bounded batch: fill only NULL rows from the parent journey's player id.
+    # Every PJE row has a NOT NULL journey_id FK to a journey with a NOT NULL
+    # unique player_api_id, so the set is exhaustible and `remaining` reaches 0.
+    result = db.session.execute(
+        text(
+            """
+            WITH batch AS (
+                SELECT id FROM player_journey_entries
+                WHERE player_api_id IS NULL
+                ORDER BY id
+                LIMIT :batch_size
+            )
+            UPDATE player_journey_entries AS pje
+            SET player_api_id = pj.player_api_id
+            FROM player_journeys AS pj, batch
+            WHERE pje.id = batch.id
+              AND pje.journey_id = pj.id
+            """
+        ),
+        {"batch_size": batch_size},
+    )
+    updated = result.rowcount
+    db.session.commit()
+
+    remaining = db.session.execute(
+        text("SELECT COUNT(*) FROM player_journey_entries WHERE player_api_id IS NULL")
+    ).scalar()
+
+    return jsonify({"updated": updated, "remaining": int(remaining or 0), "batch_size": batch_size})
+
+
 # Maps FixturePlayerStats.position codes to TrackedPlayer.position conventions
 _PROFILE_POSITION_MAP = {"G": "Goalkeeper", "D": "Defender", "M": "Midfielder", "F": "Attacker"}
 

--- a/academy-watch-backend/src/services/journey_sync.py
+++ b/academy-watch-backend/src/services/journey_sync.py
@@ -30,6 +30,41 @@ from src.utils.player_names import clean_name, is_placeholder_name, resolve_play
 logger = logging.getLogger(__name__)
 
 
+def _stat_int(value) -> int | None:
+    """Coerce an API-Football stat field to int, preserving NULL.
+
+    Rich per-season fields are frequently null/absent; a missing field must
+    stay NULL (unknown), never collapse to 0 (a real observed zero). Accepts
+    numeric strings and percentage strings like "82%".
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, str):
+        value = value.strip().rstrip("%").strip()
+        if not value:
+            return None
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _stat_float(value) -> float | None:
+    """Coerce an API-Football stat field to float, preserving NULL (e.g. rating)."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
 # Regex to extract a specific level token from a club name.
 # Ordered so longer / more specific tokens match first (U23 before U2, etc).
 _CLUB_NAME_LEVEL_RE = re.compile(
@@ -215,7 +250,7 @@ class JourneySyncService:
                         if not self._is_official_competition(stat):
                             logger.debug(f"Skipping non-official competition: {stat.get('league', {}).get('name')}")
                             continue
-                        entry = self._create_entry_from_stat(journey.id, season, stat)
+                        entry = self._create_entry_from_stat(journey.id, season, stat, player_api_id)
                         if entry:
                             all_entries.append(entry)
 
@@ -329,12 +364,30 @@ class JourneySyncService:
             logger.error(f"Failed to get player {player_api_id} season {season}: {e}")
             return None
 
-    def _create_entry_from_stat(self, journey_id: int, season: int, stat: dict) -> PlayerJourneyEntry | None:
-        """Create a journey entry from API-Football statistics block"""
+    def _create_entry_from_stat(
+        self, journey_id: int, season: int, stat: dict, player_api_id: int | None = None
+    ) -> PlayerJourneyEntry | None:
+        """Create a journey entry from API-Football statistics block.
+
+        Persists the full rich per-season block the /players?id&season payload
+        carries (shots, passes, tackles, duels, dribbles, fouls, cards,
+        penalties, rating, position, keeper numbers) into the sea01 columns —
+        the same payload the sync already fetched, previously discarded down to
+        4 fields. Zero extra API calls. All rich fields are defensively coerced
+        and may be NULL (the payload is frequently sparse).
+        """
         team = stat.get("team", {})
         league = stat.get("league", {})
-        games = stat.get("games", {})
-        goals = stat.get("goals", {})
+        games = stat.get("games", {}) or {}
+        goals = stat.get("goals", {}) or {}
+        shots = stat.get("shots", {}) or {}
+        passes = stat.get("passes", {}) or {}
+        tackles = stat.get("tackles", {}) or {}
+        duels = stat.get("duels", {}) or {}
+        dribbles = stat.get("dribbles", {}) or {}
+        fouls = stat.get("fouls", {}) or {}
+        cards = stat.get("cards", {}) or {}
+        penalty = stat.get("penalty", {}) or {}
 
         team_id = team.get("id")
         league_id = league.get("id")
@@ -353,8 +406,13 @@ class JourneySyncService:
         is_youth = level in YOUTH_LEVELS
         is_international = self._is_international(league_name)
 
+        position = games.get("position")
+        if position:
+            position = str(position)[:10]
+
         entry = PlayerJourneyEntry(
             journey_id=journey_id,
+            player_api_id=player_api_id,
             season=season,
             club_api_id=team_id,
             club_name=team_name,
@@ -372,6 +430,33 @@ class JourneySyncService:
             assists=goals.get("assists") or 0,
             minutes=games.get("minutes") or 0,
             sort_priority=LEVEL_PRIORITY.get(level, 0),
+            # Rich per-season fields (sea01) — durable archive of the free payload.
+            rating=_stat_float(games.get("rating")),
+            position=position,
+            lineups=_stat_int(games.get("lineups")),
+            shots_total=_stat_int(shots.get("total")),
+            shots_on=_stat_int(shots.get("on")),
+            passes_total=_stat_int(passes.get("total")),
+            passes_key=_stat_int(passes.get("key")),
+            passes_accuracy=_stat_int(passes.get("accuracy")),
+            tackles_total=_stat_int(tackles.get("total")),
+            tackles_blocks=_stat_int(tackles.get("blocks")),
+            tackles_interceptions=_stat_int(tackles.get("interceptions")),
+            duels_total=_stat_int(duels.get("total")),
+            duels_won=_stat_int(duels.get("won")),
+            dribbles_attempts=_stat_int(dribbles.get("attempts")),
+            dribbles_success=_stat_int(dribbles.get("success")),
+            fouls_drawn=_stat_int(fouls.get("drawn")),
+            fouls_committed=_stat_int(fouls.get("committed")),
+            cards_yellow=_stat_int(cards.get("yellow")),
+            cards_red=_stat_int(cards.get("red")),
+            penalty_scored=_stat_int(penalty.get("scored")),
+            penalty_missed=_stat_int(penalty.get("missed")),
+            penalty_saved=_stat_int(penalty.get("saved")),
+            goals_conceded=_stat_int(goals.get("conceded")),
+            saves=_stat_int(goals.get("saves")),
+            stats_source="journey-api",
+            stats_synced_at=datetime.now(UTC),
         )
 
         return entry
@@ -765,10 +850,19 @@ class JourneySyncService:
         """Merge entries that share (club_api_id, league_api_id, season).
 
         After _correct_club_ids_from_transfers, a corrected entry may now
-        share the same club+league+season as an existing entry.  Keep the
-        one with more appearances (more complete data).
+        share the same club+league+season as an existing entry. Keep the one
+        with more appearances (more complete data); the whole winning entry is
+        retained, so its rich per-season fields (sea01) ride along. When
+        appearances tie, prefer the 'journey-api' (rich) source, then the newer
+        stats_synced_at — so a duplicate never drops the richer/newer row.
         """
         from collections import defaultdict
+
+        def _winner_key(e):
+            source_rank = 1 if getattr(e, "stats_source", None) == "journey-api" else 0
+            synced = getattr(e, "stats_synced_at", None)
+            synced_ts = synced.timestamp() if synced else 0.0
+            return (e.appearances or 0, source_rank, synced_ts)
 
         groups = defaultdict(list)
         for entry in entries:
@@ -781,7 +875,7 @@ class JourneySyncService:
             if len(group) == 1:
                 result.append(group[0])
                 continue
-            winner = max(group, key=lambda e: e.appearances or 0)
+            winner = max(group, key=_winner_key)
             merged += len(group) - 1
             result.append(winner)
 

--- a/academy-watch-backend/tests/test_season_data_sea01.py
+++ b/academy-watch-backend/tests/test_season_data_sea01.py
@@ -94,30 +94,45 @@ def _sqlite_index_exists(name):
     return any(name in {ix["name"] for ix in inspector.get_indexes(t)} for t in inspector.get_table_names())
 
 
-# Rich columns the migration must add (a representative spread — keeper, shooter,
-# passer, discipline, provenance, and the dormant split-season hook).
-_EXPECTED_RICH_COLUMNS = {
-    "player_api_id",
-    "rating",
-    "position",
-    "lineups",
-    "shots_total",
-    "shots_on",
-    "passes_total",
-    "passes_key",
-    "passes_accuracy",
-    "tackles_total",
-    "duels_won",
-    "dribbles_success",
-    "fouls_committed",
-    "cards_red",
-    "penalty_saved",
-    "goals_conceded",
-    "saves",
-    "stats_source",
-    "stats_synced_at",
-    "season_phase",
-}
+# The FULL 28-column contract sea01 adds to player_journey_entries (27 rich
+# columns + the server-defaulted stats_source). Pinned here as an explicit
+# literal, INDEPENDENTLY of both the migration's own _COLUMNS list and the ORM
+# model — so a column silently dropped or renamed on either side fails a test.
+# That drift (migration omits a column the shipped model still SELECTs) is the
+# exact failure mode that 500s every journey / D1-provenance read with psycopg
+# UndefinedColumn; a hand-picked subset let 8 of these slip through unpinned.
+_SEA01_COLUMNS = frozenset(
+    {
+        "player_api_id",
+        "rating",
+        "position",
+        "lineups",
+        "shots_total",
+        "shots_on",
+        "passes_total",
+        "passes_key",
+        "passes_accuracy",
+        "tackles_total",
+        "tackles_blocks",
+        "tackles_interceptions",
+        "duels_total",
+        "duels_won",
+        "dribbles_attempts",
+        "dribbles_success",
+        "fouls_drawn",
+        "fouls_committed",
+        "cards_yellow",
+        "cards_red",
+        "penalty_scored",
+        "penalty_missed",
+        "penalty_saved",
+        "goals_conceded",
+        "saves",
+        "season_phase",
+        "stats_synced_at",
+        "stats_source",
+    }
+)
 
 
 @pytest.fixture
@@ -130,6 +145,40 @@ def _pje_base_engine():
             sa.text("CREATE TABLE player_journey_entries (id INTEGER PRIMARY KEY, journey_id INTEGER, season INTEGER)")
         )
         conn.execute(sa.text("INSERT INTO player_journey_entries (id, journey_id, season) VALUES (1, 7, 2024)"))
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture
+def _pje_partial_engine():
+    """A `player_journey_entries` where a SUBSET of sea01's artifacts already
+    exists out-of-band: the `player_api_id` + `rating` columns and the
+    `ix_pje_player_season` index, plus a legacy row carrying a real rating.
+
+    This is the documented drift mode (invariants §8): prod schema has had
+    columns/indexes hand-added, so `flask db upgrade` runs against a schema where
+    part of the migration's target already exists. upgrade() must ADD only the
+    26 missing columns, SKIP the 2 pre-existing ones and the pre-existing index,
+    and leave the seeded data untouched — never crash with DuplicateColumn."""
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "CREATE TABLE player_journey_entries ("
+                "id INTEGER PRIMARY KEY, journey_id INTEGER, season INTEGER, "
+                "player_api_id INTEGER, rating REAL)"
+            )
+        )
+        # The read-path index sea01 also creates — already present out-of-band.
+        conn.execute(sa.text("CREATE INDEX ix_pje_player_season ON player_journey_entries (player_api_id, season)"))
+        conn.execute(
+            sa.text(
+                "INSERT INTO player_journey_entries (id, journey_id, season, player_api_id, rating) "
+                "VALUES (1, 7, 2024, 303010, 6.5)"
+            )
+        )
     try:
         yield engine
     finally:
@@ -158,10 +207,69 @@ class TestSea01Idempotency:
 
         inspector = sa.inspect(engine)
         columns = {c["name"] for c in inspector.get_columns("player_journey_entries")}
-        assert _EXPECTED_RICH_COLUMNS.issubset(columns)
+        # All 28 contract columns land (not just a hand-picked subset).
+        assert columns >= _SEA01_COLUMNS
         index_names = [ix["name"] for ix in inspector.get_indexes("player_journey_entries")]
         # Created exactly once despite two upgrade passes.
         assert index_names.count("ix_pje_player_season") == 1
+
+    def test_upgrade_over_partial_out_of_band_schema(self, _pje_partial_engine, _sea01_module):
+        """Partial-application replay — the drift mode the file docstring claims
+        but the double-upgrade test never exercised (that starts from a bare
+        table where the first pass adds everything and the second full-skips).
+
+        Here 2 of the 28 columns and the read-path index already exist
+        out-of-band. A SINGLE upgrade() must: complete without a mid-DDL
+        DuplicateColumn crash, add the other 26 columns, and leave the
+        pre-existing column data and index untouched. This is what catches a
+        future 'consolidate the 28 guards into one sentinel probe' refactor:
+        the sentinel would be absent here, the batch would re-add `rating`, and
+        upgrade() would raise instead of no-op'ing."""
+        engine = _pje_partial_engine
+        # A single pass (not a double-upgrade) — the crash, if any, is here.
+        with _alembic_ops(engine):
+            _sea01_module.upgrade()
+
+        inspector = sa.inspect(engine)
+        columns = {c["name"] for c in inspector.get_columns("player_journey_entries")}
+        # Every contract column present: the 26 missing were added, the 2
+        # pre-existing were skipped (no duplicate, no crash).
+        assert columns >= _SEA01_COLUMNS
+        # The pre-existing index survived exactly once (create_index_safe skipped it).
+        index_names = [ix["name"] for ix in inspector.get_indexes("player_journey_entries")]
+        assert index_names.count("ix_pje_player_season") == 1
+        # The pre-existing columns' data is untouched (columns were not dropped/re-added),
+        # while a freshly-added rich column defaults NULL and stats_source takes its
+        # server default.
+        with engine.connect() as conn:
+            row = conn.execute(
+                sa.text("SELECT rating, player_api_id, stats_source, saves FROM player_journey_entries WHERE id=1")
+            ).one()
+        assert row.rating == 6.5  # pre-existing value preserved
+        assert row.player_api_id == 303010  # pre-existing value preserved
+        assert row.stats_source == "legacy-basic"  # newly-added column's server default
+        assert row.saves is None  # newly-added rich column defaults NULL
+
+    def test_migration_ddl_matches_model_contract(self, _sea01_module):
+        """DDL ↔ ORM-model parity. The migration's own _COLUMNS list AND the
+        shipped model must both agree with the 28-column sea01 contract. Drop or
+        rename a column on either side and this fails — instead of shipping a
+        migration that omits a column the model still SELECTs, which 500s every
+        journey / D1-provenance read with psycopg UndefinedColumn (the drift a
+        prior fix on this branch already had to undo once)."""
+        from src.models.journey import PlayerJourneyEntry
+
+        migration_cols = {name for name, _ in _sea01_module._COLUMNS} | {"stats_source"}
+        assert migration_cols == _SEA01_COLUMNS, (
+            "sea01 _COLUMNS drifted from the 28-column contract — "
+            f"missing={sorted(_SEA01_COLUMNS - migration_cols)}, "
+            f"extra={sorted(migration_cols - _SEA01_COLUMNS)}"
+        )
+
+        model_cols = {c.name for c in PlayerJourneyEntry.__table__.columns}
+        assert model_cols >= _SEA01_COLUMNS, (
+            f"the ORM model is missing sea01 columns it will SELECT at runtime: {sorted(_SEA01_COLUMNS - model_cols)}"
+        )
 
     def test_legacy_row_backfills_source_default(self, _pje_base_engine, _sea01_module):
         """The pre-existing row reads as 'legacy-basic' (server_default) with NULL

--- a/academy-watch-backend/tests/test_season_data_sea01.py
+++ b/academy-watch-backend/tests/test_season_data_sea01.py
@@ -1,0 +1,582 @@
+"""D2 season-data (sea01) pinning tests — proposal §2 / §3 / §7 D2.
+
+Locks the four load-bearing guarantees of the PR2 (`sea01`) work:
+
+1. **Migration head stays single** and is `sea01` (chained off `aw23`) — a second
+   head would make `flask db upgrade` ambiguous on deploy.
+2. **`sea01` is idempotent** — every DDL is guarded, so a re-applied or
+   partially-applied upgrade is a pure no-op (migrations do NOT auto-run on
+   deploy; prod schema has drifted out-of-band, invariants §8).
+3. **Rich extraction** — `_create_entry_from_stat` banks the full API-Football
+   per-season statistics block into the sea01 columns with
+   ``stats_source='journey-api'`` while the basic 4 fields stay byte-identical to
+   the pre-sea01 behavior; a sparse/null payload yields NULL rich columns and
+   never crashes (missing ≠ observed-zero).
+4. **Duplicate-merge survival** — after a club-ID correction produces a duplicate,
+   the merged survivor keeps its rich fields (journey-api / newer-synced wins the
+   tie), and the primary "more appearances" rule is untouched.
+5. **Backfill endpoint** — `POST /api/admin/journeys/backfill-entry-player-ids`
+   fills only NULL `player_api_id` rows, converges to zero in bounded batches,
+   is idempotent on re-run, never clobbers a set value, clamps its batch bound,
+   and 401s without admin auth.
+"""
+
+import importlib
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic import op as alembic_op
+from alembic.config import Config
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from alembic.script import ScriptDirectory
+from flask import Flask
+from src.services.journey_sync import JourneySyncService, _stat_float, _stat_int
+
+# ---------------------------------------------------------------------------
+# (1) Migration head
+# ---------------------------------------------------------------------------
+
+
+def _script_directory():
+    repo_root = Path(__file__).resolve().parent.parent
+    cfg = Config(str(repo_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(repo_root / "migrations"))
+    return ScriptDirectory.from_config(cfg)
+
+
+class TestMigrationHead:
+    def test_single_head_is_sea01(self):
+        """The whole chain resolves to exactly one head, and it is sea01."""
+        heads = _script_directory().get_heads()
+        assert heads == ["sea01"], f"expected the single head to be sea01, got {heads}"
+
+    def test_sea01_chains_off_aw23(self):
+        """sea01 branches from the real prod tip (aw23), keeping the line linear."""
+        script = _script_directory()
+        sea01 = script.get_revision("sea01")
+        assert sea01.down_revision == "aw23"
+        assert script.get_revision("aw23") is not None
+
+
+# ---------------------------------------------------------------------------
+# (2) sea01 idempotency (guarded DDL runs twice cleanly under SQLite)
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _alembic_ops(engine):
+    """Bind an Alembic Operations proxy to `engine` (matches the sibling
+    migration tests)."""
+    conn = engine.connect()
+    trans = conn.begin()
+    ctx = MigrationContext.configure(conn)
+    operations = Operations(ctx)
+    original = getattr(alembic_op, "_proxy", None)
+    alembic_op._proxy = operations
+    try:
+        yield operations
+        trans.commit()
+    finally:
+        alembic_op._proxy = original
+        conn.close()
+
+
+def _sqlite_column_exists(table, column):
+    return column in {c["name"] for c in sa.inspect(alembic_op.get_bind()).get_columns(table)}
+
+
+def _sqlite_index_exists(name):
+    inspector = sa.inspect(alembic_op.get_bind())
+    return any(name in {ix["name"] for ix in inspector.get_indexes(t)} for t in inspector.get_table_names())
+
+
+# Rich columns the migration must add (a representative spread — keeper, shooter,
+# passer, discipline, provenance, and the dormant split-season hook).
+_EXPECTED_RICH_COLUMNS = {
+    "player_api_id",
+    "rating",
+    "position",
+    "lineups",
+    "shots_total",
+    "shots_on",
+    "passes_total",
+    "passes_key",
+    "passes_accuracy",
+    "tackles_total",
+    "duels_won",
+    "dribbles_success",
+    "fouls_committed",
+    "cards_red",
+    "penalty_saved",
+    "goals_conceded",
+    "saves",
+    "stats_source",
+    "stats_synced_at",
+    "season_phase",
+}
+
+
+@pytest.fixture
+def _pje_base_engine():
+    """A bare `player_journey_entries` (id/journey_id/season only) with one legacy
+    row — the pre-sea01 shape the guarded migration must widen."""
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text("CREATE TABLE player_journey_entries (id INTEGER PRIMARY KEY, journey_id INTEGER, season INTEGER)")
+        )
+        conn.execute(sa.text("INSERT INTO player_journey_entries (id, journey_id, season) VALUES (1, 7, 2024)"))
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture
+def _sea01_module(monkeypatch):
+    """Import the sea01 migration with its Postgres-only guards (information_schema
+    / pg_indexes) swapped for SQLite-aware inspection, so upgrade() runs offline."""
+    import migrations._migration_helpers as mh
+
+    monkeypatch.setattr(mh, "column_exists", _sqlite_column_exists)
+    monkeypatch.setattr(mh, "index_exists", _sqlite_index_exists)
+    return importlib.import_module("migrations.versions.sea01_widen_journey_entries")
+
+
+class TestSea01Idempotency:
+    def test_upgrade_twice_is_a_no_op(self, _pje_base_engine, _sea01_module):
+        engine = _pje_base_engine
+        with _alembic_ops(engine):
+            _sea01_module.upgrade()
+        # Re-apply: guarded helpers must make this a clean no-op, never a crash.
+        with _alembic_ops(engine):
+            _sea01_module.upgrade()
+
+        inspector = sa.inspect(engine)
+        columns = {c["name"] for c in inspector.get_columns("player_journey_entries")}
+        assert _EXPECTED_RICH_COLUMNS.issubset(columns)
+        index_names = [ix["name"] for ix in inspector.get_indexes("player_journey_entries")]
+        # Created exactly once despite two upgrade passes.
+        assert index_names.count("ix_pje_player_season") == 1
+
+    def test_legacy_row_backfills_source_default(self, _pje_base_engine, _sea01_module):
+        """The pre-existing row reads as 'legacy-basic' (server_default) with NULL
+        rich fields — it predates the wider extraction."""
+        engine = _pje_base_engine
+        with _alembic_ops(engine):
+            _sea01_module.upgrade()
+        with engine.connect() as conn:
+            row = conn.execute(
+                sa.text(
+                    "SELECT stats_source, rating, player_api_id, shots_total FROM player_journey_entries WHERE id=1"
+                )
+            ).one()
+        assert row.stats_source == "legacy-basic"
+        assert row.rating is None
+        assert row.player_api_id is None
+        assert row.shots_total is None
+
+
+# ---------------------------------------------------------------------------
+# (3) Rich extraction from the API-Football statistics block
+# ---------------------------------------------------------------------------
+
+
+def _service():
+    # `object()` stands in for the API client — extraction never touches self.api,
+    # and this avoids constructing a real (networked) APIFootballClient.
+    return JourneySyncService(api_client=object())
+
+
+def _legacy_basic_four(stat):
+    """Reproduce the exact pre-sea01 4-field computation, to prove the new
+    extraction leaves the basic fields byte-identical."""
+    games = stat.get("games", {})
+    goals = stat.get("goals", {})
+    return {
+        "appearances": games.get("appearences") or games.get("appearances") or 0,
+        "goals": goals.get("total") or 0,
+        "assists": goals.get("assists") or 0,
+        "minutes": games.get("minutes") or 0,
+    }
+
+
+def _full_payload():
+    """A faithful /players?id&season statistics[] block (British 'appearences'
+    spelling, a '82%' accuracy string, an explicit-null penalty.saved, and a real
+    observed goals.conceded=0)."""
+    return {
+        "team": {"id": 33, "name": "Manchester United", "logo": "mu.png"},
+        "league": {"id": 39, "name": "Premier League", "country": "England", "logo": "pl.png"},
+        "games": {"appearences": 25, "lineups": 22, "minutes": 1980, "position": "Midfielder", "rating": "7.42"},
+        "shots": {"total": 30, "on": 12},
+        "goals": {"total": 5, "conceded": 0, "assists": 7, "saves": 3},
+        "passes": {"total": 1200, "key": 40, "accuracy": "82%"},
+        "tackles": {"total": 45, "blocks": 3, "interceptions": 20},
+        "duels": {"total": 200, "won": 110},
+        "dribbles": {"attempts": 60, "success": 40},
+        "fouls": {"drawn": 25, "committed": 18},
+        "cards": {"yellow": 4, "red": 0},
+        "penalty": {"scored": 1, "missed": 0, "saved": None},
+    }
+
+
+class TestRichExtraction:
+    def test_full_payload_lands_every_rich_column(self):
+        entry = _service()._create_entry_from_stat(1, 2025, _full_payload(), player_api_id=303010)
+
+        # Provenance + denormalized id.
+        assert entry.stats_source == "journey-api"
+        assert entry.player_api_id == 303010
+        assert isinstance(entry.stats_synced_at, datetime)
+
+        # Every rich column landed with the coerced value.
+        assert entry.rating == pytest.approx(7.42)
+        assert entry.position == "Midfielder"
+        assert entry.lineups == 22
+        assert entry.shots_total == 30
+        assert entry.shots_on == 12
+        assert entry.passes_total == 1200
+        assert entry.passes_key == 40
+        assert entry.passes_accuracy == 82  # "82%" -> 82
+        assert entry.tackles_total == 45
+        assert entry.tackles_blocks == 3
+        assert entry.tackles_interceptions == 20
+        assert entry.duels_total == 200
+        assert entry.duels_won == 110
+        assert entry.dribbles_attempts == 60
+        assert entry.dribbles_success == 40
+        assert entry.fouls_drawn == 25
+        assert entry.fouls_committed == 18
+        assert entry.cards_yellow == 4
+        assert entry.cards_red == 0
+        assert entry.penalty_scored == 1
+        assert entry.penalty_missed == 0
+        assert entry.penalty_saved is None  # explicit null preserved
+        assert entry.saves == 3
+
+    def test_observed_zero_is_kept_not_nulled(self):
+        """A real observed zero (goals.conceded == 0) stays 0 — only a
+        missing/None field becomes NULL. Missing ≠ zero."""
+        entry = _service()._create_entry_from_stat(1, 2025, _full_payload(), player_api_id=1)
+        assert entry.goals_conceded == 0
+        assert entry.goals_conceded is not None
+
+    @pytest.mark.parametrize(
+        "stat",
+        [
+            _full_payload(),
+            # British spelling absent -> American 'appearances' fallback.
+            {"team": {"id": 1}, "games": {"appearances": 9, "minutes": 700}, "goals": {"total": 2, "assists": 1}},
+            # Everything absent -> all four default to 0.
+            {"team": {"id": 1}},
+            # Zeroes must survive the `or 0` guard as 0 (they already are 0).
+            {"team": {"id": 1}, "games": {"appearences": 0, "minutes": 0}, "goals": {"total": 0, "assists": 0}},
+        ],
+    )
+    def test_basic_four_unchanged_vs_legacy(self, stat):
+        entry = _service()._create_entry_from_stat(1, 2025, stat, player_api_id=1)
+        expected = _legacy_basic_four(stat)
+        assert entry.appearances == expected["appearances"]
+        assert entry.goals == expected["goals"]
+        assert entry.assists == expected["assists"]
+        assert entry.minutes == expected["minutes"]
+
+    def test_sparse_payload_yields_null_rich_columns(self):
+        """Blocks absent OR present-but-null both coerce to NULL rich columns
+        with no crash; basic fields default to 0."""
+        sparse = {
+            "team": {"id": 50, "name": "Sparse FC"},
+            "league": {"id": 1, "name": "Some League"},
+            "games": {"minutes": None},
+            "goals": {},
+            "shots": None,  # present but null
+            "passes": None,
+        }
+        entry = _service()._create_entry_from_stat(1, 2025, sparse, player_api_id=None)
+        assert entry.appearances == 0
+        assert entry.goals == 0
+        assert entry.minutes == 0
+        for field in (
+            "rating",
+            "position",
+            "lineups",
+            "shots_total",
+            "shots_on",
+            "passes_total",
+            "tackles_total",
+            "duels_won",
+            "dribbles_success",
+            "penalty_scored",
+            "saves",
+            "goals_conceded",
+        ):
+            assert getattr(entry, field) is None, f"{field} should be NULL for a sparse payload"
+
+    def test_missing_team_returns_none(self):
+        assert _service()._create_entry_from_stat(1, 2025, {"team": {}}) is None
+        assert _service()._create_entry_from_stat(1, 2025, {}) is None
+
+
+class TestStatCoercionHelpers:
+    """The NULL-preserving coercion contract (missing ≠ 0)."""
+
+    def test_stat_int(self):
+        assert _stat_int("82%") == 82  # percentage string
+        assert _stat_int("12.9") == 12  # numeric string, truncated
+        assert _stat_int(7) == 7
+        assert _stat_int(True) == 1  # bool coerces
+        assert _stat_int(None) is None  # missing stays NULL
+        assert _stat_int("") is None  # empty stays NULL
+        assert _stat_int("  ") is None
+        assert _stat_int("n/a") is None  # non-numeric -> NULL, no crash
+
+    def test_stat_float(self):
+        assert _stat_float("7.5") == pytest.approx(7.5)
+        assert _stat_float(6) == pytest.approx(6.0)
+        assert _stat_float(None) is None
+        assert _stat_float("") is None
+        assert _stat_float("x") is None
+
+
+# ---------------------------------------------------------------------------
+# (4) Duplicate-merge keeps rich fields
+# ---------------------------------------------------------------------------
+
+
+def _entry(appearances, source, synced_at, season=2025, rating=None, shots_total=None):
+    """A journey entry sharing the (club, league, season) key so the merge groups
+    it — simulates a club-ID correction colliding two rows."""
+    from src.models.journey import PlayerJourneyEntry
+
+    return PlayerJourneyEntry(
+        journey_id=1,
+        season=season,
+        club_api_id=99,
+        league_api_id=39,
+        appearances=appearances,
+        stats_source=source,
+        stats_synced_at=synced_at,
+        rating=rating,
+        shots_total=shots_total,
+    )
+
+
+_NOW = datetime.now(UTC)
+_OLDER = datetime(2020, 1, 1, tzinfo=UTC)
+
+
+class TestMergeSurvivorKeepsRichData:
+    def test_tie_appearances_prefers_journey_api_and_rich_fields_ride_along(self):
+        legacy = _entry(10, "legacy-basic", _OLDER)
+        rich = _entry(10, "journey-api", _NOW, rating=7.1, shots_total=30)
+        survivors = _service()._merge_corrected_duplicates([legacy, rich])
+        assert len(survivors) == 1
+        winner = survivors[0]
+        assert winner.stats_source == "journey-api"
+        assert winner.rating == pytest.approx(7.1)
+        assert winner.shots_total == 30  # rich data survives the merge
+
+    def test_more_appearances_wins_even_if_legacy(self):
+        """The primary 'more complete data' rule is untouched — appearances still
+        beats source rank."""
+        more = _entry(20, "legacy-basic", _OLDER)
+        fewer = _entry(10, "journey-api", _NOW)
+        survivors = _service()._merge_corrected_duplicates([more, fewer])
+        assert len(survivors) == 1
+        assert survivors[0].appearances == 20
+        assert survivors[0].stats_source == "legacy-basic"
+
+    def test_tie_prefers_newer_synced_at(self):
+        older = _entry(10, "journey-api", _OLDER, shots_total=1)
+        newer = _entry(10, "journey-api", _NOW, shots_total=99)
+        survivors = _service()._merge_corrected_duplicates([older, newer])
+        assert len(survivors) == 1
+        assert survivors[0].shots_total == 99  # newer stats_synced_at wins
+
+    def test_non_duplicate_entries_pass_through(self):
+        a = _entry(10, "journey-api", _NOW, season=2025)
+        b = _entry(5, "journey-api", _NOW, season=2024)  # different season -> not a dup
+        survivors = _service()._merge_corrected_duplicates([a, b])
+        assert len(survivors) == 2
+
+
+# ---------------------------------------------------------------------------
+# (5) Backfill endpoint
+# ---------------------------------------------------------------------------
+
+ADMIN_KEY = "test-admin-key"
+_BACKFILL_URL = "/api/admin/journeys/backfill-entry-player-ids"
+
+
+@pytest.fixture
+def backfill_app(monkeypatch):
+    monkeypatch.setenv("SKIP_API_HANDSHAKE", "1")
+    monkeypatch.setenv("API_USE_STUB_DATA", "true")
+    monkeypatch.setenv("ADMIN_API_KEY", ADMIN_KEY)
+    monkeypatch.setenv("ADMIN_IP_WHITELIST", "")
+
+    from src.models.league import db
+    from src.routes.journey import journey_bp
+
+    application = Flask(__name__)
+    application.config.update(
+        TESTING=True,
+        SECRET_KEY="test-secret-key",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+    db.init_app(application)
+    application.register_blueprint(journey_bp, url_prefix="/api")
+
+    ctx = application.app_context()
+    ctx.push()
+    db.create_all()
+    yield application
+    db.session.remove()
+    db.drop_all()
+    ctx.pop()
+
+
+@pytest.fixture
+def backfill_client(backfill_app):
+    return backfill_app.test_client()
+
+
+@pytest.fixture
+def admin_headers(backfill_app):
+    from src.auth import issue_user_token
+
+    token = issue_user_token("admin@test.com", role="admin")["token"]
+    return {"Authorization": f"Bearer {token}", "X-API-Key": ADMIN_KEY}
+
+
+def _seed_null_entries(count, entries_per_journey=2):
+    """Create `count` PlayerJourneyEntry rows with NULL player_api_id, spread
+    across journeys. Returns {entry_id: expected_player_api_id}."""
+    from src.models.journey import PlayerJourney, PlayerJourneyEntry
+    from src.models.league import db
+
+    expected = {}
+    made = 0
+    journey_seq = 0
+    while made < count:
+        journey_seq += 1
+        player_api_id = 5000 + journey_seq
+        journey = PlayerJourney(player_api_id=player_api_id, player_name=f"P{player_api_id}")
+        db.session.add(journey)
+        db.session.flush()
+        for _ in range(entries_per_journey):
+            if made >= count:
+                break
+            entry = PlayerJourneyEntry(journey_id=journey.id, season=2025, club_api_id=player_api_id * 10)
+            db.session.add(entry)
+            db.session.flush()
+            expected[entry.id] = player_api_id
+            made += 1
+    db.session.commit()
+    return expected
+
+
+def _null_count():
+    from src.models.journey import PlayerJourneyEntry
+
+    return PlayerJourneyEntry.query.filter(PlayerJourneyEntry.player_api_id.is_(None)).count()
+
+
+class TestBackfillEntryPlayerIds:
+    def test_batches_converge_to_zero_and_data_is_correct(self, backfill_app, backfill_client, admin_headers):
+        expected = _seed_null_entries(7, entries_per_journey=2)
+        assert _null_count() == 7
+
+        remaining = None
+        guard = 0
+        while remaining != 0:
+            guard += 1
+            assert guard < 20, "backfill did not converge"
+            before = _null_count()
+            resp = backfill_client.post(f"{_BACKFILL_URL}?batch_size=3", headers=admin_headers)
+            assert resp.status_code == 200
+            body = resp.get_json()
+            remaining = body["remaining"]
+            # Endpoint's own count agrees with the DB, and each call fills at most
+            # the batch bound (3), monotonically shrinking the NULL set.
+            assert remaining == _null_count()
+            assert before - remaining <= 3
+            assert remaining < before or before == 0
+
+        # Every entry now carries its parent journey's player id.
+        from src.models.journey import PlayerJourneyEntry
+        from src.models.league import db
+
+        db.session.expire_all()
+        for entry_id, player_api_id in expected.items():
+            assert db.session.get(PlayerJourneyEntry, entry_id).player_api_id == player_api_id
+
+    def test_respects_batch_bound(self, backfill_app, backfill_client, admin_headers):
+        _seed_null_entries(5, entries_per_journey=5)
+        assert _null_count() == 5
+        resp = backfill_client.post(f"{_BACKFILL_URL}?batch_size=2", headers=admin_headers)
+        assert resp.status_code == 200
+        # Exactly 2 of 5 filled -> 3 remain.
+        assert resp.get_json()["remaining"] == 3
+        assert _null_count() == 3
+
+    def test_idempotent_on_rerun(self, backfill_app, backfill_client, admin_headers):
+        _seed_null_entries(4, entries_per_journey=1)
+        # Drain to zero.
+        for _ in range(4):
+            backfill_client.post(f"{_BACKFILL_URL}?batch_size=10", headers=admin_headers)
+        assert _null_count() == 0
+        # Re-running after completion is a clean no-op.
+        resp = backfill_client.post(f"{_BACKFILL_URL}?batch_size=10", headers=admin_headers)
+        assert resp.status_code == 200
+        assert resp.get_json()["remaining"] == 0
+        assert _null_count() == 0
+
+    def test_never_overwrites_an_already_set_id(self, backfill_app, backfill_client, admin_headers):
+        """The batch targets NULL rows only — a row with a value set (even a
+        deliberately 'wrong' one) is never clobbered."""
+        from src.models.journey import PlayerJourney, PlayerJourneyEntry
+        from src.models.league import db
+
+        journey = PlayerJourney(player_api_id=9000, player_name="P9000")
+        db.session.add(journey)
+        db.session.flush()
+        # Pre-set to a sentinel that does NOT match the parent (9000).
+        pinned = PlayerJourneyEntry(journey_id=journey.id, season=2025, club_api_id=1, player_api_id=123456)
+        null_row = PlayerJourneyEntry(journey_id=journey.id, season=2024, club_api_id=2)
+        db.session.add_all([pinned, null_row])
+        db.session.flush()
+        pinned_id, null_id = pinned.id, null_row.id
+        db.session.commit()
+
+        resp = backfill_client.post(f"{_BACKFILL_URL}?batch_size=100", headers=admin_headers)
+        assert resp.status_code == 200
+        assert resp.get_json()["remaining"] == 0
+
+        db.session.expire_all()
+        assert db.session.get(PlayerJourneyEntry, pinned_id).player_api_id == 123456  # untouched
+        assert db.session.get(PlayerJourneyEntry, null_id).player_api_id == 9000  # filled from parent
+
+    @pytest.mark.parametrize(
+        "requested,expected",
+        [
+            ("999999", 50000),  # clamped down to the 50k ceiling
+            ("0", 5000),  # < 1 -> default
+            ("-5", 5000),  # negative -> default
+            ("abc", 5000),  # non-integer -> default
+        ],
+    )
+    def test_clamps_batch_size(self, backfill_app, backfill_client, admin_headers, requested, expected):
+        resp = backfill_client.post(f"{_BACKFILL_URL}?batch_size={requested}", headers=admin_headers)
+        assert resp.status_code == 200
+        assert resp.get_json()["batch_size"] == expected
+
+    def test_requires_admin_auth(self, backfill_app, backfill_client):
+        resp = backfill_client.post(_BACKFILL_URL)
+        assert resp.status_code == 401


### PR DESCRIPTION
## What

Phase D2 of the approved seasons design (`ledgers/research/seasons-design-proposal.md` §2/§3/§6-Q7) — write-side only, zero display changes. Built by a 14-agent workflow (impl + two adversarial reviewers per stage), independently reviewed by the orchestrating session.

- **Migration `sea01`** (`aw23 → sea01`, all DDL guarded via `_migration_helpers`): widens `player_journey_entries` with 28 nullable columns (rating, position, lineups, shots/passes/tackles/duels/dribbles/fouls/cards/penalties, goals_conceded, saves, `player_api_id`, `stats_source`, `stats_synced_at`, dormant `season_phase`) + `ix_pje_player_season`. **Not auto-applied** — prod DDL runs post-merge per invariants.
- **Wider extraction** in `JourneySyncService`: persists the rich per-season fields from the `players?id&season` payload the sync already fetches and discarded — **zero additional API-Football calls**. Duplicate-merge (club-ID correction) prefers `journey-api`/newer rich data.
- **Backfill endpoint** `POST /api/admin/journeys/backfill-entry-player-ids`: admin-authed, batched (bounded per request — the 0.5 CPU container never sees 77k rows at once), idempotent, returns `{updated, remaining}`.
- **Drift fixes the reviewers forced**: model metadata now matches prod's real indexes (aw15 composite `ix_fps_player_team` declared; redundant single-column index dropped from sea01; `journey_id` index name aligned; phantom `uq_journey_entry` removed from metadata — autogenerate is now a genuine no-op against a migrated DB).

## Verification

- ruff check + format --check: clean.
- Suite: 810 passed / 23 failed / 12 collection errors — failure+error sets **byte-identical to merge-base** (re-verified at 3abaa72); +29 new tests (`test_season_data_sea01.py`) including partial-out-of-band replay (the invariants §8 drift mode, mutation-proven) and a 28-column DDL↔model parity pin.
- Post-merge ops (B0, pure-DB): apply sea01 DDL to prod, stamp alembic, run the batched backfill to completion.

Next: D3 (sea02 rollup tables + service) per the proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)