### PR TITLE
fix(stats): persist the full API-Football stat block at every fixture-stats writer

### DIFF
--- a/academy-watch-backend/src/agents/weekly_newsletter_agent.py
+++ b/academy-watch-backend/src/agents/weekly_newsletter_agent.py
@@ -37,6 +37,7 @@ from src.models.journey import PlayerJourney, PlayerJourneyEntry, derive_journey
 from src.models.league import AdminSetting, Newsletter, NewsletterCommentary, Team, db
 from src.models.tracked_player import TrackedPlayer
 from src.services.graph_service import GraphService
+from src.utils.fixture_stats_mapper import map_player_stat_block
 from src.utils.newsletter_slug import compose_newsletter_public_slug
 
 dotenv.load_dotenv(dotenv.find_dotenv())
@@ -1938,16 +1939,6 @@ def _sync_team_fixtures_for_week(
                     st = statistics[0]
 
                     games = st.get("games", {}) or {}
-                    goals_obj = st.get("goals", {}) or {}
-                    cards = st.get("cards", {}) or {}
-                    shots = st.get("shots", {}) or {}
-                    passes = st.get("passes", {}) or {}
-                    tackles = st.get("tackles", {}) or {}
-                    duels = st.get("duels", {}) or {}
-                    dribbles = st.get("dribbles", {}) or {}
-                    fouls = st.get("fouls", {}) or {}
-                    penalty = st.get("penalty", {}) or {}
-
                     minutes = games.get("minutes", 0) or 0
 
                     if minutes > 0 or games.get("substitute") is not None:
@@ -1955,28 +1946,9 @@ def _sync_team_fixtures_for_week(
                             fixture_id=existing_fixture.id,
                             player_api_id=pid,
                             team_api_id=club_api_id,
-                            minutes=minutes,
-                            position=games.get("position"),
-                            rating=games.get("rating"),
-                            captain=bool(games.get("captain")),
-                            substitute=bool(games.get("substitute")),
-                            goals=goals_obj.get("total", 0) or 0,
-                            assists=goals_obj.get("assists", 0) or 0,
-                            yellows=cards.get("yellow", 0) or 0,
-                            reds=cards.get("red", 0) or 0,
-                            shots_total=shots.get("total"),
-                            shots_on=shots.get("on"),
-                            passes_total=passes.get("total"),
-                            passes_key=passes.get("key"),
-                            tackles_total=tackles.get("total"),
-                            duels_won=duels.get("won"),
-                            duels_total=duels.get("total"),
-                            dribbles_success=dribbles.get("success"),
-                            saves=goals_obj.get("saves"),
-                            goals_conceded=goals_obj.get("conceded"),
-                            fouls_drawn=fouls.get("drawn"),
-                            fouls_committed=fouls.get("committed"),
-                            penalty_saved=penalty.get("saved"),
+                            raw_json=json.dumps(p),
+                            # Full API-Football stat block (minutes, substitute, cards, ...)
+                            **map_player_stat_block(st),
                         )
                         db.session.add(fps)
                         total_synced += 1

--- a/academy-watch-backend/src/api_football_client.py
+++ b/academy-watch-backend/src/api_football_client.py
@@ -4719,119 +4719,13 @@ class APIFootballClient:
         - Goalkeeper-specific stats (saves, goals conceded)
         """
         from src.models.weekly import FixturePlayerStats
+        from src.utils.fixture_stats_mapper import map_player_stat_block
 
         stats = (pstats_row or {}).get("statistics", [])
 
-        # Initialize all stats with defaults
-        stats_dict = {
-            "minutes": 0,
-            "goals": 0,
-            "assists": 0,
-            "yellows": 0,
-            "reds": 0,
-            "position": None,
-            "number": None,
-            "rating": None,
-            "captain": False,
-            "substitute": False,
-            "goals_conceded": None,
-            "saves": None,
-            "shots_total": None,
-            "shots_on": None,
-            "passes_total": None,
-            "passes_key": None,
-            "passes_accuracy": None,
-            "tackles_total": None,
-            "tackles_blocks": None,
-            "tackles_interceptions": None,
-            "duels_total": None,
-            "duels_won": None,
-            "dribbles_attempts": None,
-            "dribbles_success": None,
-            "dribbles_past": None,
-            "fouls_drawn": None,
-            "fouls_committed": None,
-            "penalty_won": None,
-            "penalty_committed": None,
-            "penalty_scored": None,
-            "penalty_missed": None,
-            "penalty_saved": None,
-            "offsides": None,
-        }
-
-        if stats:
-            # First statistics block contains the data
-            stat_block = stats[0]
-
-            # Games (basic info)
-            games = stat_block.get("games", {}) or {}
-            stats_dict["minutes"] = games.get("minutes") or 0
-            stats_dict["position"] = games.get("position")
-            stats_dict["number"] = games.get("number")
-            stats_dict["rating"] = float(games.get("rating")) if games.get("rating") else None
-            stats_dict["captain"] = games.get("captain", False)
-            stats_dict["substitute"] = games.get("substitute", False)
-
-            # Goals and assists
-            goals_block = stat_block.get("goals", {}) or {}
-            stats_dict["goals"] = goals_block.get("total") or 0
-            stats_dict["assists"] = goals_block.get("assists") or 0
-            stats_dict["goals_conceded"] = goals_block.get("conceded")
-            stats_dict["saves"] = goals_block.get("saves")
-
-            # Cards
-            cards = stat_block.get("cards", {}) or {}
-            stats_dict["yellows"] = cards.get("yellow") or 0
-            stats_dict["reds"] = cards.get("red") or 0
-
-            # Shots
-            shots = stat_block.get("shots", {}) or {}
-            stats_dict["shots_total"] = shots.get("total")
-            stats_dict["shots_on"] = shots.get("on")
-
-            # Passes
-            passes = stat_block.get("passes", {}) or {}
-            stats_dict["passes_total"] = passes.get("total")
-            stats_dict["passes_key"] = passes.get("key")
-            # Store accuracy as string (e.g. "68%")
-            pass_accuracy = passes.get("accuracy")
-            if pass_accuracy is not None:
-                stats_dict["passes_accuracy"] = (
-                    str(pass_accuracy) if isinstance(pass_accuracy, str) else f"{pass_accuracy}%"
-                )
-
-            # Tackles
-            tackles = stat_block.get("tackles", {}) or {}
-            stats_dict["tackles_total"] = tackles.get("total")
-            stats_dict["tackles_blocks"] = tackles.get("blocks")
-            stats_dict["tackles_interceptions"] = tackles.get("interceptions")
-
-            # Duels
-            duels = stat_block.get("duels", {}) or {}
-            stats_dict["duels_total"] = duels.get("total")
-            stats_dict["duels_won"] = duels.get("won")
-
-            # Dribbles
-            dribbles = stat_block.get("dribbles", {}) or {}
-            stats_dict["dribbles_attempts"] = dribbles.get("attempts")
-            stats_dict["dribbles_success"] = dribbles.get("success")
-            stats_dict["dribbles_past"] = dribbles.get("past")
-
-            # Fouls
-            fouls = stat_block.get("fouls", {}) or {}
-            stats_dict["fouls_drawn"] = fouls.get("drawn")
-            stats_dict["fouls_committed"] = fouls.get("committed")
-
-            # Penalties
-            penalty = stat_block.get("penalty", {}) or {}
-            stats_dict["penalty_won"] = penalty.get("won")
-            stats_dict["penalty_committed"] = penalty.get("commited")  # Note: API has typo "commited"
-            stats_dict["penalty_scored"] = penalty.get("scored")
-            stats_dict["penalty_missed"] = penalty.get("missed")
-            stats_dict["penalty_saved"] = penalty.get("saved")
-
-            # Offsides
-            stats_dict["offsides"] = stat_block.get("offsides")
+        # Full stat mapping shared by every FixturePlayerStats writer; an empty
+        # block yields the defaults (0 counting stats, False flags, None rest).
+        stats_dict = map_player_stat_block(stats[0] if stats else None)
 
         # Find or create the stats record
         row = db_session.query(FixturePlayerStats).filter_by(fixture_id=fixture_pk, player_api_id=player_api_id).first()

--- a/academy-watch-backend/src/routes/api.py
+++ b/academy-watch-backend/src/routes/api.py
@@ -96,6 +96,7 @@ from src.utils.background_jobs import (
 from src.utils.background_jobs import (
     update_job as _update_job,
 )
+from src.utils.fixture_stats_mapper import map_player_stat_block
 from src.utils.newsletter_slug import compose_newsletter_public_slug
 from src.utils.player_names import resolve_player_name
 from src.utils.sanitize import (
@@ -1596,26 +1597,13 @@ def _sync_player_club_fixtures(player_id: int, loan_team_api_id: int, season: in
                     continue
                 st = stat_list[0] if isinstance(stat_list, list) else stat_list
 
-                # Extract stats from the nested structure
                 games = st.get("games", {}) or {}
-                goals_obj = st.get("goals", {}) or {}
-                cards = st.get("cards", {}) or {}
-                shots = st.get("shots", {}) or {}
-                passes = st.get("passes", {}) or {}
-                tackles = st.get("tackles", {}) or {}
-                duels = st.get("duels", {}) or {}
-                dribbles = st.get("dribbles", {}) or {}
-
                 minutes = games.get("minutes", 0) or 0
 
                 # Record if player played (minutes > 0) or was listed as substitute
                 # API-Football returns null minutes for some leagues, so we also
                 # check the substitute flag to avoid dropping valid appearances
                 if minutes > 0 or games.get("substitute") is not None:
-                    # Fouls and penalties for more complete stats
-                    fouls = st.get("fouls", {}) or {}
-                    penalty = st.get("penalty", {}) or {}
-
                     formation, grid, formation_pos = _extract_lineup_info(
                         api_client, fixture_id_api, player_id, loan_team_api_id
                     )
@@ -1624,33 +1612,13 @@ def _sync_player_club_fixtures(player_id: int, loan_team_api_id: int, season: in
                         fixture_id=existing_fixture.id,
                         player_api_id=player_id,
                         team_api_id=loan_team_api_id,
-                        minutes=minutes,
-                        substitute=bool(games.get("substitute")),
-                        position=games.get("position"),
-                        rating=games.get("rating"),
-                        goals=goals_obj.get("total", 0) or 0,
-                        assists=goals_obj.get("assists", 0) or 0,
-                        yellows=cards.get("yellow", 0) or 0,
-                        reds=cards.get("red", 0) or 0,
-                        shots_total=shots.get("total"),
-                        shots_on=shots.get("on"),
-                        passes_total=passes.get("total"),
-                        passes_key=passes.get("key"),
-                        tackles_total=tackles.get("total"),
-                        duels_won=duels.get("won"),
-                        duels_total=duels.get("total"),
-                        dribbles_success=dribbles.get("success"),
-                        # Goalkeeper stats - saves and conceded are in goals block
-                        saves=goals_obj.get("saves"),
-                        goals_conceded=goals_obj.get("conceded"),
-                        # Additional stats
-                        fouls_drawn=fouls.get("drawn"),
-                        fouls_committed=fouls.get("committed"),
-                        penalty_saved=penalty.get("saved"),
                         # Formation & tactical position
                         formation=formation,
                         grid=grid,
                         formation_position=formation_pos,
+                        raw_json=json.dumps(player_stats),
+                        # Full API-Football stat block (minutes, substitute, cards, ...)
+                        **map_player_stat_block(st),
                     )
                     db.session.add(fps)
                     synced += 1
@@ -5097,18 +5065,7 @@ def admin_sync_player_fixtures(player_id: int):
                         continue
                     st = stat_list[0] if isinstance(stat_list, list) else stat_list
 
-                    # Extract stats from the nested structure
                     games = st.get("games", {}) or {}
-                    goals_block = st.get("goals", {}) or {}
-                    cards = st.get("cards", {}) or {}
-                    shots = st.get("shots", {}) or {}
-                    passes = st.get("passes", {}) or {}
-                    tackles = st.get("tackles", {}) or {}
-                    duels = st.get("duels", {}) or {}
-                    dribbles = st.get("dribbles", {}) or {}
-                    fouls = st.get("fouls", {}) or {}
-                    penalty = st.get("penalty", {}) or {}
-
                     minutes = games.get("minutes", 0) or 0
 
                     # Record if player played or was listed as substitute
@@ -5120,30 +5077,12 @@ def admin_sync_player_fixtures(player_id: int):
                             fixture_id=existing_fixture.id,
                             player_api_id=player_id,
                             team_api_id=team_api_id,
-                            minutes=minutes,
-                            substitute=bool(games.get("substitute")),
-                            position=games.get("position"),
-                            rating=games.get("rating"),
-                            goals=goals_block.get("total", 0) or 0,
-                            assists=goals_block.get("assists", 0) or 0,
-                            yellows=cards.get("yellow", 0) or 0,
-                            reds=cards.get("red", 0) or 0,
-                            shots_total=shots.get("total"),
-                            shots_on=shots.get("on"),
-                            passes_total=passes.get("total"),
-                            passes_key=passes.get("key"),
-                            tackles_total=tackles.get("total"),
-                            duels_won=duels.get("won"),
-                            duels_total=duels.get("total"),
-                            dribbles_success=dribbles.get("success"),
-                            saves=goals_block.get("saves"),
-                            goals_conceded=goals_block.get("conceded"),
-                            fouls_drawn=fouls.get("drawn"),
-                            fouls_committed=fouls.get("committed"),
-                            penalty_saved=penalty.get("saved"),
                             formation=formation,
                             grid=grid,
                             formation_position=formation_pos,
+                            raw_json=json.dumps(player_stats),
+                            # Full API-Football stat block (minutes, substitute, cards, ...)
+                            **map_player_stat_block(st),
                         )
                         db.session.add(fps)
                         synced += 1
@@ -5550,16 +5489,6 @@ def _run_batch_fixture_sync(data: dict, job_id: str = None) -> dict:
                         st = statistics[0]
 
                         games = st.get("games", {}) or {}
-                        goals_obj = st.get("goals", {}) or {}
-                        cards = st.get("cards", {}) or {}
-                        shots = st.get("shots", {}) or {}
-                        passes = st.get("passes", {}) or {}
-                        tackles = st.get("tackles", {}) or {}
-                        duels = st.get("duels", {}) or {}
-                        dribbles = st.get("dribbles", {}) or {}
-                        fouls = st.get("fouls", {}) or {}
-                        penalty = st.get("penalty", {}) or {}
-
                         minutes = games.get("minutes", 0) or 0
 
                         if minutes > 0 or games.get("substitute") is not None:
@@ -5571,29 +5500,12 @@ def _run_batch_fixture_sync(data: dict, job_id: str = None) -> dict:
                                     fixture_id=existing_fixture.id,
                                     player_api_id=pid,
                                     team_api_id=team_api_id,
-                                    minutes=minutes,
-                                    position=games.get("position"),
-                                    rating=games.get("rating"),
-                                    goals=goals_obj.get("total", 0) or 0,
-                                    assists=goals_obj.get("assists", 0) or 0,
-                                    yellows=cards.get("yellow", 0) or 0,
-                                    reds=cards.get("red", 0) or 0,
-                                    shots_total=shots.get("total"),
-                                    shots_on=shots.get("on"),
-                                    passes_total=passes.get("total"),
-                                    passes_key=passes.get("key"),
-                                    tackles_total=tackles.get("total"),
-                                    duels_won=duels.get("won"),
-                                    duels_total=duels.get("total"),
-                                    dribbles_success=dribbles.get("success"),
-                                    saves=goals_obj.get("saves"),
-                                    goals_conceded=goals_obj.get("conceded"),
-                                    fouls_drawn=fouls.get("drawn"),
-                                    fouls_committed=fouls.get("committed"),
-                                    penalty_saved=penalty.get("saved"),
                                     formation=formation,
                                     grid=grid_val,
                                     formation_position=formation_pos,
+                                    raw_json=json.dumps(p),
+                                    # Full API-Football stat block (minutes, substitute, cards, ...)
+                                    **map_player_stat_block(st),
                                 )
                                 db.session.add(fps)
                             team_result["synced"] += 1
@@ -6137,18 +6049,7 @@ def _run_team_fixtures_sync(team_id: int, data: dict, job_id: str = None) -> dic
                                 continue
                             st = stat_list[0] if isinstance(stat_list, list) else stat_list
 
-                            # Extract stats
                             games = st.get("games", {}) or {}
-                            goals_block = st.get("goals", {}) or {}
-                            cards = st.get("cards", {}) or {}
-                            shots = st.get("shots", {}) or {}
-                            passes = st.get("passes", {}) or {}
-                            tackles = st.get("tackles", {}) or {}
-                            duels = st.get("duels", {}) or {}
-                            dribbles = st.get("dribbles", {}) or {}
-                            fouls = st.get("fouls", {}) or {}
-                            penalty = st.get("penalty", {}) or {}
-
                             minutes = games.get("minutes", 0) or 0
 
                             if (
@@ -6163,29 +6064,12 @@ def _run_team_fixtures_sync(team_id: int, data: dict, job_id: str = None) -> dic
                                     fixture_id=existing_fixture.id,
                                     player_api_id=p_api_id,
                                     team_api_id=p_team_api_id,
-                                    minutes=minutes,
-                                    position=games.get("position"),
-                                    rating=games.get("rating"),
-                                    goals=goals_block.get("total", 0) or 0,
-                                    assists=goals_block.get("assists", 0) or 0,
-                                    yellows=cards.get("yellow", 0) or 0,
-                                    reds=cards.get("red", 0) or 0,
-                                    shots_total=shots.get("total"),
-                                    shots_on=shots.get("on"),
-                                    passes_total=passes.get("total"),
-                                    passes_key=passes.get("key"),
-                                    tackles_total=tackles.get("total"),
-                                    duels_won=duels.get("won"),
-                                    duels_total=duels.get("total"),
-                                    dribbles_success=dribbles.get("success"),
-                                    saves=goals_block.get("saves"),
-                                    goals_conceded=goals_block.get("conceded"),
-                                    fouls_drawn=fouls.get("drawn"),
-                                    fouls_committed=fouls.get("committed"),
-                                    penalty_saved=penalty.get("saved"),
                                     formation=formation,
                                     grid=grid_val,
                                     formation_position=formation_pos,
+                                    raw_json=json.dumps(player_stats),
+                                    # Full API-Football stat block (minutes, substitute, cards, ...)
+                                    **map_player_stat_block(st),
                                 )
                                 db.session.add(fps)
                                 player_result["synced"] += 1

--- a/academy-watch-backend/src/utils/fixture_stats_mapper.py
+++ b/academy-watch-backend/src/utils/fixture_stats_mapper.py
@@ -1,0 +1,83 @@
+"""Shared mapping from an API-Football player stat block to FixturePlayerStats columns.
+
+API-Football's ``/fixtures/players`` endpoint returns one ``statistics[0]`` dict per
+player. Historically each writer hand-picked a subset of fields, which left rich
+columns (tackles_interceptions, tackles_blocks, passes_accuracy, dribbles_attempts,
+dribbles_past, the penalty set, offsides) almost entirely NULL in prod. Every
+FixturePlayerStats writer must build its stat fields through
+:func:`map_player_stat_block` so the full block is persisted everywhere.
+
+The parsing semantics mirror ``APIFootballClient._upsert_player_fixture_stats`` (the
+historical reference implementation): ``or {}`` guards on nested blocks, ``or 0``
+coercion for counting stats, float coercion for rating, and string coercion for pass
+accuracy. Identity fields (fixture_id, player_api_id, team_api_id), the formation
+fields (formation, grid, formation_position) and raw_json are owned by callers.
+"""
+
+
+def map_player_stat_block(stat_block: dict | None) -> dict:
+    """Map an API-Football ``statistics[0]`` dict to FixturePlayerStats column values.
+
+    Returns a dict covering every stat column of ``FixturePlayerStats``. Passing an
+    empty (or ``None``) block yields the defaults: 0 for counting stats
+    (minutes/goals/assists/yellows/reds), ``False`` for flags, ``None`` for the rest.
+    """
+    stat_block = stat_block or {}
+
+    games = stat_block.get("games", {}) or {}
+    goals_block = stat_block.get("goals", {}) or {}
+    cards = stat_block.get("cards", {}) or {}
+    shots = stat_block.get("shots", {}) or {}
+    passes = stat_block.get("passes", {}) or {}
+    tackles = stat_block.get("tackles", {}) or {}
+    duels = stat_block.get("duels", {}) or {}
+    dribbles = stat_block.get("dribbles", {}) or {}
+    fouls = stat_block.get("fouls", {}) or {}
+    penalty = stat_block.get("penalty", {}) or {}
+
+    # Store accuracy as a string (e.g. "68%"); the API sends an int or a string.
+    pass_accuracy = passes.get("accuracy")
+    if pass_accuracy is not None:
+        pass_accuracy = pass_accuracy if isinstance(pass_accuracy, str) else f"{pass_accuracy}%"
+
+    # The API spells it "commited" (known API-Football typo); fall back to the
+    # correct spelling in case the provider ever fixes it.
+    penalty_committed = penalty.get("commited")
+    if penalty_committed is None:
+        penalty_committed = penalty.get("committed")
+
+    return {
+        "minutes": games.get("minutes") or 0,
+        "position": games.get("position"),
+        "number": games.get("number"),
+        "rating": float(games.get("rating")) if games.get("rating") else None,
+        "captain": games.get("captain", False),
+        "substitute": games.get("substitute", False),
+        "goals": goals_block.get("total") or 0,
+        "assists": goals_block.get("assists") or 0,
+        "goals_conceded": goals_block.get("conceded"),
+        "saves": goals_block.get("saves"),
+        "yellows": cards.get("yellow") or 0,
+        "reds": cards.get("red") or 0,
+        "shots_total": shots.get("total"),
+        "shots_on": shots.get("on"),
+        "passes_total": passes.get("total"),
+        "passes_key": passes.get("key"),
+        "passes_accuracy": pass_accuracy,
+        "tackles_total": tackles.get("total"),
+        "tackles_blocks": tackles.get("blocks"),
+        "tackles_interceptions": tackles.get("interceptions"),
+        "duels_total": duels.get("total"),
+        "duels_won": duels.get("won"),
+        "dribbles_attempts": dribbles.get("attempts"),
+        "dribbles_success": dribbles.get("success"),
+        "dribbles_past": dribbles.get("past"),
+        "fouls_drawn": fouls.get("drawn"),
+        "fouls_committed": fouls.get("committed"),
+        "penalty_won": penalty.get("won"),
+        "penalty_committed": penalty_committed,
+        "penalty_scored": penalty.get("scored"),
+        "penalty_missed": penalty.get("missed"),
+        "penalty_saved": penalty.get("saved"),
+        "offsides": stat_block.get("offsides"),
+    }

--- a/academy-watch-backend/tests/test_fixture_stats_mapper.py
+++ b/academy-watch-backend/tests/test_fixture_stats_mapper.py
@@ -1,0 +1,216 @@
+"""Tests for src/utils/fixture_stats_mapper.py — the shared FixturePlayerStats mapping.
+
+The mapper is the single source of truth for turning an API-Football
+``statistics[0]`` block into FixturePlayerStats column values. Prod data showed
+tackles_interceptions / tackles_blocks / passes_accuracy / dribbles_attempts /
+dribbles_past / the penalty set / offsides almost entirely NULL because writers
+hand-picked field subsets; these tests pin the full mapping.
+"""
+
+from src.utils.fixture_stats_mapper import map_player_stat_block
+
+# Realistic /fixtures/players statistics[0] payload (API-Football v3 shape),
+# including the API's "commited" typo in the penalty block.
+FULL_STAT_BLOCK = {
+    "games": {
+        "minutes": 90,
+        "number": 22,
+        "position": "M",
+        "rating": "7.6",
+        "captain": True,
+        "substitute": False,
+    },
+    "offsides": 1,
+    "shots": {"total": 3, "on": 2},
+    "goals": {"total": 1, "conceded": 0, "assists": 1, "saves": None},
+    "passes": {"total": 54, "key": 3, "accuracy": 46},
+    "tackles": {"total": 4, "blocks": 1, "interceptions": 2},
+    "duels": {"total": 15, "won": 9},
+    "dribbles": {"attempts": 5, "success": 3, "past": 2},
+    "fouls": {"drawn": 2, "committed": 1},
+    "cards": {"yellow": 1, "red": 0},
+    "penalty": {"won": 1, "commited": 0, "scored": 1, "missed": 0, "saved": None},
+}
+
+EXPECTED_FULL = {
+    "minutes": 90,
+    "position": "M",
+    "number": 22,
+    "rating": 7.6,
+    "captain": True,
+    "substitute": False,
+    "goals": 1,
+    "assists": 1,
+    "goals_conceded": 0,
+    "saves": None,
+    "yellows": 1,
+    "reds": 0,
+    "shots_total": 3,
+    "shots_on": 2,
+    "passes_total": 54,
+    "passes_key": 3,
+    "passes_accuracy": "46%",
+    "tackles_total": 4,
+    "tackles_blocks": 1,
+    "tackles_interceptions": 2,
+    "duels_total": 15,
+    "duels_won": 9,
+    "dribbles_attempts": 5,
+    "dribbles_success": 3,
+    "dribbles_past": 2,
+    "fouls_drawn": 2,
+    "fouls_committed": 1,
+    "penalty_won": 1,
+    "penalty_committed": 0,
+    "penalty_scored": 1,
+    "penalty_missed": 0,
+    "penalty_saved": None,
+    "offsides": 1,
+}
+
+
+class TestFullPayload:
+    def test_every_column_maps(self):
+        assert map_player_stat_block(FULL_STAT_BLOCK) == EXPECTED_FULL
+
+    def test_rating_is_coerced_to_float(self):
+        mapped = map_player_stat_block(FULL_STAT_BLOCK)
+        assert isinstance(mapped["rating"], float)
+        assert mapped["rating"] == 7.6
+
+    def test_penalty_committed_zero_is_kept_not_defaulted(self):
+        # 0 is a real value; the "committed" fallback must only fire on None/absent.
+        mapped = map_player_stat_block(FULL_STAT_BLOCK)
+        assert mapped["penalty_committed"] == 0
+
+
+class TestModelCoverage:
+    def test_mapper_covers_every_stat_column_of_fixture_player_stats(self):
+        """The mapper's key set must exactly equal the model's stat columns.
+
+        Identity, formation and raw_json are caller-owned; everything else must
+        be produced by the mapper so no writer can silently trim fields again.
+        """
+        from src.models.weekly import FixturePlayerStats
+
+        caller_owned = {
+            "id",
+            "fixture_id",
+            "player_api_id",
+            "team_api_id",
+            "formation",
+            "grid",
+            "formation_position",
+            "raw_json",
+        }
+        stat_columns = {c.name for c in FixturePlayerStats.__table__.columns} - caller_owned
+        assert set(map_player_stat_block(FULL_STAT_BLOCK).keys()) == stat_columns
+
+
+class TestDefaults:
+    EXPECTED_DEFAULTS = {
+        "minutes": 0,
+        "goals": 0,
+        "assists": 0,
+        "yellows": 0,
+        "reds": 0,
+        "captain": False,
+        "substitute": False,
+    }
+
+    def test_empty_block_yields_defaults(self):
+        mapped = map_player_stat_block({})
+        for key, value in self.EXPECTED_DEFAULTS.items():
+            assert mapped[key] == value
+        for key in set(mapped) - set(self.EXPECTED_DEFAULTS):
+            assert mapped[key] is None, f"{key} should default to None"
+
+    def test_none_block_yields_defaults(self):
+        assert map_player_stat_block(None) == map_player_stat_block({})
+
+
+class TestNullHandling:
+    def test_null_values_in_blocks(self):
+        """API-Football sends explicit nulls; counting stats coerce to 0."""
+        block = {
+            "games": {"minutes": None, "rating": None, "position": None, "number": None},
+            "goals": {"total": None, "assists": None, "conceded": None, "saves": None},
+            "cards": {"yellow": None, "red": None},
+            "shots": {"total": None, "on": None},
+            "passes": {"total": None, "key": None, "accuracy": None},
+            "tackles": {"total": None, "blocks": None, "interceptions": None},
+            "duels": {"total": None, "won": None},
+            "dribbles": {"attempts": None, "success": None, "past": None},
+            "fouls": {"drawn": None, "committed": None},
+            "penalty": {"won": None, "commited": None, "scored": None, "missed": None, "saved": None},
+            "offsides": None,
+        }
+        mapped = map_player_stat_block(block)
+        assert mapped["minutes"] == 0
+        assert mapped["goals"] == 0
+        assert mapped["assists"] == 0
+        assert mapped["yellows"] == 0
+        assert mapped["reds"] == 0
+        assert mapped["rating"] is None
+        assert mapped["passes_accuracy"] is None
+        assert mapped["tackles_interceptions"] is None
+        assert mapped["penalty_committed"] is None
+        assert mapped["offsides"] is None
+
+    def test_null_nested_blocks_are_guarded(self):
+        """Whole sub-blocks can be null (``or {}`` guard) without blowing up."""
+        block = {
+            "games": None,
+            "goals": None,
+            "cards": None,
+            "shots": None,
+            "passes": None,
+            "tackles": None,
+            "duels": None,
+            "dribbles": None,
+            "fouls": None,
+            "penalty": None,
+        }
+        mapped = map_player_stat_block(block)
+        assert mapped["minutes"] == 0
+        assert mapped["shots_total"] is None
+        assert mapped["duels_won"] is None
+
+
+class TestPenaltyCommittedTypo:
+    def test_reads_api_typo_commited(self):
+        mapped = map_player_stat_block({"penalty": {"commited": 2}})
+        assert mapped["penalty_committed"] == 2
+
+    def test_falls_back_to_correct_spelling(self):
+        mapped = map_player_stat_block({"penalty": {"committed": 3}})
+        assert mapped["penalty_committed"] == 3
+
+    def test_typo_key_wins_when_both_present(self):
+        mapped = map_player_stat_block({"penalty": {"commited": 2, "committed": 5}})
+        assert mapped["penalty_committed"] == 2
+
+
+class TestPassesAccuracyCoercion:
+    def test_int_accuracy_gets_percent_suffix(self):
+        assert map_player_stat_block({"passes": {"accuracy": 68}})["passes_accuracy"] == "68%"
+
+    def test_string_accuracy_kept_as_is(self):
+        assert map_player_stat_block({"passes": {"accuracy": "68%"}})["passes_accuracy"] == "68%"
+        assert map_player_stat_block({"passes": {"accuracy": "68"}})["passes_accuracy"] == "68"
+
+    def test_missing_accuracy_is_none(self):
+        assert map_player_stat_block({"passes": {"total": 10}})["passes_accuracy"] is None
+
+
+class TestGameFlags:
+    def test_substitute_true_passthrough(self):
+        assert map_player_stat_block({"games": {"substitute": True}})["substitute"] is True
+
+    def test_captain_true_passthrough(self):
+        assert map_player_stat_block({"games": {"captain": True}})["captain"] is True
+
+    def test_missing_flags_default_false(self):
+        mapped = map_player_stat_block({"games": {"minutes": 45}})
+        assert mapped["captain"] is False
+        assert mapped["substitute"] is False


### PR DESCRIPTION
## Why

Prod `fixture_player_stats` shows `tackles_interceptions` 0%, `tackles_blocks` 0%, `passes_accuracy` 0.2%, `dribbles_attempts` 0.1% populated — not because API-Football lacks the data, but because the four sync sites in `routes/api.py` and the weekly agent's pre-sync hand-picked a trimmed field subset and discarded the rest of the payload they already had. Only the API client's own upsert parsed the complete block (and it produced just 131 of 74k rows).

## What

- New pure mapper `src/utils/fixture_stats_mapper.py::map_player_stat_block` covering all 33 stat columns — including the API's `"commited"` penalty typo (with fallback to the correct spelling), pass-accuracy string coercion, and or-0 defaults, mirroring the client upsert's reference semantics
- All six writers route through it; per-site identity/formation/dry-run logic preserved exactly
- Sync sites now also store `raw_json`, matching the client convention (enables future backfills without API calls)

## Impact

Interceptions, blocks, pass accuracy, dribble attempts/past, the penalty set, offsides, jersey number, and captain start accruing on every newly synced fixture. Historical rows stay as-is — backfilling them would need an API re-sync (quota + prod-container constraints, deliberately not part of this PR).

## Verification

- 17 new mapper tests (column coverage asserted against the model via introspection, typo handling, null payloads, coercions)
- Full suite delta vs main: exactly +17, byte-identical pre-existing failure list (stale modules importing deleted models — no CI pytest job exists)
- `ruff check` + `ruff format --check` clean
- Old-vs-new parser equivalence verified mechanically over 7 payload shapes for the refactored client upsert

🤖 Generated with [Claude Code](https://claude.com/claude-code)