### PR TITLE
feat(registry): league admission + club program verification (F2)

### DIFF
--- a/academy-watch-backend/env.template
+++ b/academy-watch-backend/env.template
@@ -133,3 +133,6 @@ OPENAI_API_KEY=
 # 2. Never commit the actual .env file to version control
 # 3. Use strong, randomly generated keys
 # 4. Consider using a secrets management service for sensitive values
+# Dedicated Fernet key for reviewer-only grassroots claim evidence.
+# Generate once and store as an application secret; never reuse SECRET_KEY.
+FUNDING_EVIDENCE_ENCRYPTION_KEY=

--- a/academy-watch-backend/migrations/versions/gf01_grassroots_identity.py
+++ b/academy-watch-backend/migrations/versions/gf01_grassroots_identity.py
@@ -1,0 +1,373 @@
+"""Grassroots league registry, club claims, and verification identity.
+
+Revision ID: gf01
+Revises: sea01
+
+IMPORTANT: ``sea01`` was the sole head on refreshed ``origin/main`` when this
+migration was authored. If another head lands first, update ``down_revision``
+before merge. Never allow a migration fork.
+
+All DDL is guarded because production has drifted out-of-band. Every new public
+schema table has RLS enabled in this same migration. No permissive policies are
+created: evidence, grants, Connect telemetry, and audit data are default-deny to
+direct/public clients and are exposed only through narrow server serializers.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from migrations._migration_helpers import (
+    add_column_safe,
+    column_exists,
+    create_index_safe,
+    index_exists,
+    table_exists,
+)
+
+revision = "gf01"
+down_revision = "sea01"
+branch_labels = None
+depends_on = None
+
+
+NEW_TABLES = (
+    "funding_leagues",
+    "club_programs",
+    "club_program_claims",
+    "club_claim_evidence",
+    "club_program_managers",
+    "club_program_profile_revisions",
+    "club_connect_accounts",
+    "funding_admin_events",
+)
+
+
+def upgrade():
+    if not table_exists("funding_leagues"):
+        op.create_table(
+            "funding_leagues",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("name", sa.String(length=160), nullable=False),
+            sa.Column("country", sa.String(length=80), nullable=False),
+            sa.Column("region", sa.String(length=120), nullable=False),
+            sa.Column("level", sa.String(length=30), nullable=False),
+            sa.Column("age_bands", sa.JSON(), nullable=False),
+            sa.Column("gender_program", sa.String(length=10), nullable=False),
+            sa.Column("season_calendar", sa.String(length=20), nullable=False),
+            sa.Column("data_tier", sa.String(length=20), nullable=False),
+            sa.Column("league_api_id", sa.Integer(), nullable=True),
+            sa.Column("existing_league_id", sa.Integer(), sa.ForeignKey("leagues.id"), nullable=True),
+            sa.Column("registry_status", sa.String(length=20), nullable=False, server_default="approved"),
+            sa.Column("admission_state", sa.String(length=20), nullable=False, server_default="waitlisted"),
+            sa.Column("proposed_by_user_id", sa.Integer(), sa.ForeignKey("user_accounts.id"), nullable=True),
+            sa.Column("reviewed_by", sa.String(length=200), nullable=True),
+            sa.Column("review_reason", sa.Text(), nullable=True),
+            sa.Column("reviewed_at", sa.DateTime(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.CheckConstraint(
+                "level IN ('pro_academy','youth_national','youth_regional','recreational')",
+                name="ck_funding_leagues_level",
+            ),
+            sa.CheckConstraint("gender_program IN ('boys','girls','both')", name="ck_funding_leagues_gender"),
+            sa.CheckConstraint(
+                "season_calendar IN ('aug_may','calendar_year','fall_spring')",
+                name="ck_funding_leagues_calendar",
+            ),
+            sa.CheckConstraint(
+                "data_tier IN ('api_football','film_room','self_reported')",
+                name="ck_funding_leagues_data_tier",
+            ),
+            sa.CheckConstraint(
+                "registry_status IN ('proposed','approved','rejected')",
+                name="ck_funding_leagues_registry_status",
+            ),
+            sa.CheckConstraint(
+                "admission_state IN ('open','waitlisted','closed')",
+                name="ck_funding_leagues_admission_state",
+            ),
+            sa.UniqueConstraint("name", "country", "region", name="uq_funding_league_identity"),
+            sa.UniqueConstraint("league_api_id", name="uq_funding_league_api_id"),
+            sa.UniqueConstraint("existing_league_id", name="uq_funding_league_bridge"),
+        )
+    create_index_safe(
+        "ix_funding_leagues_admission",
+        "funding_leagues",
+        ["registry_status", "admission_state"],
+    )
+    create_index_safe("ix_funding_leagues_location", "funding_leagues", ["country", "region"])
+
+    if not table_exists("club_programs"):
+        op.create_table(
+            "club_programs",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("funding_league_id", sa.Integer(), sa.ForeignKey("funding_leagues.id"), nullable=False),
+            sa.Column("team_api_id", sa.Integer(), sa.ForeignKey("team_profiles.team_id"), nullable=True),
+            sa.Column("name", sa.String(length=180), nullable=False),
+            sa.Column("legal_name", sa.String(length=220), nullable=False),
+            sa.Column("slug", sa.String(length=200), nullable=False),
+            sa.Column("crest_url", sa.String(length=500), nullable=True),
+            sa.Column("country", sa.String(length=80), nullable=False),
+            sa.Column("region", sa.String(length=120), nullable=False),
+            sa.Column("city", sa.String(length=120), nullable=True),
+            sa.Column("currency", sa.String(length=3), nullable=False, server_default="USD"),
+            sa.Column("provenance_tier", sa.String(length=30), nullable=False, server_default="self_reported"),
+            sa.Column("platform_status", sa.String(length=20), nullable=False, server_default="pending"),
+            sa.Column("donations_enabled", sa.Boolean(), nullable=False, server_default="false"),
+            sa.Column("emergency_hidden", sa.Boolean(), nullable=False, server_default="false"),
+            sa.Column("approved_profile_revision_id", sa.Integer(), nullable=True),
+            sa.Column("reviewed_by", sa.String(length=200), nullable=True),
+            sa.Column("review_reason", sa.Text(), nullable=True),
+            sa.Column("reviewed_at", sa.DateTime(), nullable=True),
+            sa.Column("verified_at", sa.DateTime(), nullable=True),
+            sa.Column("next_review_at", sa.DateTime(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.CheckConstraint(
+                "provenance_tier IN ('provider_covered','film_room_verified','self_reported')",
+                name="ck_club_programs_provenance",
+            ),
+            sa.CheckConstraint(
+                "platform_status IN ('pending','approved','rejected','suspended')",
+                name="ck_club_programs_status",
+            ),
+            sa.UniqueConstraint("slug", name="uq_club_programs_slug"),
+            sa.UniqueConstraint("team_api_id", name="uq_club_programs_team_api_id"),
+        )
+    create_index_safe("ix_club_programs_league", "club_programs", ["funding_league_id"])
+    create_index_safe("ix_club_programs_location", "club_programs", ["country", "region"])
+    create_index_safe("ix_club_programs_status", "club_programs", ["platform_status"])
+
+    if not table_exists("club_program_claims"):
+        op.create_table(
+            "club_program_claims",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "program_id",
+                sa.Integer(),
+                sa.ForeignKey("club_programs.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("user_account_id", sa.Integer(), sa.ForeignKey("user_accounts.id"), nullable=False),
+            sa.Column("relationship_type", sa.String(length=30), nullable=False),
+            sa.Column("status", sa.String(length=20), nullable=False, server_default="pending"),
+            sa.Column("applicant_message", sa.Text(), nullable=True),
+            sa.Column("reviewed_by", sa.String(length=200), nullable=True),
+            sa.Column("review_reason", sa.Text(), nullable=True),
+            sa.Column("reviewed_at", sa.DateTime(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.CheckConstraint(
+                "status IN ('pending','approved','rejected','revoked')",
+                name="ck_club_program_claims_status",
+            ),
+            sa.UniqueConstraint("program_id", "user_account_id", name="uq_club_claim_program_user"),
+        )
+    create_index_safe("ix_club_claims_status", "club_program_claims", ["status", "created_at"])
+    create_index_safe("ix_club_claims_user", "club_program_claims", ["user_account_id"])
+
+    if not table_exists("club_claim_evidence"):
+        op.create_table(
+            "club_claim_evidence",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "claim_id",
+                sa.Integer(),
+                sa.ForeignKey("club_program_claims.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("adult_authority_attested", sa.Boolean(), nullable=False, server_default="false"),
+            sa.Column("official_email", sa.Text(), nullable=True),
+            sa.Column("authorization_method", sa.String(length=40), nullable=False),
+            sa.Column("authorization_reference", sa.Text(), nullable=True),
+            sa.Column("organization_form", sa.String(length=40), nullable=False),
+            sa.Column("registration_reference", sa.Text(), nullable=False),
+            sa.Column("official_contact_name", sa.Text(), nullable=False),
+            sa.Column("official_contact_reference", sa.Text(), nullable=False),
+            sa.Column("safeguarding_contact_email", sa.Text(), nullable=False),
+            sa.Column("safeguarding_policy_url", sa.Text(), nullable=True),
+            sa.Column("safeguarding_policy_attested", sa.Boolean(), nullable=False, server_default="false"),
+            sa.Column("eligible_organization_attested", sa.Boolean(), nullable=False, server_default="false"),
+            sa.Column("payout_control_attested", sa.Boolean(), nullable=False, server_default="false"),
+            sa.Column("evidence_notes", sa.Text(), nullable=True),
+            sa.Column("retention_expires_at", sa.DateTime(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.UniqueConstraint("claim_id", name="uq_club_claim_evidence_claim"),
+        )
+    create_index_safe("ix_club_claim_evidence_retention", "club_claim_evidence", ["retention_expires_at"])
+
+    if not table_exists("club_program_managers"):
+        op.create_table(
+            "club_program_managers",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "program_id",
+                sa.Integer(),
+                sa.ForeignKey("club_programs.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("user_account_id", sa.Integer(), sa.ForeignKey("user_accounts.id"), nullable=False),
+            sa.Column("source_claim_id", sa.Integer(), sa.ForeignKey("club_program_claims.id"), nullable=False),
+            sa.Column("status", sa.String(length=20), nullable=False, server_default="active"),
+            sa.Column("granted_by", sa.String(length=200), nullable=False),
+            sa.Column("granted_at", sa.DateTime(), nullable=True),
+            sa.Column("revoked_by", sa.String(length=200), nullable=True),
+            sa.Column("revoked_reason", sa.Text(), nullable=True),
+            sa.Column("revoked_at", sa.DateTime(), nullable=True),
+            sa.CheckConstraint("status IN ('active','revoked')", name="ck_club_program_managers_status"),
+            sa.UniqueConstraint("program_id", "user_account_id", name="uq_club_manager_program_user"),
+        )
+    create_index_safe(
+        "ix_club_managers_user_status",
+        "club_program_managers",
+        ["user_account_id", "status"],
+    )
+
+    if not table_exists("club_program_profile_revisions"):
+        op.create_table(
+            "club_program_profile_revisions",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "program_id",
+                sa.Integer(),
+                sa.ForeignKey("club_programs.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("submitted_by_user_id", sa.Integer(), sa.ForeignKey("user_accounts.id"), nullable=False),
+            sa.Column("status", sa.String(length=20), nullable=False, server_default="pending"),
+            sa.Column("summary", sa.Text(), nullable=True),
+            sa.Column("age_groups", sa.JSON(), nullable=False),
+            sa.Column("activities", sa.JSON(), nullable=False),
+            sa.Column("funding_purpose", sa.Text(), nullable=True),
+            sa.Column("official_url", sa.String(length=500), nullable=True),
+            sa.Column("safeguarding_url", sa.String(length=500), nullable=True),
+            sa.Column("media_urls", sa.JSON(), nullable=False),
+            sa.Column("reviewed_by", sa.String(length=200), nullable=True),
+            sa.Column("review_reason", sa.Text(), nullable=True),
+            sa.Column("reviewed_at", sa.DateTime(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.CheckConstraint(
+                "status IN ('pending','approved','rejected','withdrawn')",
+                name="ck_club_program_revisions_status",
+            ),
+        )
+    create_index_safe(
+        "ix_club_program_revisions_program",
+        "club_program_profile_revisions",
+        ["program_id", "created_at"],
+    )
+    op.execute(
+        sa.text(
+            """
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                    WHERE conname = 'fk_club_programs_approved_revision'
+                ) THEN
+                    ALTER TABLE club_programs
+                    ADD CONSTRAINT fk_club_programs_approved_revision
+                    FOREIGN KEY (approved_profile_revision_id)
+                    REFERENCES club_program_profile_revisions(id);
+                END IF;
+            END
+            $$;
+            """
+        )
+    )
+
+    if not table_exists("club_connect_accounts"):
+        op.create_table(
+            "club_connect_accounts",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "program_id",
+                sa.Integer(),
+                sa.ForeignKey("club_programs.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("stripe_account_id", sa.String(length=255), nullable=True),
+            sa.Column("account_type", sa.String(length=20), nullable=False, server_default="express"),
+            sa.Column("country", sa.String(length=2), nullable=False, server_default="US"),
+            sa.Column("business_type", sa.String(length=30), nullable=False, server_default="company"),
+            sa.Column("livemode", sa.Boolean(), nullable=False, server_default="false"),
+            sa.Column("transfers_active", sa.Boolean(), nullable=False, server_default="false"),
+            sa.Column("details_submitted", sa.Boolean(), nullable=False, server_default="false"),
+            sa.Column("payouts_enabled", sa.Boolean(), nullable=False, server_default="false"),
+            sa.Column("charges_enabled", sa.Boolean(), nullable=False, server_default="false"),
+            sa.Column("requirements_due", sa.JSON(), nullable=False),
+            sa.Column("disabled_reason", sa.String(length=255), nullable=True),
+            sa.Column("onboarding_url", sa.String(length=1000), nullable=True),
+            sa.Column("onboarding_expires_at", sa.DateTime(), nullable=True),
+            sa.Column("deauthorized_at", sa.DateTime(), nullable=True),
+            sa.Column("last_synced_at", sa.DateTime(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.UniqueConstraint("program_id", name="uq_club_connect_program"),
+            sa.UniqueConstraint("stripe_account_id", name="uq_club_connect_stripe_account"),
+        )
+    create_index_safe(
+        "ix_club_connect_readiness",
+        "club_connect_accounts",
+        ["transfers_active", "payouts_enabled"],
+    )
+
+    if not table_exists("funding_admin_events"):
+        op.create_table(
+            "funding_admin_events",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("actor_email", sa.String(length=254), nullable=False),
+            sa.Column("action", sa.String(length=80), nullable=False),
+            sa.Column("target_type", sa.String(length=40), nullable=False),
+            sa.Column("target_id", sa.Integer(), nullable=False),
+            sa.Column("reason", sa.Text(), nullable=False),
+            sa.Column("event_metadata", sa.JSON(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+        )
+    create_index_safe(
+        "ix_funding_admin_events_target",
+        "funding_admin_events",
+        ["target_type", "target_id"],
+    )
+    create_index_safe("ix_funding_admin_events_created", "funding_admin_events", ["created_at"])
+
+    add_column_safe(
+        "follows",
+        sa.Column("notify_when_fundable", sa.Boolean(), nullable=False, server_default="false"),
+    )
+
+    for table_name in NEW_TABLES:
+        # Idempotent and intentionally policy-free: direct/public roles see no
+        # rows. Flask publishes only explicitly serialized fields.
+        op.execute(sa.text(f'ALTER TABLE "{table_name}" ENABLE ROW LEVEL SECURITY'))
+
+
+def downgrade():
+    if column_exists("follows", "notify_when_fundable"):
+        op.drop_column("follows", "notify_when_fundable")
+
+    if table_exists("club_programs"):
+        op.execute(sa.text("ALTER TABLE club_programs DROP CONSTRAINT IF EXISTS fk_club_programs_approved_revision"))
+
+    indexes = (
+        ("ix_funding_admin_events_created", "funding_admin_events"),
+        ("ix_funding_admin_events_target", "funding_admin_events"),
+        ("ix_club_connect_readiness", "club_connect_accounts"),
+        ("ix_club_program_revisions_program", "club_program_profile_revisions"),
+        ("ix_club_managers_user_status", "club_program_managers"),
+        ("ix_club_claim_evidence_retention", "club_claim_evidence"),
+        ("ix_club_claims_user", "club_program_claims"),
+        ("ix_club_claims_status", "club_program_claims"),
+        ("ix_club_programs_status", "club_programs"),
+        ("ix_club_programs_location", "club_programs"),
+        ("ix_club_programs_league", "club_programs"),
+        ("ix_funding_leagues_location", "funding_leagues"),
+        ("ix_funding_leagues_admission", "funding_leagues"),
+    )
+    for index_name, table_name in indexes:
+        if index_exists(index_name):
+            op.drop_index(index_name, table_name=table_name)
+
+    for table_name in reversed(NEW_TABLES):
+        if table_exists(table_name):
+            op.drop_table(table_name)

--- a/academy-watch-backend/requirements.txt
+++ b/academy-watch-backend/requirements.txt
@@ -12,6 +12,7 @@ charset-normalizer==3.4.9
 click==8.4.2
 colorama==0.4.6
 contourpy==1.3.3
+cryptography==49.0.0
 cycler==0.12.1
 Deprecated==1.3.1
 distro==1.9.0

--- a/academy-watch-backend/src/main.py
+++ b/academy-watch-backend/src/main.py
@@ -25,6 +25,7 @@ from src.routes.curator import curator_bp
 from src.routes.events import events_bp
 from src.routes.feeder import feeder_bp
 from src.routes.formation import formation_bp
+from src.routes.funding import funding_bp
 from src.routes.gol import gol_bp
 from src.routes.journalist import journalist_bp
 from src.routes.journey import journey_bp
@@ -97,6 +98,7 @@ app.register_blueprint(scout_bp, url_prefix="/api")
 # Registered BEFORE api_bp (mirroring players_bp) so /players/<id>/showcase*
 # routes take priority over any api_bp /players/<id>/* catch-alls.
 app.register_blueprint(showcase_bp, url_prefix="/api")
+app.register_blueprint(funding_bp, url_prefix="/api")
 app.register_blueprint(api_bp, url_prefix="/api")
 app.register_blueprint(auth_bp, url_prefix="/api")
 app.register_blueprint(journalist_bp, url_prefix="/api")

--- a/academy-watch-backend/src/models/follow.py
+++ b/academy-watch-backend/src/models/follow.py
@@ -66,6 +66,9 @@ class Follow(db.Model):
     selector = db.Column(db.JSON, nullable=False)
     label = db.Column(db.String(160))  # display label, server-derived where possible
     note = db.Column(db.Text)  # migrated watchlist note (player kind)
+    # Funding F2 reuses academy_club follows as an explicit future-support
+    # notification and expansion-demand signal. It never affects ranking.
+    notify_when_fundable = db.Column(db.Boolean, nullable=False, default=False, server_default="false")
     created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
 
     # Exact (kind, selector) duplicates within a list are rejected in code — a

--- a/academy-watch-backend/src/models/funding.py
+++ b/academy-watch-backend/src/models/funding.py
@@ -1,0 +1,391 @@
+"""Grassroots league admission and verified club-program identity models.
+
+F2 deliberately stops before money movement.  These rows establish the league,
+organization, authority, moderation, and Connect-readiness gates that F3 may
+later reference.  Public APIs serialize narrow projections; evidence, manager,
+Connect, and audit rows remain server-only/default-deny under RLS.
+"""
+
+from datetime import UTC, datetime
+
+from src.models.league import db
+from src.services.funding_evidence_crypto import EncryptedEvidenceText
+
+
+def _iso(value):
+    return value.isoformat() if value else None
+
+
+class FundingLeague(db.Model):
+    """MJ-controlled league registry, optionally bridged to API-Football."""
+
+    __tablename__ = "funding_leagues"
+    __table_args__ = (
+        db.CheckConstraint(
+            "level IN ('pro_academy','youth_national','youth_regional','recreational')",
+            name="ck_funding_leagues_level",
+        ),
+        db.CheckConstraint(
+            "gender_program IN ('boys','girls','both')",
+            name="ck_funding_leagues_gender",
+        ),
+        db.CheckConstraint(
+            "season_calendar IN ('aug_may','calendar_year','fall_spring')",
+            name="ck_funding_leagues_calendar",
+        ),
+        db.CheckConstraint(
+            "data_tier IN ('api_football','film_room','self_reported')",
+            name="ck_funding_leagues_data_tier",
+        ),
+        db.CheckConstraint(
+            "registry_status IN ('proposed','approved','rejected')",
+            name="ck_funding_leagues_registry_status",
+        ),
+        db.CheckConstraint(
+            "admission_state IN ('open','waitlisted','closed')",
+            name="ck_funding_leagues_admission_state",
+        ),
+        db.UniqueConstraint("name", "country", "region", name="uq_funding_league_identity"),
+        db.UniqueConstraint("league_api_id", name="uq_funding_league_api_id"),
+        db.UniqueConstraint("existing_league_id", name="uq_funding_league_bridge"),
+        db.Index("ix_funding_leagues_admission", "registry_status", "admission_state"),
+        db.Index("ix_funding_leagues_location", "country", "region"),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(160), nullable=False)
+    country = db.Column(db.String(80), nullable=False)
+    region = db.Column(db.String(120), nullable=False)
+    level = db.Column(db.String(30), nullable=False)
+    age_bands = db.Column(db.JSON, nullable=False, default=list)
+    gender_program = db.Column(db.String(10), nullable=False)
+    season_calendar = db.Column(db.String(20), nullable=False)
+    data_tier = db.Column(db.String(20), nullable=False)
+    league_api_id = db.Column(db.Integer)
+    existing_league_id = db.Column(db.Integer, db.ForeignKey("leagues.id"))
+    registry_status = db.Column(db.String(20), nullable=False, default="approved", server_default="approved")
+    admission_state = db.Column(db.String(20), nullable=False, default="waitlisted", server_default="waitlisted")
+    proposed_by_user_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"))
+    reviewed_by = db.Column(db.String(200))
+    review_reason = db.Column(db.Text)
+    reviewed_at = db.Column(db.DateTime)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
+    updated_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+
+    existing_league = db.relationship("League", foreign_keys=[existing_league_id])
+
+    @property
+    def data_tier_key(self):
+        if self.data_tier == "api_football" and self.league_api_id is not None:
+            return f"api_football:{self.league_api_id}"
+        return self.data_tier
+
+    def to_dict(self, *, admin=False):
+        payload = {
+            "id": self.id,
+            "name": self.name,
+            "country": self.country,
+            "region": self.region,
+            "level": self.level,
+            "age_bands": self.age_bands or [],
+            "gender_program": self.gender_program,
+            "season_calendar": self.season_calendar,
+            "data_tier": self.data_tier_key,
+            "league_api_id": self.league_api_id,
+            "existing_league_id": self.existing_league_id,
+            "is_provider_bridge": self.existing_league_id is not None,
+            "registry_status": self.registry_status,
+            "admission_state": self.admission_state,
+            "created_at": _iso(self.created_at),
+            "updated_at": _iso(self.updated_at),
+        }
+        if admin:
+            payload.update(
+                {
+                    "proposed_by_user_id": self.proposed_by_user_id,
+                    "reviewed_by": self.reviewed_by,
+                    "review_reason": self.review_reason,
+                    "reviewed_at": _iso(self.reviewed_at),
+                }
+            )
+        return payload
+
+
+class ClubProgram(db.Model):
+    """One public program and one future legal recipient per v1 row."""
+
+    __tablename__ = "club_programs"
+    __table_args__ = (
+        db.CheckConstraint(
+            "provenance_tier IN ('provider_covered','film_room_verified','self_reported')",
+            name="ck_club_programs_provenance",
+        ),
+        db.CheckConstraint(
+            "platform_status IN ('pending','approved','rejected','suspended')",
+            name="ck_club_programs_status",
+        ),
+        db.UniqueConstraint("slug", name="uq_club_programs_slug"),
+        db.UniqueConstraint("team_api_id", name="uq_club_programs_team_api_id"),
+        db.Index("ix_club_programs_league", "funding_league_id"),
+        db.Index("ix_club_programs_location", "country", "region"),
+        db.Index("ix_club_programs_status", "platform_status"),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    funding_league_id = db.Column(db.Integer, db.ForeignKey("funding_leagues.id"), nullable=False)
+    team_api_id = db.Column(db.Integer, db.ForeignKey("team_profiles.team_id"))
+    name = db.Column(db.String(180), nullable=False)
+    legal_name = db.Column(db.String(220), nullable=False)
+    slug = db.Column(db.String(200), nullable=False)
+    crest_url = db.Column(db.String(500))
+    country = db.Column(db.String(80), nullable=False)
+    region = db.Column(db.String(120), nullable=False)
+    city = db.Column(db.String(120))
+    currency = db.Column(db.String(3), nullable=False, default="USD", server_default="USD")
+    provenance_tier = db.Column(db.String(30), nullable=False, default="self_reported", server_default="self_reported")
+    platform_status = db.Column(db.String(20), nullable=False, default="pending", server_default="pending")
+    donations_enabled = db.Column(db.Boolean, nullable=False, default=False, server_default="false")
+    emergency_hidden = db.Column(db.Boolean, nullable=False, default=False, server_default="false")
+    approved_profile_revision_id = db.Column(
+        db.Integer,
+        db.ForeignKey(
+            "club_program_profile_revisions.id",
+            name="fk_club_programs_approved_revision",
+            use_alter=True,
+        ),
+    )
+    reviewed_by = db.Column(db.String(200))
+    review_reason = db.Column(db.Text)
+    reviewed_at = db.Column(db.DateTime)
+    verified_at = db.Column(db.DateTime)
+    next_review_at = db.Column(db.DateTime)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
+    updated_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+
+    league = db.relationship("FundingLeague", backref=db.backref("programs", lazy="dynamic"))
+    team_profile = db.relationship("TeamProfile", foreign_keys=[team_api_id])
+
+    @property
+    def has_active_manager(self):
+        return any(manager.status == "active" for manager in self.managers)
+
+    @property
+    def connect_account(self):
+        return self.connect_accounts[0] if self.connect_accounts else None
+
+    @property
+    def is_verified_program(self):
+        if self.platform_status != "approved" or self.emergency_hidden or not self.has_active_manager:
+            return False
+        if self.country.strip().upper() not in {"US", "USA", "UNITED STATES", "UNITED STATES OF AMERICA"}:
+            return True
+        return bool(self.connect_account and self.connect_account.is_ready)
+
+    def public_dict(self):
+        provenance_labels = {
+            "provider_covered": "Provider-covered",
+            "film_room_verified": "Film Room-verified",
+            "self_reported": "Self-reported",
+        }
+        return {
+            "id": self.id,
+            "slug": self.slug,
+            "name": self.name,
+            "crest_url": self.crest_url,
+            "country": self.country,
+            "region": self.region,
+            "city": self.city,
+            "league": self.league.to_dict() if self.league else None,
+            "team_api_id": self.team_api_id,
+            "team_slug": self.team_profile.slug if self.team_profile else None,
+            "team_name": self.team_profile.name if self.team_profile else None,
+            "is_verified_program": self.is_verified_program,
+            "verified_at": _iso(self.verified_at),
+            "provenance": {
+                "tier": self.provenance_tier,
+                "label": provenance_labels[self.provenance_tier],
+            },
+            "is_fundable": False,
+        }
+
+
+class ClubProgramClaim(db.Model):
+    __tablename__ = "club_program_claims"
+    __table_args__ = (
+        db.CheckConstraint(
+            "status IN ('pending','approved','rejected','revoked')",
+            name="ck_club_program_claims_status",
+        ),
+        db.UniqueConstraint("program_id", "user_account_id", name="uq_club_claim_program_user"),
+        db.Index("ix_club_claims_status", "status", "created_at"),
+        db.Index("ix_club_claims_user", "user_account_id"),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    program_id = db.Column(db.Integer, db.ForeignKey("club_programs.id", ondelete="CASCADE"), nullable=False)
+    user_account_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"), nullable=False)
+    relationship_type = db.Column(db.String(30), nullable=False, default="club_official")
+    status = db.Column(db.String(20), nullable=False, default="pending", server_default="pending")
+    applicant_message = db.Column(db.Text)
+    reviewed_by = db.Column(db.String(200))
+    review_reason = db.Column(db.Text)
+    reviewed_at = db.Column(db.DateTime)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
+    updated_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+
+    program = db.relationship("ClubProgram", backref=db.backref("claims", lazy="dynamic"))
+    user = db.relationship("UserAccount", foreign_keys=[user_account_id])
+
+
+class ClubClaimEvidence(db.Model):
+    """Private evidence metadata; identity documents stay with Stripe/off-platform."""
+
+    __tablename__ = "club_claim_evidence"
+    __table_args__ = (
+        db.UniqueConstraint("claim_id", name="uq_club_claim_evidence_claim"),
+        db.Index("ix_club_claim_evidence_retention", "retention_expires_at"),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    claim_id = db.Column(db.Integer, db.ForeignKey("club_program_claims.id", ondelete="CASCADE"), nullable=False)
+    adult_authority_attested = db.Column(db.Boolean, nullable=False, default=False, server_default="false")
+    official_email = db.Column(EncryptedEvidenceText())
+    authorization_method = db.Column(db.String(40), nullable=False)
+    authorization_reference = db.Column(EncryptedEvidenceText())
+    organization_form = db.Column(db.String(40), nullable=False)
+    registration_reference = db.Column(EncryptedEvidenceText(), nullable=False)
+    official_contact_name = db.Column(EncryptedEvidenceText(), nullable=False)
+    official_contact_reference = db.Column(EncryptedEvidenceText(), nullable=False)
+    safeguarding_contact_email = db.Column(EncryptedEvidenceText(), nullable=False)
+    safeguarding_policy_url = db.Column(EncryptedEvidenceText())
+    safeguarding_policy_attested = db.Column(db.Boolean, nullable=False, default=False, server_default="false")
+    eligible_organization_attested = db.Column(db.Boolean, nullable=False, default=False, server_default="false")
+    payout_control_attested = db.Column(db.Boolean, nullable=False, default=False, server_default="false")
+    evidence_notes = db.Column(EncryptedEvidenceText())
+    retention_expires_at = db.Column(db.DateTime)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
+    updated_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+
+    claim = db.relationship(
+        "ClubProgramClaim",
+        backref=db.backref("evidence", uselist=False, cascade="all, delete-orphan"),
+    )
+
+
+class ClubProgramManager(db.Model):
+    __tablename__ = "club_program_managers"
+    __table_args__ = (
+        db.CheckConstraint("status IN ('active','revoked')", name="ck_club_program_managers_status"),
+        db.UniqueConstraint("program_id", "user_account_id", name="uq_club_manager_program_user"),
+        db.Index("ix_club_managers_user_status", "user_account_id", "status"),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    program_id = db.Column(db.Integer, db.ForeignKey("club_programs.id", ondelete="CASCADE"), nullable=False)
+    user_account_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"), nullable=False)
+    source_claim_id = db.Column(db.Integer, db.ForeignKey("club_program_claims.id"), nullable=False)
+    status = db.Column(db.String(20), nullable=False, default="active", server_default="active")
+    granted_by = db.Column(db.String(200), nullable=False)
+    granted_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
+    revoked_by = db.Column(db.String(200))
+    revoked_reason = db.Column(db.Text)
+    revoked_at = db.Column(db.DateTime)
+
+    program = db.relationship("ClubProgram", backref=db.backref("managers", lazy=True))
+    user = db.relationship("UserAccount", foreign_keys=[user_account_id])
+
+
+class ClubProgramProfileRevision(db.Model):
+    __tablename__ = "club_program_profile_revisions"
+    __table_args__ = (
+        db.CheckConstraint(
+            "status IN ('pending','approved','rejected','withdrawn')",
+            name="ck_club_program_revisions_status",
+        ),
+        db.Index("ix_club_program_revisions_program", "program_id", "created_at"),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    program_id = db.Column(db.Integer, db.ForeignKey("club_programs.id", ondelete="CASCADE"), nullable=False)
+    submitted_by_user_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"), nullable=False)
+    status = db.Column(db.String(20), nullable=False, default="pending", server_default="pending")
+    summary = db.Column(db.Text)
+    age_groups = db.Column(db.JSON, nullable=False, default=list)
+    activities = db.Column(db.JSON, nullable=False, default=list)
+    funding_purpose = db.Column(db.Text)
+    official_url = db.Column(db.String(500))
+    safeguarding_url = db.Column(db.String(500))
+    media_urls = db.Column(db.JSON, nullable=False, default=list)
+    reviewed_by = db.Column(db.String(200))
+    review_reason = db.Column(db.Text)
+    reviewed_at = db.Column(db.DateTime)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
+
+    program = db.relationship(
+        "ClubProgram",
+        foreign_keys=[program_id],
+        backref=db.backref("profile_revisions", lazy="dynamic"),
+    )
+
+
+class ClubConnectAccount(db.Model):
+    __tablename__ = "club_connect_accounts"
+    __table_args__ = (
+        db.UniqueConstraint("program_id", name="uq_club_connect_program"),
+        db.UniqueConstraint("stripe_account_id", name="uq_club_connect_stripe_account"),
+        db.Index("ix_club_connect_readiness", "transfers_active", "payouts_enabled"),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    program_id = db.Column(db.Integer, db.ForeignKey("club_programs.id", ondelete="CASCADE"), nullable=False)
+    stripe_account_id = db.Column(db.String(255))
+    account_type = db.Column(db.String(20), nullable=False, default="express", server_default="express")
+    country = db.Column(db.String(2), nullable=False, default="US", server_default="US")
+    business_type = db.Column(db.String(30), nullable=False, default="company", server_default="company")
+    livemode = db.Column(db.Boolean, nullable=False, default=False, server_default="false")
+    transfers_active = db.Column(db.Boolean, nullable=False, default=False, server_default="false")
+    details_submitted = db.Column(db.Boolean, nullable=False, default=False, server_default="false")
+    payouts_enabled = db.Column(db.Boolean, nullable=False, default=False, server_default="false")
+    charges_enabled = db.Column(db.Boolean, nullable=False, default=False, server_default="false")
+    requirements_due = db.Column(db.JSON, nullable=False, default=list)
+    disabled_reason = db.Column(db.String(255))
+    onboarding_url = db.Column(db.String(1000))
+    onboarding_expires_at = db.Column(db.DateTime)
+    deauthorized_at = db.Column(db.DateTime)
+    last_synced_at = db.Column(db.DateTime)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
+    updated_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+
+    program = db.relationship("ClubProgram", backref=db.backref("connect_accounts", lazy=True))
+
+    @property
+    def is_ready(self):
+        return bool(
+            self.stripe_account_id
+            and not self.livemode
+            and self.transfers_active
+            and self.details_submitted
+            and self.payouts_enabled
+            and not (self.requirements_due or [])
+            and not self.disabled_reason
+            and not self.deauthorized_at
+        )
+
+
+class FundingAdminEvent(db.Model):
+    """Append-only audit event for every registry and claim transition."""
+
+    __tablename__ = "funding_admin_events"
+    __table_args__ = (
+        db.Index("ix_funding_admin_events_target", "target_type", "target_id"),
+        db.Index("ix_funding_admin_events_created", "created_at"),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    actor_email = db.Column(db.String(254), nullable=False)
+    action = db.Column(db.String(80), nullable=False)
+    target_type = db.Column(db.String(40), nullable=False)
+    target_id = db.Column(db.Integer, nullable=False)
+    reason = db.Column(db.Text, nullable=False)
+    event_metadata = db.Column(db.JSON, nullable=False, default=dict)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))

--- a/academy-watch-backend/src/routes/auth_routes.py
+++ b/academy-watch-backend/src/routes/auth_routes.py
@@ -36,6 +36,7 @@ from src.models.league import (
     _as_utc,
     db,
 )
+from src.services.account_roles import derive_account_role
 from src.services.email_service import email_service
 
 logger = logging.getLogger(__name__)
@@ -210,6 +211,7 @@ def verify_login_code():
             {
                 "message": "Logged in",
                 "role": role,
+                "account_role": derive_account_role(user),
                 "display_name": user.display_name if user else None,
                 "display_name_confirmed": bool(user.display_name_confirmed) if user else False,
                 **out,
@@ -244,6 +246,7 @@ def auth_me():
             {
                 "email": email,
                 "role": role,
+                "account_role": derive_account_role(user),
                 "user_id": user.id if user else None,
                 "display_name": user.display_name if user else None,
                 "display_name_confirmed": bool(user.display_name_confirmed) if user else False,

--- a/academy-watch-backend/src/routes/funding.py
+++ b/academy-watch-backend/src/routes/funding.py
@@ -1,0 +1,1144 @@
+"""Grassroots league registry, club admission, verification, and program pages."""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import UTC, datetime, timedelta
+
+from flask import Blueprint, g, jsonify, request
+from sqlalchemy import func, or_
+from sqlalchemy.exc import IntegrityError
+from src.auth import _ensure_user_account, _safe_error_payload, require_api_key, require_user_auth
+from src.extensions import limiter
+from src.models.follow import Follow, FollowList
+from src.models.funding import (
+    ClubClaimEvidence,
+    ClubConnectAccount,
+    ClubProgram,
+    ClubProgramClaim,
+    ClubProgramManager,
+    ClubProgramProfileRevision,
+    FundingAdminEvent,
+    FundingLeague,
+)
+from src.models.league import League, TeamProfile, UserAccount, db
+from src.services.stripe_connect import (
+    StripeConnectConfigurationError,
+    create_express_organization_onboarding,
+    retrieve_test_express_account,
+    test_connect_configured,
+)
+from src.utils.sanitize import is_safe_https_url, sanitize_plain_text
+
+logger = logging.getLogger(__name__)
+funding_bp = Blueprint("funding", __name__)
+
+LEVELS = {"pro_academy", "youth_national", "youth_regional", "recreational"}
+GENDER_PROGRAMS = {"boys", "girls", "both"}
+SEASON_CALENDARS = {"aug_may", "calendar_year", "fall_spring"}
+DATA_TIERS = {"api_football", "film_room", "self_reported"}
+REGISTRY_STATUSES = {"proposed", "approved", "rejected"}
+ADMISSION_STATES = {"open", "waitlisted", "closed"}
+CLAIM_STATUSES = {"pending", "approved", "rejected", "revoked"}
+ORGANIZATION_FORMS = {"nonprofit", "company", "association", "school", "municipal", "other_organization"}
+AUTHORIZATION_METHODS = {"official_domain_email", "signed_officer_authorization"}
+MAX_PAGE = 200
+
+
+def _clean(value, field, *, required=True, max_len=240):
+    if value is None:
+        if required:
+            raise ValueError(f"{field} is required")
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a string")
+    cleaned = sanitize_plain_text(value).strip()
+    if not cleaned:
+        if required:
+            raise ValueError(f"{field} is required")
+        return None
+    if len(cleaned) > max_len:
+        raise ValueError(f"{field} must be at most {max_len} characters")
+    return cleaned
+
+
+def _enum(value, field, allowed):
+    cleaned = _clean(value, field, max_len=40).lower()
+    if cleaned not in allowed:
+        raise ValueError(f"{field} must be one of {sorted(allowed)}")
+    return cleaned
+
+
+def _bool(value, field, *, must_be_true=False):
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a boolean")
+    if must_be_true and not value:
+        raise ValueError(f"{field} must be accepted")
+    return value
+
+
+def _https(value, field, *, required=False):
+    cleaned = _clean(value, field, required=required, max_len=500)
+    if cleaned and not is_safe_https_url(cleaned):
+        raise ValueError(f"{field} must be an absolute https URL")
+    return cleaned
+
+
+def _slug(value):
+    normalized = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return normalized[:180] or "program"
+
+
+def _is_us(country):
+    return (country or "").strip().upper() in {"US", "USA", "UNITED STATES", "UNITED STATES OF AMERICA"}
+
+
+def _same_country(first, second):
+    if _is_us(first) and _is_us(second):
+        return True
+    return (first or "").strip().casefold() == (second or "").strip().casefold()
+
+
+def _current_user_account():
+    user = getattr(g, "user", None)
+    if user is not None:
+        return user
+    email = getattr(g, "user_email", None)
+    if not email:
+        return None
+    user = UserAccount.query.filter_by(email=email).first()
+    if user is None:
+        user = _ensure_user_account(email)
+        db.session.flush()
+    return user
+
+
+def _rate_limit_key():
+    return getattr(g, "user_email", None) or request.remote_addr or "anon"
+
+
+def _audit(action, target_type, target_id, reason, metadata=None):
+    reason = _clean(reason, "reason", max_len=2000)
+    event = FundingAdminEvent(
+        actor_email=getattr(g, "user_email", None) or "system",
+        action=action,
+        target_type=target_type,
+        target_id=target_id,
+        reason=reason,
+        event_metadata=metadata or {},
+    )
+    db.session.add(event)
+    return event
+
+
+def _parse_age_bands(value):
+    if not isinstance(value, list) or not value:
+        raise ValueError("age_bands must be a non-empty list")
+    if len(value) > 20:
+        raise ValueError("age_bands must contain at most 20 values")
+    out = []
+    for item in value:
+        cleaned = _clean(item, "age_bands item", max_len=30)
+        if cleaned not in out:
+            out.append(cleaned)
+    return out
+
+
+def _parse_data_tier(payload):
+    raw = _clean(payload.get("data_tier"), "data_tier", max_len=60).lower()
+    league_api_id = payload.get("league_api_id")
+    if raw.startswith("api_football:"):
+        raw_id = raw.split(":", 1)[1]
+        try:
+            league_api_id = int(raw_id)
+        except ValueError as exc:
+            raise ValueError("api_football data tier requires a positive league_api_id") from exc
+        raw = "api_football"
+    if raw not in DATA_TIERS:
+        raise ValueError("data_tier must be api_football:<league_api_id>, film_room, or self_reported")
+    if raw == "api_football":
+        if isinstance(league_api_id, bool):
+            raise ValueError("league_api_id must be a positive integer")
+        try:
+            league_api_id = int(league_api_id)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("api_football data tier requires a positive league_api_id") from exc
+        if league_api_id <= 0:
+            raise ValueError("league_api_id must be a positive integer")
+    else:
+        league_api_id = None
+    return raw, league_api_id
+
+
+def _league_values(payload, *, proposal=False):
+    data_tier, league_api_id = _parse_data_tier(payload)
+    existing = League.query.filter_by(league_id=league_api_id).first() if league_api_id else None
+    name = _clean(payload.get("name"), "name", max_len=160)
+    country = _clean(payload.get("country"), "country", max_len=80)
+    if existing is not None:
+        # Provider-covered identity is bridged, never copied into a second
+        # provider record or silently edited by registry users.
+        name = existing.name
+        country = existing.country
+    return {
+        "name": name,
+        "country": country,
+        "region": _clean(payload.get("region"), "region", max_len=120),
+        "level": _enum(payload.get("level"), "level", LEVELS),
+        "age_bands": _parse_age_bands(payload.get("age_bands")),
+        "gender_program": _enum(payload.get("gender_program"), "gender_program", GENDER_PROGRAMS),
+        "season_calendar": _enum(payload.get("season_calendar"), "season_calendar", SEASON_CALENDARS),
+        "data_tier": data_tier,
+        "league_api_id": league_api_id,
+        "existing_league_id": existing.id if existing else None,
+        "registry_status": "proposed"
+        if proposal
+        else _enum(payload.get("registry_status", "approved"), "registry_status", REGISTRY_STATUSES),
+        "admission_state": "waitlisted"
+        if proposal
+        else _enum(payload.get("admission_state", "waitlisted"), "admission_state", ADMISSION_STATES),
+    }
+
+
+def _league_duplicate(values):
+    if values.get("league_api_id"):
+        row = FundingLeague.query.filter_by(league_api_id=values["league_api_id"]).first()
+        if row:
+            return row
+    return FundingLeague.query.filter(
+        func.lower(FundingLeague.name) == values["name"].lower(),
+        func.lower(FundingLeague.country) == values["country"].lower(),
+        func.lower(FundingLeague.region) == values["region"].lower(),
+    ).first()
+
+
+def _evidence_values(payload):
+    evidence = payload.get("evidence")
+    if not isinstance(evidence, dict):
+        raise ValueError("evidence is required")
+    authorization_method = _enum(evidence.get("authorization_method"), "authorization_method", AUTHORIZATION_METHODS)
+    official_email = _clean(evidence.get("official_email"), "official_email", required=False, max_len=254)
+    authorization_reference = _clean(
+        evidence.get("authorization_reference"), "authorization_reference", required=False, max_len=500
+    )
+    if authorization_method == "official_domain_email" and not official_email:
+        raise ValueError("official_email is required for official-domain authorization")
+    if authorization_method == "signed_officer_authorization" and not authorization_reference:
+        raise ValueError("authorization_reference is required for signed officer authorization")
+    if official_email and ("@" not in official_email or official_email.startswith("@") or official_email.endswith("@")):
+        raise ValueError("official_email must be a valid email address")
+    safeguarding_email = _clean(evidence.get("safeguarding_contact_email"), "safeguarding_contact_email", max_len=254)
+    if "@" not in safeguarding_email:
+        raise ValueError("safeguarding_contact_email must be a valid email address")
+    return {
+        "adult_authority_attested": _bool(
+            evidence.get("adult_authority_attested"), "adult_authority_attested", must_be_true=True
+        ),
+        "official_email": official_email,
+        "authorization_method": authorization_method,
+        "authorization_reference": authorization_reference,
+        "organization_form": _enum(evidence.get("organization_form"), "organization_form", ORGANIZATION_FORMS),
+        "registration_reference": _clean(evidence.get("registration_reference"), "registration_reference", max_len=240),
+        "official_contact_name": _clean(evidence.get("official_contact_name"), "official_contact_name", max_len=160),
+        "official_contact_reference": _clean(
+            evidence.get("official_contact_reference"), "official_contact_reference", max_len=500
+        ),
+        "safeguarding_contact_email": safeguarding_email,
+        "safeguarding_policy_url": _https(evidence.get("safeguarding_policy_url"), "safeguarding_policy_url"),
+        "safeguarding_policy_attested": _bool(
+            evidence.get("safeguarding_policy_attested"), "safeguarding_policy_attested", must_be_true=True
+        ),
+        "eligible_organization_attested": _bool(
+            evidence.get("eligible_organization_attested"), "eligible_organization_attested", must_be_true=True
+        ),
+        "payout_control_attested": _bool(
+            evidence.get("payout_control_attested"), "payout_control_attested", must_be_true=True
+        ),
+        "evidence_notes": _clean(evidence.get("evidence_notes"), "evidence_notes", required=False, max_len=2000),
+        "retention_expires_at": datetime.now(UTC) + timedelta(days=365),
+    }
+
+
+def _evidence_dict(evidence):
+    if evidence is None:
+        return None
+    return {
+        "adult_authority_attested": evidence.adult_authority_attested,
+        "official_email": evidence.official_email,
+        "authorization_method": evidence.authorization_method,
+        "authorization_reference": evidence.authorization_reference,
+        "organization_form": evidence.organization_form,
+        "registration_reference": evidence.registration_reference,
+        "official_contact_name": evidence.official_contact_name,
+        "official_contact_reference": evidence.official_contact_reference,
+        "safeguarding_contact_email": evidence.safeguarding_contact_email,
+        "safeguarding_policy_url": evidence.safeguarding_policy_url,
+        "safeguarding_policy_attested": evidence.safeguarding_policy_attested,
+        "eligible_organization_attested": evidence.eligible_organization_attested,
+        "payout_control_attested": evidence.payout_control_attested,
+        "evidence_notes": evidence.evidence_notes,
+        "retention_expires_at": evidence.retention_expires_at.isoformat() if evidence.retention_expires_at else None,
+    }
+
+
+def _evidence_meets_bar(evidence):
+    if evidence is None:
+        return False
+    authorization_present = bool(
+        (evidence.authorization_method == "official_domain_email" and evidence.official_email)
+        or (evidence.authorization_method == "signed_officer_authorization" and evidence.authorization_reference)
+    )
+    return bool(
+        evidence.adult_authority_attested
+        and authorization_present
+        and evidence.organization_form
+        and evidence.registration_reference
+        and evidence.official_contact_name
+        and evidence.official_contact_reference
+        and evidence.safeguarding_contact_email
+        and evidence.safeguarding_policy_attested
+        and evidence.eligible_organization_attested
+        and evidence.payout_control_attested
+    )
+
+
+def _connect_dict(account):
+    if account is None:
+        return None
+    return {
+        "stripe_account_id": account.stripe_account_id,
+        "account_type": account.account_type,
+        "country": account.country,
+        "business_type": account.business_type,
+        "livemode": account.livemode,
+        "transfers_active": account.transfers_active,
+        "details_submitted": account.details_submitted,
+        "payouts_enabled": account.payouts_enabled,
+        "charges_enabled": account.charges_enabled,
+        "requirements_due": account.requirements_due or [],
+        "disabled_reason": account.disabled_reason,
+        "onboarding_url": account.onboarding_url,
+        "onboarding_expires_at": account.onboarding_expires_at.isoformat() if account.onboarding_expires_at else None,
+        "is_ready": account.is_ready,
+    }
+
+
+def _refresh_program_verification(program, *, now=None):
+    """Recompute the badge timestamp from current approval/grant/Connect rows."""
+    db.session.flush()
+    db.session.expire(program, ["managers", "connect_accounts"])
+    verified = program.is_verified_program
+    if verified:
+        program.verified_at = program.verified_at or now or datetime.now(UTC)
+    else:
+        program.verified_at = None
+    return verified
+
+
+def _claim_dict(claim, *, admin=False):
+    program = claim.program
+    payload = {
+        "id": claim.id,
+        "status": claim.status,
+        "relationship_type": claim.relationship_type,
+        "applicant_message": claim.applicant_message,
+        "review_reason": claim.review_reason,
+        "reviewed_at": claim.reviewed_at.isoformat() if claim.reviewed_at else None,
+        "created_at": claim.created_at.isoformat() if claim.created_at else None,
+        "program": {
+            **program.public_dict(),
+            "platform_status": program.platform_status,
+            "legal_name": program.legal_name if admin else None,
+        },
+    }
+    if admin:
+        payload.update(
+            {
+                "applicant_email": claim.user.email if claim.user else None,
+                "evidence": _evidence_dict(claim.evidence),
+                "connect": _connect_dict(program.connect_account),
+                "audit_trail": [
+                    {
+                        "action": event.action,
+                        "reason": event.reason,
+                        "actor_email": event.actor_email,
+                        "created_at": event.created_at.isoformat() if event.created_at else None,
+                    }
+                    for event in FundingAdminEvent.query.filter_by(target_type="claim", target_id=claim.id)
+                    .order_by(FundingAdminEvent.created_at.asc(), FundingAdminEvent.id.asc())
+                    .all()
+                ],
+            }
+        )
+    return payload
+
+
+@funding_bp.route("/funding/leagues", methods=["GET"])
+def public_funding_leagues():
+    query = FundingLeague.query.filter_by(registry_status="approved", admission_state="open")
+    country = _clean(request.args.get("country"), "country", required=False, max_len=80)
+    if country:
+        query = query.filter(func.lower(FundingLeague.country) == country.lower())
+    rows = query.order_by(FundingLeague.country, FundingLeague.region, FundingLeague.name).limit(MAX_PAGE).all()
+    return jsonify({"leagues": [row.to_dict() for row in rows]})
+
+
+@funding_bp.route("/admin/funding/leagues", methods=["GET"])
+@require_api_key
+def admin_funding_leagues():
+    query = FundingLeague.query
+    for arg, column, allowed in (
+        ("admission_state", FundingLeague.admission_state, ADMISSION_STATES),
+        ("registry_status", FundingLeague.registry_status, REGISTRY_STATUSES),
+        ("level", FundingLeague.level, LEVELS),
+        ("gender_program", FundingLeague.gender_program, GENDER_PROGRAMS),
+    ):
+        value = (request.args.get(arg) or "").strip().lower()
+        if value:
+            if value not in allowed:
+                return jsonify({"error": f"{arg} must be one of {sorted(allowed)}"}), 400
+            query = query.filter(column == value)
+    country = (request.args.get("country") or "").strip()
+    if country:
+        query = query.filter(func.lower(FundingLeague.country) == country.lower())
+    search = (request.args.get("q") or "").strip()
+    if search:
+        token = f"%{search}%"
+        query = query.filter(or_(FundingLeague.name.ilike(token), FundingLeague.region.ilike(token)))
+    rows = query.order_by(FundingLeague.created_at.desc(), FundingLeague.id.desc()).limit(MAX_PAGE).all()
+    return jsonify({"leagues": [row.to_dict(admin=True) for row in rows]})
+
+
+@funding_bp.route("/admin/funding/leagues", methods=["POST"])
+@require_api_key
+def admin_create_funding_league():
+    try:
+        payload = request.get_json(silent=True) or {}
+        reason = _clean(payload.get("reason"), "reason", max_len=2000)
+        values = _league_values(payload)
+        duplicate = _league_duplicate(values)
+        if duplicate:
+            return jsonify({"error": "league is already registered", "league": duplicate.to_dict(admin=True)}), 409
+        league = FundingLeague(**values, reviewed_by=getattr(g, "user_email", None), reviewed_at=datetime.now(UTC))
+        db.session.add(league)
+        db.session.flush()
+        _audit("league.created", "league", league.id, reason, {"admission_state": league.admission_state})
+        db.session.commit()
+        return jsonify({"league": league.to_dict(admin=True)}), 201
+    except ValueError as exc:
+        db.session.rollback()
+        return jsonify({"error": str(exc)}), 400
+    except IntegrityError:
+        db.session.rollback()
+        return jsonify({"error": "league is already registered"}), 409
+    except Exception as exc:
+        db.session.rollback()
+        logger.exception("Failed to create funding league")
+        return jsonify(_safe_error_payload(exc, "Failed to create league")), 500
+
+
+@funding_bp.route("/admin/funding/leagues/<int:league_id>", methods=["GET"])
+@require_api_key
+def admin_get_funding_league(league_id):
+    league = db.session.get(FundingLeague, league_id)
+    if league is None:
+        return jsonify({"error": "league not found"}), 404
+    return jsonify({"league": league.to_dict(admin=True)})
+
+
+@funding_bp.route("/admin/funding/leagues/<int:league_id>", methods=["PATCH"])
+@require_api_key
+def admin_update_funding_league(league_id):
+    try:
+        league = db.session.get(FundingLeague, league_id)
+        if league is None:
+            return jsonify({"error": "league not found"}), 404
+        payload = request.get_json(silent=True) or {}
+        reason = _clean(payload.get("reason"), "reason", max_len=2000)
+        before = {"admission_state": league.admission_state, "registry_status": league.registry_status}
+
+        if league.existing_league_id and any(
+            key in payload for key in ("name", "country", "data_tier", "league_api_id")
+        ):
+            return jsonify({"error": "provider-bridged identity fields are read-only"}), 409
+        if "name" in payload:
+            league.name = _clean(payload["name"], "name", max_len=160)
+        if "country" in payload:
+            league.country = _clean(payload["country"], "country", max_len=80)
+        if "region" in payload:
+            league.region = _clean(payload["region"], "region", max_len=120)
+        if "level" in payload:
+            league.level = _enum(payload["level"], "level", LEVELS)
+        if "age_bands" in payload:
+            league.age_bands = _parse_age_bands(payload["age_bands"])
+        if "gender_program" in payload:
+            league.gender_program = _enum(payload["gender_program"], "gender_program", GENDER_PROGRAMS)
+        if "season_calendar" in payload:
+            league.season_calendar = _enum(payload["season_calendar"], "season_calendar", SEASON_CALENDARS)
+        if "admission_state" in payload:
+            league.admission_state = _enum(payload["admission_state"], "admission_state", ADMISSION_STATES)
+        if "registry_status" in payload:
+            league.registry_status = _enum(payload["registry_status"], "registry_status", REGISTRY_STATUSES)
+        if not league.existing_league_id and ("data_tier" in payload or "league_api_id" in payload):
+            merged = {"data_tier": payload.get("data_tier", league.data_tier_key)}
+            if "league_api_id" in payload:
+                merged["league_api_id"] = payload["league_api_id"]
+            tier, api_id = _parse_data_tier(merged)
+            league.data_tier = tier
+            league.league_api_id = api_id
+            existing = League.query.filter_by(league_id=api_id).first() if api_id else None
+            league.existing_league_id = existing.id if existing else None
+            if existing:
+                league.name, league.country = existing.name, existing.country
+        league.reviewed_by = getattr(g, "user_email", None)
+        league.review_reason = reason
+        league.reviewed_at = datetime.now(UTC)
+        _audit(
+            "league.updated",
+            "league",
+            league.id,
+            reason,
+            {
+                "before": before,
+                "after": {"admission_state": league.admission_state, "registry_status": league.registry_status},
+            },
+        )
+        db.session.commit()
+        return jsonify({"league": league.to_dict(admin=True)})
+    except ValueError as exc:
+        db.session.rollback()
+        return jsonify({"error": str(exc)}), 400
+    except IntegrityError:
+        db.session.rollback()
+        return jsonify({"error": "league update conflicts with an existing registry row"}), 409
+    except Exception as exc:
+        db.session.rollback()
+        logger.exception("Failed to update funding league")
+        return jsonify(_safe_error_payload(exc, "Failed to update league")), 500
+
+
+@funding_bp.route("/admin/funding/leagues/<int:league_id>", methods=["DELETE"])
+@require_api_key
+def admin_delete_funding_league(league_id):
+    try:
+        league = db.session.get(FundingLeague, league_id)
+        if league is None:
+            return jsonify({"deleted": False})
+        if league.existing_league_id:
+            return jsonify({"error": "provider-bridged leagues are read-only"}), 409
+        if league.programs.count():
+            return jsonify({"error": "league has club programs and cannot be deleted"}), 409
+        payload = request.get_json(silent=True) or {}
+        reason = _clean(payload.get("reason"), "reason", max_len=2000)
+        _audit("league.deleted", "league", league.id, reason, {"name": league.name})
+        db.session.delete(league)
+        db.session.commit()
+        return jsonify({"deleted": True})
+    except ValueError as exc:
+        db.session.rollback()
+        return jsonify({"error": str(exc)}), 400
+    except Exception as exc:
+        db.session.rollback()
+        logger.exception("Failed to delete funding league")
+        return jsonify(_safe_error_payload(exc, "Failed to delete league")), 500
+
+
+@funding_bp.route("/funding/claims", methods=["POST"])
+@require_user_auth
+@limiter.limit("3 per hour", key_func=_rate_limit_key)
+def submit_program_claim():
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        payload = request.get_json(silent=True) or {}
+        proposed = payload.get("proposed_league")
+        league_id = payload.get("funding_league_id")
+        if bool(proposed) == bool(league_id):
+            raise ValueError("choose one approved league or propose one new league")
+        if proposed:
+            if not isinstance(proposed, dict):
+                raise ValueError("proposed_league must be an object")
+            values = _league_values(proposed, proposal=True)
+            league = _league_duplicate(values)
+            if league is None:
+                league = FundingLeague(**values, proposed_by_user_id=user.id)
+                db.session.add(league)
+                db.session.flush()
+                _audit(
+                    "league.proposed",
+                    "league",
+                    league.id,
+                    "League proposed through a club program claim",
+                    {"admission_state": league.admission_state},
+                )
+            elif league.registry_status == "approved" and league.admission_state == "open":
+                raise ValueError("this league is already open; select it from the approved registry")
+        else:
+            if isinstance(league_id, bool):
+                raise ValueError("funding_league_id must be a positive integer")
+            try:
+                league_id = int(league_id)
+            except (TypeError, ValueError) as exc:
+                raise ValueError("funding_league_id must be a positive integer") from exc
+            league = db.session.get(FundingLeague, league_id)
+            if league is None or league.registry_status != "approved" or league.admission_state != "open":
+                return jsonify({"error": "league is not approved and open for admission"}), 409
+
+        evidence_values = _evidence_values(payload)
+        team_api_id = payload.get("team_api_id")
+        team_profile = None
+        if team_api_id is not None:
+            if isinstance(team_api_id, bool):
+                raise ValueError("team_api_id must be a positive integer")
+            try:
+                team_api_id = int(team_api_id)
+            except (TypeError, ValueError) as exc:
+                raise ValueError("team_api_id must be a positive integer") from exc
+            team_profile = db.session.get(TeamProfile, team_api_id)
+            if team_profile is None:
+                raise ValueError("team_api_id does not map to a covered Team")
+
+        submitted_name = _clean(payload.get("club_name"), "club_name", max_len=180)
+        name = team_profile.name if team_profile else submitted_name
+        country = (
+            team_profile.country
+            if team_profile and team_profile.country
+            else _clean(payload.get("country"), "country", max_len=80)
+        )
+        legal_name = _clean(payload.get("legal_name"), "legal_name", max_len=220)
+        region = _clean(payload.get("region"), "region", max_len=120)
+        city = _clean(payload.get("city"), "city", required=False, max_len=120)
+        crest_url = (
+            team_profile.logo_url
+            if team_profile and team_profile.logo_url
+            else _https(payload.get("crest_url"), "crest_url")
+        )
+        if not _same_country(country, league.country):
+            raise ValueError("club country must match the selected league country")
+        program = ClubProgram.query.filter_by(team_api_id=team_api_id).first() if team_api_id else None
+        if program is not None and program.funding_league_id != league.id:
+            return jsonify({"error": "this covered club is already registered in another league"}), 409
+        if program is None:
+            base_slug = _slug(name)
+            slug = base_slug
+            suffix = 2
+            while ClubProgram.query.filter_by(slug=slug).first():
+                slug = f"{base_slug}-{suffix}"
+                suffix += 1
+            program = ClubProgram(
+                funding_league_id=league.id,
+                team_api_id=team_api_id,
+                name=name,
+                legal_name=legal_name,
+                slug=slug,
+                crest_url=crest_url,
+                country=country,
+                region=region,
+                city=city,
+                currency="USD"
+                if _is_us(country)
+                else _clean(payload.get("currency", "USD"), "currency", max_len=3).upper(),
+                provenance_tier="provider_covered" if team_profile else "self_reported",
+                platform_status="pending",
+            )
+            db.session.add(program)
+            db.session.flush()
+
+        existing_claim = ClubProgramClaim.query.filter_by(program_id=program.id, user_account_id=user.id).first()
+        if existing_claim and existing_claim.status not in {"rejected", "revoked"}:
+            return jsonify(
+                {"error": "you already have a claim for this program", "claim": _claim_dict(existing_claim)}
+            ), 409
+        if existing_claim:
+            claim = existing_claim
+            claim.status = "pending"
+            claim.reviewed_by = None
+            claim.review_reason = None
+            claim.reviewed_at = None
+            if claim.evidence:
+                for key, value in evidence_values.items():
+                    setattr(claim.evidence, key, value)
+            else:
+                db.session.add(ClubClaimEvidence(claim=claim, **evidence_values))
+        else:
+            claim = ClubProgramClaim(
+                program=program,
+                user_account_id=user.id,
+                relationship_type="club_official",
+                status="pending",
+                applicant_message=_clean(
+                    payload.get("applicant_message"), "applicant_message", required=False, max_len=1000
+                ),
+            )
+            db.session.add(claim)
+            db.session.flush()
+            db.session.add(ClubClaimEvidence(claim=claim, **evidence_values))
+        db.session.flush()
+        league_waitlisted = league.registry_status != "approved" or league.admission_state != "open"
+        _audit(
+            "claim.resubmitted" if existing_claim else "claim.submitted",
+            "claim",
+            claim.id,
+            "Club program claim submitted for review",
+            {"program_id": program.id, "league_id": league.id, "league_waitlisted": league_waitlisted},
+        )
+        db.session.commit()
+        return jsonify({"claim": _claim_dict(claim), "league_waitlisted": league_waitlisted}), 201
+    except ValueError as exc:
+        db.session.rollback()
+        return jsonify({"error": str(exc)}), 400
+    except IntegrityError:
+        db.session.rollback()
+        return jsonify({"error": "this club or league claim already exists"}), 409
+    except Exception as exc:
+        db.session.rollback()
+        logger.exception("Failed to submit club program claim")
+        return jsonify(_safe_error_payload(exc, "Failed to submit claim")), 500
+
+
+@funding_bp.route("/funding/claims/me", methods=["GET"])
+@require_user_auth
+def my_program_claims():
+    user = _current_user_account()
+    if user is None:
+        return jsonify({"error": "auth context missing email"}), 401
+    claims = (
+        ClubProgramClaim.query.filter_by(user_account_id=user.id)
+        .order_by(ClubProgramClaim.created_at.desc(), ClubProgramClaim.id.desc())
+        .all()
+    )
+    return jsonify({"claims": [_claim_dict(claim) for claim in claims]})
+
+
+@funding_bp.route("/admin/funding/claims", methods=["GET"])
+@require_api_key
+def admin_program_claims():
+    status = (request.args.get("status") or "pending").strip().lower()
+    query = ClubProgramClaim.query
+    if status != "all":
+        if status not in CLAIM_STATUSES:
+            return jsonify({"error": f"status must be one of {sorted(CLAIM_STATUSES)} or all"}), 400
+        query = query.filter(ClubProgramClaim.status == status)
+    claims = query.order_by(ClubProgramClaim.created_at.asc(), ClubProgramClaim.id.asc()).limit(MAX_PAGE).all()
+    return jsonify({"claims": [_claim_dict(claim, admin=True) for claim in claims]})
+
+
+def _apply_connect_result(account, result):
+    for field in (
+        "stripe_account_id",
+        "livemode",
+        "account_type",
+        "country",
+        "business_type",
+        "details_submitted",
+        "charges_enabled",
+        "payouts_enabled",
+        "transfers_active",
+        "requirements_due",
+        "disabled_reason",
+        "onboarding_url",
+        "onboarding_expires_at",
+    ):
+        if field in result:
+            setattr(account, field, result[field])
+    account.last_synced_at = datetime.now(UTC)
+
+
+@funding_bp.route("/admin/funding/claims/<int:claim_id>/approve", methods=["POST"])
+@require_api_key
+def approve_program_claim(claim_id):
+    try:
+        claim = db.session.get(ClubProgramClaim, claim_id)
+        if claim is None:
+            return jsonify({"error": "claim not found"}), 404
+        if claim.status not in {"pending", "rejected", "revoked"}:
+            return jsonify({"error": f"cannot approve a {claim.status} claim"}), 409
+        payload = request.get_json(silent=True) or {}
+        reason = _clean(payload.get("reason"), "reason", max_len=2000)
+        league = claim.program.league
+        if league.registry_status != "approved" or league.admission_state != "open":
+            return jsonify({"error": "the program league must be approved and open before claim approval"}), 409
+        if not _evidence_meets_bar(claim.evidence):
+            return jsonify({"error": "claim evidence no longer meets the approved verification bar"}), 409
+
+        now = datetime.now(UTC)
+        claim.status = "approved"
+        claim.reviewed_by = getattr(g, "user_email", None)
+        claim.review_reason = reason
+        claim.reviewed_at = now
+        program = claim.program
+        program.platform_status = "approved"
+        program.reviewed_by = getattr(g, "user_email", None)
+        program.review_reason = reason
+        program.reviewed_at = now
+        program.next_review_at = now + timedelta(days=365)
+
+        manager = ClubProgramManager.query.filter_by(
+            program_id=program.id, user_account_id=claim.user_account_id
+        ).first()
+        if manager is None:
+            manager = ClubProgramManager(
+                program=program,
+                user_account_id=claim.user_account_id,
+                source_claim_id=claim.id,
+                status="active",
+                granted_by=getattr(g, "user_email", None) or "admin",
+                granted_at=now,
+            )
+            db.session.add(manager)
+        else:
+            manager.status = "active"
+            manager.source_claim_id = claim.id
+            manager.granted_by = getattr(g, "user_email", None) or "admin"
+            manager.granted_at = now
+            manager.revoked_at = None
+            manager.revoked_reason = None
+
+        connect_error = None
+        if _is_us(program.country):
+            account = ClubConnectAccount.query.filter_by(program_id=program.id).first()
+            if account is None:
+                account = ClubConnectAccount(
+                    program=program,
+                    country="US",
+                    business_type="company",
+                    account_type="express",
+                    requirements_due=["connect.onboarding_not_started"],
+                )
+                db.session.add(account)
+            db.session.flush()
+            if not account.stripe_account_id and test_connect_configured():
+                try:
+                    _apply_connect_result(account, create_express_organization_onboarding(program))
+                except Exception as exc:  # approval survives an integration outage; badge remains off
+                    logger.exception("Test Connect onboarding failed for program %s", program.id)
+                    connect_error = type(exc).__name__
+                    account.requirements_due = ["connect.onboarding_retry_required"]
+
+        verified = _refresh_program_verification(program, now=now)
+        _audit(
+            "claim.approved",
+            "claim",
+            claim.id,
+            reason,
+            {
+                "program_id": program.id,
+                "verified": verified,
+                "connect_test_configured": test_connect_configured(),
+                "connect_error": connect_error,
+            },
+        )
+        db.session.commit()
+        return jsonify({"claim": _claim_dict(claim, admin=True)})
+    except ValueError as exc:
+        db.session.rollback()
+        return jsonify({"error": str(exc)}), 400
+    except Exception as exc:
+        db.session.rollback()
+        logger.exception("Failed to approve club program claim")
+        return jsonify(_safe_error_payload(exc, "Failed to approve claim")), 500
+
+
+@funding_bp.route("/admin/funding/claims/<int:claim_id>/reject", methods=["POST"])
+@require_api_key
+def reject_program_claim(claim_id):
+    try:
+        claim = db.session.get(ClubProgramClaim, claim_id)
+        if claim is None:
+            return jsonify({"error": "claim not found"}), 404
+        if claim.status != "pending":
+            return jsonify({"error": f"cannot reject a {claim.status} claim"}), 409
+        payload = request.get_json(silent=True) or {}
+        reason = _clean(payload.get("reason"), "reason", max_len=2000)
+        claim.status = "rejected"
+        claim.reviewed_by = getattr(g, "user_email", None)
+        claim.review_reason = reason
+        claim.reviewed_at = datetime.now(UTC)
+        program = claim.program
+        has_active_manager = (
+            ClubProgramManager.query.filter_by(program_id=program.id, status="active").first() is not None
+        )
+        if not has_active_manager:
+            program.platform_status = "rejected"
+            program.review_reason = reason
+            program.reviewed_by = getattr(g, "user_email", None)
+            program.reviewed_at = claim.reviewed_at
+            program.verified_at = None
+        _audit(
+            "claim.rejected",
+            "claim",
+            claim.id,
+            reason,
+            {"program_id": claim.program_id, "program_remains_approved": has_active_manager},
+        )
+        db.session.commit()
+        return jsonify({"claim": _claim_dict(claim, admin=True)})
+    except ValueError as exc:
+        db.session.rollback()
+        return jsonify({"error": str(exc)}), 400
+    except Exception as exc:
+        db.session.rollback()
+        logger.exception("Failed to reject club program claim")
+        return jsonify(_safe_error_payload(exc, "Failed to reject claim")), 500
+
+
+@funding_bp.route("/admin/funding/claims/<int:claim_id>/revoke", methods=["POST"])
+@require_api_key
+def revoke_program_claim(claim_id):
+    try:
+        claim = db.session.get(ClubProgramClaim, claim_id)
+        if claim is None:
+            return jsonify({"error": "claim not found"}), 404
+        if claim.status != "approved":
+            return jsonify({"error": f"cannot revoke a {claim.status} claim"}), 409
+        payload = request.get_json(silent=True) or {}
+        reason = _clean(payload.get("reason"), "reason", max_len=2000)
+        now = datetime.now(UTC)
+        actor = getattr(g, "user_email", None) or "admin"
+
+        claim.status = "revoked"
+        claim.reviewed_by = actor
+        claim.review_reason = reason
+        claim.reviewed_at = now
+        manager = ClubProgramManager.query.filter_by(
+            program_id=claim.program_id,
+            user_account_id=claim.user_account_id,
+            source_claim_id=claim.id,
+        ).first()
+        if manager is not None and manager.status == "active":
+            manager.status = "revoked"
+            manager.revoked_by = actor
+            manager.revoked_reason = reason
+            manager.revoked_at = now
+
+        db.session.flush()
+        remaining_manager = (
+            ClubProgramManager.query.filter_by(program_id=claim.program_id, status="active").first() is not None
+        )
+        program = claim.program
+        if not remaining_manager:
+            program.platform_status = "suspended"
+            program.donations_enabled = False
+            program.reviewed_by = actor
+            program.review_reason = reason
+            program.reviewed_at = now
+        verified = _refresh_program_verification(program, now=now)
+        _audit(
+            "claim.revoked",
+            "claim",
+            claim.id,
+            reason,
+            {
+                "program_id": claim.program_id,
+                "manager_grant_id": manager.id if manager else None,
+                "remaining_active_manager": remaining_manager,
+                "verified": verified,
+            },
+        )
+        db.session.commit()
+        return jsonify({"claim": _claim_dict(claim, admin=True)})
+    except ValueError as exc:
+        db.session.rollback()
+        return jsonify({"error": str(exc)}), 400
+    except Exception as exc:
+        db.session.rollback()
+        logger.exception("Failed to revoke club program claim")
+        return jsonify(_safe_error_payload(exc, "Failed to revoke claim")), 500
+
+
+@funding_bp.route("/admin/funding/programs/<int:program_id>/connect/sync", methods=["POST"])
+@require_api_key
+def sync_program_connect_account(program_id):
+    try:
+        program = db.session.get(ClubProgram, program_id)
+        if program is None:
+            return jsonify({"error": "program not found"}), 404
+        if not _is_us(program.country):
+            return jsonify({"error": "Connect readiness is only used for US programs in F2"}), 409
+        account = ClubConnectAccount.query.filter_by(program_id=program.id).first()
+        if account is None or not account.stripe_account_id:
+            return jsonify({"error": "test Connect onboarding has not started"}), 409
+        payload = request.get_json(silent=True) or {}
+        reason = _clean(payload.get("reason"), "reason", max_len=2000)
+        result = retrieve_test_express_account(account.stripe_account_id)
+        if str(result.get("country") or "").upper() != "US":
+            raise StripeConnectConfigurationError("F2 supports US connected accounts only")
+        _apply_connect_result(account, result)
+        verified = _refresh_program_verification(program)
+        _audit(
+            "connect.synced",
+            "program",
+            program.id,
+            reason,
+            {
+                "stripe_account_id": account.stripe_account_id,
+                "livemode": account.livemode,
+                "verified": verified,
+            },
+        )
+        db.session.commit()
+        return jsonify(
+            {
+                "program": {**program.public_dict(), "platform_status": program.platform_status},
+                "connect": _connect_dict(account),
+            }
+        )
+    except (ValueError, StripeConnectConfigurationError) as exc:
+        db.session.rollback()
+        return jsonify({"error": str(exc)}), 400
+    except Exception as exc:
+        db.session.rollback()
+        logger.exception("Failed to sync test Connect account for program %s", program_id)
+        return jsonify(_safe_error_payload(exc, "Failed to sync test Connect account")), 502
+
+
+def _approved_revision(program):
+    if program.approved_profile_revision_id:
+        revision = db.session.get(ClubProgramProfileRevision, program.approved_profile_revision_id)
+        if revision and revision.program_id == program.id and revision.status == "approved":
+            return revision
+    return (
+        ClubProgramProfileRevision.query.filter_by(program_id=program.id, status="approved")
+        .order_by(ClubProgramProfileRevision.created_at.desc(), ClubProgramProfileRevision.id.desc())
+        .first()
+    )
+
+
+@funding_bp.route("/programs/<string:slug>", methods=["GET"])
+def public_program(slug):
+    program = ClubProgram.query.filter_by(slug=slug, platform_status="approved", emergency_hidden=False).first()
+    if program is None:
+        return jsonify({"error": "program not found"}), 404
+    payload = program.public_dict()
+    revision = _approved_revision(program)
+    payload["program_provided"] = (
+        {
+            "label": "Program-provided",
+            "summary": revision.summary,
+            "age_groups": revision.age_groups or [],
+            "activities": revision.activities or [],
+            "funding_purpose": revision.funding_purpose,
+            "official_url": revision.official_url,
+            "safeguarding_url": revision.safeguarding_url,
+            "updated_at": revision.created_at.isoformat() if revision.created_at else None,
+        }
+        if revision
+        else None
+    )
+    payload["roster_links"] = (
+        {
+            "team_page": f"/teams/{program.team_profile.slug}" if program.team_profile.slug else None,
+            "academy_roster_api": f"/teams/{program.team_api_id}/players?academy_only=true",
+        }
+        if program.team_profile
+        else None
+    )
+    return jsonify({"program": payload})
+
+
+@funding_bp.route("/programs/<string:slug>/save", methods=["POST"])
+@require_user_auth
+@limiter.limit("30 per minute", key_func=_rate_limit_key)
+def save_program(slug):
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        program = ClubProgram.query.filter_by(slug=slug, platform_status="approved", emergency_hidden=False).first()
+        if program is None:
+            return jsonify({"error": "program not found"}), 404
+        payload = request.get_json(silent=True) or {}
+        notify = payload.get("notify_when_fundable", True)
+        notify = _bool(notify, "notify_when_fundable")
+        follow_list = FollowList.query.filter_by(user_account_id=user.id, is_default=True).first()
+        if follow_list is None:
+            follow_list = FollowList(user_account_id=user.id, name="My Watchlist", is_default=True)
+            db.session.add(follow_list)
+            db.session.flush()
+        follow = next(
+            (
+                row
+                for row in follow_list.follows.filter(Follow.kind == "academy_club").all()
+                if (row.selector or {}).get("program_id") == program.id
+            ),
+            None,
+        )
+        created = follow is None
+        if follow is None:
+            follow = Follow(
+                list_id=follow_list.id,
+                kind="academy_club",
+                selector={"program_id": program.id},
+                label=f"Club program: {program.name}"[:160],
+                notify_when_fundable=notify,
+            )
+            db.session.add(follow)
+        else:
+            follow.notify_when_fundable = notify
+        db.session.commit()
+        return (
+            jsonify(
+                {
+                    "saved": True,
+                    "notify_when_fundable": follow.notify_when_fundable,
+                    "follow_id": follow.id,
+                }
+            ),
+            201 if created else 200,
+        )
+    except ValueError as exc:
+        db.session.rollback()
+        return jsonify({"error": str(exc)}), 400
+    except Exception as exc:
+        db.session.rollback()
+        logger.exception("Failed to save program")
+        return jsonify(_safe_error_payload(exc, "Failed to save program")), 500
+
+
+@funding_bp.route("/admin/funding/demand", methods=["GET"])
+@require_api_key
+def admin_funding_demand():
+    program_id_expr = Follow.selector["program_id"].as_integer()
+    saved_users = func.count(func.distinct(FollowList.user_account_id))
+    rows = (
+        db.session.query(ClubProgram, saved_users.label("saved_count"))
+        .join(
+            Follow,
+            (Follow.kind == "academy_club")
+            & (Follow.notify_when_fundable.is_(True))
+            & (program_id_expr == ClubProgram.id),
+        )
+        .join(FollowList, FollowList.id == Follow.list_id)
+        .filter(ClubProgram.platform_status == "approved", ClubProgram.emergency_hidden.is_(False))
+        .group_by(ClubProgram.id)
+        .order_by(saved_users.desc(), ClubProgram.id.asc())
+        .all()
+    )
+    by_region = {}
+    by_league = {}
+    programs = []
+    for program, count in rows:
+        region_key = f"{program.country} / {program.region}"
+        by_region[region_key] = by_region.get(region_key, 0) + count
+        league_name = program.league.name
+        by_league[league_name] = by_league.get(league_name, 0) + count
+        programs.append(
+            {
+                "program_id": program.id,
+                "program_name": program.name,
+                "slug": program.slug,
+                "region": program.region,
+                "country": program.country,
+                "league": league_name,
+                "saved_count": count,
+            }
+        )
+    return jsonify(
+        {
+            "programs": programs,
+            "by_region": [{"region": key, "saved_count": value} for key, value in sorted(by_region.items())],
+            "by_league": [{"league": key, "saved_count": value} for key, value in sorted(by_league.items())],
+        }
+    )

--- a/academy-watch-backend/src/routes/scout.py
+++ b/academy-watch-backend/src/routes/scout.py
@@ -1391,7 +1391,9 @@ def _follow_read_payload(follow, name_map, team_map):
     if follow.kind == "player":
         name = name_map.get(selector.get("player_api_id"))
     elif follow.kind == "academy_club":
-        name = team_map.get(selector.get("team_id"))
+        name = follow.label.removeprefix("Club program: ") if selector.get("program_id") and follow.label else None
+        if not selector.get("program_id"):
+            name = team_map.get(selector.get("team_id"))
     else:
         name = None
     return {
@@ -1400,6 +1402,7 @@ def _follow_read_payload(follow, name_map, team_map):
         "selector": follow.selector,
         "label": derive_label(follow.kind, selector, name),
         "note": follow.note,
+        "notify_when_fundable": bool(follow.notify_when_fundable),
         "created_at": follow.created_at.isoformat() if follow.created_at else None,
     }
 
@@ -1435,6 +1438,7 @@ def _follow_payload(follow):
         "selector": follow.selector,
         "label": follow.label,
         "note": follow.note,
+        "notify_when_fundable": bool(follow.notify_when_fundable),
         "created_at": follow.created_at.isoformat() if follow.created_at else None,
     }
 
@@ -1658,12 +1662,36 @@ def scout_list_add_follow(list_id):
                     shadow_created = True
                 label = derive_label("player", clean_selector, shadow.player_name)
         elif kind == "academy_club":
-            team = Team.query.filter_by(id=clean_selector["team_id"]).first()
-            label = derive_label("academy_club", clean_selector, team.name if team else None)
+            if clean_selector.get("program_id"):
+                from src.models.funding import ClubProgram
+
+                program = ClubProgram.query.filter_by(
+                    id=clean_selector["program_id"],
+                    platform_status="approved",
+                    emergency_hidden=False,
+                ).first()
+                if program is None:
+                    return jsonify({"error": "program not found"}), 404
+                label = derive_label("academy_club", clean_selector, program.name)
+            else:
+                team = Team.query.filter_by(id=clean_selector["team_id"]).first()
+                label = derive_label("academy_club", clean_selector, team.name if team else None)
         else:
             label = derive_label(kind, clean_selector)
 
-        follow = Follow(list_id=follow_list.id, kind=kind, selector=clean_selector, label=label, note=note)
+        notify_when_fundable = payload.get("notify_when_fundable", False)
+        if not isinstance(notify_when_fundable, bool):
+            return jsonify({"error": "notify_when_fundable must be a boolean"}), 400
+        if notify_when_fundable and not (kind == "academy_club" and clean_selector.get("program_id")):
+            return jsonify({"error": "notify_when_fundable is only valid for club programs"}), 400
+        follow = Follow(
+            list_id=follow_list.id,
+            kind=kind,
+            selector=clean_selector,
+            label=label,
+            note=note,
+            notify_when_fundable=notify_when_fundable,
+        )
         db.session.add(follow)
         db.session.commit()
         return jsonify({"follow": _follow_payload(follow), "shadow_created": shadow_created}), 201

--- a/academy-watch-backend/src/services/account_roles.py
+++ b/academy-watch-backend/src/services/account_roles.py
@@ -1,0 +1,45 @@
+"""Derived account personas backed only by current authoritative grants."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from src.models.funding import ClubProgramManager
+from src.models.league import db
+from src.models.showcase import PlayerProfileClaim
+
+if TYPE_CHECKING:
+    from src.models.league import UserAccount
+
+AccountRole = Literal["scout", "player", "club_manager"]
+ACCOUNT_ROLE_PRECEDENCE: tuple[AccountRole, ...] = ("club_manager", "player", "scout")
+
+
+def derive_account_role(user: UserAccount | None) -> AccountRole:
+    """Project the highest-precedence persona; never persist the label itself."""
+    roles: set[AccountRole] = {"scout"}
+    if user is not None and user.id is not None:
+        manager_grant = (
+            db.session.query(ClubProgramManager.id)
+            .filter(
+                ClubProgramManager.user_account_id == user.id,
+                ClubProgramManager.status == "active",
+            )
+            .first()
+        )
+        if manager_grant is not None:
+            roles.add("club_manager")
+
+        player_claim = (
+            db.session.query(PlayerProfileClaim.id)
+            .filter(
+                PlayerProfileClaim.user_account_id == user.id,
+                PlayerProfileClaim.relationship_type == "player",
+                PlayerProfileClaim.status == "approved",
+            )
+            .first()
+        )
+        if player_claim is not None:
+            roles.add("player")
+
+    return next(role for role in ACCOUNT_ROLE_PRECEDENCE if role in roles)

--- a/academy-watch-backend/src/services/follow_resolver.py
+++ b/academy-watch-backend/src/services/follow_resolver.py
@@ -69,9 +69,16 @@ def _validate_player(selector: dict):
 
 
 def _validate_academy_club(selector: dict):
-    extra = set(selector) - {"team_id"}
+    extra = set(selector) - {"team_id", "program_id"}
     if extra:
         return None, f"unexpected keys for academy_club selector: {sorted(extra)}"
+    if ("team_id" in selector) == ("program_id" in selector):
+        return None, "academy_club selector must contain exactly one of team_id or program_id"
+    if "program_id" in selector:
+        program_id = selector.get("program_id")
+        if not _positive_int(program_id):
+            return None, "program_id must be a positive integer"
+        return {"program_id": int(program_id)}, None
     team_id = selector.get("team_id")
     if not _positive_int(team_id):
         return None, "team_id must be a positive integer (internal teams.id)"
@@ -155,6 +162,8 @@ def derive_label(kind: str, selector: dict, name: str | None = None) -> str:
     if kind == "player":
         return (name or f"Player {selector.get('player_api_id')}")[:160]
     if kind == "academy_club":
+        if selector.get("program_id"):
+            return (f"Club program: {name}" if name else f"Club program #{selector.get('program_id')}")[:160]
         return (f"Club academy: {name}" if name else f"Club academy #{selector.get('team_id')}")[:160]
     if kind == "geo":
         countries = ", ".join(selector.get("countries", []))
@@ -200,6 +209,10 @@ def _resolve_player(selector: dict) -> list[tuple[int, str]]:
 def _resolve_academy_club(selector: dict, limit: int | None) -> list[tuple[int, str]]:
     from src.routes.scout import _base_scout_query
 
+    # A saved future-funding program is an expansion-demand/notification
+    # signal only. It must never resolve players or affect digest/ranking.
+    if selector.get("program_id"):
+        return []
     team_id = selector.get("team_id")
     if not team_id:
         return []

--- a/academy-watch-backend/src/services/funding_evidence_crypto.py
+++ b/academy-watch-backend/src/services/funding_evidence_crypto.py
@@ -1,0 +1,49 @@
+"""Authenticated field encryption for private grassroots claim evidence."""
+
+from __future__ import annotations
+
+import os
+
+from cryptography.fernet import Fernet, InvalidToken
+from sqlalchemy.types import Text, TypeDecorator
+
+_PREFIX = "fernet:v1:"
+
+
+class EvidenceEncryptionError(RuntimeError):
+    """Raised when evidence cannot be encrypted or safely decrypted."""
+
+
+def _fernet() -> Fernet:
+    raw_key = (os.getenv("FUNDING_EVIDENCE_ENCRYPTION_KEY") or "").strip()
+    if not raw_key:
+        raise EvidenceEncryptionError("FUNDING_EVIDENCE_ENCRYPTION_KEY is required")
+    try:
+        return Fernet(raw_key.encode("ascii"))
+    except (ValueError, UnicodeEncodeError) as exc:
+        raise EvidenceEncryptionError("FUNDING_EVIDENCE_ENCRYPTION_KEY must be a valid Fernet key") from exc
+
+
+class EncryptedEvidenceText(TypeDecorator):
+    """Store claim evidence as opaque, authenticated ciphertext."""
+
+    impl = Text
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise EvidenceEncryptionError("evidence values must be strings")
+        token = _fernet().encrypt(value.encode("utf-8")).decode("ascii")
+        return f"{_PREFIX}{token}"
+
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return None
+        if not isinstance(value, str) or not value.startswith(_PREFIX):
+            raise EvidenceEncryptionError("unencrypted evidence value rejected")
+        try:
+            return _fernet().decrypt(value.removeprefix(_PREFIX).encode("ascii")).decode("utf-8")
+        except (InvalidToken, UnicodeDecodeError, UnicodeEncodeError) as exc:
+            raise EvidenceEncryptionError("evidence value failed authentication") from exc

--- a/academy-watch-backend/src/services/stripe_connect.py
+++ b/academy-watch-backend/src/services/stripe_connect.py
@@ -1,0 +1,119 @@
+"""Strictly test-mode Stripe Connect Express onboarding for grassroots clubs.
+
+F2 never creates payments, Checkout Sessions, transfers, or live-mode objects.
+Calls are possible only when an explicit feature flag and an ``sk_test_`` key
+are both present. The organization is onboarded as a company, never as the
+claimant/coach/parent personally.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from urllib.parse import urljoin
+
+import stripe
+
+
+class StripeConnectConfigurationError(RuntimeError):
+    pass
+
+
+def _enabled(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def test_connect_configured() -> bool:
+    key = (os.getenv("STRIPE_SECRET_KEY") or "").strip()
+    return _enabled(os.getenv("STRIPE_CONNECT_TEST_MODE")) and key.startswith("sk_test_")
+
+
+def _test_key() -> str:
+    key = (os.getenv("STRIPE_SECRET_KEY") or "").strip()
+    if not _enabled(os.getenv("STRIPE_CONNECT_TEST_MODE")):
+        raise StripeConnectConfigurationError("Stripe Connect test mode is disabled")
+    if not key.startswith("sk_test_"):
+        raise StripeConnectConfigurationError("Stripe Connect requires an sk_test_ key in F2")
+    return key
+
+
+def _onboarding_urls(program_slug: str) -> tuple[str, str]:
+    base = (os.getenv("PUBLIC_BASE_URL") or "https://example.com").rstrip("/") + "/"
+    refresh_url = os.getenv("STRIPE_CONNECT_REFRESH_URL") or urljoin(base, f"programs/{program_slug}?connect=refresh")
+    return_url = os.getenv("STRIPE_CONNECT_RETURN_URL") or urljoin(base, f"programs/{program_slug}?connect=complete")
+    if not refresh_url.startswith("https://") or not return_url.startswith("https://"):
+        raise StripeConnectConfigurationError("Stripe Connect onboarding URLs must use https")
+    return refresh_url, return_url
+
+
+def create_express_organization_onboarding(program) -> dict:
+    """Create one test Express organization account and hosted onboarding link."""
+    stripe.api_key = _test_key()
+    refresh_url, return_url = _onboarding_urls(program.slug)
+
+    account = stripe.Account.create(
+        type="express",
+        country="US",
+        business_type="company",
+        business_profile={
+            "name": program.legal_name,
+            "product_description": "Grassroots soccer program support",
+        },
+        capabilities={"transfers": {"requested": True}},
+        metadata={"club_program_id": str(program.id), "environment": "test"},
+    )
+    if bool(account.get("livemode")):
+        raise StripeConnectConfigurationError("Live-mode connected accounts are forbidden in F2")
+
+    link = stripe.AccountLink.create(
+        account=account["id"],
+        refresh_url=refresh_url,
+        return_url=return_url,
+        type="account_onboarding",
+    )
+    return {
+        **_account_result(account),
+        "onboarding_url": link["url"],
+        "onboarding_expires_at": datetime.fromtimestamp(link["expires_at"], tz=UTC) if link.get("expires_at") else None,
+    }
+
+
+def retrieve_test_express_account(stripe_account_id: str) -> dict:
+    """Refresh readiness from Stripe after hosted test onboarding completes."""
+    if not isinstance(stripe_account_id, str) or not stripe_account_id.startswith("acct_"):
+        raise StripeConnectConfigurationError("A valid connected account ID is required")
+    stripe.api_key = _test_key()
+    account = stripe.Account.retrieve(stripe_account_id)
+    if account.get("id") != stripe_account_id:
+        raise StripeConnectConfigurationError("Stripe returned a different connected account")
+    if bool(account.get("livemode")):
+        raise StripeConnectConfigurationError("Live-mode connected accounts are forbidden in F2")
+    return _account_result(account)
+
+
+def _account_result(account) -> dict:
+    """Normalize the narrow Connect readiness projection stored by F2."""
+    return {
+        "stripe_account_id": account["id"],
+        "livemode": False,
+        "account_type": account.get("type") or "express",
+        "country": account.get("country") or "US",
+        "business_type": account.get("business_type") or "company",
+        "details_submitted": bool(account.get("details_submitted")),
+        "charges_enabled": bool(account.get("charges_enabled")),
+        "payouts_enabled": bool(account.get("payouts_enabled")),
+        "transfers_active": (account.get("capabilities") or {}).get("transfers") == "active",
+        "requirements_due": _requirements_due(account),
+        "disabled_reason": (account.get("requirements") or {}).get("disabled_reason"),
+    }
+
+
+def _requirements_due(account) -> list[str]:
+    requirements = account.get("requirements") or {}
+    return sorted(
+        {
+            str(item)
+            for key in ("currently_due", "past_due", "pending_verification")
+            for item in (requirements.get(key) or [])
+        }
+    )

--- a/academy-watch-backend/tests/test_follow_graph.py
+++ b/academy-watch-backend/tests/test_follow_graph.py
@@ -16,6 +16,7 @@ from types import SimpleNamespace
 import pytest
 from flask import Flask
 from src.models.follow import Follow, FollowList, FollowPlayerSnapshot, PlayerShadow, PlayerShadowStats
+from src.models.funding import ClubProgram, FundingLeague
 from src.models.league import League, Team, db
 from src.models.scout_watchlist import ScoutWatchlistEntry
 from src.models.tracked_player import TrackedPlayer
@@ -353,6 +354,49 @@ class TestFollowValidation:
         )
         assert resp.status_code == 400
 
+    def test_program_follow_requires_public_approved_program(self, client, seeded):
+        lid = self._list(client)
+        league = FundingLeague(
+            name="Follow Visibility League (Fixture)",
+            country="Japan",
+            region="Follow Visibility Region",
+            level="recreational",
+            age_bands=["U12"],
+            gender_program="both",
+            season_calendar="calendar_year",
+            data_tier="self_reported",
+            registry_status="approved",
+            admission_state="open",
+        )
+        db.session.add(league)
+        db.session.flush()
+        program = ClubProgram(
+            funding_league_id=league.id,
+            name="Hidden Follow Program (Fixture)",
+            legal_name="Hidden Follow Program Association (Fixture)",
+            slug="hidden-follow-program-fixture",
+            country="Japan",
+            region="Follow Visibility Region",
+            platform_status="pending",
+        )
+        db.session.add(program)
+        db.session.commit()
+        payload = {
+            "kind": "academy_club",
+            "selector": {"program_id": program.id},
+            "notify_when_fundable": True,
+        }
+        assert client.post(f"/api/scout/lists/{lid}/follows", json=payload, headers=_headers()).status_code == 404
+
+        program.platform_status = "approved"
+        program.emergency_hidden = True
+        db.session.commit()
+        assert client.post(f"/api/scout/lists/{lid}/follows", json=payload, headers=_headers()).status_code == 404
+
+        program.emergency_hidden = False
+        db.session.commit()
+        assert client.post(f"/api/scout/lists/{lid}/follows", json=payload, headers=_headers()).status_code == 201
+
     def test_geo_bad_match_and_too_many_countries_400(self, client, seeded):
         lid = self._list(client)
         assert (
@@ -453,7 +497,15 @@ class TestEmbeddedFollows:
         board = next(x for x in lists if x["id"] == lid)
         assert board["follow_count"] == 5
         follows = board["follows"]
-        assert set(follows[0].keys()) == {"id", "kind", "selector", "label", "note", "created_at"}
+        assert set(follows[0].keys()) == {
+            "id",
+            "kind",
+            "selector",
+            "label",
+            "note",
+            "notify_when_fundable",
+            "created_at",
+        }
         labels = {f["kind"]: f["label"] for f in follows if f["kind"] != "geo"}
         geo_labels = {f["label"] for f in follows if f["kind"] == "geo"}
         assert labels["player"] == "Alfie Striker"  # resolved player name

--- a/academy-watch-backend/tests/test_funding_registry.py
+++ b/academy-watch-backend/tests/test_funding_registry.py
@@ -1,0 +1,629 @@
+"""F2 league registry, club admission, verification, and save-flow tests."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+from sqlalchemy import text
+from src.auth import issue_user_token
+from src.extensions import limiter
+from src.models.follow import Follow, FollowList
+from src.models.funding import ClubConnectAccount, ClubProgramManager, FundingAdminEvent, FundingLeague
+from src.models.league import League, UserAccount, db
+from src.routes.funding import funding_bp
+from src.services.account_roles import derive_account_role
+
+
+@pytest.fixture
+def funding_app(monkeypatch):
+    monkeypatch.setenv("ADMIN_API_KEY", "funding-admin-test-key")
+    monkeypatch.setenv("STRIPE_CONNECT_TEST_MODE", "false")
+    monkeypatch.delenv("STRIPE_SECRET_KEY", raising=False)
+    monkeypatch.setenv(
+        "FUNDING_EVIDENCE_ENCRYPTION_KEY",
+        "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=",
+    )
+    app = Flask(__name__)
+    app.config.update(
+        TESTING=True,
+        SECRET_KEY="funding-fixture-secret",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        RATELIMIT_ENABLED=False,
+    )
+    db.init_app(app)
+    limiter.init_app(app)
+    app.register_blueprint(funding_bp, url_prefix="/api")
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def funding_client(funding_app):
+    return funding_app.test_client()
+
+
+@pytest.fixture
+def admin_headers(funding_app):
+    with funding_app.app_context():
+        token = issue_user_token("mj-admin@example.com", role="admin")["token"]
+    return {
+        "Authorization": f"Bearer {token}",
+        "X-API-Key": "funding-admin-test-key",
+    }
+
+
+def _user_headers(email="club-manager-fixture@example.com"):
+    user = UserAccount(email=email, display_name=email.split("@", 1)[0], display_name_lower=email.split("@", 1)[0])
+    db.session.add(user)
+    db.session.commit()
+    return user, {"Authorization": f"Bearer {issue_user_token(email)['token']}"}
+
+
+def _league_payload(**overrides):
+    payload = {
+        "name": "Test League (Fixture)",
+        "country": "Japan",
+        "region": "Kanto Fixture Region",
+        "level": "youth_regional",
+        "age_bands": ["U12", "U14"],
+        "gender_program": "both",
+        "season_calendar": "calendar_year",
+        "data_tier": "self_reported",
+        "registry_status": "approved",
+        "admission_state": "open",
+        "reason": "Fixture registry setup",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _evidence():
+    return {
+        "adult_authority_attested": True,
+        "official_email": "officer@test-club-fixture.example",
+        "authorization_method": "official_domain_email",
+        "organization_form": "association",
+        "registration_reference": "TEST-REG-FIXTURE-001",
+        "official_contact_name": "Test Officer (Fixture)",
+        "official_contact_reference": "Fixture association directory entry",
+        "safeguarding_contact_email": "safeguarding@test-club-fixture.example",
+        "safeguarding_policy_url": "https://example.com/test-fixture-safeguarding",
+        "safeguarding_policy_attested": True,
+        "eligible_organization_attested": True,
+        "payout_control_attested": True,
+    }
+
+
+def _claim_payload(league_id, *, country="Japan", club_name="Test Club Program (Fixture)"):
+    return {
+        "funding_league_id": league_id,
+        "club_name": club_name,
+        "legal_name": f"{club_name} Association",
+        "country": country,
+        "region": "Fixture Region",
+        "city": "Fixture City",
+        "currency": "JPY" if country == "Japan" else "USD",
+        "evidence": _evidence(),
+        "applicant_message": "Fixture claim for registry workflow testing.",
+    }
+
+
+def _create_open_league(client, headers, **overrides):
+    response = client.post("/api/admin/funding/leagues", json=_league_payload(**overrides), headers=headers)
+    assert response.status_code == 201, response.get_json()
+    return response.get_json()["league"]
+
+
+def _submit_claim(client, user_headers, league_id, **overrides):
+    payload = _claim_payload(league_id, **overrides)
+    response = client.post("/api/funding/claims", json=payload, headers=user_headers)
+    assert response.status_code == 201, response.get_json()
+    return response.get_json()["claim"]
+
+
+class TestLeagueRegistry:
+    def test_admin_crud_filters_and_admission_transitions(self, funding_app, funding_client, admin_headers):
+        with funding_app.app_context():
+            created = _create_open_league(funding_client, admin_headers)
+            league_id = created["id"]
+
+            filtered = funding_client.get(
+                "/api/admin/funding/leagues?admission_state=open&level=youth_regional&q=Fixture",
+                headers=admin_headers,
+            )
+            assert filtered.status_code == 200
+            assert [row["id"] for row in filtered.get_json()["leagues"]] == [league_id]
+
+            for state in ("waitlisted", "closed", "open"):
+                changed = funding_client.patch(
+                    f"/api/admin/funding/leagues/{league_id}",
+                    json={"admission_state": state, "reason": f"Fixture transition to {state}"},
+                    headers=admin_headers,
+                )
+                assert changed.status_code == 200, changed.get_json()
+                assert changed.get_json()["league"]["admission_state"] == state
+
+            public_rows = funding_client.get("/api/funding/leagues").get_json()["leagues"]
+            assert [row["id"] for row in public_rows] == [league_id]
+
+            deleted = funding_client.delete(
+                f"/api/admin/funding/leagues/{league_id}",
+                json={"reason": "Fixture cleanup"},
+                headers=admin_headers,
+            )
+            assert deleted.status_code == 200
+            assert deleted.get_json()["deleted"] is True
+            assert db.session.get(FundingLeague, league_id) is None
+
+    def test_api_football_registry_row_bridges_existing_league_read_only(
+        self, funding_app, funding_client, admin_headers
+    ):
+        with funding_app.app_context():
+            provider = League(
+                league_id=99001,
+                name="Test Provider League (Fixture)",
+                country="United States",
+                season=2026,
+            )
+            db.session.add(provider)
+            db.session.commit()
+            response = funding_client.post(
+                "/api/admin/funding/leagues",
+                json=_league_payload(
+                    name="Ignored Fixture Name",
+                    country="Ignored Fixture Country",
+                    region="Test US Region (Fixture)",
+                    data_tier="api_football:99001",
+                ),
+                headers=admin_headers,
+            )
+            assert response.status_code == 201, response.get_json()
+            league = response.get_json()["league"]
+            assert league["name"] == provider.name
+            assert league["existing_league_id"] == provider.id
+            assert league["is_provider_bridge"] is True
+            assert League.query.filter_by(league_id=99001).count() == 1
+
+            update = funding_client.patch(
+                f"/api/admin/funding/leagues/{league['id']}",
+                json={"name": "Mutated Fixture", "reason": "Should remain read-only"},
+                headers=admin_headers,
+            )
+            assert update.status_code == 409
+            delete = funding_client.delete(
+                f"/api/admin/funding/leagues/{league['id']}",
+                json={"reason": "Should remain bridged"},
+                headers=admin_headers,
+            )
+            assert delete.status_code == 409
+
+    def test_invalid_admission_transition_is_rejected(self, funding_app, funding_client, admin_headers):
+        with funding_app.app_context():
+            league = _create_open_league(funding_client, admin_headers)
+            response = funding_client.patch(
+                f"/api/admin/funding/leagues/{league['id']}",
+                json={"admission_state": "fundraising", "reason": "Invalid fixture"},
+                headers=admin_headers,
+            )
+            assert response.status_code == 400
+
+
+class TestClubAdmission:
+    def test_non_us_claim_approval_derives_manager_and_verified_without_connect(
+        self, funding_app, funding_client, admin_headers
+    ):
+        with funding_app.app_context():
+            league = _create_open_league(funding_client, admin_headers)
+            user, headers = _user_headers()
+            claim = _submit_claim(funding_client, headers, league["id"])
+            assert claim["status"] == "pending"
+            assert derive_account_role(user) == "scout"
+            stored_email = db.session.execute(
+                text("SELECT official_email FROM club_claim_evidence WHERE claim_id = :claim_id"),
+                {"claim_id": claim["id"]},
+            ).scalar_one()
+            assert stored_email.startswith("fernet:v1:")
+            assert "officer@test-club-fixture.example" not in stored_email
+
+            approved = funding_client.post(
+                f"/api/admin/funding/claims/{claim['id']}/approve",
+                json={"reason": "Fixture evidence meets the approved bar"},
+                headers=admin_headers,
+            )
+            assert approved.status_code == 200, approved.get_json()
+            reviewed = approved.get_json()["claim"]
+            assert reviewed["status"] == "approved"
+            assert reviewed["program"]["is_verified_program"] is True
+            assert reviewed["connect"] is None
+            assert derive_account_role(user) == "club_manager"
+
+            public = funding_client.get(f"/api/programs/{reviewed['program']['slug']}")
+            assert public.status_code == 200
+            program = public.get_json()["program"]
+            assert program["is_verified_program"] is True
+            assert program["provenance"]["label"] == "Self-reported"
+            assert program["program_provided"] is None
+
+    def test_rejection_requires_reason_and_records_audit(self, funding_app, funding_client, admin_headers):
+        with funding_app.app_context():
+            league = _create_open_league(funding_client, admin_headers)
+            _, headers = _user_headers("rejected-manager-fixture@example.com")
+            claim = _submit_claim(
+                funding_client,
+                headers,
+                league["id"],
+                club_name="Rejected Test Club (Fixture)",
+            )
+            missing_reason = funding_client.post(
+                f"/api/admin/funding/claims/{claim['id']}/reject", json={}, headers=admin_headers
+            )
+            assert missing_reason.status_code == 400
+
+            rejected = funding_client.post(
+                f"/api/admin/funding/claims/{claim['id']}/reject",
+                json={"reason": "Fixture registration evidence does not match"},
+                headers=admin_headers,
+            )
+            assert rejected.status_code == 200
+            assert rejected.get_json()["claim"]["status"] == "rejected"
+            queue = funding_client.get("/api/admin/funding/claims?status=rejected", headers=admin_headers)
+            assert queue.status_code == 200
+            audit = queue.get_json()["claims"][0]["audit_trail"]
+            assert audit[0]["action"] == "claim.submitted"
+            assert audit[-1]["action"] == "claim.rejected"
+            assert FundingAdminEvent.query.filter_by(target_type="claim", target_id=claim["id"]).count() == 2
+
+    def test_rejecting_co_manager_claim_does_not_deverify_approved_program(
+        self, funding_app, funding_client, admin_headers
+    ):
+        with funding_app.app_context():
+            from src.models.funding import ClubProgram, ClubProgramClaim
+
+            league = _create_open_league(funding_client, admin_headers)
+            _, owner_headers = _user_headers("approved-owner-fixture@example.com")
+            owner_claim = _submit_claim(funding_client, owner_headers, league["id"])
+            approved = funding_client.post(
+                f"/api/admin/funding/claims/{owner_claim['id']}/approve",
+                json={"reason": "Fixture primary organization authority approved"},
+                headers=admin_headers,
+            ).get_json()["claim"]
+            program = db.session.get(ClubProgram, approved["program"]["id"])
+            co_manager, _ = _user_headers("rejected-co-manager-fixture@example.com")
+            pending = ClubProgramClaim(
+                program_id=program.id,
+                user_account_id=co_manager.id,
+                relationship_type="club_official",
+                status="pending",
+            )
+            db.session.add(pending)
+            db.session.commit()
+
+            rejected = funding_client.post(
+                f"/api/admin/funding/claims/{pending.id}/reject",
+                json={"reason": "Fixture co-manager authority was not established"},
+                headers=admin_headers,
+            )
+            assert rejected.status_code == 200, rejected.get_json()
+            db.session.refresh(program)
+            assert rejected.get_json()["claim"]["status"] == "rejected"
+            assert program.platform_status == "approved"
+            assert program.is_verified_program is True
+
+    def test_proposed_league_waitlists_until_mj_opens_it(self, funding_app, funding_client, admin_headers):
+        with funding_app.app_context():
+            _, headers = _user_headers("proposal-manager-fixture@example.com")
+            payload = _claim_payload(1, club_name="Proposed Test Club (Fixture)")
+            payload.pop("funding_league_id")
+            payload["proposed_league"] = _league_payload(
+                name="Proposed Test League (Fixture)",
+                region="Proposed Fixture Region",
+            )
+            response = funding_client.post("/api/funding/claims", json=payload, headers=headers)
+            assert response.status_code == 201, response.get_json()
+            body = response.get_json()
+            assert body["league_waitlisted"] is True
+            claim = body["claim"]
+            proposed_id = claim["program"]["league"]["id"]
+            proposed = db.session.get(FundingLeague, proposed_id)
+            assert proposed.registry_status == "proposed"
+            assert proposed.admission_state == "waitlisted"
+
+            blocked = funding_client.post(
+                f"/api/admin/funding/claims/{claim['id']}/approve",
+                json={"reason": "Fixture approval attempted early"},
+                headers=admin_headers,
+            )
+            assert blocked.status_code == 409
+
+            opened = funding_client.patch(
+                f"/api/admin/funding/leagues/{proposed_id}",
+                json={
+                    "registry_status": "approved",
+                    "admission_state": "open",
+                    "reason": "MJ fixture registry review completed",
+                },
+                headers=admin_headers,
+            )
+            assert opened.status_code == 200
+            approved = funding_client.post(
+                f"/api/admin/funding/claims/{claim['id']}/approve",
+                json={"reason": "Fixture club evidence approved after league opening"},
+                headers=admin_headers,
+            )
+            assert approved.status_code == 200
+
+    def test_us_claim_uses_only_mocked_test_connect_readiness(self, funding_app, funding_client, admin_headers):
+        with funding_app.app_context():
+            league = _create_open_league(
+                funding_client,
+                admin_headers,
+                name="US Test League (Fixture)",
+                country="United States",
+                region="US Fixture Region",
+            )
+            _, headers = _user_headers("us-manager-fixture@example.com")
+            claim = _submit_claim(
+                funding_client,
+                headers,
+                league["id"],
+                country="United States",
+                club_name="US Test Club (Fixture)",
+            )
+            connect_result = {
+                "stripe_account_id": "acct_test_fixture_001",
+                "livemode": False,
+                "account_type": "express",
+                "business_type": "company",
+                "details_submitted": True,
+                "charges_enabled": False,
+                "payouts_enabled": True,
+                "transfers_active": True,
+                "requirements_due": [],
+                "disabled_reason": None,
+                "onboarding_url": "https://connect.stripe.com/test-fixture",
+                "onboarding_expires_at": None,
+            }
+            with (
+                patch("src.routes.funding.test_connect_configured", return_value=True),
+                patch(
+                    "src.routes.funding.create_express_organization_onboarding",
+                    return_value=connect_result,
+                ) as create_connect,
+            ):
+                approved = funding_client.post(
+                    f"/api/admin/funding/claims/{claim['id']}/approve",
+                    json={"reason": "Fixture US organization and Connect readiness approved"},
+                    headers=admin_headers,
+                )
+            assert approved.status_code == 200, approved.get_json()
+            create_connect.assert_called_once()
+            result = approved.get_json()["claim"]
+            assert result["program"]["is_verified_program"] is True
+            assert result["connect"]["livemode"] is False
+            assert result["connect"]["is_ready"] is True
+
+    def test_us_approval_without_test_keys_never_calls_stripe_or_verifies(
+        self, funding_app, funding_client, admin_headers
+    ):
+        with funding_app.app_context():
+            league = _create_open_league(
+                funding_client,
+                admin_headers,
+                name="Second US Test League (Fixture)",
+                country="United States",
+                region="Second US Fixture Region",
+            )
+            _, headers = _user_headers("us-no-connect-fixture@example.com")
+            claim = _submit_claim(
+                funding_client,
+                headers,
+                league["id"],
+                country="United States",
+                club_name="US Pending Connect Club (Fixture)",
+            )
+            with patch("src.routes.funding.create_express_organization_onboarding") as create_connect:
+                approved = funding_client.post(
+                    f"/api/admin/funding/claims/{claim['id']}/approve",
+                    json={"reason": "Fixture platform approval; Connect remains pending"},
+                    headers=admin_headers,
+                )
+            assert approved.status_code == 200
+            create_connect.assert_not_called()
+            result = approved.get_json()["claim"]
+            assert result["program"]["is_verified_program"] is False
+            assert result["connect"]["stripe_account_id"] is None
+            assert ClubConnectAccount.query.count() == 1
+
+    def test_us_connect_sync_recomputes_verification_after_hosted_onboarding(
+        self, funding_app, funding_client, admin_headers
+    ):
+        with funding_app.app_context():
+            league = _create_open_league(
+                funding_client,
+                admin_headers,
+                name="Connect Sync US Test League (Fixture)",
+                country="United States",
+                region="Connect Sync Fixture Region",
+            )
+            _, headers = _user_headers("connect-sync-manager-fixture@example.com")
+            claim = _submit_claim(
+                funding_client,
+                headers,
+                league["id"],
+                country="United States",
+                club_name="Connect Sync US Test Club (Fixture)",
+            )
+            approved = funding_client.post(
+                f"/api/admin/funding/claims/{claim['id']}/approve",
+                json={"reason": "Fixture platform approval before test onboarding"},
+                headers=admin_headers,
+            ).get_json()["claim"]
+            account = ClubConnectAccount.query.one()
+            account.stripe_account_id = "acct_test_sync_fixture_001"
+            db.session.commit()
+            assert approved["program"]["is_verified_program"] is False
+
+            refreshed = {
+                "stripe_account_id": account.stripe_account_id,
+                "livemode": False,
+                "account_type": "express",
+                "country": "US",
+                "business_type": "company",
+                "details_submitted": True,
+                "charges_enabled": False,
+                "payouts_enabled": True,
+                "transfers_active": True,
+                "requirements_due": [],
+                "disabled_reason": None,
+            }
+            with patch("src.routes.funding.retrieve_test_express_account", return_value=refreshed) as retrieve:
+                synced = funding_client.post(
+                    f"/api/admin/funding/programs/{approved['program']['id']}/connect/sync",
+                    json={"reason": "Fixture hosted onboarding completed"},
+                    headers=admin_headers,
+                )
+            assert synced.status_code == 200, synced.get_json()
+            retrieve.assert_called_once_with("acct_test_sync_fixture_001")
+            assert synced.get_json()["program"]["is_verified_program"] is True
+            assert synced.get_json()["connect"]["is_ready"] is True
+            assert FundingAdminEvent.query.filter_by(action="connect.synced").count() == 1
+
+
+class TestSaveProgram:
+    def test_save_reuses_academy_follow_and_drives_admin_demand(self, funding_app, funding_client, admin_headers):
+        with funding_app.app_context():
+            league = _create_open_league(funding_client, admin_headers)
+            _, manager_headers = _user_headers("save-program-manager-fixture@example.com")
+            claim = _submit_claim(funding_client, manager_headers, league["id"])
+            approved = funding_client.post(
+                f"/api/admin/funding/claims/{claim['id']}/approve",
+                json={"reason": "Fixture program approved for save-flow test"},
+                headers=admin_headers,
+            ).get_json()["claim"]
+            slug = approved["program"]["slug"]
+
+            _, saver_headers = _user_headers("program-saver-fixture@example.com")
+            first = funding_client.post(
+                f"/api/programs/{slug}/save",
+                json={"notify_when_fundable": True},
+                headers=saver_headers,
+            )
+            second = funding_client.post(
+                f"/api/programs/{slug}/save",
+                json={"notify_when_fundable": True},
+                headers=saver_headers,
+            )
+            assert first.status_code == 201
+            assert second.status_code == 200
+            assert Follow.query.count() == 1
+            follow = Follow.query.one()
+            assert follow.kind == "academy_club"
+            assert follow.selector == {"program_id": approved["program"]["id"]}
+            assert follow.notify_when_fundable is True
+
+            duplicate_list = FollowList(
+                user_account_id=follow.follow_list.user_account_id,
+                name="Duplicate Fixture Signal",
+                is_default=False,
+            )
+            db.session.add(duplicate_list)
+            db.session.flush()
+            db.session.add(
+                Follow(
+                    list_id=duplicate_list.id,
+                    kind="academy_club",
+                    selector={"program_id": approved["program"]["id"]},
+                    label=follow.label,
+                    notify_when_fundable=True,
+                )
+            )
+            db.session.commit()
+
+            demand = funding_client.get("/api/admin/funding/demand", headers=admin_headers)
+            assert demand.status_code == 200, demand.get_json()
+            assert demand.get_json()["programs"][0]["saved_count"] == 1
+            assert demand.get_json()["by_league"][0] == {
+                "league": "Test League (Fixture)",
+                "saved_count": 1,
+            }
+
+
+def test_revoke_api_removes_manager_role_and_records_deverification(funding_app, funding_client, admin_headers):
+    with funding_app.app_context():
+        user = UserAccount(
+            email="revoked-manager-fixture@example.com",
+            display_name="RevokedManagerFixture",
+            display_name_lower="revokedmanagerfixture",
+        )
+        db.session.add(user)
+        league = FundingLeague(
+            name="Role Test League (Fixture)",
+            country="Japan",
+            region="Role Fixture Region",
+            level="recreational",
+            age_bands=["U12"],
+            gender_program="both",
+            season_calendar="calendar_year",
+            data_tier="self_reported",
+            registry_status="approved",
+            admission_state="open",
+        )
+        db.session.add(league)
+        db.session.flush()
+        from src.models.funding import ClubProgram, ClubProgramClaim
+
+        program = ClubProgram(
+            funding_league_id=league.id,
+            name="Role Test Club (Fixture)",
+            legal_name="Role Test Club Association (Fixture)",
+            slug="role-test-club-fixture",
+            country="Japan",
+            region="Role Fixture Region",
+            platform_status="approved",
+        )
+        db.session.add(program)
+        db.session.flush()
+        claim = ClubProgramClaim(
+            program_id=program.id,
+            user_account_id=user.id,
+            relationship_type="club_official",
+            status="approved",
+        )
+        db.session.add(claim)
+        db.session.flush()
+        manager = ClubProgramManager(
+            program_id=program.id,
+            user_account_id=user.id,
+            source_claim_id=claim.id,
+            status="active",
+            granted_by="mj-admin@example.com",
+        )
+        db.session.add(manager)
+        db.session.commit()
+        assert derive_account_role(user) == "club_manager"
+        response = funding_client.post(
+            f"/api/admin/funding/claims/{claim.id}/revoke",
+            json={"reason": "Fixture authority grant withdrawn"},
+            headers=admin_headers,
+        )
+        assert response.status_code == 200, response.get_json()
+        assert response.get_json()["claim"]["status"] == "revoked"
+        assert response.get_json()["claim"]["program"]["platform_status"] == "suspended"
+        assert response.get_json()["claim"]["program"]["is_verified_program"] is False
+        assert derive_account_role(user) == "scout"
+        assert FundingAdminEvent.query.filter_by(action="claim.revoked", target_id=claim.id).count() == 1
+
+
+def test_gf01_is_single_head_guarded_and_enables_rls():
+    migration = Path(__file__).resolve().parents[1] / "migrations" / "versions" / "gf01_grassroots_identity.py"
+    source = migration.read_text()
+    assert 'down_revision = "sea01"' in source
+    assert source.count("ENABLE ROW LEVEL SECURITY") >= 1
+    assert "for table_name in NEW_TABLES" in source
+    assert "if not table_exists" in source
+    assert "add_column_safe" in source

--- a/academy-watch-frontend/src/App.jsx
+++ b/academy-watch-frontend/src/App.jsx
@@ -83,6 +83,7 @@ import { AdminTools } from '@/pages/admin/AdminTools'
 import { AdminSandbox } from '@/pages/admin/AdminSandbox'
 import { AdminFormation } from '@/pages/admin/AdminFormation'
 import { AdminShowcase } from '@/pages/admin/AdminShowcase'
+import { AdminFunding } from '@/pages/admin/AdminFunding'
 import { HomePage } from '@/pages/HomePage'
 import { PublicFormationBuilder } from '@/pages/PublicFormationBuilder'
 import { CohortBrowser } from '@/pages/CohortBrowser'
@@ -104,6 +105,8 @@ import { CuratorDashboard } from '@/pages/curator/CuratorDashboard'
 import { WriteupPage } from '@/pages/WriteupPage'
 import { PlayerPage } from '@/pages/PlayerPage'
 import { TeamDetailPage } from '@/pages/TeamDetailPage'
+import { ProgramClaimPage } from '@/pages/ProgramClaimPage'
+import { ProgramPage } from '@/pages/ProgramPage'
 import { JournalistProfile } from '@/pages/JournalistProfile'
 import { JournalistNewsletterView } from '@/components/JournalistNewsletterView'
 import {
@@ -4073,6 +4076,15 @@ function AppRoutes() {
       <Route path="/" element={<HomePage />} />
       <Route path="/teams" element={<TeamsPage />} />
       <Route path="/teams/:teamSlug" element={<TeamDetailPage />} />
+      <Route
+        path="/programs/claim"
+        element={(
+          <RequireAuth>
+            <ProgramClaimPage />
+          </RequireAuth>
+        )}
+      />
+      <Route path="/programs/:slug" element={<ProgramPage />} />
       <Route path="/dream-team" element={<PublicFormationBuilder />} />
       <Route path="/newsletters" element={<NewslettersPage />} />
       <Route path="/newsletters/:newsletterId" element={<NewslettersPage />} />
@@ -4122,6 +4134,7 @@ function AppRoutes() {
         <Route path="video" element={<AdminVideo />} />
         <Route path="video/:matchId" element={<AdminVideoMatch />} />
         <Route path="showcase" element={<AdminShowcase />} />
+        <Route path="funding" element={<AdminFunding />} />
         <Route path="settings" element={<AdminSettings />} />
         <Route path="tools" element={<AdminTools />} />
         <Route path="sandbox" element={<AdminSandbox />} />

--- a/academy-watch-frontend/src/components/admin/AdminSidebar.jsx
+++ b/academy-watch-frontend/src/components/admin/AdminSidebar.jsx
@@ -21,6 +21,7 @@ import {
     Wrench,
     UserCog,
     Star,
+    HandHeart,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible'
@@ -69,6 +70,7 @@ const sidebarGroups = [
         items: [
             { icon: Video, label: 'Film Room', href: '/admin/video' },
             { icon: Star, label: 'Showcase', href: '/admin/showcase' },
+            { icon: HandHeart, label: 'Funding Registry', href: '/admin/funding' },
         ],
     },
     {

--- a/academy-watch-frontend/src/lib/api.js
+++ b/academy-watch-frontend/src/lib/api.js
@@ -1285,6 +1285,85 @@ export class APIService {
         return this.request(`/admin/showcase/player-search?${query}`, {}, { admin: true })
     }
 
+    // ── Grassroots program registry + admission (F2; no checkout) ───────
+    static async getFundingLeagues(params = {}) {
+        const query = new URLSearchParams(params).toString()
+        return this.request(`/funding/leagues${query ? '?' + query : ''}`)
+    }
+
+    static async submitClubProgramClaim(payload) {
+        return this.request('/funding/claims', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        })
+    }
+
+    static async getMyProgramClaims() {
+        return this.request('/funding/claims/me')
+    }
+
+    static async getProgram(slug) {
+        if (!slug) throw new Error('program slug is required')
+        return this.request(`/programs/${encodeURIComponent(slug)}`)
+    }
+
+    static async saveProgram(slug, notifyWhenFundable = true) {
+        if (!slug) throw new Error('program slug is required')
+        return this.request(`/programs/${encodeURIComponent(slug)}/save`, {
+            method: 'POST',
+            body: JSON.stringify({ notify_when_fundable: Boolean(notifyWhenFundable) }),
+        })
+    }
+
+    static async adminFundingLeagues(params = {}) {
+        const query = new URLSearchParams(params).toString()
+        return this.request(`/admin/funding/leagues${query ? '?' + query : ''}`, {}, { admin: true })
+    }
+
+    static async adminCreateFundingLeague(payload) {
+        return this.request('/admin/funding/leagues', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        }, { admin: true })
+    }
+
+    static async adminUpdateFundingLeague(id, payload) {
+        return this.request(`/admin/funding/leagues/${encodeURIComponent(id)}`, {
+            method: 'PATCH',
+            body: JSON.stringify(payload),
+        }, { admin: true })
+    }
+
+    static async adminDeleteFundingLeague(id, reason) {
+        return this.request(`/admin/funding/leagues/${encodeURIComponent(id)}`, {
+            method: 'DELETE',
+            body: JSON.stringify({ reason }),
+        }, { admin: true })
+    }
+
+    static async adminFundingClaims(params = {}) {
+        const query = new URLSearchParams(params).toString()
+        return this.request(`/admin/funding/claims${query ? '?' + query : ''}`, {}, { admin: true })
+    }
+
+    static async adminReviewFundingClaim(id, action, reason) {
+        return this.request(`/admin/funding/claims/${encodeURIComponent(id)}/${action}`, {
+            method: 'POST',
+            body: JSON.stringify({ reason }),
+        }, { admin: true })
+    }
+
+    static async adminSyncFundingConnect(programId, reason) {
+        return this.request(`/admin/funding/programs/${encodeURIComponent(programId)}/connect/sync`, {
+            method: 'POST',
+            body: JSON.stringify({ reason }),
+        }, { admin: true })
+    }
+
+    static async adminFundingDemand() {
+        return this.request('/admin/funding/demand', {}, { admin: true })
+    }
+
     // Writer Portal API methods
     static async getWriterTeams() {
         return this.request('/writer/teams')

--- a/academy-watch-frontend/src/pages/ProgramClaimPage.jsx
+++ b/academy-watch-frontend/src/pages/ProgramClaimPage.jsx
@@ -1,0 +1,327 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import {
+    ArrowRight,
+    Building2,
+    CheckCircle2,
+    ChevronRight,
+    Clock3,
+    FileCheck2,
+    Landmark,
+    Loader2,
+    LockKeyhole,
+    MailCheck,
+    MapPinned,
+    ShieldCheck,
+} from 'lucide-react'
+
+import { APIService } from '@/lib/api'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
+
+const EMPTY_FORM = {
+    leagueMode: 'approved',
+    funding_league_id: '',
+    club_name: '',
+    legal_name: '',
+    team_api_id: 'none',
+    country: '',
+    region: '',
+    city: '',
+    currency: 'USD',
+    crest_url: '',
+    applicant_message: '',
+    official_email: '',
+    authorization_method: 'official_domain_email',
+    authorization_reference: '',
+    organization_form: 'association',
+    registration_reference: '',
+    official_contact_name: '',
+    official_contact_reference: '',
+    safeguarding_contact_email: '',
+    safeguarding_policy_url: '',
+    adult_authority_attested: false,
+    safeguarding_policy_attested: false,
+    eligible_organization_attested: false,
+    payout_control_attested: false,
+    proposed_name: '',
+    proposed_country: '',
+    proposed_region: '',
+    proposed_level: 'youth_regional',
+    proposed_age_bands: 'U12, U14',
+    proposed_gender_program: 'both',
+    proposed_season_calendar: 'calendar_year',
+    proposed_data_tier: 'self_reported',
+    proposed_league_api_id: '',
+}
+
+function Field({ id, label, hint, children }) {
+    return (
+        <div className="space-y-2">
+            <Label htmlFor={id}>{label}</Label>
+            {children}
+            {hint ? <p className="text-xs leading-relaxed text-muted-foreground">{hint}</p> : null}
+        </div>
+    )
+}
+
+function Attestation({ checked, onCheckedChange, title, description }) {
+    return (
+        <label className="flex cursor-pointer items-start gap-3 rounded-xl border bg-background p-4 transition-colors hover:border-emerald-300">
+            <Checkbox checked={checked} onCheckedChange={onCheckedChange} className="mt-0.5" />
+            <span><span className="block text-sm font-medium">{title}</span><span className="mt-1 block text-xs leading-relaxed text-muted-foreground">{description}</span></span>
+        </label>
+    )
+}
+
+function StepLabel({ number, title, active }) {
+    return (
+        <div className="flex items-center gap-3">
+            <div className={`flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold ${active ? 'bg-emerald-700 text-white' : 'bg-secondary text-muted-foreground'}`}>{number}</div>
+            <span className={`text-sm font-medium ${active ? 'text-foreground' : 'text-muted-foreground'}`}>{title}</span>
+        </div>
+    )
+}
+
+export function ProgramClaimPage() {
+    const [form, setForm] = useState(EMPTY_FORM)
+    const [leagues, setLeagues] = useState([])
+    const [teams, setTeams] = useState([])
+    const [claims, setClaims] = useState([])
+    const [teamQuery, setTeamQuery] = useState('')
+    const [loading, setLoading] = useState(true)
+    const [submitting, setSubmitting] = useState(false)
+    const [error, setError] = useState('')
+    const [submitted, setSubmitted] = useState(null)
+
+    useEffect(() => {
+        let cancelled = false
+        Promise.all([
+            APIService.getFundingLeagues(),
+            APIService.getTeams(),
+            APIService.getMyProgramClaims(),
+        ]).then(([leagueData, teamData, claimData]) => {
+            if (cancelled) return
+            setLeagues(leagueData?.leagues || [])
+            setTeams(Array.isArray(teamData) ? teamData : teamData?.teams || [])
+            setClaims(claimData?.claims || [])
+        }).catch((err) => {
+            if (!cancelled) setError(err.message || 'Unable to load the admission form')
+        }).finally(() => {
+            if (!cancelled) setLoading(false)
+        })
+        return () => { cancelled = true }
+    }, [])
+
+    const update = (key, value) => setForm((current) => ({ ...current, [key]: value }))
+    const visibleTeams = useMemo(() => {
+        const query = teamQuery.trim().toLowerCase()
+        const seen = new Set()
+        const rows = []
+        for (const team of teams) {
+            const apiId = team?.team_id
+            if (!apiId || !team?.slug || seen.has(apiId)) continue
+            if (query && !`${team.name || ''} ${team.country || ''}`.toLowerCase().includes(query)) continue
+            seen.add(apiId)
+            rows.push(team)
+            if (rows.length >= 60) break
+        }
+        return rows
+    }, [teamQuery, teams])
+
+    const chooseTeam = (value) => {
+        update('team_api_id', value)
+        if (value === 'none') return
+        const team = teams.find((row) => String(row.team_id) === value)
+        if (!team) return
+        setForm((current) => ({
+            ...current,
+            team_api_id: value,
+            club_name: team.name || current.club_name,
+            country: team.country || current.country,
+            crest_url: team.logo || team.logo_url || current.crest_url,
+        }))
+    }
+
+    const submit = async (event) => {
+        event.preventDefault()
+        setSubmitting(true)
+        setError('')
+        const evidence = {
+            adult_authority_attested: form.adult_authority_attested,
+            official_email: form.official_email || null,
+            authorization_method: form.authorization_method,
+            authorization_reference: form.authorization_reference || null,
+            organization_form: form.organization_form,
+            registration_reference: form.registration_reference,
+            official_contact_name: form.official_contact_name,
+            official_contact_reference: form.official_contact_reference,
+            safeguarding_contact_email: form.safeguarding_contact_email,
+            safeguarding_policy_url: form.safeguarding_policy_url || null,
+            safeguarding_policy_attested: form.safeguarding_policy_attested,
+            eligible_organization_attested: form.eligible_organization_attested,
+            payout_control_attested: form.payout_control_attested,
+        }
+        const payload = {
+            club_name: form.club_name,
+            legal_name: form.legal_name,
+            team_api_id: form.team_api_id === 'none' ? null : Number(form.team_api_id),
+            country: form.country,
+            region: form.region,
+            city: form.city || null,
+            currency: form.currency.toUpperCase(),
+            crest_url: form.crest_url || null,
+            applicant_message: form.applicant_message || null,
+            evidence,
+        }
+        if (form.leagueMode === 'approved') {
+            payload.funding_league_id = Number(form.funding_league_id)
+        } else {
+            payload.proposed_league = {
+                name: form.proposed_name,
+                country: form.proposed_country,
+                region: form.proposed_region,
+                level: form.proposed_level,
+                age_bands: form.proposed_age_bands.split(',').map((item) => item.trim()).filter(Boolean),
+                gender_program: form.proposed_gender_program,
+                season_calendar: form.proposed_season_calendar,
+                data_tier: form.proposed_data_tier === 'api_football'
+                    ? `api_football:${form.proposed_league_api_id}`
+                    : form.proposed_data_tier,
+            }
+        }
+        try {
+            const response = await APIService.submitClubProgramClaim(payload)
+            setSubmitted(response)
+            setClaims((current) => [response.claim, ...current])
+            const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+            window.scrollTo({ top: 0, behavior: reduceMotion ? 'auto' : 'smooth' })
+        } catch (err) {
+            setError(err.message || 'Unable to submit the club claim')
+        } finally {
+            setSubmitting(false)
+        }
+    }
+
+    const registerAnother = () => {
+        setForm({ ...EMPTY_FORM })
+        setTeamQuery('')
+        setError('')
+        setSubmitted(null)
+    }
+
+    if (loading) {
+        return <div className="flex min-h-[60vh] items-center justify-center gap-2 text-muted-foreground"><Loader2 className="h-5 w-5 animate-spin motion-reduce:animate-none" />Loading program admission…</div>
+    }
+
+    if (submitted) {
+        return (
+            <div className="mx-auto max-w-3xl px-4 py-16">
+                <Card className="overflow-hidden border-0 shadow-2xl">
+                    <div className="bg-[#0b1f19] px-8 py-10 text-white"><div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-300/15"><CheckCircle2 className="h-6 w-6 text-emerald-200" /></div><p className="mt-6 text-xs font-semibold uppercase tracking-[0.22em] text-emerald-200/70">Application received</p><h1 className="mt-2 font-serif text-4xl">{submitted.claim?.program?.name}</h1><p className="mt-3 max-w-xl text-emerald-50/70">Your club claim is pending an adult-authority and organization review. Approval—not this submission—creates a club-manager grant.</p></div>
+                    <CardContent className="space-y-5 p-8">
+                        <div className="flex items-start gap-3 rounded-xl border bg-secondary/50 p-4"><Clock3 className="mt-0.5 h-5 w-5 text-amber-700" /><div><p className="font-medium">{submitted.league_waitlisted ? 'League proposal added to MJ’s waitlist' : 'Club evidence entered the approval queue'}</p><p className="mt-1 text-sm text-muted-foreground">No Stripe onboarding or funding begins until the platform review is approved.</p></div></div>
+                        <div className="flex flex-wrap gap-3"><Button onClick={registerAnother}>Register another program</Button><Button variant="outline" asChild><Link to="/">Return home</Link></Button></div>
+                    </CardContent>
+                </Card>
+            </div>
+        )
+    }
+
+    return (
+        <div className="min-h-screen bg-[#f4f1e8] py-10 text-stone-950">
+            <div className="mx-auto max-w-6xl px-4">
+                <header className="relative overflow-hidden rounded-[2rem] bg-[#0b1f19] px-6 py-10 text-white shadow-2xl sm:px-10">
+                    <div className="absolute right-[-6rem] top-[-8rem] h-72 w-72 rounded-full border-[48px] border-emerald-100/5" />
+                    <div className="relative max-w-3xl"><Badge className="border-emerald-200/20 bg-emerald-200/10 text-emerald-100">Club representatives · F2 admission</Badge><h1 className="mt-5 font-serif text-4xl font-semibold tracking-tight sm:text-6xl">Put your program on the verified path.</h1><p className="mt-5 max-w-2xl text-base leading-relaxed text-emerald-50/70">Register a legal club or academy program—not an individual player. League eligibility, adult authority, and safeguarding evidence are reviewed before any badge is shown.</p></div>
+                </header>
+
+                <div className="mt-6 grid gap-6 lg:grid-cols-[260px_1fr]">
+                    <aside className="space-y-5 lg:sticky lg:top-6 lg:self-start">
+                        <Card className="border-stone-200 bg-white/80"><CardHeader><CardTitle className="font-serif text-xl">Admission route</CardTitle></CardHeader><CardContent className="space-y-4"><StepLabel number="1" title="League gate" active /><ChevronRight className="ml-2 h-4 w-4 text-stone-300" /><StepLabel number="2" title="Program identity" active /><ChevronRight className="ml-2 h-4 w-4 text-stone-300" /><StepLabel number="3" title="Authority evidence" active /><ChevronRight className="ml-2 h-4 w-4 text-stone-300" /><StepLabel number="4" title="MJ review" /></CardContent></Card>
+                        <Card className="border-stone-200 bg-white/80"><CardContent className="space-y-3 p-5"><div className="flex items-center gap-2 font-medium"><LockKeyhole className="h-4 w-4 text-emerald-800" />Private by default</div><p className="text-xs leading-relaxed text-muted-foreground">Evidence metadata is reviewer-only. Never submit a minor’s ID or bank data; Stripe-hosted onboarding handles organization KYC later for approved US programs.</p></CardContent></Card>
+                        {claims.length > 0 ? <Card className="border-stone-200 bg-white/80"><CardHeader><CardTitle className="text-base">Your claims</CardTitle></CardHeader><CardContent className="space-y-3">{claims.slice(0, 3).map((claim) => <div key={claim.id} className="border-l-2 border-amber-500 pl-3"><p className="text-sm font-medium">{claim.program?.name}</p><p className="text-xs capitalize text-muted-foreground">{claim.status}</p></div>)}</CardContent></Card> : null}
+                    </aside>
+
+                    <form onSubmit={submit} className="space-y-6">
+                        {error ? <Alert className="border-rose-300 bg-rose-50 text-rose-900"><AlertDescription>{error}</AlertDescription></Alert> : null}
+                        <Card className="border-stone-200 bg-white/90 shadow-lg">
+                            <CardHeader><div className="flex items-center gap-3"><div className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-100"><Landmark className="h-5 w-5 text-emerald-900" /></div><div><CardTitle className="font-serif text-2xl">1. League gate</CardTitle><CardDescription>Choose an MJ-approved open league or submit a proposal to the waitlist.</CardDescription></div></div></CardHeader>
+                            <CardContent className="space-y-5">
+                                <div className="grid grid-cols-2 rounded-xl bg-stone-100 p-1"><button type="button" onClick={() => update('leagueMode', 'approved')} className={`rounded-lg px-4 py-2.5 text-sm font-medium transition ${form.leagueMode === 'approved' ? 'bg-white shadow-sm' : 'text-muted-foreground'}`}>Approved league</button><button type="button" onClick={() => update('leagueMode', 'propose')} className={`rounded-lg px-4 py-2.5 text-sm font-medium transition ${form.leagueMode === 'propose' ? 'bg-white shadow-sm' : 'text-muted-foreground'}`}>Propose a league</button></div>
+                                {form.leagueMode === 'approved' ? (
+                                    <Field id="claim-funding-league" label="Open league">
+                                        <Select name="funding_league_id" value={form.funding_league_id} onValueChange={(value) => update('funding_league_id', value)} required><SelectTrigger id="claim-funding-league"><SelectValue placeholder="Select an approved league" /></SelectTrigger><SelectContent>{leagues.map((league) => <SelectItem key={league.id} value={String(league.id)}>{league.name} · {league.region}, {league.country}</SelectItem>)}</SelectContent></Select>
+                                        {leagues.length === 0 ? <p className="text-xs text-amber-800">No leagues are currently open. Propose one for MJ review.</p> : null}
+                                    </Field>
+                                ) : (
+                                    <div className="grid gap-4 sm:grid-cols-2">
+                                        <Field id="claim-proposed-league-name" label="League name"><Input id="claim-proposed-league-name" name="proposed_name" autoComplete="off" value={form.proposed_name} onChange={(e) => update('proposed_name', e.target.value)} required /></Field>
+                                        <Field id="claim-proposed-country" label="Country"><Input id="claim-proposed-country" name="proposed_country" autoComplete="country-name" value={form.proposed_country} onChange={(e) => update('proposed_country', e.target.value)} required /></Field>
+                                        <Field id="claim-proposed-region" label="Region"><Input id="claim-proposed-region" name="proposed_region" autoComplete="address-level1" value={form.proposed_region} onChange={(e) => update('proposed_region', e.target.value)} required /></Field>
+                                        <Field id="claim-proposed-level" label="Level"><Select name="proposed_level" value={form.proposed_level} onValueChange={(value) => update('proposed_level', value)}><SelectTrigger id="claim-proposed-level"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="pro_academy">Pro academy</SelectItem><SelectItem value="youth_national">Youth · national</SelectItem><SelectItem value="youth_regional">Youth · regional</SelectItem><SelectItem value="recreational">Recreational</SelectItem></SelectContent></Select></Field>
+                                        <Field id="claim-proposed-age-bands" label="Age bands"><Input id="claim-proposed-age-bands" name="proposed_age_bands" autoComplete="off" value={form.proposed_age_bands} onChange={(e) => update('proposed_age_bands', e.target.value)} required /></Field>
+                                        <Field id="claim-proposed-gender-program" label="Gender program"><Select name="proposed_gender_program" value={form.proposed_gender_program} onValueChange={(value) => update('proposed_gender_program', value)}><SelectTrigger id="claim-proposed-gender-program"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="boys">Boys</SelectItem><SelectItem value="girls">Girls</SelectItem><SelectItem value="both">Both</SelectItem></SelectContent></Select></Field>
+                                        <Field id="claim-proposed-season" label="Season"><Select name="proposed_season_calendar" value={form.proposed_season_calendar} onValueChange={(value) => update('proposed_season_calendar', value)}><SelectTrigger id="claim-proposed-season"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="aug_may">August–May</SelectItem><SelectItem value="calendar_year">Calendar year</SelectItem><SelectItem value="fall_spring">Fall–spring</SelectItem></SelectContent></Select></Field>
+                                        <Field id="claim-proposed-data-tier" label="Data tier"><Select name="proposed_data_tier" value={form.proposed_data_tier} onValueChange={(value) => update('proposed_data_tier', value)}><SelectTrigger id="claim-proposed-data-tier"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="self_reported">Self-reported</SelectItem><SelectItem value="film_room">Film Room</SelectItem><SelectItem value="api_football">API-Football</SelectItem></SelectContent></Select></Field>
+                                        {form.proposed_data_tier === 'api_football' ? <Field id="claim-proposed-league-api-id" label="API-Football league ID"><Input id="claim-proposed-league-api-id" name="proposed_league_api_id" type="number" min="1" value={form.proposed_league_api_id} onChange={(e) => update('proposed_league_api_id', e.target.value)} required /></Field> : null}
+                                    </div>
+                                )}
+                            </CardContent>
+                        </Card>
+
+                        <Card className="border-stone-200 bg-white/90 shadow-lg">
+                            <CardHeader><div className="flex items-center gap-3"><div className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-100"><Building2 className="h-5 w-5 text-emerald-900" /></div><div><CardTitle className="font-serif text-2xl">2. Program identity</CardTitle><CardDescription>Link provider coverage where it exists; standalone grassroots clubs are welcome.</CardDescription></div></div></CardHeader>
+                            <CardContent className="grid gap-4 sm:grid-cols-2">
+                                <div className="space-y-4 sm:col-span-2">
+                                    <Field id="claim-covered-team-filter" label="Find a covered team"><Input id="claim-covered-team-filter" name="covered_team_filter" autoComplete="off" value={teamQuery} onChange={(e) => setTeamQuery(e.target.value)} placeholder="Search by team or country…" /></Field>
+                                    <Field id="claim-covered-team" label="Covered team (optional)" hint="Selecting a covered team uses its provider-controlled name and crest."><Select name="team_api_id" value={form.team_api_id} onValueChange={chooseTeam}><SelectTrigger id="claim-covered-team"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="none">Free-standing registered club</SelectItem>{visibleTeams.map((team) => <SelectItem key={team.team_id} value={String(team.team_id)}>{team.name} · {team.country}</SelectItem>)}</SelectContent></Select></Field>
+                                </div>
+                                <Field id="claim-club-name" label="Club / program name"><Input id="claim-club-name" name="club_name" autoComplete="organization" value={form.club_name} onChange={(e) => update('club_name', e.target.value)} required /></Field>
+                                <Field id="claim-legal-name" label="Legal organization name"><Input id="claim-legal-name" name="legal_name" autoComplete="organization" value={form.legal_name} onChange={(e) => update('legal_name', e.target.value)} required /></Field>
+                                <Field id="claim-country" label="Country"><Input id="claim-country" name="country" autoComplete="country-name" value={form.country} onChange={(e) => update('country', e.target.value)} required /></Field>
+                                <Field id="claim-region" label="Region / state"><Input id="claim-region" name="region" autoComplete="address-level1" value={form.region} onChange={(e) => update('region', e.target.value)} required /></Field>
+                                <Field id="claim-city" label="City"><Input id="claim-city" name="city" autoComplete="address-level2" value={form.city} onChange={(e) => update('city', e.target.value)} /></Field>
+                                <Field id="claim-currency" label="Currency" hint="Money remains disabled in F2."><Input id="claim-currency" name="currency" autoComplete="off" maxLength={3} value={form.currency} onChange={(e) => update('currency', e.target.value.toUpperCase())} required /></Field>
+                                <div className="sm:col-span-2"><Field id="claim-crest-url" label="Official crest URL (optional)"><Input id="claim-crest-url" name="crest_url" type="url" autoComplete="url" value={form.crest_url} onChange={(e) => update('crest_url', e.target.value)} placeholder="https://…" /></Field></div>
+                            </CardContent>
+                        </Card>
+
+                        <Card className="border-stone-200 bg-white/90 shadow-lg">
+                            <CardHeader><div className="flex items-center gap-3"><div className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-100"><FileCheck2 className="h-5 w-5 text-emerald-900" /></div><div><CardTitle className="font-serif text-2xl">3. Authority + safeguarding</CardTitle><CardDescription>Private evidence metadata for MJ’s review. Weak or mismatched evidence escalates.</CardDescription></div></div></CardHeader>
+                            <CardContent className="space-y-5">
+                                <div className="grid gap-4 sm:grid-cols-2">
+                                    <Field id="claim-authorization-method" label="Authorization route"><Select name="authorization_method" value={form.authorization_method} onValueChange={(value) => update('authorization_method', value)}><SelectTrigger id="claim-authorization-method"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="official_domain_email">Official-domain email</SelectItem><SelectItem value="signed_officer_authorization">Signed officer authorization</SelectItem></SelectContent></Select></Field>
+                                    <Field id="claim-organization-form" label="Organization form"><Select name="organization_form" value={form.organization_form} onValueChange={(value) => update('organization_form', value)}><SelectTrigger id="claim-organization-form"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="nonprofit">Nonprofit</SelectItem><SelectItem value="company">Company</SelectItem><SelectItem value="association">Association</SelectItem><SelectItem value="school">School</SelectItem><SelectItem value="municipal">Municipal</SelectItem><SelectItem value="other_organization">Other organization</SelectItem></SelectContent></Select></Field>
+                                    <Field id="claim-official-email" label="Official email"><Input id="claim-official-email" name="official_email" type="email" autoComplete="email" spellCheck={false} value={form.official_email} onChange={(e) => update('official_email', e.target.value)} required={form.authorization_method === 'official_domain_email'} /></Field>
+                                    {form.authorization_method === 'signed_officer_authorization' ? <Field id="claim-authorization-reference" label="Signed authorization reference"><Input id="claim-authorization-reference" name="authorization_reference" autoComplete="off" value={form.authorization_reference} onChange={(e) => update('authorization_reference', e.target.value)} required /></Field> : null}
+                                    <Field id="claim-registration-reference" label="League / legal registration reference"><Input id="claim-registration-reference" name="registration_reference" autoComplete="off" value={form.registration_reference} onChange={(e) => update('registration_reference', e.target.value)} required /></Field>
+                                    <Field id="claim-official-contact-name" label="Official contact name"><Input id="claim-official-contact-name" name="official_contact_name" autoComplete="name" value={form.official_contact_name} onChange={(e) => update('official_contact_name', e.target.value)} required /></Field>
+                                    <Field id="claim-official-contact-reference" label="Official contact cross-check"><Input id="claim-official-contact-reference" name="official_contact_reference" autoComplete="off" value={form.official_contact_reference} onChange={(e) => update('official_contact_reference', e.target.value)} required /></Field>
+                                    <Field id="claim-safeguarding-email" label="Safeguarding contact email"><Input id="claim-safeguarding-email" name="safeguarding_contact_email" type="email" autoComplete="email" spellCheck={false} value={form.safeguarding_contact_email} onChange={(e) => update('safeguarding_contact_email', e.target.value)} required /></Field>
+                                    <div className="sm:col-span-2"><Field id="claim-safeguarding-policy-url" label="Safeguarding policy URL (optional)"><Input id="claim-safeguarding-policy-url" name="safeguarding_policy_url" type="url" autoComplete="url" value={form.safeguarding_policy_url} onChange={(e) => update('safeguarding_policy_url', e.target.value)} placeholder="https://…" /></Field></div>
+                                </div>
+                                <div className="grid gap-3 sm:grid-cols-2">
+                                    <Attestation checked={form.adult_authority_attested} onCheckedChange={(value) => update('adult_authority_attested', Boolean(value))} title="I am an authorized adult" description="I have authority to represent this organization and am not applying on behalf of a minor personally." />
+                                    <Attestation checked={form.safeguarding_policy_attested} onCheckedChange={(value) => update('safeguarding_policy_attested', Boolean(value))} title="Safeguarding controls exist" description="The organization has a safeguarding contact and policy/process for youth participants." />
+                                    <Attestation checked={form.eligible_organization_attested} onCheckedChange={(value) => update('eligible_organization_attested', Boolean(value))} title="Organization-only recipient" description="Any future recipient is the eligible legal organization—not a coach, parent, manager, or player." />
+                                    <Attestation checked={form.payout_control_attested} onCheckedChange={(value) => update('payout_control_attested', Boolean(value))} title="Organization controls payouts" description="Any future payout account will be controlled by the legal organization." />
+                                </div>
+                                <Field id="claim-applicant-message" label="Applicant note (optional)"><Textarea id="claim-applicant-message" name="applicant_message" autoComplete="off" value={form.applicant_message} onChange={(e) => update('applicant_message', e.target.value)} placeholder="Add context that helps MJ cross-check the application…" /></Field>
+                            </CardContent>
+                        </Card>
+
+                        <div className="flex flex-col justify-between gap-4 rounded-2xl bg-[#0b1f19] p-6 text-white sm:flex-row sm:items-center"><div><div className="flex items-center gap-2 font-medium"><ShieldCheck className="h-5 w-5 text-emerald-200" />Submit for human review</div><p className="mt-1 text-xs text-emerald-50/60">No badge, payout access, or club-manager grant is created automatically.</p></div><Button type="submit" disabled={submitting} className="bg-emerald-300 text-emerald-950 hover:bg-emerald-200">{submitting ? <Loader2 className="mr-2 h-4 w-4 animate-spin motion-reduce:animate-none" /> : <MailCheck className="mr-2 h-4 w-4" />}Send application <ArrowRight className="ml-2 h-4 w-4" /></Button></div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/academy-watch-frontend/src/pages/ProgramPage.jsx
+++ b/academy-watch-frontend/src/pages/ProgramPage.jsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import {
+    ArrowLeft,
+    Bell,
+    Check,
+    ExternalLink,
+    FileText,
+    Landmark,
+    Loader2,
+    MapPin,
+    ShieldCheck,
+    Sparkles,
+    Users,
+} from 'lucide-react'
+
+import { APIService } from '@/lib/api'
+import { useAuth, useAuthUI } from '@/context/AuthContext'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+
+const PROVENANCE_COPY = {
+    'Provider-covered': 'Identity and roster linkage come from the platform’s football-data provider.',
+    'Film Room-verified': 'Identity is supported by finalized footage and human-confirmed Film Room review.',
+    'Self-reported': 'Program identity was supplied by the club and remains visibly labeled.',
+}
+
+function initials(name) {
+    return String(name || 'Program').split(/\s+/).slice(0, 2).map((part) => part[0]).join('').toUpperCase()
+}
+
+export function ProgramPage() {
+    const { slug } = useParams()
+
+    return <ProgramPageContent key={slug} slug={slug} />
+}
+
+function ProgramPageContent({ slug }) {
+    const auth = useAuth()
+    const { openLoginModal } = useAuthUI()
+    const [program, setProgram] = useState(null)
+    const [loading, setLoading] = useState(true)
+    const [error, setError] = useState('')
+    const [saving, setSaving] = useState(false)
+    const [saved, setSaved] = useState(false)
+
+    useEffect(() => {
+        let cancelled = false
+        APIService.getProgram(slug)
+            .then((data) => { if (!cancelled) setProgram(data?.program || null) })
+            .catch((err) => { if (!cancelled) setError(err.message || 'Program not found') })
+            .finally(() => { if (!cancelled) setLoading(false) })
+        return () => { cancelled = true }
+    }, [slug])
+
+    const save = async () => {
+        if (!auth.token) {
+            openLoginModal()
+            return
+        }
+        setSaving(true)
+        setError('')
+        try {
+            await APIService.saveProgram(slug, true)
+            setSaved(true)
+        } catch (err) {
+            setError(err.message || 'Unable to save this program')
+        } finally {
+            setSaving(false)
+        }
+    }
+
+    if (loading) {
+        return <div className="flex min-h-[65vh] items-center justify-center gap-2 text-muted-foreground"><Loader2 className="h-5 w-5 animate-spin motion-reduce:animate-none" />Loading program…</div>
+    }
+
+    if (!program) {
+        return (
+            <div className="mx-auto max-w-xl px-4 py-20 text-center">
+                <Landmark className="mx-auto h-9 w-9 text-muted-foreground" />
+                <h1 className="mt-4 font-serif text-3xl">Program unavailable</h1>
+                <p className="mt-2 text-muted-foreground">{error || 'This page is not published.'}</p>
+                <Button asChild variant="outline" className="mt-6"><Link to="/"><ArrowLeft className="mr-2 h-4 w-4" />Return home</Link></Button>
+            </div>
+        )
+    }
+
+    const location = [program.city, program.region, program.country].filter(Boolean).join(', ')
+    const provenanceLabel = program.provenance?.label || 'Self-reported'
+    const provided = program.program_provided
+
+    return (
+        <div className="min-h-screen bg-[#efece2] text-stone-950">
+            <section className="relative overflow-hidden bg-[#081c17] text-white">
+                <div className="absolute inset-0 opacity-[0.12]" style={{ backgroundImage: 'linear-gradient(rgba(255,255,255,.22) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.22) 1px, transparent 1px)', backgroundSize: '52px 52px' }} />
+                <div className="absolute left-1/2 top-1/2 h-80 w-48 -translate-x-1/2 -translate-y-1/2 rounded-[50%] border border-white/20" />
+                <div className="relative mx-auto max-w-6xl px-4 py-14 sm:py-20">
+                    <Link to="/programs/claim" className="mb-10 inline-flex items-center text-xs font-semibold uppercase tracking-[0.18em] text-emerald-200/70 hover:text-emerald-100"><ArrowLeft className="mr-2 h-3.5 w-3.5" />Program registry</Link>
+                    <div className="grid items-end gap-8 lg:grid-cols-[1fr_auto]">
+                        <div className="flex min-w-0 flex-col gap-6 sm:flex-row sm:items-center">
+                            <div className="flex h-28 w-28 shrink-0 items-center justify-center overflow-hidden rounded-[1.75rem] border border-white/20 bg-white/10 shadow-2xl">
+                                {program.crest_url ? <img src={program.crest_url} alt={`${program.name} crest`} width={112} height={112} className="h-full w-full object-contain p-3" /> : <span className="font-serif text-3xl text-emerald-100">{initials(program.name)}</span>}
+                            </div>
+                            <div className="min-w-0">
+                                <div className="mb-3 flex flex-wrap items-center gap-2">
+                                    {program.is_verified_program ? <Badge className="border-emerald-200/30 bg-emerald-200 text-emerald-950"><ShieldCheck className="mr-1 h-3.5 w-3.5" />Verified program</Badge> : null}
+                                    <Badge className="border-white/20 bg-white/10 text-white">{provenanceLabel}</Badge>
+                                </div>
+                                <h1 className="break-words font-serif text-4xl font-semibold tracking-tight [overflow-wrap:anywhere] sm:text-6xl">{program.name}</h1>
+                                <div className="mt-4 flex min-w-0 flex-wrap gap-x-5 gap-y-2 text-sm text-emerald-50/70"><span className="inline-flex min-w-0 break-words [overflow-wrap:anywhere]"><Landmark className="mr-2 h-4 w-4 shrink-0" />{program.league?.name}</span><span className="inline-flex min-w-0 break-words [overflow-wrap:anywhere]"><MapPin className="mr-2 h-4 w-4 shrink-0" />{location}</span></div>
+                            </div>
+                        </div>
+                        <Button onClick={save} disabled={saving || saved} className="h-12 rounded-full bg-emerald-200 px-6 text-emerald-950 hover:bg-emerald-100">
+                            {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin motion-reduce:animate-none" /> : saved ? <Check className="mr-2 h-4 w-4" /> : <Bell className="mr-2 h-4 w-4" />}
+                            {saved ? 'Saved for future support' : 'Save this program'}
+                        </Button>
+                    </div>
+                </div>
+            </section>
+
+            <main className="mx-auto grid max-w-6xl gap-6 px-4 py-10 lg:grid-cols-[1fr_340px]">
+                <div className="space-y-6">
+                    {error ? <Alert className="border-rose-300 bg-rose-50"><AlertDescription>{error}</AlertDescription></Alert> : null}
+                    <Card className="border-stone-200 bg-white/80 shadow-sm">
+                        <CardHeader><div className="flex items-center gap-3"><div className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-100"><FileText className="h-5 w-5 text-emerald-900" /></div><div><CardTitle className="font-serif text-2xl">Program overview</CardTitle><CardDescription>{provided?.label || 'Program-provided content'}</CardDescription></div></div></CardHeader>
+                        <CardContent className="space-y-5">
+                            {provided ? (
+                                <>
+                                    {provided.summary ? <p className="max-w-3xl break-words text-base leading-7 text-stone-700 [overflow-wrap:anywhere]">{provided.summary}</p> : null}
+                                    <div className="grid gap-4 sm:grid-cols-2">
+                                        <div className="min-w-0 rounded-xl bg-stone-100 p-4"><p className="text-xs font-semibold uppercase tracking-wide text-stone-500">Age groups</p><p className="mt-2 break-words font-medium [overflow-wrap:anywhere]">{provided.age_groups?.join(' · ') || 'Not supplied'}</p></div>
+                                        <div className="min-w-0 rounded-xl bg-stone-100 p-4"><p className="text-xs font-semibold uppercase tracking-wide text-stone-500">Activities</p><p className="mt-2 break-words font-medium [overflow-wrap:anywhere]">{provided.activities?.join(' · ') || 'Not supplied'}</p></div>
+                                    </div>
+                                    {provided.funding_purpose ? <div className="min-w-0 border-l-4 border-amber-400 pl-4"><p className="text-xs font-semibold uppercase tracking-wide text-stone-500">Program-wide use</p><p className="mt-1 break-words text-stone-700 [overflow-wrap:anywhere]">{provided.funding_purpose}</p></div> : null}
+                                </>
+                            ) : (
+                                <div className="rounded-xl border border-dashed border-stone-300 bg-stone-50 px-5 py-8"><p className="font-medium">No program-provided overview has been approved yet.</p><p className="mt-1 text-sm text-stone-500">The registry facts above remain available without invented placeholder content.</p></div>
+                            )}
+                        </CardContent>
+                    </Card>
+
+                    {program.roster_links?.team_page ? (
+                        <Card className="border-stone-200 bg-white/80 shadow-sm"><CardHeader><CardTitle className="flex items-center gap-2 font-serif text-2xl"><Users className="h-5 w-5 text-emerald-800" />Covered roster</CardTitle><CardDescription>This program maps to an existing provider-covered Team.</CardDescription></CardHeader><CardContent><Button variant="outline" asChild><Link to={program.roster_links.team_page}>View team + academy roster <ExternalLink className="ml-2 h-4 w-4" /></Link></Button></CardContent></Card>
+                    ) : null}
+                </div>
+
+                <aside className="space-y-5">
+                    <Card className="border-0 bg-[#f5c95d] text-stone-950 shadow-lg"><CardHeader><div className="flex h-10 w-10 items-center justify-center rounded-full bg-stone-950/10"><Sparkles className="h-5 w-5" /></div><CardTitle className="font-serif text-2xl">Support is not live yet</CardTitle><CardDescription className="text-stone-700">F2 establishes identity and verification only. There is no checkout or live money processing on this page.</CardDescription></CardHeader></Card>
+                    <Card className="border-stone-200 bg-white/80"><CardHeader><CardTitle className="font-serif text-xl">What the badge means</CardTitle></CardHeader><CardContent className="space-y-3 text-sm text-stone-600"><p className="flex gap-2"><ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-emerald-800" /><span>MJ approved the organization and an active adult manager grant exists.</span></p><p className="flex gap-2"><Landmark className="mt-0.5 h-4 w-4 shrink-0 text-emerald-800" /><span>US programs also require test-mode Connect readiness; non-US programs remain informational.</span></p><p className="text-xs text-stone-500">It is not a charity, safeguarding, tax, or every-statement accreditation.</p></CardContent></Card>
+                    <Card className="border-stone-200 bg-white/80"><CardHeader><CardTitle className="text-base">Data provenance</CardTitle></CardHeader><CardContent><Badge variant="outline">{provenanceLabel}</Badge><p className="mt-3 text-sm leading-relaxed text-stone-600">{PROVENANCE_COPY[provenanceLabel] || PROVENANCE_COPY['Self-reported']}</p></CardContent></Card>
+                </aside>
+            </main>
+        </div>
+    )
+}

--- a/academy-watch-frontend/src/pages/admin/AdminFunding.jsx
+++ b/academy-watch-frontend/src/pages/admin/AdminFunding.jsx
@@ -1,0 +1,558 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
+import {
+    AlertTriangle,
+    BellRing,
+    Check,
+    CheckCircle2,
+    Clock3,
+    Database,
+    ExternalLink,
+    FileCheck2,
+    Landmark,
+    Link2,
+    Loader2,
+    MapPinned,
+    Pencil,
+    Plus,
+    Search,
+    ShieldCheck,
+    Trash2,
+    UsersRound,
+    X,
+} from 'lucide-react'
+
+import { APIService } from '@/lib/api'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Textarea } from '@/components/ui/textarea'
+
+const LEVEL_OPTIONS = [
+    ['pro_academy', 'Pro academy'],
+    ['youth_national', 'Youth · national'],
+    ['youth_regional', 'Youth · regional'],
+    ['recreational', 'Recreational'],
+]
+const ADMISSION_OPTIONS = ['open', 'waitlisted', 'closed']
+const REGISTRY_OPTIONS = ['approved', 'proposed', 'rejected']
+
+const EMPTY_FORM = {
+    name: '',
+    country: '',
+    region: '',
+    level: 'youth_regional',
+    ageBands: 'U12, U14, U16',
+    gender_program: 'both',
+    season_calendar: 'calendar_year',
+    dataTier: 'self_reported',
+    leagueApiId: '',
+    registry_status: 'approved',
+    admission_state: 'open',
+    reason: '',
+}
+
+const STATUS_STYLES = {
+    approved: 'border-emerald-200 bg-emerald-50 text-emerald-800',
+    open: 'border-emerald-200 bg-emerald-50 text-emerald-800',
+    pending: 'border-amber-200 bg-amber-50 text-amber-800',
+    proposed: 'border-amber-200 bg-amber-50 text-amber-800',
+    waitlisted: 'border-amber-200 bg-amber-50 text-amber-800',
+    closed: 'border-stone-200 bg-stone-100 text-stone-700',
+    rejected: 'border-rose-200 bg-rose-50 text-rose-800',
+    revoked: 'border-stone-200 bg-stone-100 text-stone-700',
+}
+
+function title(value) {
+    return String(value || '').replaceAll('_', ' ').replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+function formatDate(value) {
+    if (!value) return '—'
+    const date = new Date(value)
+    return Number.isNaN(date.getTime())
+        ? '—'
+        : date.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
+function StatusBadge({ value }) {
+    return <Badge className={STATUS_STYLES[value] || 'border-border bg-secondary text-foreground'}>{title(value)}</Badge>
+}
+
+function LoadingState({ label }) {
+    return (
+        <div className="flex items-center justify-center gap-2 py-16 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            {label}
+        </div>
+    )
+}
+
+function Field({ id, label, children, hint }) {
+    return (
+        <div className="space-y-2">
+            <Label htmlFor={id}>{label}</Label>
+            {children}
+            {hint ? <p className="text-xs leading-relaxed text-muted-foreground">{hint}</p> : null}
+        </div>
+    )
+}
+
+function leagueForm(league) {
+    if (!league) return EMPTY_FORM
+    const apiTier = league.data_tier?.startsWith('api_football:')
+    return {
+        name: league.name || '',
+        country: league.country || '',
+        region: league.region || '',
+        level: league.level || 'youth_regional',
+        ageBands: (league.age_bands || []).join(', '),
+        gender_program: league.gender_program || 'both',
+        season_calendar: league.season_calendar || 'calendar_year',
+        dataTier: apiTier ? 'api_football' : league.data_tier || 'self_reported',
+        leagueApiId: apiTier ? String(league.league_api_id || '') : '',
+        registry_status: league.registry_status || 'approved',
+        admission_state: league.admission_state || 'waitlisted',
+        reason: '',
+    }
+}
+
+function LeagueDialog({ open, onOpenChange, league, onSaved }) {
+    const [form, setForm] = useState(() => leagueForm(league))
+    const [saving, setSaving] = useState(false)
+    const [error, setError] = useState('')
+
+    const update = (key, value) => setForm((current) => ({ ...current, [key]: value }))
+
+    const submit = async (event) => {
+        event.preventDefault()
+        setSaving(true)
+        setError('')
+        const payload = {
+            name: form.name,
+            country: form.country,
+            region: form.region,
+            level: form.level,
+            age_bands: form.ageBands.split(',').map((item) => item.trim()).filter(Boolean),
+            gender_program: form.gender_program,
+            season_calendar: form.season_calendar,
+            data_tier: form.dataTier === 'api_football'
+                ? `api_football:${form.leagueApiId}`
+                : form.dataTier,
+            registry_status: form.registry_status,
+            admission_state: form.admission_state,
+            reason: form.reason,
+        }
+        if (league?.is_provider_bridge) {
+            delete payload.name
+            delete payload.country
+            delete payload.data_tier
+        }
+        try {
+            if (league) await APIService.adminUpdateFundingLeague(league.id, payload)
+            else await APIService.adminCreateFundingLeague(payload)
+            onOpenChange(false)
+            onSaved(league ? 'League registry updated.' : 'League admitted to the registry.')
+        } catch (err) {
+            setError(err.message || 'Unable to save league')
+        } finally {
+            setSaving(false)
+        }
+    }
+
+    const identityLocked = Boolean(league?.is_provider_bridge)
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-h-[92vh] max-w-3xl overflow-y-auto border-0 p-0 shadow-2xl">
+                <div className="border-b bg-[#0b1f19] px-6 py-5 text-white">
+                    <DialogHeader>
+                        <DialogTitle className="font-serif text-2xl tracking-tight">
+                            {league ? 'Edit league admission' : 'Admit a league'}
+                        </DialogTitle>
+                        <DialogDescription className="text-emerald-100/70">
+                            Registry facts control which club programs may enter verification.
+                        </DialogDescription>
+                    </DialogHeader>
+                </div>
+                <form onSubmit={submit} className="space-y-6 px-6 pb-6">
+                    {identityLocked ? (
+                        <Alert className="border-sky-200 bg-sky-50 text-sky-900">
+                            <Link2 className="h-4 w-4" />
+                            <AlertDescription>Provider identity is bridged read-only. Admission metadata remains editable.</AlertDescription>
+                        </Alert>
+                    ) : null}
+                    {error ? (
+                        <Alert variant="destructive"><AlertTriangle className="h-4 w-4" /><AlertDescription>{error}</AlertDescription></Alert>
+                    ) : null}
+                    <div className="grid gap-4 sm:grid-cols-2">
+                        <Field id="funding-league-name" label="League name"><Input id="funding-league-name" name="name" autoComplete="off" value={form.name} onChange={(e) => update('name', e.target.value)} disabled={identityLocked} required /></Field>
+                        <Field id="funding-league-country" label="Country"><Input id="funding-league-country" name="country" autoComplete="country-name" value={form.country} onChange={(e) => update('country', e.target.value)} disabled={identityLocked} required /></Field>
+                        <Field id="funding-league-region" label="Region"><Input id="funding-league-region" name="region" autoComplete="address-level1" value={form.region} onChange={(e) => update('region', e.target.value)} required /></Field>
+                        <Field id="funding-league-level" label="Competitive level">
+                            <Select name="level" value={form.level} onValueChange={(value) => update('level', value)}>
+                                <SelectTrigger id="funding-league-level"><SelectValue /></SelectTrigger>
+                                <SelectContent>{LEVEL_OPTIONS.map(([value, label]) => <SelectItem key={value} value={value}>{label}</SelectItem>)}</SelectContent>
+                            </Select>
+                        </Field>
+                        <Field id="funding-league-age-bands" label="Age bands" hint="Comma-separated, for example U10, U12, U14.">
+                            <Input id="funding-league-age-bands" name="age_bands" autoComplete="off" value={form.ageBands} onChange={(e) => update('ageBands', e.target.value)} required />
+                        </Field>
+                        <Field id="funding-league-gender" label="Gender program">
+                            <Select name="gender_program" value={form.gender_program} onValueChange={(value) => update('gender_program', value)}>
+                                <SelectTrigger id="funding-league-gender"><SelectValue /></SelectTrigger>
+                                <SelectContent><SelectItem value="boys">Boys</SelectItem><SelectItem value="girls">Girls</SelectItem><SelectItem value="both">Boys + girls</SelectItem></SelectContent>
+                            </Select>
+                        </Field>
+                        <Field id="funding-league-season" label="Season calendar">
+                            <Select name="season_calendar" value={form.season_calendar} onValueChange={(value) => update('season_calendar', value)}>
+                                <SelectTrigger id="funding-league-season"><SelectValue /></SelectTrigger>
+                                <SelectContent><SelectItem value="aug_may">August–May</SelectItem><SelectItem value="calendar_year">Calendar year</SelectItem><SelectItem value="fall_spring">Fall–spring</SelectItem></SelectContent>
+                            </Select>
+                        </Field>
+                        <Field id="funding-league-data-tier" label="Data tier">
+                            <Select name="data_tier" value={form.dataTier} onValueChange={(value) => update('dataTier', value)} disabled={identityLocked}>
+                                <SelectTrigger id="funding-league-data-tier"><SelectValue /></SelectTrigger>
+                                <SelectContent><SelectItem value="api_football">API-Football bridge</SelectItem><SelectItem value="film_room">Film Room</SelectItem><SelectItem value="self_reported">Self-reported</SelectItem></SelectContent>
+                            </Select>
+                        </Field>
+                        {form.dataTier === 'api_football' ? (
+                            <Field id="funding-league-api-id" label="API-Football league ID" hint="Existing provider records are linked, never duplicated.">
+                                <Input id="funding-league-api-id" name="league_api_id" type="number" min="1" value={form.leagueApiId} onChange={(e) => update('leagueApiId', e.target.value)} disabled={identityLocked} required />
+                            </Field>
+                        ) : null}
+                        <Field id="funding-league-registry-status" label="Registry review">
+                            <Select name="registry_status" value={form.registry_status} onValueChange={(value) => update('registry_status', value)}>
+                                <SelectTrigger id="funding-league-registry-status"><SelectValue /></SelectTrigger>
+                                <SelectContent>{REGISTRY_OPTIONS.map((value) => <SelectItem key={value} value={value}>{title(value)}</SelectItem>)}</SelectContent>
+                            </Select>
+                        </Field>
+                        <Field id="funding-league-admission-state" label="Admission state">
+                            <Select name="admission_state" value={form.admission_state} onValueChange={(value) => update('admission_state', value)}>
+                                <SelectTrigger id="funding-league-admission-state"><SelectValue /></SelectTrigger>
+                                <SelectContent>{ADMISSION_OPTIONS.map((value) => <SelectItem key={value} value={value}>{title(value)}</SelectItem>)}</SelectContent>
+                            </Select>
+                        </Field>
+                    </div>
+                    <Field id="funding-league-reason" label="Audit reason" hint="Required. This explanation is retained in the funding audit trail.">
+                        <Textarea id="funding-league-reason" name="reason" autoComplete="off" value={form.reason} onChange={(e) => update('reason', e.target.value)} placeholder="Explain why this league is being admitted or changed…" required />
+                    </Field>
+                    <DialogFooter>
+                        <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>Cancel</Button>
+                        <Button type="submit" disabled={saving} className="bg-emerald-700 hover:bg-emerald-800">
+                            {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <ShieldCheck className="mr-2 h-4 w-4" />}
+                            {league ? 'Save admission' : 'Add league'}
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    )
+}
+
+function RegistryTab({ leagues, loading, filters, setFilters, onEdit, onCreate, onDelete }) {
+    return (
+        <div className="space-y-4">
+            <div className="grid gap-3 rounded-2xl border bg-card p-4 shadow-sm md:grid-cols-[1fr_180px_180px_auto]">
+                <div className="relative">
+                    <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                    <Input aria-label="Search leagues" name="funding_league_search" autoComplete="off" value={filters.q} onChange={(e) => setFilters((current) => ({ ...current, q: e.target.value }))} placeholder="Search by league or region…" className="pl-9" />
+                </div>
+                <Select value={filters.admission_state} onValueChange={(value) => setFilters((current) => ({ ...current, admission_state: value }))}>
+                    <SelectTrigger aria-label="Filter by admission state"><SelectValue placeholder="Admission" /></SelectTrigger>
+                    <SelectContent><SelectItem value="all">All admissions</SelectItem>{ADMISSION_OPTIONS.map((value) => <SelectItem key={value} value={value}>{title(value)}</SelectItem>)}</SelectContent>
+                </Select>
+                <Select value={filters.registry_status} onValueChange={(value) => setFilters((current) => ({ ...current, registry_status: value }))}>
+                    <SelectTrigger aria-label="Filter by registry status"><SelectValue placeholder="Registry status" /></SelectTrigger>
+                    <SelectContent><SelectItem value="all">All registry states</SelectItem>{REGISTRY_OPTIONS.map((value) => <SelectItem key={value} value={value}>{title(value)}</SelectItem>)}</SelectContent>
+                </Select>
+                <Button onClick={onCreate} className="bg-emerald-700 hover:bg-emerald-800"><Plus className="mr-2 h-4 w-4" />Add league</Button>
+            </div>
+            {loading ? <LoadingState label="Loading registry…" /> : leagues.length === 0 ? (
+                <Card><CardContent className="py-14 text-center"><Landmark className="mx-auto mb-3 h-7 w-7 text-muted-foreground" /><p className="font-medium">No leagues match this view.</p><p className="mt-1 text-sm text-muted-foreground">Add one directly or review a proposed waitlist entry.</p></CardContent></Card>
+            ) : (
+                <div className="grid gap-4 xl:grid-cols-2">
+                    {leagues.map((league) => (
+                        <Card key={league.id} className="overflow-hidden border-l-4 border-l-emerald-700 shadow-sm">
+                            <CardHeader className="pb-3">
+                                <div className="flex items-start justify-between gap-4">
+                                    <div>
+                                        <div className="mb-2 flex flex-wrap gap-2"><StatusBadge value={league.registry_status} /><StatusBadge value={league.admission_state} />{league.is_provider_bridge ? <Badge variant="outline"><Database className="mr-1 h-3 w-3" />Provider bridge</Badge> : null}</div>
+                                        <CardTitle className="font-serif text-xl">{league.name}</CardTitle>
+                                        <CardDescription className="mt-1 flex items-center gap-1"><MapPinned className="h-3.5 w-3.5" />{league.region}, {league.country}</CardDescription>
+                                    </div>
+                                    <div className="flex gap-1"><Button size="icon" variant="ghost" aria-label={`Edit ${league.name}`} onClick={() => onEdit(league)}><Pencil className="h-4 w-4" /></Button>{league.is_provider_bridge ? null : <Button size="icon" variant="ghost" className="text-muted-foreground hover:text-destructive" aria-label={`Delete ${league.name}`} onClick={() => onDelete(league)}><Trash2 className="h-4 w-4" /></Button>}</div>
+                                </div>
+                            </CardHeader>
+                            <CardContent className="grid grid-cols-2 gap-x-5 gap-y-3 text-sm">
+                                <div><p className="text-xs uppercase tracking-wide text-muted-foreground">Level</p><p className="font-medium">{title(league.level)}</p></div>
+                                <div><p className="text-xs uppercase tracking-wide text-muted-foreground">Program</p><p className="font-medium">{title(league.gender_program)}</p></div>
+                                <div><p className="text-xs uppercase tracking-wide text-muted-foreground">Age bands</p><p className="font-medium">{(league.age_bands || []).join(' · ')}</p></div>
+                                <div><p className="text-xs uppercase tracking-wide text-muted-foreground">Data</p><p className="font-medium">{league.data_tier?.replace('_', ' ')}</p></div>
+                            </CardContent>
+                        </Card>
+                    ))}
+                </div>
+            )}
+        </div>
+    )
+}
+
+function safeHttpsUrl(value) {
+    if (typeof value !== 'string') return null
+    try {
+        const parsed = new URL(value)
+        return parsed.protocol === 'https:' ? parsed.href : null
+    } catch {
+        return null
+    }
+}
+
+function EvidenceChecklist({ evidence }) {
+    const rows = [
+        { label: 'Adult authority', value: evidence?.adult_authority_attested, type: 'attestation' },
+        { label: 'Authorization route', value: evidence?.authorization_method, type: 'enum' },
+        { label: 'Official-domain email', value: evidence?.official_email },
+        { label: 'Signed officer authorization', value: evidence?.authorization_reference },
+        { label: 'Eligible organization form', value: evidence?.organization_form, type: 'enum' },
+        { label: 'League / legal registration match', value: evidence?.registration_reference },
+        { label: 'Official contact name', value: evidence?.official_contact_name },
+        { label: 'Official contact cross-check', value: evidence?.official_contact_reference },
+        { label: 'Safeguarding contact', value: evidence?.safeguarding_contact_email },
+        { label: 'Safeguarding policy URL', value: evidence?.safeguarding_policy_url },
+        { label: 'Safeguarding controls', value: evidence?.safeguarding_policy_attested, type: 'attestation' },
+        { label: 'Organization-only recipient', value: evidence?.eligible_organization_attested, type: 'attestation' },
+        { label: 'Organization payout control', value: evidence?.payout_control_attested, type: 'attestation' },
+    ]
+    return (
+        <div className="grid gap-2 sm:grid-cols-2">
+            {rows.map(({ label, value, type }) => {
+                const isAttestation = type === 'attestation'
+                const isPresent = isAttestation ? value === true : typeof value === 'string' && value.trim().length > 0
+                const displayValue = type === 'enum' && isPresent ? title(value) : value
+                const href = safeHttpsUrl(value)
+                return (
+                    <div key={label} className="flex min-w-0 items-start gap-2 rounded-lg border bg-background/70 px-3 py-2 text-xs">
+                        {isPresent ? <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-700" /> : <X className="mt-0.5 h-3.5 w-3.5 shrink-0 text-rose-600" />}
+                        <span className="min-w-0 flex-1">
+                            <span className="block text-muted-foreground">{label}</span>
+                            {isAttestation ? (
+                                <span className="block font-medium text-foreground">{isPresent ? 'Attested' : 'Not attested'}</span>
+                            ) : href ? (
+                                <a href={href} target="_blank" rel="noreferrer" className="block break-words font-medium text-primary underline underline-offset-2 [overflow-wrap:anywhere]">
+                                    {value}<ExternalLink className="ml-1 inline h-3 w-3" aria-hidden="true" />
+                                </a>
+                            ) : (
+                                <span className="block break-words font-medium text-foreground [overflow-wrap:anywhere]">{isPresent ? displayValue : 'Not supplied'}</span>
+                            )}
+                        </span>
+                    </div>
+                )
+            })}
+        </div>
+    )
+}
+
+function ClaimsTab({ claims, loading, status, setStatus, onReview, onSyncConnect }) {
+    return (
+        <div className="space-y-4">
+            <div className="flex flex-col justify-between gap-3 rounded-2xl border bg-card p-4 shadow-sm sm:flex-row sm:items-center">
+                <div><h3 className="font-serif text-xl font-semibold">Organization approval queue</h3><p className="text-sm text-muted-foreground">League eligibility never substitutes for the club evidence bar.</p></div>
+                <Select value={status} onValueChange={setStatus}><SelectTrigger aria-label="Filter claims by status" className="w-44"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="all">All claims</SelectItem>{['pending', 'approved', 'rejected', 'revoked'].map((value) => <SelectItem key={value} value={value}>{title(value)}</SelectItem>)}</SelectContent></Select>
+            </div>
+            {loading ? <LoadingState label="Loading approval queue…" /> : claims.length === 0 ? (
+                <Card><CardContent className="py-14 text-center"><CheckCircle2 className="mx-auto mb-3 h-7 w-7 text-emerald-700" /><p className="font-medium">No {status === 'all' ? '' : status} claims in the queue.</p></CardContent></Card>
+            ) : claims.map((claim) => {
+                const league = claim.program?.league
+                const leagueReady = league?.registry_status === 'approved' && league?.admission_state === 'open'
+                return (
+                    <Card key={claim.id} className="overflow-hidden shadow-sm">
+                        <div className={`h-1 ${claim.status === 'pending' ? 'bg-amber-400' : claim.status === 'approved' ? 'bg-emerald-600' : 'bg-rose-500'}`} />
+                        <CardHeader>
+                            <div className="flex flex-col justify-between gap-4 lg:flex-row lg:items-start">
+                                <div className="space-y-2">
+                                    <div className="flex flex-wrap gap-2"><StatusBadge value={claim.status} />{claim.program?.is_verified_program ? <Badge className="border-emerald-300 bg-emerald-700 text-white"><ShieldCheck className="mr-1 h-3 w-3" />Verified program</Badge> : <Badge variant="outline"><Clock3 className="mr-1 h-3 w-3" />Verification incomplete</Badge>}</div>
+                                    <CardTitle className="font-serif text-2xl">{claim.program?.name}</CardTitle>
+                                    <CardDescription>{claim.program?.legal_name} · {claim.applicant_email}</CardDescription>
+                                </div>
+                                {claim.status === 'pending' ? (
+                                    <div className="flex gap-2"><Button size="sm" disabled={!leagueReady} onClick={() => onReview(claim, 'approve')} className="bg-emerald-700 hover:bg-emerald-800"><Check className="mr-1 h-4 w-4" />Approve</Button><Button size="sm" variant="outline" className="border-rose-300 text-rose-700" onClick={() => onReview(claim, 'reject')}><X className="mr-1 h-4 w-4" />Reject</Button></div>
+                                ) : claim.status === 'approved' ? (
+                                    <Button size="sm" variant="outline" className="border-rose-300 text-rose-700" onClick={() => onReview(claim, 'revoke')}><X className="mr-1 h-4 w-4" />Revoke access</Button>
+                                ) : null}
+                            </div>
+                        </CardHeader>
+                        <CardContent className="space-y-5">
+                            <div className="grid gap-3 rounded-xl bg-secondary/60 p-4 md:grid-cols-3">
+                                <div><p className="text-xs uppercase tracking-wide text-muted-foreground">League gate</p><p className="mt-1 font-medium">{league?.name}</p><div className="mt-2 flex gap-1"><StatusBadge value={league?.registry_status} /><StatusBadge value={league?.admission_state} /></div></div>
+                                <div><p className="text-xs uppercase tracking-wide text-muted-foreground">Location</p><p className="mt-1 font-medium">{claim.program?.region}, {claim.program?.country}</p><p className="mt-1 text-xs text-muted-foreground">{claim.program?.provenance?.label}</p></div>
+                                <div><p className="text-xs uppercase tracking-wide text-muted-foreground">Connect</p><p className="mt-1 font-medium">{claim.connect ? (claim.connect.is_ready ? 'Test account ready' : 'Onboarding pending') : 'Not required outside US'}</p>{claim.connect?.onboarding_url ? <a href={claim.connect.onboarding_url} target="_blank" rel="noreferrer" className="mt-1 inline-flex items-center text-xs text-primary underline">Open test onboarding <ExternalLink className="ml-1 h-3 w-3" /></a> : null}{claim.connect?.stripe_account_id && !claim.connect?.is_ready ? <Button size="sm" variant="link" className="mt-1 h-auto p-0 text-xs" onClick={() => onSyncConnect(claim)}>Sync test readiness</Button> : null}</div>
+                            </div>
+                            {!leagueReady && claim.status === 'pending' ? <Alert className="border-amber-200 bg-amber-50 text-amber-900"><AlertTriangle className="h-4 w-4" /><AlertDescription>Approve and open the proposed league before this club claim can be approved.</AlertDescription></Alert> : null}
+                            <EvidenceChecklist evidence={claim.evidence} />
+                            {claim.audit_trail?.length > 0 ? (
+                                <details className="rounded-lg border px-4 py-3 text-sm"><summary className="cursor-pointer font-medium">Audit trail · {claim.audit_trail.length}</summary><div className="mt-3 space-y-2 border-l pl-4">{claim.audit_trail.map((event, index) => <div key={`${event.action}-${index}`}><p className="font-medium">{title(event.action)}</p><p className="text-xs text-muted-foreground">{event.reason} · {formatDate(event.created_at)}</p></div>)}</div></details>
+                            ) : null}
+                        </CardContent>
+                    </Card>
+                )
+            })}
+        </div>
+    )
+}
+
+function DemandTab({ demand, loading }) {
+    if (loading) return <LoadingState label="Reading future-support demand…" />
+    const total = (demand.programs || []).reduce((sum, row) => sum + Number(row.saved_count || 0), 0)
+    return (
+        <div className="space-y-5">
+            <div className="grid gap-4 md:grid-cols-3">
+                <Card className="border-0 bg-[#0b1f19] text-white shadow-lg"><CardHeader><CardDescription className="text-emerald-100/60">Notify requests</CardDescription><CardTitle className="font-serif text-4xl">{total}</CardTitle></CardHeader></Card>
+                <Card><CardHeader><CardDescription>Regions with demand</CardDescription><CardTitle className="font-serif text-4xl">{demand.by_region?.length || 0}</CardTitle></CardHeader></Card>
+                <Card><CardHeader><CardDescription>Saved programs</CardDescription><CardTitle className="font-serif text-4xl">{demand.programs?.length || 0}</CardTitle></CardHeader></Card>
+            </div>
+            <div className="grid gap-5 lg:grid-cols-2">
+                <Card><CardHeader><CardTitle className="flex items-center gap-2 font-serif"><MapPinned className="h-5 w-5 text-emerald-700" />By region</CardTitle></CardHeader><CardContent className="space-y-3">{demand.by_region?.length ? demand.by_region.map((row) => <div key={row.region} className="flex items-center justify-between border-b pb-3"><span className="font-medium">{row.region}</span><Badge variant="secondary">{row.saved_count} saves</Badge></div>) : <p className="text-sm text-muted-foreground">No future-support signals yet.</p>}</CardContent></Card>
+                <Card><CardHeader><CardTitle className="flex items-center gap-2 font-serif"><Landmark className="h-5 w-5 text-emerald-700" />By league</CardTitle></CardHeader><CardContent className="space-y-3">{demand.by_league?.length ? demand.by_league.map((row) => <div key={row.league} className="flex items-center justify-between border-b pb-3"><span className="font-medium">{row.league}</span><Badge variant="secondary">{row.saved_count} saves</Badge></div>) : <p className="text-sm text-muted-foreground">No future-support signals yet.</p>}</CardContent></Card>
+            </div>
+            {demand.programs?.length ? <Card><CardHeader><CardTitle className="font-serif">Program signals</CardTitle><CardDescription>Expansion demand only—never an admission or ranking signal.</CardDescription></CardHeader><CardContent className="divide-y">{demand.programs.map((row) => <div key={row.program_id} className="flex flex-col justify-between gap-2 py-4 sm:flex-row sm:items-center"><div><Link className="font-medium hover:underline" to={`/programs/${row.slug}`}>{row.program_name}</Link><p className="text-xs text-muted-foreground">{row.league} · {row.region}, {row.country}</p></div><Badge><BellRing className="mr-1 h-3 w-3" />{row.saved_count}</Badge></div>)}</CardContent></Card> : null}
+        </div>
+    )
+}
+
+export function AdminFunding() {
+    const [searchParams, setSearchParams] = useSearchParams()
+    const requestedTab = searchParams.get('tab')
+    const [tab, setTab] = useState(['registry', 'claims', 'demand'].includes(requestedTab) ? requestedTab : 'registry')
+    const [filters, setFilters] = useState({ q: '', admission_state: 'all', registry_status: 'all' })
+    const [claimStatus, setClaimStatus] = useState('pending')
+    const [leagues, setLeagues] = useState([])
+    const [claims, setClaims] = useState([])
+    const [demand, setDemand] = useState({ programs: [], by_region: [], by_league: [] })
+    const [loading, setLoading] = useState(true)
+    const [message, setMessage] = useState(null)
+    const [dialogOpen, setDialogOpen] = useState(false)
+    const [editingLeague, setEditingLeague] = useState(null)
+    const [review, setReview] = useState(null)
+    const [reviewReason, setReviewReason] = useState('')
+    const [reviewing, setReviewing] = useState(false)
+
+    const leagueParams = useMemo(() => Object.fromEntries(
+        Object.entries(filters).filter(([, value]) => value && value !== 'all')
+    ), [filters])
+
+    const load = useCallback(async () => {
+        await Promise.resolve()
+        setLoading(true)
+        try {
+            const [leagueData, claimData, demandData] = await Promise.all([
+                APIService.adminFundingLeagues(leagueParams),
+                APIService.adminFundingClaims({ status: claimStatus }),
+                APIService.adminFundingDemand(),
+            ])
+            setLeagues(leagueData?.leagues || [])
+            setClaims(claimData?.claims || [])
+            setDemand(demandData || { programs: [], by_region: [], by_league: [] })
+        } catch (err) {
+            setMessage({ type: 'error', text: err.message || 'Unable to load funding registry' })
+        } finally {
+            setLoading(false)
+        }
+    }, [claimStatus, leagueParams])
+
+    useEffect(() => { load() }, [load])
+
+    const changeTab = (value) => {
+        setTab(value)
+        setSearchParams(value === 'registry' ? {} : { tab: value }, { replace: true })
+    }
+
+    const saved = (text) => {
+        setMessage({ type: 'success', text })
+        load()
+    }
+
+    const removeLeague = async (league) => {
+        const reason = window.prompt(`Audit reason for deleting ${league.name}:`)
+        if (!reason) return
+        try {
+            await APIService.adminDeleteFundingLeague(league.id, reason)
+            saved('League removed from the registry.')
+        } catch (err) {
+            setMessage({ type: 'error', text: err.message || 'Unable to delete league' })
+        }
+    }
+
+    const submitReview = async () => {
+        if (!reviewReason.trim()) return
+        setReviewing(true)
+        try {
+            await APIService.adminReviewFundingClaim(review.claim.id, review.action, reviewReason.trim())
+            setReview(null)
+            setReviewReason('')
+            const actionLabel = review.action === 'approve' ? 'approved' : review.action === 'revoke' ? 'revoked' : 'rejected'
+            saved(`Claim ${actionLabel} with an audit record.`)
+        } catch (err) {
+            setMessage({ type: 'error', text: err.message || 'Unable to review claim' })
+        } finally {
+            setReviewing(false)
+        }
+    }
+
+    const syncConnect = async (claim) => {
+        const reason = window.prompt(`Audit reason for syncing ${claim.program?.name} with test-mode Connect:`)
+        if (!reason?.trim()) return
+        try {
+            await APIService.adminSyncFundingConnect(claim.program.id, reason.trim())
+            saved('Test-mode Connect readiness synced and verification recomputed.')
+        } catch (err) {
+            setMessage({ type: 'error', text: err.message || 'Unable to sync test-mode Connect' })
+        }
+    }
+
+    const stats = {
+        open: leagues.filter((league) => league.admission_state === 'open' && league.registry_status === 'approved').length,
+        proposed: leagues.filter((league) => league.registry_status === 'proposed').length,
+        pending: claims.filter((claim) => claim.status === 'pending').length,
+    }
+
+    return (
+        <div className="space-y-6">
+            <section className="relative overflow-hidden rounded-3xl bg-[#0b1f19] px-6 py-7 text-white shadow-xl sm:px-8">
+                <div className="absolute inset-0 opacity-20" style={{ backgroundImage: 'linear-gradient(rgba(255,255,255,.12) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.12) 1px, transparent 1px)', backgroundSize: '36px 36px' }} />
+                <div className="relative flex flex-col justify-between gap-6 lg:flex-row lg:items-end">
+                    <div className="max-w-2xl"><div className="mb-4 flex h-11 w-11 items-center justify-center rounded-full border border-emerald-200/30 bg-emerald-200/10"><ShieldCheck className="h-5 w-5 text-emerald-200" /></div><p className="text-xs font-semibold uppercase tracking-[0.24em] text-emerald-200/70">Grassroots funding · F2</p><h1 className="mt-2 font-serif text-4xl font-semibold tracking-tight sm:text-5xl">Registry control room</h1><p className="mt-3 max-w-xl text-sm leading-relaxed text-emerald-50/70">League-gated admission, adult authority evidence, and organization verification. No donations are processed in this build.</p></div>
+                    <div className="grid grid-cols-3 gap-3"><div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3"><p className="text-2xl font-semibold">{stats.open}</p><p className="text-xs text-emerald-50/60">Open leagues</p></div><div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3"><p className="text-2xl font-semibold">{stats.proposed}</p><p className="text-xs text-emerald-50/60">Waitlist</p></div><div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3"><p className="text-2xl font-semibold">{stats.pending}</p><p className="text-xs text-emerald-50/60">Claims</p></div></div>
+                </div>
+            </section>
+
+            {message ? <Alert className={message.type === 'error' ? 'border-rose-300 bg-rose-50 text-rose-900' : 'border-emerald-300 bg-emerald-50 text-emerald-900'}>{message.type === 'error' ? <AlertTriangle className="h-4 w-4" /> : <CheckCircle2 className="h-4 w-4" />}<AlertDescription>{message.text}</AlertDescription></Alert> : null}
+
+            <Tabs value={tab} onValueChange={changeTab}>
+                <TabsList className="grid h-auto w-full grid-cols-3 rounded-2xl bg-secondary p-1 sm:w-[560px]">
+                    <TabsTrigger value="registry" className="rounded-xl py-2.5"><Landmark className="mr-2 h-4 w-4" />League registry</TabsTrigger>
+                    <TabsTrigger value="claims" className="rounded-xl py-2.5"><FileCheck2 className="mr-2 h-4 w-4" />Approval queue</TabsTrigger>
+                    <TabsTrigger value="demand" className="rounded-xl py-2.5"><BellRing className="mr-2 h-4 w-4" />Demand</TabsTrigger>
+                </TabsList>
+                <TabsContent value="registry" className="mt-5"><RegistryTab leagues={leagues} loading={loading} filters={filters} setFilters={setFilters} onCreate={() => { setEditingLeague(null); setDialogOpen(true) }} onEdit={(league) => { setEditingLeague(league); setDialogOpen(true) }} onDelete={removeLeague} /></TabsContent>
+                <TabsContent value="claims" className="mt-5"><ClaimsTab claims={claims} loading={loading} status={claimStatus} setStatus={setClaimStatus} onReview={(claim, action) => { setReview({ claim, action }); setReviewReason('') }} onSyncConnect={syncConnect} /></TabsContent>
+                <TabsContent value="demand" className="mt-5"><DemandTab demand={demand} loading={loading} /></TabsContent>
+            </Tabs>
+
+            {dialogOpen ? <LeagueDialog open onOpenChange={setDialogOpen} league={editingLeague} onSaved={saved} /> : null}
+            <Dialog open={Boolean(review)} onOpenChange={(open) => { if (!open) setReview(null) }}>
+                <DialogContent>
+                    <DialogHeader><DialogTitle className="font-serif text-2xl">{review?.action === 'approve' ? 'Approve organization' : review?.action === 'revoke' ? 'Revoke manager access' : 'Reject claim'}</DialogTitle><DialogDescription>{review?.claim?.program?.name} · the reason is retained in the immutable admin trail.</DialogDescription></DialogHeader>
+                    <Field id="funding-review-reason" label="Review reason"><Textarea id="funding-review-reason" name="review_reason" autoComplete="off" autoFocus value={reviewReason} onChange={(e) => setReviewReason(e.target.value)} placeholder="Record the evidence decision and any follow-up…" /></Field>
+                    <DialogFooter><Button variant="ghost" onClick={() => setReview(null)}>Cancel</Button><Button disabled={reviewing || !reviewReason.trim()} onClick={submitReview} className={review?.action === 'approve' ? 'bg-emerald-700 hover:bg-emerald-800' : 'bg-rose-700 hover:bg-rose-800'}>{reviewing ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : review?.action === 'approve' ? <ShieldCheck className="mr-2 h-4 w-4" /> : <X className="mr-2 h-4 w-4" />}{review?.action === 'approve' ? 'Approve claim' : review?.action === 'revoke' ? 'Revoke manager' : 'Reject claim'}</Button></DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </div>
+    )
+}


### PR DESCRIPTION
## Summary

- Adds the MJ-controlled league registry, admission-state CRUD/filtering, and bridges existing API-Football league rows instead of duplicating them.
- Adds encrypted club-program claims/evidence, approval/rejection/revocation audit, derived club-manager grants, and admin approval/demand surfaces.
- Scaffolds Stripe Connect Express in test mode only for US programs; non-US approval remains informational with no money rail.
- Reuses `academy_club` follows for Save this program plus `notify_when_fundable` demand, and adds the verified public program stub with provenance labels.

## Schema before code

Deploy `gf01` before the application revision. It creates eight guarded public tables (`funding_leagues`, `club_programs`, `club_program_claims`, `club_claim_evidence`, `club_program_managers`, `club_program_profile_revisions`, `club_connect_accounts`, `funding_admin_events`), enables RLS on each in the same migration, and adds `follows.notify_when_fundable`.

Set `FUNDING_EVIDENCE_ENCRYPTION_KEY` before accepting claims. Do not configure live Stripe keys for F2.

## Migration-head warning

> **Important:** `gf01.down_revision = sea01`, which is the sole `origin/main` Alembic head at authoring and at the final pre-push refresh. If another migration head merges first, update `down_revision` before merge; do not create a sibling head.

## Verification

- Focused backend suite: 143 passed.
- Ruff check: passed.
- Ruff format check: passed.
- Frontend lint: passed with 0 errors (161 existing repository warnings).
- Frontend production build: passed (existing large-chunk warning).
- `git diff --check`: passed.
- Local PostgreSQL `sea01 -> gf01` downgrade/upgrade replay: passed; all eight new tables report RLS enabled and the guarded approved-revision FK exists.
- Live local flow: league admission, claim approval, derived `club_manager`, pending queue, save + distinct-user demand, and verified public stub passed.

## Local screenshots

- `/private/tmp/claude-502/-Users-michaeljones-Projects-loanarmy/13405ba5-f800-4492-8fc1-5c5f35b65dd7/scratchpad/f2-admin-league.png`
- `/private/tmp/claude-502/-Users-michaeljones-Projects-loanarmy/13405ba5-f800-4492-8fc1-5c5f35b65dd7/scratchpad/f2-approval-queue.png`
- `/private/tmp/claude-502/-Users-michaeljones-Projects-loanarmy/13405ba5-f800-4492-8fc1-5c5f35b65dd7/scratchpad/f2-program-page.png`

## Scope guard

No checkout, donation flow, live money movement, production Connect onboarding, or F3/F4 scope is included.