### PR TITLE
feat(roles): derived account roles — scout/player/club_manager

### DIFF
--- a/academy-watch-backend/src/routes/auth_routes.py
+++ b/academy-watch-backend/src/routes/auth_routes.py
@@ -36,6 +36,7 @@ from src.models.league import (
     _as_utc,
     db,
 )
+from src.services.account_roles import derive_account_role
 from src.services.email_service import email_service
 
 logger = logging.getLogger(__name__)
@@ -210,6 +211,7 @@ def verify_login_code():
             {
                 "message": "Logged in",
                 "role": role,
+                "account_role": derive_account_role(user),
                 "display_name": user.display_name if user else None,
                 "display_name_confirmed": bool(user.display_name_confirmed) if user else False,
                 **out,
@@ -244,6 +246,7 @@ def auth_me():
             {
                 "email": email,
                 "role": role,
+                "account_role": derive_account_role(user),
                 "user_id": user.id if user else None,
                 "display_name": user.display_name if user else None,
                 "display_name_confirmed": bool(user.display_name_confirmed) if user else False,

--- a/academy-watch-backend/src/services/account_roles.py
+++ b/academy-watch-backend/src/services/account_roles.py
@@ -1,0 +1,42 @@
+"""Derived account personas for signed-in users.
+
+The persona is a projection of authoritative approvals, not stored account
+state. Keeping that distinction here prevents the auth payload from drifting
+away from claim/grant revocations.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from src.models.league import db
+from src.models.showcase import PlayerProfileClaim
+
+if TYPE_CHECKING:
+    from src.models.league import UserAccount
+
+AccountRole = Literal["scout", "player", "club_manager"]
+
+# Highest-authority persona wins. F2 will add ``club_manager`` to the derived
+# role set below when its approved club-grant model exists; F1 deliberately
+# does not query or invent that source.
+ACCOUNT_ROLE_PRECEDENCE: tuple[AccountRole, ...] = ("club_manager", "player", "scout")
+
+
+def derive_account_role(user: UserAccount | None) -> AccountRole:
+    """Return the user's highest-precedence persona from approved records."""
+    derived_roles: set[AccountRole] = {"scout"}
+    if user is not None and user.id is not None:
+        approved_player_claim = (
+            db.session.query(PlayerProfileClaim.id)
+            .filter(
+                PlayerProfileClaim.user_account_id == user.id,
+                PlayerProfileClaim.relationship_type == "player",
+                PlayerProfileClaim.status == "approved",
+            )
+            .first()
+        )
+        if approved_player_claim is not None:
+            derived_roles.add("player")
+
+    return next(role for role in ACCOUNT_ROLE_PRECEDENCE if role in derived_roles)

--- a/academy-watch-backend/tests/test_auth_endpoints.py
+++ b/academy-watch-backend/tests/test_auth_endpoints.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 from flask import Flask
 from src.models.league import EmailToken, UserAccount, db
+from src.models.showcase import PlayerProfileClaim
+from src.services.account_roles import derive_account_role
 
 
 @pytest.fixture
@@ -120,6 +122,34 @@ class TestVerifyLoginCode:
             assert "token" in data
             assert "expires_in" in data
             assert data["message"] == "Logged in"
+            assert data["account_role"] == "scout"
+
+    def test_verify_code_returns_player_for_approved_self_claim(self, auth_bp_app, auth_bp_client, mock_email_service):
+        """Login returns the role derived from an existing approved claim."""
+        with auth_bp_app.app_context():
+            user = UserAccount(
+                email="claimed-player@example.com",
+                display_name="ClaimedPlayer",
+                display_name_lower="claimedplayer",
+            )
+            db.session.add(user)
+            db.session.flush()
+            db.session.add(
+                PlayerProfileClaim(
+                    player_api_id=5001,
+                    user_account_id=user.id,
+                    relationship_type="player",
+                    status="approved",
+                )
+            )
+            db.session.commit()
+
+            auth_bp_client.post("/api/auth/request-code", json={"email": user.email})
+            token = EmailToken.query.filter_by(email=user.email, purpose="login").first()
+            res = auth_bp_client.post("/api/auth/verify-code", json={"email": user.email, "code": token.token})
+
+            assert res.status_code == 200
+            assert res.get_json()["account_role"] == "player"
 
     def test_verify_code_invalid_code_returns_400(self, auth_bp_app, auth_bp_client, mock_email_service):
         """Should return 400 for invalid code."""
@@ -163,11 +193,77 @@ class TestAuthMe:
             assert data["email"] == "me@example.com"
             assert data["display_name"] == "TestUser"
             assert data["role"] == "user"
+            assert data["account_role"] == "scout"
+
+    def test_auth_me_returns_player_for_approved_self_claim(self, auth_bp_app, auth_bp_client):
+        """An approved player relationship is reflected in the auth payload."""
+        from src.auth import issue_user_token
+
+        with auth_bp_app.app_context():
+            user = UserAccount(
+                email="player@example.com",
+                display_name="PlayerUser",
+                display_name_lower="playeruser",
+            )
+            db.session.add(user)
+            db.session.flush()
+            db.session.add(
+                PlayerProfileClaim(
+                    player_api_id=5001,
+                    user_account_id=user.id,
+                    relationship_type="player",
+                    status="approved",
+                )
+            )
+            db.session.commit()
+
+            token = issue_user_token(user.email)["token"]
+            res = auth_bp_client.get("/api/auth/me", headers={"Authorization": f"Bearer {token}"})
+
+            assert res.status_code == 200
+            assert res.get_json()["account_role"] == "player"
 
     def test_auth_me_without_token_returns_401(self, auth_bp_client):
         """Should return 401 without auth token."""
         res = auth_bp_client.get("/api/auth/me")
         assert res.status_code == 401
+
+
+class TestAccountRoleDerivation:
+    """Role labels come only from authoritative, approved self-claims."""
+
+    def test_user_without_claim_defaults_to_scout(self, auth_bp_app):
+        with auth_bp_app.app_context():
+            user = UserAccount(email="scout@example.com", display_name="Scout", display_name_lower="scout")
+            db.session.add(user)
+            db.session.commit()
+
+            assert derive_account_role(user) == "scout"
+
+    @pytest.mark.parametrize(
+        ("relationship_type", "status"),
+        (("player", "pending"), ("agent", "approved")),
+    )
+    def test_non_player_or_pending_claim_stays_scout(self, auth_bp_app, relationship_type, status):
+        with auth_bp_app.app_context():
+            user = UserAccount(
+                email=f"{relationship_type}-{status}@example.com",
+                display_name=f"{relationship_type}-{status}",
+                display_name_lower=f"{relationship_type}-{status}",
+            )
+            db.session.add(user)
+            db.session.flush()
+            db.session.add(
+                PlayerProfileClaim(
+                    player_api_id=5002,
+                    user_account_id=user.id,
+                    relationship_type=relationship_type,
+                    status=status,
+                )
+            )
+            db.session.commit()
+
+            assert derive_account_role(user) == "scout"
 
 
 class TestDisplayName:


### PR DESCRIPTION
## Summary

- expose account_role in successful POST /api/auth/verify-code and GET /api/auth/me payloads
- derive player only from an approved Showcase self-claim; default every other current account to scout
- keep the existing signed-token role (user/admin) separate from the UI persona
- reserve club_manager precedence for the authoritative F2 manager-grant source

## Derived roles, no DDL

This PR deliberately adds no account-role column, migration, or backfill. PlayerProfileClaim remains authoritative, so approvals and revocations are reflected at response time without stale stored labels. Because no Alembic revision is added, this branch cannot fork the in-flight sea02 chain.

## Verification

- 58 combined auth + Showcase tests passed
- migration-head test passed; one head (sea01 on current main)
- ruff check academy-watch-backend
- ruff format --check academy-watch-backend
- real Flask app + isolated seeded claim: GET /api/auth/me returned account_role=player and role=user