### PR TITLE
feat(showcase): P2 — profile claiming, local entities, moderated media

### DIFF
--- a/academy-watch-backend/env.template
+++ b/academy-watch-backend/env.template
@@ -64,6 +64,26 @@ ADMIN_EMAILS=
 SECRET_KEY=your_flask_secret_key_here
 FLASK_ENV=development
 
+# === AZURE BLOB STORAGE ===
+# Shared storage-account connection string used to mint direct browser-upload SAS URLs.
+# Required for Film Room and Showcase photo uploads in production.
+AZURE_STORAGE_CONNECTION_STRING=
+
+# Film Room native match-video storage (private; club-consented pipeline only).
+VIDEO_BLOB_CONTAINER=video-matches
+# Maximum native match-video upload size in GiB.
+VIDEO_MAX_UPLOAD_GB=12
+
+# Player Showcase photo storage. Originals remain in the private pending container;
+# EXIF-stripped, moderated JPEGs are published to the public-read container.
+SHOWCASE_MEDIA_PENDING_CONTAINER=showcase-media-pending
+SHOWCASE_MEDIA_CONTAINER=showcase-media
+# Maximum source photo size in MiB.
+SHOWCASE_PHOTO_MAX_MB=8
+# Local development/tests only. Used when Azure is unconfigured and the app environment
+# is not production/staging; the dev PUT/GET routes serve files beneath this directory.
+SHOWCASE_MEDIA_LOCAL_DIR=.local/showcase-media
+
 # === EMAIL DELIVERY (Direct via Mailgun + SMTP fallback) ===
 # Primary provider: Mailgun API
 # Get your API key from https://app.mailgun.com/settings/api_security

--- a/academy-watch-backend/migrations/versions/shp01_showcase_media.py
+++ b/academy-watch-backend/migrations/versions/shp01_showcase_media.py
@@ -39,6 +39,17 @@ _PROFILE_COLUMNS = (
 )
 
 
+def _guard_media_rows_before_downgrade() -> None:
+    if not table_exists("player_showcase_media"):
+        return
+    row_exists = op.get_bind().execute(sa.text("SELECT 1 FROM player_showcase_media LIMIT 1")).scalar() is not None
+    if row_exists:
+        raise RuntimeError(
+            "Cannot downgrade shp01 while player_showcase_media contains rows; "
+            "reconcile or purge the referenced showcase blobs before retrying."
+        )
+
+
 def upgrade():
     if not table_exists("player_showcase_media"):
         op.create_table(
@@ -79,6 +90,8 @@ def upgrade():
 
 
 def downgrade():
+    _guard_media_rows_before_downgrade()
+
     for column in reversed(_PROFILE_COLUMNS):
         if column_exists("player_showcase_profiles", column.name):
             op.drop_column("player_showcase_profiles", column.name)

--- a/academy-watch-backend/migrations/versions/shp01_showcase_media.py
+++ b/academy-watch-backend/migrations/versions/shp01_showcase_media.py
@@ -1,0 +1,89 @@
+"""Showcase P2 — moderated player photos and profile enrichment.
+
+Adds the private-upload/publication metadata used by the pre-moderated player
+photo flow and widens ``player_showcase_profiles`` with self-reported contract,
+availability, representation, nationality, and language fields.
+
+Idempotent (guards + helpers) — production has had objects added out-of-band,
+so every DDL op is safe to re-run in both directions. Row Level Security is
+enabled in this migration alongside the new public table.
+
+Revision ID: shp01
+Revises: sea01
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from migrations._migration_helpers import (
+    add_column_safe,
+    column_exists,
+    create_index_safe,
+    index_exists,
+    table_exists,
+)
+
+revision = "shp01"
+down_revision = "sea01"
+branch_labels = None
+depends_on = None
+
+
+_PROFILE_COLUMNS = (
+    sa.Column("contract_status", sa.String(length=30), nullable=True),
+    sa.Column("contract_until", sa.Date(), nullable=True),
+    sa.Column("availability", sa.String(length=30), nullable=True),
+    sa.Column("agent_name", sa.String(length=200), nullable=True),
+    sa.Column("agent_contact_email", sa.String(length=320), nullable=True),
+    sa.Column("nationality_secondary", sa.String(length=100), nullable=True),
+    sa.Column("languages", sa.String(length=300), nullable=True),
+)
+
+
+def upgrade():
+    if not table_exists("player_showcase_media"):
+        op.create_table(
+            "player_showcase_media",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("player_api_id", sa.Integer(), nullable=False),
+            sa.Column("kind", sa.String(length=20), nullable=False, server_default="photo"),
+            sa.Column("blob_path", sa.Text(), nullable=False),
+            sa.Column("public_url", sa.Text(), nullable=True),
+            sa.Column("content_type", sa.String(length=50), nullable=True),
+            sa.Column("size_bytes", sa.Integer(), nullable=True),
+            sa.Column("is_primary", sa.Boolean(), nullable=False, server_default="false"),
+            sa.Column("sort_order", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("status", sa.String(length=20), nullable=False, server_default="pending_upload"),
+            sa.Column(
+                "uploaded_by_user_id",
+                sa.Integer(),
+                sa.ForeignKey("user_accounts.id"),
+                nullable=True,
+            ),
+            sa.Column("reviewed_by", sa.String(length=200), nullable=True),
+            sa.Column("reviewed_at", sa.DateTime(), nullable=True),
+            sa.Column("review_note", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+        )
+
+    if table_exists("player_showcase_media"):
+        op.execute("ALTER TABLE player_showcase_media ENABLE ROW LEVEL SECURITY;")
+        create_index_safe(
+            "ix_showcase_media_player_status",
+            "player_showcase_media",
+            ["player_api_id", "status"],
+        )
+
+    for column in _PROFILE_COLUMNS:
+        add_column_safe("player_showcase_profiles", column)
+
+
+def downgrade():
+    for column in reversed(_PROFILE_COLUMNS):
+        if column_exists("player_showcase_profiles", column.name):
+            op.drop_column("player_showcase_profiles", column.name)
+
+    if index_exists("ix_showcase_media_player_status"):
+        op.drop_index("ix_showcase_media_player_status", table_name="player_showcase_media")
+    if table_exists("player_showcase_media"):
+        op.drop_table("player_showcase_media")

--- a/academy-watch-backend/migrations/versions/shp02_claim_verification.py
+++ b/academy-watch-backend/migrations/versions/shp02_claim_verification.py
@@ -1,0 +1,47 @@
+"""Showcase P2 — social-profile claim verification metadata.
+
+Adds the one-time code and best-effort social-proof check fields used to help
+admins assess profile claims. Admin review remains the only approval gate.
+
+Idempotent (guards + helpers) — production has had objects added out-of-band,
+so every DDL op is safe to re-run in both directions. This migration changes
+an existing table only, so no new Row Level Security statement is required.
+
+Revision ID: shp02
+Revises: shp01
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from migrations._migration_helpers import add_column_safe, column_exists
+
+revision = "shp02"
+down_revision = "shp01"
+branch_labels = None
+depends_on = None
+
+
+_CLAIM_COLUMNS = (
+    sa.Column("verification_code", sa.String(length=24), nullable=True),
+    sa.Column("verification_proof_url", sa.String(length=500), nullable=True),
+    sa.Column(
+        "verification_status",
+        sa.String(length=20),
+        nullable=False,
+        server_default="unverified",
+    ),
+    sa.Column("verification_checked_at", sa.DateTime(), nullable=True),
+    sa.Column("verification_note", sa.String(length=500), nullable=True),
+    sa.Column("verification_method", sa.String(length=20), nullable=True),
+)
+
+
+def upgrade():
+    for column in _CLAIM_COLUMNS:
+        add_column_safe("player_profile_claims", column)
+
+
+def downgrade():
+    for column in reversed(_CLAIM_COLUMNS):
+        if column_exists("player_profile_claims", column.name):
+            op.drop_column("player_profile_claims", column.name)

--- a/academy-watch-backend/migrations/versions/shp03_local_clubs.py
+++ b/academy-watch-backend/migrations/versions/shp03_local_clubs.py
@@ -1,0 +1,117 @@
+"""Showcase P2 — local clubs and player affiliations.
+
+Adds a moderated, user-created club layer for clubs outside API-Football and
+pre-moderated player affiliations that can reference either a local club or an
+API-Football team. These records are showcase-only and remain separate from
+the API-synced ``teams`` table.
+
+Idempotent (guards + helpers) — production has had objects added out-of-band,
+so every DDL op is safe to re-run in both directions. Row Level Security is
+enabled in this migration alongside both new public tables.
+
+Revision ID: shp03
+Revises: shp02
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from migrations._migration_helpers import create_index_safe, index_exists, table_exists
+
+revision = "shp03"
+down_revision = "shp02"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if not table_exists("local_clubs"):
+        op.create_table(
+            "local_clubs",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("name", sa.String(length=200), nullable=False),
+            sa.Column("normalized_name", sa.String(length=220), nullable=False),
+            sa.Column("country", sa.String(length=100), nullable=True),
+            sa.Column("city", sa.String(length=120), nullable=True),
+            sa.Column("level", sa.String(length=30), nullable=True),
+            sa.Column("status", sa.String(length=20), nullable=False, server_default="pending"),
+            sa.Column("api_team_id", sa.Integer(), nullable=True),
+            sa.Column(
+                "merged_into_local_club_id",
+                sa.Integer(),
+                sa.ForeignKey("local_clubs.id"),
+                nullable=True,
+            ),
+            sa.Column("provenance", sa.String(length=20), nullable=False, server_default="user"),
+            sa.Column(
+                "created_by_user_id",
+                sa.Integer(),
+                sa.ForeignKey("user_accounts.id"),
+                nullable=True,
+            ),
+            sa.Column("reviewed_by", sa.String(length=200), nullable=True),
+            sa.Column("reviewed_at", sa.DateTime(), nullable=True),
+            sa.Column("review_note", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+        )
+
+    if table_exists("local_clubs"):
+        op.execute("ALTER TABLE local_clubs ENABLE ROW LEVEL SECURITY;")
+        create_index_safe(
+            "ix_local_clubs_normalized_name",
+            "local_clubs",
+            ["normalized_name"],
+        )
+        create_index_safe("ix_local_clubs_status", "local_clubs", ["status"])
+
+    if not table_exists("player_club_affiliations"):
+        op.create_table(
+            "player_club_affiliations",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("player_api_id", sa.Integer(), nullable=False),
+            sa.Column(
+                "local_club_id",
+                sa.Integer(),
+                sa.ForeignKey("local_clubs.id"),
+                nullable=True,
+            ),
+            sa.Column("team_api_id", sa.Integer(), nullable=True),
+            sa.Column("season", sa.String(length=20), nullable=True),
+            sa.Column("status", sa.String(length=20), nullable=False, server_default="pending"),
+            sa.Column(
+                "created_by_user_id",
+                sa.Integer(),
+                sa.ForeignKey("user_accounts.id"),
+                nullable=True,
+            ),
+            sa.Column("reviewed_by", sa.String(length=200), nullable=True),
+            sa.Column("reviewed_at", sa.DateTime(), nullable=True),
+            sa.Column("review_note", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+        )
+
+    if table_exists("player_club_affiliations"):
+        op.execute("ALTER TABLE player_club_affiliations ENABLE ROW LEVEL SECURITY;")
+        create_index_safe(
+            "ix_player_club_affiliations_player_status",
+            "player_club_affiliations",
+            ["player_api_id", "status"],
+        )
+
+
+def downgrade():
+    if index_exists("ix_player_club_affiliations_player_status"):
+        op.drop_index(
+            "ix_player_club_affiliations_player_status",
+            table_name="player_club_affiliations",
+        )
+    if table_exists("player_club_affiliations"):
+        op.drop_table("player_club_affiliations")
+
+    if index_exists("ix_local_clubs_status"):
+        op.drop_index("ix_local_clubs_status", table_name="local_clubs")
+    if index_exists("ix_local_clubs_normalized_name"):
+        op.drop_index("ix_local_clubs_normalized_name", table_name="local_clubs")
+    if table_exists("local_clubs"):
+        op.drop_table("local_clubs")

--- a/academy-watch-backend/migrations/versions/shp04_club_officials.py
+++ b/academy-watch-backend/migrations/versions/shp04_club_officials.py
@@ -1,0 +1,100 @@
+"""Showcase P2 — club-official claims and vouching.
+
+Adds moderated claims for officials representing either an API-Football team
+or a local club. Club-reference exclusivity is enforced by the application so
+the claim lifecycle can share the existing social-proof verification ladder.
+
+Idempotent (guards + helpers) — production has had objects added out-of-band,
+so every DDL op is safe to re-run in both directions. Row Level Security is
+enabled in this migration alongside the new public table.
+
+Revision ID: shp04
+Revises: shp03
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from migrations._migration_helpers import create_index_safe, index_exists, table_exists
+
+revision = "shp04"
+down_revision = "shp03"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if not table_exists("club_official_claims"):
+        op.create_table(
+            "club_official_claims",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "user_account_id",
+                sa.Integer(),
+                sa.ForeignKey("user_accounts.id"),
+                nullable=False,
+            ),
+            sa.Column("team_api_id", sa.Integer(), nullable=True),
+            sa.Column(
+                "local_club_id",
+                sa.Integer(),
+                sa.ForeignKey("local_clubs.id"),
+                nullable=True,
+            ),
+            sa.Column("role_title", sa.String(length=100), nullable=True),
+            sa.Column("message", sa.Text(), nullable=True),
+            sa.Column("status", sa.String(length=20), nullable=False, server_default="pending"),
+            sa.Column("verification_code", sa.String(length=24), nullable=True),
+            sa.Column("verification_proof_url", sa.String(length=500), nullable=True),
+            sa.Column(
+                "verification_status",
+                sa.String(length=20),
+                nullable=False,
+                server_default="unverified",
+            ),
+            sa.Column("verification_checked_at", sa.DateTime(), nullable=True),
+            sa.Column("verification_note", sa.String(length=500), nullable=True),
+            sa.Column("verification_method", sa.String(length=20), nullable=True),
+            sa.Column("reviewed_by", sa.String(length=200), nullable=True),
+            sa.Column("reviewed_at", sa.DateTime(), nullable=True),
+            sa.Column("review_note", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+        )
+
+    if table_exists("club_official_claims"):
+        op.execute("ALTER TABLE club_official_claims ENABLE ROW LEVEL SECURITY;")
+        create_index_safe(
+            "ix_club_official_claims_user_status",
+            "club_official_claims",
+            ["user_account_id", "status"],
+        )
+        create_index_safe(
+            "ix_club_official_claims_team",
+            "club_official_claims",
+            ["team_api_id"],
+        )
+        create_index_safe(
+            "ix_club_official_claims_local_club",
+            "club_official_claims",
+            ["local_club_id"],
+        )
+
+
+def downgrade():
+    if index_exists("ix_club_official_claims_local_club"):
+        op.drop_index(
+            "ix_club_official_claims_local_club",
+            table_name="club_official_claims",
+        )
+    if index_exists("ix_club_official_claims_team"):
+        op.drop_index(
+            "ix_club_official_claims_team",
+            table_name="club_official_claims",
+        )
+    if index_exists("ix_club_official_claims_user_status"):
+        op.drop_index(
+            "ix_club_official_claims_user_status",
+            table_name="club_official_claims",
+        )
+    if table_exists("club_official_claims"):
+        op.drop_table("club_official_claims")

--- a/academy-watch-backend/migrations/versions/shp05_local_players.py
+++ b/academy-watch-backend/migrations/versions/shp05_local_players.py
@@ -1,0 +1,179 @@
+"""Showcase P2 — local player identities and subject-aware showcase rows.
+
+Adds the moderated, community-created ``local_players`` identity layer. Local
+players are showcase-only and never overload API-Football ids. The existing
+showcase subject tables (and ``player_links`` for reels) gain an explicit
+``local_player_id`` foreign key, while their API player key becomes nullable so
+each row can reference exactly one kind of player. That XOR is deliberately
+application-enforced rather than a database CHECK constraint.
+
+Idempotent (guards + helpers) — production has had objects added out-of-band,
+so every DDL op is safe to re-run in both directions. Row Level Security is
+enabled in this migration alongside the new public table. Downgrading removes
+local-subject rows before restoring the legacy API keys to NOT NULL because
+those rows cannot be represented by the pre-shp05 schema.
+
+Revision ID: shp05
+Revises: shp04
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from migrations._migration_helpers import (
+    add_column_safe,
+    column_exists,
+    create_index_safe,
+    index_exists,
+    table_exists,
+)
+
+revision = "shp05"
+down_revision = "shp04"
+branch_labels = None
+depends_on = None
+
+
+_SHOWCASE_SUBJECTS = (
+    ("player_profile_claims", "player_api_id", "ix_profile_claims_local_player"),
+    ("player_showcase_profiles", "player_api_id", "ix_showcase_profiles_local_player"),
+    ("player_showcase_media", "player_api_id", "ix_showcase_media_local_player"),
+    (
+        "player_club_affiliations",
+        "player_api_id",
+        "ix_player_club_affiliations_local_player",
+    ),
+)
+
+
+def _widen_subject_table(table_name: str, api_column: str, index_name: str) -> None:
+    if not table_exists(table_name):
+        return
+    add_column_safe(
+        table_name,
+        sa.Column(
+            "local_player_id",
+            sa.Integer(),
+            sa.ForeignKey("local_players.id"),
+            nullable=True,
+        ),
+    )
+    if column_exists(table_name, api_column):
+        op.alter_column(
+            table_name,
+            api_column,
+            existing_type=sa.Integer(),
+            nullable=True,
+        )
+    if column_exists(table_name, "local_player_id"):
+        create_index_safe(
+            index_name,
+            table_name,
+            ["local_player_id"],
+            unique=table_name == "player_showcase_profiles",
+        )
+
+
+def _restore_api_only_subject(table_name: str, api_column: str, index_name: str) -> None:
+    if not table_exists(table_name):
+        return
+
+    # Local-only rows have no representation before shp05. Remove them before
+    # restoring the legacy API key's NOT NULL constraint.
+    if column_exists(table_name, api_column):
+        op.execute(f"DELETE FROM {table_name} WHERE {api_column} IS NULL")
+    if index_exists(index_name):
+        op.drop_index(index_name, table_name=table_name)
+    if column_exists(table_name, "local_player_id"):
+        op.drop_column(table_name, "local_player_id")
+    if column_exists(table_name, api_column):
+        op.alter_column(
+            table_name,
+            api_column,
+            existing_type=sa.Integer(),
+            nullable=False,
+        )
+
+
+def upgrade():
+    if not table_exists("local_players"):
+        op.create_table(
+            "local_players",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("display_name", sa.String(length=200), nullable=False),
+            sa.Column("normalized_name", sa.String(length=220), nullable=False),
+            sa.Column("birth_year", sa.Integer(), nullable=True),
+            sa.Column("position", sa.String(length=50), nullable=True),
+            sa.Column("country", sa.String(length=100), nullable=True),
+            sa.Column("city", sa.String(length=120), nullable=True),
+            sa.Column("status", sa.String(length=20), nullable=False, server_default="pending"),
+            sa.Column("api_player_id", sa.Integer(), nullable=True),
+            sa.Column(
+                "merged_into_local_player_id",
+                sa.Integer(),
+                sa.ForeignKey("local_players.id"),
+                nullable=True,
+            ),
+            sa.Column("provenance", sa.String(length=20), nullable=False, server_default="user"),
+            sa.Column(
+                "created_by_user_id",
+                sa.Integer(),
+                sa.ForeignKey("user_accounts.id"),
+                nullable=True,
+            ),
+            sa.Column("reviewed_by", sa.String(length=200), nullable=True),
+            sa.Column("reviewed_at", sa.DateTime(), nullable=True),
+            sa.Column("review_note", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+        )
+
+    if table_exists("local_players"):
+        op.execute("ALTER TABLE local_players ENABLE ROW LEVEL SECURITY;")
+        create_index_safe(
+            "ix_local_players_normalized_name",
+            "local_players",
+            ["normalized_name"],
+        )
+        create_index_safe("ix_local_players_status", "local_players", ["status"])
+
+    for table_name, api_column, index_name in _SHOWCASE_SUBJECTS:
+        _widen_subject_table(table_name, api_column, index_name)
+
+    if table_exists("player_profile_claims"):
+        create_index_safe(
+            "uq_profile_claim_local_player_user",
+            "player_profile_claims",
+            ["local_player_id", "user_account_id"],
+            unique=True,
+        )
+
+    _widen_subject_table(
+        "player_links",
+        "player_id",
+        "ix_player_links_local_player_id",
+    )
+
+
+def downgrade():
+    if index_exists("uq_profile_claim_local_player_user"):
+        op.drop_index(
+            "uq_profile_claim_local_player_user",
+            table_name="player_profile_claims",
+        )
+    _restore_api_only_subject(
+        "player_links",
+        "player_id",
+        "ix_player_links_local_player_id",
+    )
+    for table_name, api_column, index_name in reversed(_SHOWCASE_SUBJECTS):
+        _restore_api_only_subject(table_name, api_column, index_name)
+
+    if index_exists("ix_local_players_status"):
+        op.drop_index("ix_local_players_status", table_name="local_players")
+    if index_exists("ix_local_players_normalized_name"):
+        op.drop_index(
+            "ix_local_players_normalized_name",
+            table_name="local_players",
+        )
+    if table_exists("local_players"):
+        op.drop_table("local_players")

--- a/academy-watch-backend/migrations/versions/shp05_local_players.py
+++ b/academy-watch-backend/migrations/versions/shp05_local_players.py
@@ -45,6 +45,17 @@ _SHOWCASE_SUBJECTS = (
 )
 
 
+def _guard_local_player_rows_before_downgrade() -> None:
+    if not table_exists("local_players"):
+        return
+    row_exists = op.get_bind().execute(sa.text("SELECT 1 FROM local_players LIMIT 1")).scalar() is not None
+    if row_exists:
+        raise RuntimeError(
+            "Cannot downgrade shp05 while local_players contains rows; reconcile the local-player records "
+            "and purge their associated showcase blobs before retrying."
+        )
+
+
 def _widen_subject_table(table_name: str, api_column: str, index_name: str) -> None:
     if not table_exists(table_name):
         return
@@ -155,6 +166,8 @@ def upgrade():
 
 
 def downgrade():
+    _guard_local_player_rows_before_downgrade()
+
     if index_exists("uq_profile_claim_local_player_user"):
         op.drop_index(
             "uq_profile_claim_local_player_user",

--- a/academy-watch-backend/src/models/league.py
+++ b/academy-watch-backend/src/models/league.py
@@ -1819,9 +1819,13 @@ class PlayerLink(db.Model):
     """User-submitted links on player pages (articles, highlights, etc.)."""
 
     __tablename__ = "player_links"
+    __table_args__ = (db.Index("ix_player_links_local_player_id", "local_player_id"),)
 
     id = db.Column(db.Integer, primary_key=True)
-    player_id = db.Column(db.Integer, nullable=False)  # API-Football player ID
+    player_id = db.Column(db.Integer, nullable=True)  # API-Football player ID
+    # Alembic owns the FK. Keeping this a plain Integer avoids making every
+    # minimal league-model test import the separate showcase model registry.
+    local_player_id = db.Column(db.Integer, nullable=True)
     user_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"), nullable=True)
     url = db.Column(db.String(500), nullable=False)
     title = db.Column(db.String(200))
@@ -1836,7 +1840,7 @@ class PlayerLink(db.Model):
     user = db.relationship("UserAccount", backref="player_links")
 
     def to_dict(self):
-        return {
+        payload = {
             "id": self.id,
             "player_id": self.player_id,
             "url": self.url,
@@ -1846,6 +1850,9 @@ class PlayerLink(db.Model):
             "upvotes": self.upvotes,
             "created_at": self.created_at.isoformat() if self.created_at else None,
         }
+        if self.local_player_id is not None:
+            payload["local_player_id"] = self.local_player_id
+        return payload
 
 
 class RebuildConfigLog(db.Model):

--- a/academy-watch-backend/src/models/showcase.py
+++ b/academy-watch-backend/src/models/showcase.py
@@ -11,6 +11,8 @@ edits reverts to ``pending`` and is hidden from the public until re-approved.
   api-football id is used directly (no FK) to mirror ``PlayerLink``.
 - ``PlayerShowcaseProfile`` — at most one self-reported card per player.
 - ``PlayerShowcaseMedia`` — pre-moderated, self-hosted player photos.
+- ``LocalClub`` — a moderated, user-created club outside the synced team layer.
+- ``PlayerClubAffiliation`` — a pre-moderated self-reported club affiliation.
 
 Reel storage reuses the existing ``PlayerLink`` model (``link_type='highlight'``)
 plus the ``sort_order`` column added in migration ``aw19``.
@@ -18,6 +20,7 @@ plus the ``sort_order`` column added in migration ``aw19``.
 
 from datetime import UTC, datetime
 
+from sqlalchemy.orm import validates
 from src.models.league import db
 
 
@@ -152,6 +155,81 @@ class PlayerShowcaseMedia(db.Model):
     sort_order = db.Column(db.Integer, nullable=False, default=0, server_default="0")
     status = db.Column(db.String(20), nullable=False, default="pending_upload", server_default="pending_upload")
     uploaded_by_user_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"), nullable=True)
+    reviewed_by = db.Column(db.String(200))
+    reviewed_at = db.Column(db.DateTime)
+    review_note = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
+    updated_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+
+
+class LocalClub(db.Model):
+    """A moderated local club kept separate from API-synced teams."""
+
+    __tablename__ = "local_clubs"
+    __table_args__ = (
+        db.Index("ix_local_clubs_normalized_name", "normalized_name"),
+        db.Index("ix_local_clubs_status", "status"),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(200), nullable=False)
+    normalized_name = db.Column(db.String(220), nullable=False)
+    country = db.Column(db.String(100))
+    city = db.Column(db.String(120))
+    level = db.Column(db.String(30))
+    status = db.Column(db.String(20), nullable=False, default="pending", server_default="pending")
+    api_team_id = db.Column(db.Integer)
+    merged_into_local_club_id = db.Column(db.Integer, db.ForeignKey("local_clubs.id"), nullable=True)
+    provenance = db.Column(db.String(20), nullable=False, default="user", server_default="user")
+    created_by_user_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"), nullable=True)
+    reviewed_by = db.Column(db.String(200))
+    reviewed_at = db.Column(db.DateTime)
+    review_note = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
+    updated_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+
+    @staticmethod
+    def normalize_name(value: str) -> str:
+        """Lowercase and collapse whitespace for duplicate detection."""
+        return " ".join(value.lower().split())
+
+    @validates("name")
+    def _sync_normalized_name(self, _key, value):
+        if isinstance(value, str):
+            self._setting_normalized_name = True
+            try:
+                self.normalized_name = self.normalize_name(value)
+            finally:
+                self._setting_normalized_name = False
+        return value
+
+    @validates("normalized_name")
+    def _enforce_normalized_name(self, _key, value):
+        if getattr(self, "_setting_normalized_name", False):
+            return self.normalize_name(value) if isinstance(value, str) else value
+        source = self.name if isinstance(self.name, str) else value
+        return self.normalize_name(source) if isinstance(source, str) else source
+
+
+class PlayerClubAffiliation(db.Model):
+    """A player's pre-moderated self-reported club affiliation."""
+
+    __tablename__ = "player_club_affiliations"
+    __table_args__ = (
+        db.Index(
+            "ix_player_club_affiliations_player_status",
+            "player_api_id",
+            "status",
+        ),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    player_api_id = db.Column(db.Integer, nullable=False)
+    local_club_id = db.Column(db.Integer, db.ForeignKey("local_clubs.id"), nullable=True)
+    team_api_id = db.Column(db.Integer)
+    season = db.Column(db.String(20))
+    status = db.Column(db.String(20), nullable=False, default="pending", server_default="pending")
+    created_by_user_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"), nullable=True)
     reviewed_by = db.Column(db.String(200))
     reviewed_at = db.Column(db.DateTime)
     review_note = db.Column(db.Text)

--- a/academy-watch-backend/src/models/showcase.py
+++ b/academy-watch-backend/src/models/showcase.py
@@ -1,4 +1,4 @@
-"""Talent Showcase models — player-claimed profiles + curated highlight reel.
+"""Talent Showcase models — player-claimed profiles, photos, and highlight reel.
 
 A player (or their agent/guardian/club official) claims their public profile;
 an admin approves the claim, after which the owner can curate a self-reported
@@ -10,6 +10,7 @@ edits reverts to ``pending`` and is hidden from the public until re-approved.
   per player are allowed (a player and their agent can both own it). A player's
   api-football id is used directly (no FK) to mirror ``PlayerLink``.
 - ``PlayerShowcaseProfile`` — at most one self-reported card per player.
+- ``PlayerShowcaseMedia`` — pre-moderated, self-hosted player photos.
 
 Reel storage reuses the existing ``PlayerLink`` model (``link_type='highlight'``)
 plus the ``sort_order`` column added in migration ``aw19``.
@@ -68,6 +69,13 @@ class PlayerShowcaseProfile(db.Model):
     positions = db.Column(db.String(100))
     preferred_foot = db.Column(db.String(10))  # left | right | both
     height_cm = db.Column(db.Integer)
+    contract_status = db.Column(db.String(30))  # under_contract | expiring | free_agent
+    contract_until = db.Column(db.Date)
+    availability = db.Column(db.String(30))  # open_to_moves | not_looking | trial_available
+    agent_name = db.Column(db.String(200))
+    agent_contact_email = db.Column(db.String(320))
+    nationality_secondary = db.Column(db.String(100))
+    languages = db.Column(db.String(300))
     status = db.Column(db.String(20), nullable=False, default="pending")  # pending | approved
     updated_by_user_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"), nullable=True)
     reviewed_by = db.Column(db.String(200))  # admin email
@@ -75,21 +83,58 @@ class PlayerShowcaseProfile(db.Model):
     created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
     updated_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
 
-    def public_dict(self):
-        """Fields exposed on the public player page (self-reported badge)."""
-        return {
+    def public_dict(self, *, include_agent_contact=False):
+        """Fields exposed on the player page (self-reported badge).
+
+        Agent contact email is withheld unless the caller has authenticated;
+        routes opt in only after validating that authentication context.
+        """
+        payload = {
             "player_api_id": self.player_api_id,
             "bio": self.bio,
             "positions": self.positions,
             "preferred_foot": self.preferred_foot,
             "height_cm": self.height_cm,
+            "contract_status": self.contract_status,
+            "contract_until": self.contract_until.isoformat() if self.contract_until else None,
+            "availability": self.availability,
+            "agent_name": self.agent_name,
+            "nationality_secondary": self.nationality_secondary,
+            "languages": self.languages,
             "self_reported": True,
         }
+        if include_agent_contact:
+            payload["agent_contact_email"] = self.agent_contact_email
+        return payload
 
     def owner_dict(self):
         """Public fields plus moderation state — for owner + admin views."""
-        payload = self.public_dict()
+        payload = self.public_dict(include_agent_contact=True)
         payload["id"] = self.id
         payload["status"] = self.status
         payload["updated_at"] = self.updated_at.isoformat() if self.updated_at else None
         return payload
+
+
+class PlayerShowcaseMedia(db.Model):
+    """A self-hosted player photo that remains private until moderation."""
+
+    __tablename__ = "player_showcase_media"
+    __table_args__ = (db.Index("ix_showcase_media_player_status", "player_api_id", "status"),)
+
+    id = db.Column(db.Integer, primary_key=True)
+    player_api_id = db.Column(db.Integer, nullable=False)  # API-Football player id
+    kind = db.Column(db.String(20), nullable=False, default="photo", server_default="photo")
+    blob_path = db.Column(db.Text, nullable=False)
+    public_url = db.Column(db.Text)
+    content_type = db.Column(db.String(50))
+    size_bytes = db.Column(db.Integer)
+    is_primary = db.Column(db.Boolean, nullable=False, default=False, server_default="false")
+    sort_order = db.Column(db.Integer, nullable=False, default=0, server_default="0")
+    status = db.Column(db.String(20), nullable=False, default="pending_upload", server_default="pending_upload")
+    uploaded_by_user_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"), nullable=True)
+    reviewed_by = db.Column(db.String(200))
+    reviewed_at = db.Column(db.DateTime)
+    review_note = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
+    updated_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))

--- a/academy-watch-backend/src/models/showcase.py
+++ b/academy-watch-backend/src/models/showcase.py
@@ -37,6 +37,17 @@ class PlayerProfileClaim(db.Model):
     relationship_type = db.Column(db.String(20), nullable=False)  # player | agent | guardian | club_official
     status = db.Column(db.String(20), nullable=False, default="pending")  # pending | approved | rejected | revoked
     message = db.Column(db.Text)  # claimant note to the admin reviewer
+    verification_code = db.Column(db.String(24), nullable=True)
+    verification_proof_url = db.Column(db.String(500), nullable=True)
+    verification_status = db.Column(
+        db.String(20),
+        nullable=False,
+        default="unverified",
+        server_default="unverified",
+    )
+    verification_checked_at = db.Column(db.DateTime, nullable=True)
+    verification_note = db.Column(db.String(500), nullable=True)
+    verification_method = db.Column(db.String(20), nullable=True)  # reserved for club vouching
     reviewed_by = db.Column(db.String(200))  # admin email
     reviewed_at = db.Column(db.DateTime)
     created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
@@ -51,6 +62,14 @@ class PlayerProfileClaim(db.Model):
             "relationship_type": self.relationship_type,
             "status": self.status,
             "message": self.message,
+            "verification_code": self.verification_code,
+            "verification_proof_url": self.verification_proof_url,
+            "verification_status": self.verification_status,
+            "verification_checked_at": (
+                self.verification_checked_at.isoformat() if self.verification_checked_at else None
+            ),
+            "verification_note": self.verification_note,
+            "verification_method": self.verification_method,
             "reviewed_by": self.reviewed_by,
             "reviewed_at": self.reviewed_at.isoformat() if self.reviewed_at else None,
             "created_at": self.created_at.isoformat() if self.created_at else None,

--- a/academy-watch-backend/src/models/showcase.py
+++ b/academy-watch-backend/src/models/showcase.py
@@ -13,6 +13,7 @@ edits reverts to ``pending`` and is hidden from the public until re-approved.
 - ``PlayerShowcaseMedia`` — pre-moderated, self-hosted player photos.
 - ``LocalClub`` — a moderated, user-created club outside the synced team layer.
 - ``PlayerClubAffiliation`` — a pre-moderated self-reported club affiliation.
+- ``ClubOfficialClaim`` — a moderated claim to represent a club.
 
 Reel storage reuses the existing ``PlayerLink`` model (``link_type='highlight'``)
 plus the ``sort_order`` column added in migration ``aw19``.
@@ -235,3 +236,68 @@ class PlayerClubAffiliation(db.Model):
     review_note = db.Column(db.Text)
     created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
     updated_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+
+
+class ClubOfficialClaim(db.Model):
+    """A user's moderated claim to represent an API or local club."""
+
+    __tablename__ = "club_official_claims"
+    __table_args__ = (
+        db.Index(
+            "ix_club_official_claims_user_status",
+            "user_account_id",
+            "status",
+        ),
+        db.Index("ix_club_official_claims_team", "team_api_id"),
+        db.Index("ix_club_official_claims_local_club", "local_club_id"),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_account_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"), nullable=False)
+    team_api_id = db.Column(db.Integer)
+    local_club_id = db.Column(db.Integer, db.ForeignKey("local_clubs.id"), nullable=True)
+    role_title = db.Column(db.String(100))
+    message = db.Column(db.Text)
+    status = db.Column(db.String(20), nullable=False, default="pending", server_default="pending")
+    verification_code = db.Column(db.String(24), nullable=True)
+    verification_proof_url = db.Column(db.String(500), nullable=True)
+    verification_status = db.Column(
+        db.String(20),
+        nullable=False,
+        default="unverified",
+        server_default="unverified",
+    )
+    verification_checked_at = db.Column(db.DateTime, nullable=True)
+    verification_note = db.Column(db.String(500), nullable=True)
+    verification_method = db.Column(db.String(20), nullable=True)
+    reviewed_by = db.Column(db.String(200))
+    reviewed_at = db.Column(db.DateTime)
+    review_note = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
+    updated_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+
+    user = db.relationship("UserAccount", backref=db.backref("club_official_claims", lazy="dynamic"))
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "user_account_id": self.user_account_id,
+            "team_api_id": self.team_api_id,
+            "local_club_id": self.local_club_id,
+            "role_title": self.role_title,
+            "message": self.message,
+            "status": self.status,
+            "verification_code": self.verification_code,
+            "verification_proof_url": self.verification_proof_url,
+            "verification_status": self.verification_status,
+            "verification_checked_at": (
+                self.verification_checked_at.isoformat() if self.verification_checked_at else None
+            ),
+            "verification_note": self.verification_note,
+            "verification_method": self.verification_method,
+            "reviewed_by": self.reviewed_by,
+            "reviewed_at": self.reviewed_at.isoformat() if self.reviewed_at else None,
+            "review_note": self.review_note,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/academy-watch-backend/src/models/showcase.py
+++ b/academy-watch-backend/src/models/showcase.py
@@ -11,6 +11,7 @@ edits reverts to ``pending`` and is hidden from the public until re-approved.
   api-football id is used directly (no FK) to mirror ``PlayerLink``.
 - ``PlayerShowcaseProfile`` — at most one self-reported card per player.
 - ``PlayerShowcaseMedia`` — pre-moderated, self-hosted player photos.
+- ``LocalPlayer`` — a moderated, community-created showcase-only identity.
 - ``LocalClub`` — a moderated, user-created club outside the synced team layer.
 - ``PlayerClubAffiliation`` — a pre-moderated self-reported club affiliation.
 - ``ClubOfficialClaim`` — a moderated claim to represent a club.
@@ -21,8 +22,59 @@ plus the ``sort_order`` column added in migration ``aw19``.
 
 from datetime import UTC, datetime
 
+from sqlalchemy import event
 from sqlalchemy.orm import validates
 from src.models.league import db
+
+
+class LocalPlayer(db.Model):
+    """A moderated local player kept outside API-synced player tracking."""
+
+    __tablename__ = "local_players"
+    __table_args__ = (
+        db.Index("ix_local_players_normalized_name", "normalized_name"),
+        db.Index("ix_local_players_status", "status"),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    display_name = db.Column(db.String(200), nullable=False)
+    normalized_name = db.Column(db.String(220), nullable=False)
+    birth_year = db.Column(db.Integer)
+    position = db.Column(db.String(50))
+    country = db.Column(db.String(100))
+    city = db.Column(db.String(120))
+    status = db.Column(db.String(20), nullable=False, default="pending", server_default="pending")
+    api_player_id = db.Column(db.Integer)
+    merged_into_local_player_id = db.Column(db.Integer, db.ForeignKey("local_players.id"), nullable=True)
+    provenance = db.Column(db.String(20), nullable=False, default="user", server_default="user")
+    created_by_user_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"), nullable=True)
+    reviewed_by = db.Column(db.String(200))
+    reviewed_at = db.Column(db.DateTime)
+    review_note = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC))
+    updated_at = db.Column(db.DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+
+    @staticmethod
+    def normalize_name(value: str) -> str:
+        """Lowercase and collapse whitespace for duplicate detection."""
+        return " ".join(value.lower().split())
+
+    @validates("display_name")
+    def _sync_normalized_name(self, _key, value):
+        if isinstance(value, str):
+            self._setting_normalized_name = True
+            try:
+                self.normalized_name = self.normalize_name(value)
+            finally:
+                self._setting_normalized_name = False
+        return value
+
+    @validates("normalized_name")
+    def _enforce_normalized_name(self, _key, value):
+        if getattr(self, "_setting_normalized_name", False):
+            return self.normalize_name(value) if isinstance(value, str) else value
+        source = self.display_name if isinstance(self.display_name, str) else value
+        return self.normalize_name(source) if isinstance(source, str) else source
 
 
 class PlayerProfileClaim(db.Model):
@@ -31,12 +83,20 @@ class PlayerProfileClaim(db.Model):
     __tablename__ = "player_profile_claims"
     __table_args__ = (
         db.UniqueConstraint("player_api_id", "user_account_id", name="uq_profile_claim_player_user"),
+        db.Index(
+            "uq_profile_claim_local_player_user",
+            "local_player_id",
+            "user_account_id",
+            unique=True,
+        ),
         db.Index("ix_profile_claims_player", "player_api_id"),
+        db.Index("ix_profile_claims_local_player", "local_player_id"),
         db.Index("ix_profile_claims_user", "user_account_id"),
     )
 
     id = db.Column(db.Integer, primary_key=True)
-    player_api_id = db.Column(db.Integer, nullable=False)  # API-Football player id
+    player_api_id = db.Column(db.Integer, nullable=True)  # API-Football player id
+    local_player_id = db.Column(db.Integer, db.ForeignKey("local_players.id"), nullable=True)
     user_account_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"), nullable=False)
     relationship_type = db.Column(db.String(20), nullable=False)  # player | agent | guardian | club_official
     status = db.Column(db.String(20), nullable=False, default="pending")  # pending | approved | rejected | revoked
@@ -84,10 +144,14 @@ class PlayerShowcaseProfile(db.Model):
     """A player's self-reported profile card — pre-moderated before it goes public."""
 
     __tablename__ = "player_showcase_profiles"
-    __table_args__ = (db.Index("ix_showcase_profiles_player", "player_api_id", unique=True),)
+    __table_args__ = (
+        db.Index("ix_showcase_profiles_player", "player_api_id", unique=True),
+        db.Index("ix_showcase_profiles_local_player", "local_player_id", unique=True),
+    )
 
     id = db.Column(db.Integer, primary_key=True)
-    player_api_id = db.Column(db.Integer, nullable=False)  # API-Football player id (unique)
+    player_api_id = db.Column(db.Integer, nullable=True)  # API-Football player id (unique)
+    local_player_id = db.Column(db.Integer, db.ForeignKey("local_players.id"), nullable=True)
     bio = db.Column(db.Text)
     positions = db.Column(db.String(100))
     preferred_foot = db.Column(db.String(10))  # left | right | both
@@ -126,6 +190,8 @@ class PlayerShowcaseProfile(db.Model):
             "languages": self.languages,
             "self_reported": True,
         }
+        if self.local_player_id is not None:
+            payload["local_player_id"] = self.local_player_id
         if include_agent_contact:
             payload["agent_contact_email"] = self.agent_contact_email
         return payload
@@ -143,10 +209,14 @@ class PlayerShowcaseMedia(db.Model):
     """A self-hosted player photo that remains private until moderation."""
 
     __tablename__ = "player_showcase_media"
-    __table_args__ = (db.Index("ix_showcase_media_player_status", "player_api_id", "status"),)
+    __table_args__ = (
+        db.Index("ix_showcase_media_player_status", "player_api_id", "status"),
+        db.Index("ix_showcase_media_local_player", "local_player_id"),
+    )
 
     id = db.Column(db.Integer, primary_key=True)
-    player_api_id = db.Column(db.Integer, nullable=False)  # API-Football player id
+    player_api_id = db.Column(db.Integer, nullable=True)  # API-Football player id
+    local_player_id = db.Column(db.Integer, db.ForeignKey("local_players.id"), nullable=True)
     kind = db.Column(db.String(20), nullable=False, default="photo", server_default="photo")
     blob_path = db.Column(db.Text, nullable=False)
     public_url = db.Column(db.Text)
@@ -222,10 +292,12 @@ class PlayerClubAffiliation(db.Model):
             "player_api_id",
             "status",
         ),
+        db.Index("ix_player_club_affiliations_local_player", "local_player_id"),
     )
 
     id = db.Column(db.Integer, primary_key=True)
-    player_api_id = db.Column(db.Integer, nullable=False)
+    player_api_id = db.Column(db.Integer, nullable=True)
+    local_player_id = db.Column(db.Integer, db.ForeignKey("local_players.id"), nullable=True)
     local_club_id = db.Column(db.Integer, db.ForeignKey("local_clubs.id"), nullable=True)
     team_api_id = db.Column(db.Integer)
     season = db.Column(db.String(20))
@@ -301,3 +373,21 @@ class ClubOfficialClaim(db.Model):
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }
+
+
+def _enforce_player_subject_xor(_mapper, _connection, target) -> None:
+    """Reject showcase rows that identify both or neither player subject."""
+    has_api_player = target.player_api_id is not None
+    has_local_player = target.local_player_id is not None
+    if has_api_player == has_local_player:
+        raise ValueError("exactly one of player_api_id or local_player_id is required")
+
+
+for _subject_model in (
+    PlayerProfileClaim,
+    PlayerShowcaseProfile,
+    PlayerShowcaseMedia,
+    PlayerClubAffiliation,
+):
+    event.listen(_subject_model, "before_insert", _enforce_player_subject_xor)
+    event.listen(_subject_model, "before_update", _enforce_player_subject_xor)

--- a/academy-watch-backend/src/routes/showcase.py
+++ b/academy-watch-backend/src/routes/showcase.py
@@ -35,8 +35,14 @@ from src.auth import (
     require_user_auth,
 )
 from src.extensions import limiter
-from src.models.league import NewsletterPlayerYoutubeLink, PlayerLink, UserAccount, db
-from src.models.showcase import PlayerProfileClaim, PlayerShowcaseMedia, PlayerShowcaseProfile
+from src.models.league import NewsletterPlayerYoutubeLink, PlayerLink, Team, UserAccount, db
+from src.models.showcase import (
+    LocalClub,
+    PlayerClubAffiliation,
+    PlayerProfileClaim,
+    PlayerShowcaseMedia,
+    PlayerShowcaseProfile,
+)
 from src.models.tracked_player import TrackedPlayer
 from src.models.video import VideoMatch, VideoPlayerReport, VideoRosterEntry
 from src.services import showcase_media_storage, social_proof
@@ -75,6 +81,15 @@ VERIFIED_FOOTAGE_CAP = 10
 PLAYER_SEARCH_CAP = 20
 VERIFICATION_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
 VERIFICATION_NOTE_MAX_LENGTH = 500
+LOCAL_CLUB_LEVELS = {"grassroots", "academy", "youth", "semi_pro", "professional", "other"}
+LOCAL_CLUB_STATUSES = {"pending", "verified", "merged", "rejected"}
+AFFILIATION_STATUSES = {"pending", "self_reported", "club_confirmed", "rejected"}
+PUBLIC_AFFILIATION_STATUSES = {"self_reported", "club_confirmed"}
+MAX_LOCAL_CLUB_NAME_LENGTH = 200
+MAX_LOCAL_CLUB_COUNTRY_LENGTH = 100
+MAX_LOCAL_CLUB_CITY_LENGTH = 120
+MAX_AFFILIATION_SEASON_LENGTH = 20
+MAX_AFFILIATIONS = 5
 
 # The only identity gate strong enough for public display (see models/video.py).
 VERIFIED_IDENTITY = "human_confirmed"
@@ -184,8 +199,22 @@ def _clean_optional_text(value, max_len: int):
     """Bleach-clean a free-text field; empty/whitespace/non-str → None."""
     if value is None or not isinstance(value, str):
         return None
-    cleaned = sanitize_plain_text(value).strip()
+    cleaned = _sanitize_text(value).strip()
     return cleaned[:max_len] if cleaned else None
+
+
+def _sanitize_text(value: str) -> str:
+    """Sanitize plain text and defensively remove any residual markup.
+
+    ``sanitize_plain_text`` is authoritative in production. The residual-tag
+    pass is defense in depth for alternate/test sanitizer implementations.
+    """
+    return re.sub(r"<[^>]*>", "", sanitize_plain_text(value))
+
+
+def _normalize_club_name(value: str) -> str:
+    """Canonical key for local-club duplicate detection."""
+    return LocalClub.normalize_name(value)
 
 
 def _mint_verification_code() -> str:
@@ -308,6 +337,79 @@ def _media_dict(media: PlayerShowcaseMedia, *, include_preview: bool = False) ->
     return payload
 
 
+def _local_club_dict(club: LocalClub) -> dict:
+    """Full local-club contract for creators and administrators."""
+    return {
+        "id": club.id,
+        "name": club.name,
+        "normalized_name": club.normalized_name,
+        "country": club.country,
+        "city": club.city,
+        "level": club.level,
+        "status": club.status,
+        "api_team_id": club.api_team_id,
+        "merged_into_local_club_id": club.merged_into_local_club_id,
+        "provenance": club.provenance,
+        "created_by_user_id": club.created_by_user_id,
+        "reviewed_by": club.reviewed_by,
+        "reviewed_at": club.reviewed_at.isoformat() if club.reviewed_at else None,
+        "review_note": club.review_note,
+        "created_at": club.created_at.isoformat() if club.created_at else None,
+        "updated_at": club.updated_at.isoformat() if club.updated_at else None,
+    }
+
+
+def _local_club_search_dict(club: LocalClub) -> dict:
+    """Public search result shape; moderation/audit metadata stays private."""
+    return {
+        "id": club.id,
+        "name": club.name,
+        "country": club.country,
+        "city": club.city,
+        "level": club.level,
+        "status": club.status,
+    }
+
+
+def _affiliation_club_name(affiliation: PlayerClubAffiliation) -> str | None:
+    """Resolve the display club, following one local-club merge hop."""
+    if affiliation.team_api_id is not None:
+        team = (
+            Team.query.filter_by(team_id=affiliation.team_api_id).order_by(Team.season.desc(), Team.id.desc()).first()
+        )
+        return team.name if team else None
+
+    club = db.session.get(LocalClub, affiliation.local_club_id) if affiliation.local_club_id else None
+    if club and club.status == "merged" and club.merged_into_local_club_id:
+        club = db.session.get(LocalClub, club.merged_into_local_club_id) or club
+    return club.name if club else None
+
+
+def _affiliation_dict(affiliation: PlayerClubAffiliation, *, include_review_note: bool = False) -> dict:
+    """Stable affiliation contract shared by showcase and admin responses."""
+    payload = {
+        "id": affiliation.id,
+        "player_api_id": affiliation.player_api_id,
+        "team_api_id": affiliation.team_api_id,
+        "local_club_id": affiliation.local_club_id,
+        "club_name": _affiliation_club_name(affiliation),
+        "season": affiliation.season,
+        "status": affiliation.status,
+        "created_at": affiliation.created_at.isoformat() if affiliation.created_at else None,
+    }
+    if include_review_note:
+        payload["review_note"] = affiliation.review_note
+    return payload
+
+
+def _player_affiliations(player_api_id: int, *, include_private: bool) -> list[dict]:
+    query = PlayerClubAffiliation.query.filter_by(player_api_id=player_api_id)
+    if not include_private:
+        query = query.filter(PlayerClubAffiliation.status.in_(PUBLIC_AFFILIATION_STATUSES))
+    rows = query.order_by(PlayerClubAffiliation.created_at.asc(), PlayerClubAffiliation.id.asc()).all()
+    return [_affiliation_dict(row, include_review_note=include_private) for row in rows]
+
+
 def _lock_photo_cap(player_api_id: int) -> None:
     """Serialize photo-row creation per player on PostgreSQL.
 
@@ -319,6 +421,15 @@ def _lock_photo_cap(player_api_id: int) -> None:
         db.session.execute(
             text("SELECT pg_advisory_xact_lock(:namespace, :player_api_id)"),
             {"namespace": 5_455_001, "player_api_id": player_api_id},
+        )
+
+
+def _lock_affiliation_cap(player_api_id: int) -> None:
+    """Serialize affiliation cap/duplicate checks per player on PostgreSQL."""
+    if db.session.get_bind().dialect.name == "postgresql":
+        db.session.execute(
+            text("SELECT pg_advisory_xact_lock(:namespace, :player_api_id)"),
+            {"namespace": 5_455_002, "player_api_id": player_api_id},
         )
 
 
@@ -461,6 +572,142 @@ def _verified_footage(player_api_id: int) -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
+# Authenticated local-club discovery + creation
+# ---------------------------------------------------------------------------
+
+
+@showcase_bp.route("/clubs/search", methods=["GET"])
+@require_user_auth
+def search_clubs():
+    """Search API-synced teams and the isolated self-reported club layer."""
+    try:
+        raw_q = request.args.get("q")
+        q = _sanitize_text(raw_q).strip() if isinstance(raw_q, str) else ""
+        q = re.sub(r"\s+", " ", q)
+        if len(q) < 2:
+            return jsonify({"error": "q must be at least 2 characters"}), 400
+
+        ranked_teams = (
+            db.session.query(
+                Team.team_id.label("team_api_id"),
+                Team.name.label("name"),
+                Team.country.label("country"),
+                func.row_number()
+                .over(
+                    partition_by=Team.team_id,
+                    order_by=(Team.season.desc(), Team.id.desc()),
+                )
+                .label("row_number"),
+            )
+            .filter(Team.name.ilike(f"%{q}%"))
+            .subquery()
+        )
+        teams = (
+            db.session.query(
+                ranked_teams.c.team_api_id,
+                ranked_teams.c.name,
+                ranked_teams.c.country,
+            )
+            .filter(ranked_teams.c.row_number == 1)
+            .order_by(ranked_teams.c.name.asc(), ranked_teams.c.team_api_id.asc())
+            .limit(10)
+            .all()
+        )
+        local_clubs = (
+            LocalClub.query.filter(
+                LocalClub.name.ilike(f"%{q}%"),
+                LocalClub.status.in_(("pending", "verified")),
+            )
+            .order_by(LocalClub.name.asc(), LocalClub.id.asc())
+            .limit(10)
+            .all()
+        )
+        return jsonify(
+            {
+                "api_teams": [
+                    {"team_api_id": team.team_api_id, "name": team.name, "country": team.country} for team in teams
+                ],
+                "local_clubs": [_local_club_search_dict(club) for club in local_clubs],
+            }
+        )
+    except Exception as e:
+        logger.error("Error in search_clubs: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to search clubs")), 500
+
+
+@showcase_bp.route("/local-clubs", methods=["POST"])
+@require_user_auth
+@limiter.limit("10 per hour", key_func=_user_rate_limit_key)
+def create_local_club():
+    """Create a pending community club without touching API-synced teams."""
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+
+        payload, payload_error = _json_object_or_400()
+        if payload_error:
+            return payload_error
+
+        raw_name = payload.get("name")
+        if not isinstance(raw_name, str):
+            return jsonify({"error": "name is required and must be a string"}), 400
+        name = _sanitize_text(raw_name).strip()
+        if not 2 <= len(name) <= MAX_LOCAL_CLUB_NAME_LENGTH:
+            return jsonify({"error": "name must be between 2 and 200 characters"}), 400
+
+        country = _clean_optional_text(payload.get("country"), MAX_LOCAL_CLUB_COUNTRY_LENGTH)
+        city = _clean_optional_text(payload.get("city"), MAX_LOCAL_CLUB_CITY_LENGTH)
+        raw_level = payload.get("level")
+        if raw_level is None or (isinstance(raw_level, str) and not raw_level.strip()):
+            level = None
+        elif isinstance(raw_level, str):
+            level = _sanitize_text(raw_level).strip().lower()
+            if level not in LOCAL_CLUB_LEVELS:
+                return jsonify({"error": f"level must be one of {sorted(LOCAL_CLUB_LEVELS)}"}), 400
+        else:
+            return jsonify({"error": f"level must be one of {sorted(LOCAL_CLUB_LEVELS)}"}), 400
+
+        normalized_name = _normalize_club_name(name)
+        existing = (
+            LocalClub.query.filter(
+                LocalClub.normalized_name == normalized_name,
+                func.lower(func.coalesce(LocalClub.country, "")) == (country or "").lower(),
+                LocalClub.status != "rejected",
+            )
+            .order_by(LocalClub.id.asc())
+            .first()
+        )
+        if existing is not None:
+            return (
+                jsonify(
+                    {
+                        "error": "A local club with this name and country already exists",
+                        "existing": _local_club_search_dict(existing),
+                    }
+                ),
+                409,
+            )
+
+        club = LocalClub(
+            name=name,
+            country=country,
+            city=city,
+            level=level,
+            status="pending",
+            provenance="user",
+            created_by_user_id=user.id,
+        )
+        db.session.add(club)
+        db.session.commit()
+        return jsonify({"club": _local_club_dict(club)}), 201
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in create_local_club: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to create local club")), 500
+
+
+# ---------------------------------------------------------------------------
 # Public
 # ---------------------------------------------------------------------------
 
@@ -479,7 +726,6 @@ def get_player_showcase(player_api_id: int):
         authenticated = auth_context is not None
         auth_user = auth_context["user"] if auth_context else None
         is_owner = bool(auth_user and _has_approved_claim(player_api_id, auth_user.id))
-
         profile_row = PlayerShowcaseProfile.query.filter_by(player_api_id=player_api_id).first()
         if profile_row and profile_row.status == "approved":
             profile = profile_row.public_dict(include_agent_contact=authenticated)
@@ -500,6 +746,10 @@ def get_player_showcase(player_api_id: int):
                 "profile": profile,
                 "reel": reel,
                 "photos": photos,
+                "affiliations": _player_affiliations(
+                    player_api_id,
+                    include_private=is_owner,
+                ),
                 "verified_footage": _verified_footage(player_api_id),
                 "claim_status": "claimed" if claimed else "unclaimed",
             }
@@ -699,8 +949,107 @@ def verify_my_claim(claim_id: int):
 
 
 # ---------------------------------------------------------------------------
-# Owner-gated — profile + reel curation
+# Owner-gated — affiliations, profile + reel curation
 # ---------------------------------------------------------------------------
+
+
+@showcase_bp.route("/players/<int:player_api_id>/showcase/affiliations", methods=["POST"])
+@require_user_auth
+@limiter.limit("10 per hour", key_func=_user_rate_limit_key)
+def create_player_affiliation(player_api_id: int):
+    """Submit one pre-moderated self-reported club affiliation."""
+    try:
+        user, error = _approved_claim_or_403(player_api_id)
+        if error:
+            return error
+
+        payload, payload_error = _json_object_or_400()
+        if payload_error:
+            return payload_error
+
+        local_club_id = payload.get("local_club_id")
+        team_api_id = payload.get("team_api_id")
+        has_local_club = local_club_id is not None
+        has_api_team = team_api_id is not None
+        if has_local_club == has_api_team:
+            return jsonify({"error": "exactly one of local_club_id or team_api_id is required"}), 400
+
+        if has_local_club:
+            if isinstance(local_club_id, bool) or not isinstance(local_club_id, int) or local_club_id <= 0:
+                return jsonify({"error": "local_club_id must reference an active local club"}), 400
+            local_club = db.session.get(LocalClub, local_club_id)
+            if local_club is None or local_club.status in ("merged", "rejected"):
+                return jsonify({"error": "local_club_id must reference an active local club"}), 400
+        elif isinstance(team_api_id, bool) or not isinstance(team_api_id, int) or team_api_id <= 0:
+            return jsonify({"error": "team_api_id must be a positive integer"}), 400
+
+        raw_season = payload.get("season")
+        if raw_season is None:
+            season = None
+        elif not isinstance(raw_season, str):
+            return jsonify({"error": "season must be a string of at most 20 characters"}), 400
+        else:
+            season = _sanitize_text(raw_season).strip() or None
+            if season is not None and len(season) > MAX_AFFILIATION_SEASON_LENGTH:
+                return jsonify({"error": "season must be a string of at most 20 characters"}), 400
+
+        _lock_affiliation_cap(player_api_id)
+        duplicate_query = PlayerClubAffiliation.query.filter(
+            PlayerClubAffiliation.player_api_id == player_api_id,
+            PlayerClubAffiliation.status != "rejected",
+        )
+        if has_local_club:
+            duplicate_query = duplicate_query.filter(PlayerClubAffiliation.local_club_id == local_club_id)
+        else:
+            duplicate_query = duplicate_query.filter(PlayerClubAffiliation.team_api_id == team_api_id)
+        if duplicate_query.first() is not None:
+            return jsonify({"error": "This club affiliation has already been submitted"}), 409
+
+        active_count = PlayerClubAffiliation.query.filter(
+            PlayerClubAffiliation.player_api_id == player_api_id,
+            PlayerClubAffiliation.status != "rejected",
+        ).count()
+        if active_count >= MAX_AFFILIATIONS:
+            return jsonify({"error": f"affiliation limit reached ({MAX_AFFILIATIONS})"}), 409
+
+        affiliation = PlayerClubAffiliation(
+            player_api_id=player_api_id,
+            local_club_id=local_club_id if has_local_club else None,
+            team_api_id=team_api_id if has_api_team else None,
+            season=season,
+            status="pending",
+            created_by_user_id=user.id,
+        )
+        db.session.add(affiliation)
+        db.session.commit()
+        return jsonify({"affiliation": _affiliation_dict(affiliation, include_review_note=True)}), 201
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in create_player_affiliation: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to create affiliation")), 500
+
+
+@showcase_bp.route(
+    "/players/<int:player_api_id>/showcase/affiliations/<int:aff_id>",
+    methods=["DELETE"],
+)
+@require_user_auth
+def delete_player_affiliation(player_api_id: int, aff_id: int):
+    """Delete an affiliation belonging to a player whose profile the caller owns."""
+    try:
+        _, error = _approved_claim_or_403(player_api_id)
+        if error:
+            return error
+        affiliation = PlayerClubAffiliation.query.filter_by(id=aff_id, player_api_id=player_api_id).first()
+        if affiliation is None:
+            return jsonify({"error": "affiliation not found"}), 404
+        db.session.delete(affiliation)
+        db.session.commit()
+        return jsonify({"deleted": True})
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in delete_player_affiliation: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to delete affiliation")), 500
 
 
 @showcase_bp.route("/players/<int:player_api_id>/showcase/profile", methods=["PUT"])
@@ -1129,6 +1478,194 @@ def delete_reel_item(player_api_id: int, link_id: int):
         db.session.rollback()
         logger.error("Error in delete_reel_item: %s", e)
         return jsonify(_safe_error_payload(e, "Failed to delete reel item")), 500
+
+
+# ---------------------------------------------------------------------------
+# Admin — local clubs + affiliation review
+# ---------------------------------------------------------------------------
+
+
+@showcase_bp.route("/admin/local-clubs", methods=["GET"])
+@require_api_key
+def admin_list_local_clubs():
+    """List local clubs, optionally filtered by moderation status."""
+    try:
+        status = (request.args.get("status") or "").strip().lower()
+        query = LocalClub.query
+        if status:
+            if status not in LOCAL_CLUB_STATUSES:
+                return jsonify({"error": f"invalid status; one of {sorted(LOCAL_CLUB_STATUSES)}"}), 400
+            query = query.filter(LocalClub.status == status)
+        clubs = query.order_by(LocalClub.created_at.desc(), LocalClub.id.desc()).all()
+        return jsonify({"clubs": [_local_club_dict(club) for club in clubs]})
+    except Exception as e:
+        logger.error("Error in admin_list_local_clubs: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to load local clubs")), 500
+
+
+@showcase_bp.route("/admin/local-clubs/<int:club_id>/review", methods=["POST"])
+@require_api_key
+def admin_review_local_club(club_id: int):
+    """Verify or reject a pending local club."""
+    try:
+        club = LocalClub.query.filter_by(id=club_id).with_for_update().first()
+        if club is None:
+            return jsonify({"error": "local club not found"}), 404
+
+        payload, payload_error = _json_object_or_400()
+        if payload_error:
+            return payload_error
+        raw_action = payload.get("action")
+        action = raw_action.strip().lower() if isinstance(raw_action, str) else ""
+        if action not in ("verify", "reject"):
+            return jsonify({"error": "action must be verify or reject"}), 400
+        if club.status != "pending":
+            return jsonify({"error": f"cannot {action} a {club.status} local club"}), 409
+
+        now = datetime.now(UTC)
+        club.status = "verified" if action == "verify" else "rejected"
+        club.review_note = _clean_optional_text(payload.get("note"), MAX_REVIEW_NOTE_LENGTH)
+        club.reviewed_by = getattr(g, "user_email", None)
+        club.reviewed_at = now
+        club.updated_at = now
+        db.session.commit()
+        return jsonify({"club": _local_club_dict(club)})
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in admin_review_local_club: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to review local club")), 500
+
+
+@showcase_bp.route("/admin/local-clubs/<int:club_id>/merge", methods=["POST"])
+@require_api_key
+def admin_merge_local_club(club_id: int):
+    """Merge one local club into another and repoint every affiliation."""
+    try:
+        source = LocalClub.query.filter_by(id=club_id).with_for_update().first()
+        if source is None:
+            return jsonify({"error": "local club not found"}), 404
+
+        payload, payload_error = _json_object_or_400()
+        if payload_error:
+            return payload_error
+        target_id = payload.get("into_local_club_id")
+        if isinstance(target_id, bool) or not isinstance(target_id, int) or target_id <= 0:
+            return jsonify({"error": "into_local_club_id must be a positive integer"}), 400
+        if target_id == source.id:
+            return jsonify({"error": "A local club cannot be merged into itself"}), 400
+        if source.status in ("merged", "rejected"):
+            return jsonify({"error": f"cannot merge a {source.status} local club"}), 409
+
+        target = LocalClub.query.filter_by(id=target_id).with_for_update().first()
+        if target is None or target.status in ("merged", "rejected"):
+            return jsonify({"error": "merge target must be an active local club"}), 400
+
+        now = datetime.now(UTC)
+        moved_affiliations = PlayerClubAffiliation.query.filter_by(local_club_id=source.id).update(
+            {
+                PlayerClubAffiliation.local_club_id: target.id,
+                PlayerClubAffiliation.updated_at: now,
+            },
+            synchronize_session=False,
+        )
+        source.status = "merged"
+        source.merged_into_local_club_id = target.id
+        source.reviewed_by = getattr(g, "user_email", None)
+        source.reviewed_at = now
+        source.updated_at = now
+        db.session.commit()
+        return jsonify(
+            {
+                "club": _local_club_dict(source),
+                "moved_affiliations": moved_affiliations,
+            }
+        )
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in admin_merge_local_club: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to merge local club")), 500
+
+
+@showcase_bp.route("/admin/local-clubs/<int:club_id>/link-api", methods=["POST"])
+@require_api_key
+def admin_link_local_club_api(club_id: int):
+    """Store an API-Football bridge id on the local row only."""
+    try:
+        club = db.session.get(LocalClub, club_id)
+        if club is None:
+            return jsonify({"error": "local club not found"}), 404
+
+        payload, payload_error = _json_object_or_400()
+        if payload_error:
+            return payload_error
+        team_api_id = payload.get("team_api_id")
+        if isinstance(team_api_id, bool) or not isinstance(team_api_id, int) or team_api_id <= 0:
+            return jsonify({"error": "team_api_id must be a positive integer"}), 400
+
+        club.api_team_id = team_api_id
+        club.updated_at = datetime.now(UTC)
+        db.session.commit()
+        return jsonify({"club": _local_club_dict(club)})
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in admin_link_local_club_api: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to link local club")), 500
+
+
+@showcase_bp.route("/admin/showcase/affiliations", methods=["GET"])
+@require_api_key
+def admin_list_affiliations():
+    """List player affiliations with resolved club names."""
+    try:
+        status = (request.args.get("status") or "").strip().lower()
+        query = PlayerClubAffiliation.query
+        if status:
+            if status not in AFFILIATION_STATUSES:
+                return jsonify({"error": f"invalid status; one of {sorted(AFFILIATION_STATUSES)}"}), 400
+            query = query.filter(PlayerClubAffiliation.status == status)
+        affiliations = query.order_by(
+            PlayerClubAffiliation.created_at.desc(),
+            PlayerClubAffiliation.id.desc(),
+        ).all()
+        return jsonify(
+            {"affiliations": [_affiliation_dict(affiliation, include_review_note=True) for affiliation in affiliations]}
+        )
+    except Exception as e:
+        logger.error("Error in admin_list_affiliations: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to load affiliations")), 500
+
+
+@showcase_bp.route("/admin/showcase/affiliations/<int:aff_id>/review", methods=["POST"])
+@require_api_key
+def admin_review_affiliation(aff_id: int):
+    """Approve a pending self-report or reject it with an optional note."""
+    try:
+        affiliation = PlayerClubAffiliation.query.filter_by(id=aff_id).with_for_update().first()
+        if affiliation is None:
+            return jsonify({"error": "affiliation not found"}), 404
+
+        payload, payload_error = _json_object_or_400()
+        if payload_error:
+            return payload_error
+        raw_action = payload.get("action")
+        action = raw_action.strip().lower() if isinstance(raw_action, str) else ""
+        if action not in ("approve", "reject"):
+            return jsonify({"error": "action must be approve or reject"}), 400
+        if affiliation.status != "pending":
+            return jsonify({"error": f"cannot {action} a {affiliation.status} affiliation"}), 409
+
+        now = datetime.now(UTC)
+        affiliation.status = "self_reported" if action == "approve" else "rejected"
+        affiliation.review_note = _clean_optional_text(payload.get("note"), MAX_REVIEW_NOTE_LENGTH)
+        affiliation.reviewed_by = getattr(g, "user_email", None)
+        affiliation.reviewed_at = now
+        affiliation.updated_at = now
+        db.session.commit()
+        return jsonify({"affiliation": _affiliation_dict(affiliation, include_review_note=True)})
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in admin_review_affiliation: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to review affiliation")), 500
 
 
 # ---------------------------------------------------------------------------

--- a/academy-watch-backend/src/routes/showcase.py
+++ b/academy-watch-backend/src/routes/showcase.py
@@ -21,11 +21,12 @@ Reuse decisions (see the build contract):
 import logging
 import re
 import secrets
+from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from urllib.parse import parse_qs, urlparse
 
 from flask import Blueprint, g, jsonify, request, send_file
-from sqlalchemy import func, text
+from sqlalchemy import func, or_, text
 from sqlalchemy.exc import IntegrityError
 from src.auth import (
     _ensure_user_account,
@@ -39,6 +40,7 @@ from src.models.league import NewsletterPlayerYoutubeLink, PlayerLink, Team, Use
 from src.models.showcase import (
     ClubOfficialClaim,
     LocalClub,
+    LocalPlayer,
     PlayerClubAffiliation,
     PlayerProfileClaim,
     PlayerShowcaseMedia,
@@ -93,9 +95,64 @@ MAX_LOCAL_CLUB_CITY_LENGTH = 120
 MAX_AFFILIATION_SEASON_LENGTH = 20
 MAX_AFFILIATIONS = 5
 MAX_CLUB_ROLE_TITLE_LENGTH = 100
+LOCAL_PLAYER_STATUSES = {"pending", "approved", "rejected", "merged"}
+LOCAL_PLAYER_RELATIONSHIP_TYPES = {"player", "agent", "guardian"}
+MAX_LOCAL_PLAYER_NAME_LENGTH = 200
+MAX_LOCAL_PLAYER_POSITION_LENGTH = 50
+MAX_LOCAL_PLAYER_COUNTRY_LENGTH = 100
+MAX_LOCAL_PLAYER_CITY_LENGTH = 120
+MIN_LOCAL_PLAYER_BIRTH_YEAR = 1950
+MAX_LOCAL_PLAYER_BIRTH_YEAR = 2020
 
 # The only identity gate strong enough for public display (see models/video.py).
 VERIFIED_IDENTITY = "human_confirmed"
+
+
+@dataclass(frozen=True)
+class ShowcaseSubject:
+    """One explicit showcase identity key (API-Football XOR local)."""
+
+    player_api_id: int | None = None
+    local_player_id: int | None = None
+
+    def __post_init__(self):
+        if (self.player_api_id is None) == (self.local_player_id is None):
+            raise ValueError("exactly one showcase subject id is required")
+        subject_id = self.player_api_id if self.player_api_id is not None else self.local_player_id
+        if isinstance(subject_id, bool) or not isinstance(subject_id, int) or subject_id <= 0:
+            raise ValueError("showcase subject ids must be positive integers")
+
+    @property
+    def is_local(self) -> bool:
+        return self.local_player_id is not None
+
+    @property
+    def subject_id(self) -> int:
+        return self.local_player_id if self.local_player_id is not None else self.player_api_id
+
+
+def _api_subject(player_api_id: int) -> ShowcaseSubject:
+    return ShowcaseSubject(player_api_id=player_api_id)
+
+
+def _local_subject(local_player_id: int) -> ShowcaseSubject:
+    return ShowcaseSubject(local_player_id=local_player_id)
+
+
+def _subject_filters(model, subject: ShowcaseSubject, *, api_field: str = "player_api_id") -> tuple:
+    """SQL predicates that enforce both sides of the subject XOR."""
+    api_column = getattr(model, api_field)
+    local_column = model.local_player_id
+    if subject.is_local:
+        return api_column.is_(None), local_column == subject.local_player_id
+    return api_column == subject.player_api_id, local_column.is_(None)
+
+
+def _subject_values(subject: ShowcaseSubject, *, api_field: str = "player_api_id") -> dict:
+    return {
+        api_field: subject.player_api_id,
+        "local_player_id": subject.local_player_id,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -124,10 +181,28 @@ def _current_user_account():
     return user
 
 
-def _has_approved_claim(player_api_id: int, user_id: int) -> bool:
+def _has_approved_subject_claim(subject: ShowcaseSubject, user_id: int) -> bool:
     return (
-        PlayerProfileClaim.query.filter_by(
-            player_api_id=player_api_id, user_account_id=user_id, status="approved"
+        PlayerProfileClaim.query.filter(
+            *_subject_filters(PlayerProfileClaim, subject),
+            PlayerProfileClaim.user_account_id == user_id,
+            PlayerProfileClaim.status == "approved",
+        ).first()
+        is not None
+    )
+
+
+def _has_approved_claim(player_api_id: int, user_id: int) -> bool:
+    """Compatibility wrapper for the existing API-player routes."""
+    return _has_approved_subject_claim(_api_subject(player_api_id), user_id)
+
+
+def _has_visible_local_claim(local_player_id: int, user_id: int) -> bool:
+    return (
+        PlayerProfileClaim.query.filter(
+            *_subject_filters(PlayerProfileClaim, _local_subject(local_player_id)),
+            PlayerProfileClaim.user_account_id == user_id,
+            PlayerProfileClaim.status.in_(("pending", "approved")),
         ).first()
         is not None
     )
@@ -179,8 +254,8 @@ def _optional_owner_user(player_api_id: int):
         return None
 
 
-def _approved_claim_or_403(player_api_id: int):
-    """Resolve the caller and require an approved claim for the player.
+def _approved_subject_claim_or_403(subject: ShowcaseSubject):
+    """Resolve the caller and require an approved claim for one subject.
 
     Returns ``(user, None)`` when the caller owns an approved claim, otherwise
     ``(None, (response, status))`` for the route to return directly.
@@ -188,9 +263,18 @@ def _approved_claim_or_403(player_api_id: int):
     user = _current_user_account()
     if user is None:
         return None, (jsonify({"error": "auth context missing email"}), 401)
-    if not _has_approved_claim(player_api_id, user.id):
+    if subject.is_local:
+        player = db.session.get(LocalPlayer, subject.local_player_id)
+        if player is None or player.status in ("merged", "rejected"):
+            return None, (jsonify({"error": "local player not found"}), 404)
+    if not _has_approved_subject_claim(subject, user.id):
         return None, (jsonify({"error": "You do not have an approved claim for this player"}), 403)
     return user, None
+
+
+def _approved_claim_or_403(player_api_id: int):
+    """Compatibility wrapper for the existing API-player owner gate."""
+    return _approved_subject_claim_or_403(_api_subject(player_api_id))
 
 
 # ---------------------------------------------------------------------------
@@ -218,6 +302,11 @@ def _sanitize_text(value: str) -> str:
 def _normalize_club_name(value: str) -> str:
     """Canonical key for local-club duplicate detection."""
     return LocalClub.normalize_name(value)
+
+
+def _normalize_local_player_name(value: str) -> str:
+    """Canonical key for local-player duplicate detection."""
+    return LocalPlayer.normalize_name(value)
 
 
 def _mint_verification_code() -> str:
@@ -299,7 +388,7 @@ def _is_youtube_url(url: str) -> bool:
 
 def _link_dict(link: PlayerLink) -> dict:
     """Compose a reel item dict — PlayerLink.to_dict lacks sort_order."""
-    return {
+    payload = {
         "id": link.id,
         "player_id": link.player_id,
         "url": link.url,
@@ -311,6 +400,9 @@ def _link_dict(link: PlayerLink) -> dict:
         "source": "user",
         "created_at": link.created_at.isoformat() if link.created_at else None,
     }
+    if link.local_player_id is not None:
+        payload["local_player_id"] = link.local_player_id
+    return payload
 
 
 def _media_dict(media: PlayerShowcaseMedia, *, include_preview: bool = False) -> dict:
@@ -328,6 +420,8 @@ def _media_dict(media: PlayerShowcaseMedia, *, include_preview: bool = False) ->
         "created_at": media.created_at.isoformat() if media.created_at else None,
         "review_note": media.review_note,
     }
+    if media.local_player_id is not None:
+        payload["local_player_id"] = media.local_player_id
     if include_preview and media.status != "approved":
         if media.status == "rejected":
             payload["pending_preview_url"] = None
@@ -338,6 +432,63 @@ def _media_dict(media: PlayerShowcaseMedia, *, include_preview: bool = False) ->
                 logger.warning("Unable to mint pending preview for media %s: %s", media.id, exc)
                 payload["pending_preview_url"] = None
     return payload
+
+
+def _profile_claim_dict(claim: PlayerProfileClaim, *, include_null_local_id: bool = False) -> dict:
+    """Serialize a profile claim without changing legacy API-player responses."""
+    payload = claim.to_dict()
+    if include_null_local_id or claim.local_player_id is not None:
+        payload["local_player_id"] = claim.local_player_id
+    return payload
+
+
+def _local_player_public_dict(player: LocalPlayer) -> dict:
+    return {
+        "id": player.id,
+        "display_name": player.display_name,
+        "birth_year": player.birth_year,
+        "position": player.position,
+        "country": player.country,
+        "city": player.city,
+        "status": player.status,
+        "api_player_id": player.api_player_id,
+    }
+
+
+def _local_player_admin_dict(player: LocalPlayer) -> dict:
+    payload = _local_player_public_dict(player)
+    payload.update(
+        {
+            "normalized_name": player.normalized_name,
+            "merged_into_local_player_id": player.merged_into_local_player_id,
+            "provenance": player.provenance,
+            "created_by_user_id": player.created_by_user_id,
+            "reviewed_by": player.reviewed_by,
+            "reviewed_at": player.reviewed_at.isoformat() if player.reviewed_at else None,
+            "review_note": player.review_note,
+            "created_at": player.created_at.isoformat() if player.created_at else None,
+            "updated_at": player.updated_at.isoformat() if player.updated_at else None,
+        }
+    )
+    return payload
+
+
+def _local_player_mini_dict(player: LocalPlayer) -> dict:
+    return {
+        "id": player.id,
+        "display_name": player.display_name,
+        "status": player.status,
+    }
+
+
+def _resolved_local_player(local_player_id: int) -> tuple[LocalPlayer | None, int | None]:
+    """Resolve one merge hop, returning ``(target-or-row, target_id)``."""
+    player = db.session.get(LocalPlayer, local_player_id)
+    if player and player.status == "merged" and player.merged_into_local_player_id:
+        target = db.session.get(LocalPlayer, player.merged_into_local_player_id)
+        if target is not None:
+            return target, target.id
+    return player, None
 
 
 def _local_club_dict(club: LocalClub) -> dict:
@@ -411,9 +562,9 @@ def _club_claim_dict(claim: ClubOfficialClaim, *, include_verification_code: boo
 
 def _player_claim_for_official_dict(claim: PlayerProfileClaim) -> dict:
     """Cross-user claim shape: verification result is visible, secret code is not."""
-    payload = claim.to_dict()
+    payload = _profile_claim_dict(claim)
     payload.pop("verification_code", None)
-    payload["player_name"] = _resolve_player_name(claim.player_api_id)
+    payload["player_name"] = _resolve_claim_player_name(claim)
     return payload
 
 
@@ -507,40 +658,60 @@ def _affiliation_dict(affiliation: PlayerClubAffiliation, *, include_review_note
         "status": affiliation.status,
         "created_at": affiliation.created_at.isoformat() if affiliation.created_at else None,
     }
+    if affiliation.local_player_id is not None:
+        payload["local_player_id"] = affiliation.local_player_id
     if include_review_note:
         payload["review_note"] = affiliation.review_note
     return payload
 
 
-def _player_affiliations(player_api_id: int, *, include_private: bool) -> list[dict]:
-    query = PlayerClubAffiliation.query.filter_by(player_api_id=player_api_id)
+def _subject_affiliations(subject: ShowcaseSubject, *, include_private: bool) -> list[dict]:
+    query = PlayerClubAffiliation.query.filter(*_subject_filters(PlayerClubAffiliation, subject))
     if not include_private:
         query = query.filter(PlayerClubAffiliation.status.in_(PUBLIC_AFFILIATION_STATUSES))
     rows = query.order_by(PlayerClubAffiliation.created_at.asc(), PlayerClubAffiliation.id.asc()).all()
     return [_affiliation_dict(row, include_review_note=include_private) for row in rows]
 
 
-def _lock_photo_cap(player_api_id: int) -> None:
+def _player_affiliations(player_api_id: int, *, include_private: bool) -> list[dict]:
+    """Compatibility wrapper for API-player showcase responses."""
+    return _subject_affiliations(_api_subject(player_api_id), include_private=include_private)
+
+
+def _lock_subject_cap(subject: ShowcaseSubject, *, api_namespace: int, local_namespace: int) -> None:
+    if db.session.get_bind().dialect.name == "postgresql":
+        db.session.execute(
+            text("SELECT pg_advisory_xact_lock(:namespace, :subject_id)"),
+            {
+                "namespace": local_namespace if subject.is_local else api_namespace,
+                "subject_id": subject.subject_id,
+            },
+        )
+
+
+def _lock_photo_cap_subject(subject: ShowcaseSubject) -> None:
     """Serialize photo-row creation per player on PostgreSQL.
 
     The eight-row cap is a conditional count and cannot be expressed as a
     portable table constraint. A transaction-scoped advisory lock closes the
     count-then-insert race in production; SQLite tests remain a no-op.
     """
-    if db.session.get_bind().dialect.name == "postgresql":
-        db.session.execute(
-            text("SELECT pg_advisory_xact_lock(:namespace, :player_api_id)"),
-            {"namespace": 5_455_001, "player_api_id": player_api_id},
-        )
+    _lock_subject_cap(subject, api_namespace=5_455_001, local_namespace=5_455_011)
+
+
+def _lock_affiliation_cap_subject(subject: ShowcaseSubject) -> None:
+    """Serialize affiliation cap/duplicate checks per player on PostgreSQL."""
+    _lock_subject_cap(subject, api_namespace=5_455_002, local_namespace=5_455_012)
+
+
+def _lock_photo_cap(player_api_id: int) -> None:
+    """Compatibility wrapper for the existing API-player cap lock."""
+    _lock_photo_cap_subject(_api_subject(player_api_id))
 
 
 def _lock_affiliation_cap(player_api_id: int) -> None:
-    """Serialize affiliation cap/duplicate checks per player on PostgreSQL."""
-    if db.session.get_bind().dialect.name == "postgresql":
-        db.session.execute(
-            text("SELECT pg_advisory_xact_lock(:namespace, :player_api_id)"),
-            {"namespace": 5_455_002, "player_api_id": player_api_id},
-        )
+    """Compatibility wrapper for the existing API-player cap lock."""
+    _lock_affiliation_cap_subject(_api_subject(player_api_id))
 
 
 def _lock_club_claims(user_id: int) -> None:
@@ -562,8 +733,11 @@ def _cleanup_failed_publication(public_url: str | None, media_id: int) -> None:
         logger.error("Failed to compensate public blob for media %s: %s", media_id, exc)
 
 
-def _player_photos(player_api_id: int, *, include_unapproved: bool) -> list[dict]:
-    query = PlayerShowcaseMedia.query.filter_by(player_api_id=player_api_id, kind="photo")
+def _subject_photos(subject: ShowcaseSubject, *, include_unapproved: bool) -> list[dict]:
+    query = PlayerShowcaseMedia.query.filter(
+        *_subject_filters(PlayerShowcaseMedia, subject),
+        PlayerShowcaseMedia.kind == "photo",
+    )
     if not include_unapproved:
         query = query.filter(PlayerShowcaseMedia.status == "approved")
     rows = query.order_by(
@@ -575,7 +749,12 @@ def _player_photos(player_api_id: int, *, include_unapproved: bool) -> list[dict
     return [_media_dict(row, include_preview=include_unapproved) for row in rows]
 
 
-def _highlight_reel(player_api_id: int, *, include_pending: bool) -> list[dict]:
+def _player_photos(player_api_id: int, *, include_unapproved: bool) -> list[dict]:
+    """Compatibility wrapper for API-player photo queries."""
+    return _subject_photos(_api_subject(player_api_id), include_unapproved=include_unapproved)
+
+
+def _subject_highlight_reel(subject: ShowcaseSubject, *, include_pending: bool) -> list[dict]:
     """The player's highlight reel: approved (and, for owners, pending) highlight
     ``PlayerLink`` rows ordered by sort_order, then newsletter YouTube links
     appended as synthetic read-only entries (dedup by URL; not reorderable)."""
@@ -583,7 +762,7 @@ def _highlight_reel(player_api_id: int, *, include_pending: bool) -> list[dict]:
     order_col = func.coalesce(PlayerLink.sort_order, 0)
     links = (
         PlayerLink.query.filter(
-            PlayerLink.player_id == player_api_id,
+            *_subject_filters(PlayerLink, subject, api_field="player_id"),
             PlayerLink.link_type == "highlight",
             PlayerLink.status.in_(statuses),
         )
@@ -598,11 +777,13 @@ def _highlight_reel(player_api_id: int, *, include_pending: bool) -> list[dict]:
         return _youtube_video_id(url) or url
 
     seen_urls = {_dedup_key(r["url"]) for r in results}
-    yt_rows = (
-        NewsletterPlayerYoutubeLink.query.filter_by(player_id=player_api_id)
-        .order_by(NewsletterPlayerYoutubeLink.created_at.desc())
-        .all()
-    )
+    yt_rows = []
+    if not subject.is_local:
+        yt_rows = (
+            NewsletterPlayerYoutubeLink.query.filter_by(player_id=subject.player_api_id)
+            .order_by(NewsletterPlayerYoutubeLink.created_at.desc())
+            .all()
+        )
     for yt in yt_rows:
         # Newsletter links are admin-entered with no write-side URL validation —
         # only merge ones that are verifiably YouTube (defense in depth: a stored
@@ -629,10 +810,29 @@ def _highlight_reel(player_api_id: int, *, include_pending: bool) -> list[dict]:
     return results
 
 
+def _highlight_reel(player_api_id: int, *, include_pending: bool) -> list[dict]:
+    """Compatibility wrapper for the existing API-player reel."""
+    return _subject_highlight_reel(_api_subject(player_api_id), include_pending=include_pending)
+
+
 def _resolve_player_name(player_api_id: int):
     """Best-effort display name from the tracking universe (may be None)."""
     tracked = TrackedPlayer.query.filter_by(player_api_id=player_api_id).order_by(TrackedPlayer.id).first()
     return tracked.player_name if tracked and tracked.player_name else None
+
+
+def _resolve_claim_player_name(claim: PlayerProfileClaim) -> str | None:
+    if claim.local_player_id is not None:
+        local_player = db.session.get(LocalPlayer, claim.local_player_id)
+        return local_player.display_name if local_player else None
+    return _resolve_player_name(claim.player_api_id)
+
+
+def _claim_subject(claim: PlayerProfileClaim) -> ShowcaseSubject:
+    return ShowcaseSubject(
+        player_api_id=claim.player_api_id,
+        local_player_id=claim.local_player_id,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -826,9 +1026,184 @@ def create_local_club():
         return jsonify(_safe_error_payload(e, "Failed to create local club")), 500
 
 
+@showcase_bp.route("/local-players", methods=["POST"])
+@require_user_auth
+@limiter.limit("5 per hour", key_func=_user_rate_limit_key)
+def create_local_player():
+    """Create a pending showcase-only identity and auto-claim it for its creator."""
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+
+        payload, payload_error = _json_object_or_400()
+        if payload_error:
+            return payload_error
+
+        raw_name = payload.get("display_name")
+        if not isinstance(raw_name, str):
+            return jsonify({"error": "display_name is required and must be a string"}), 400
+        display_name = _sanitize_text(raw_name).strip()
+        if not 2 <= len(display_name) <= MAX_LOCAL_PLAYER_NAME_LENGTH:
+            return jsonify({"error": "display_name must be between 2 and 200 characters"}), 400
+
+        birth_year = payload.get("birth_year")
+        if birth_year is not None:
+            if isinstance(birth_year, bool) or not isinstance(birth_year, int):
+                return jsonify({"error": "birth_year must be an integer between 1950 and 2020"}), 400
+            if not MIN_LOCAL_PLAYER_BIRTH_YEAR <= birth_year <= MAX_LOCAL_PLAYER_BIRTH_YEAR:
+                return jsonify({"error": "birth_year must be between 1950 and 2020"}), 400
+
+        position = _clean_optional_text(payload.get("position"), MAX_LOCAL_PLAYER_POSITION_LENGTH)
+        country = _clean_optional_text(payload.get("country"), MAX_LOCAL_PLAYER_COUNTRY_LENGTH)
+        city = _clean_optional_text(payload.get("city"), MAX_LOCAL_PLAYER_CITY_LENGTH)
+
+        raw_relationship = payload.get("relationship_type", "player")
+        relationship_type = raw_relationship.strip().lower() if isinstance(raw_relationship, str) else ""
+        if relationship_type not in LOCAL_PLAYER_RELATIONSHIP_TYPES:
+            return (
+                jsonify({"error": f"relationship_type must be one of {sorted(LOCAL_PLAYER_RELATIONSHIP_TYPES)}"}),
+                400,
+            )
+
+        duplicate_query = LocalPlayer.query.filter(
+            LocalPlayer.normalized_name == _normalize_local_player_name(display_name),
+            LocalPlayer.status.notin_(("rejected", "merged")),
+        )
+        if birth_year is None:
+            duplicate_query = duplicate_query.filter(LocalPlayer.birth_year.is_(None))
+        else:
+            duplicate_query = duplicate_query.filter(LocalPlayer.birth_year == birth_year)
+        existing = duplicate_query.order_by(LocalPlayer.id.asc()).first()
+        if existing is not None:
+            return (
+                jsonify(
+                    {
+                        "error": "A local player with this name and birth year already exists",
+                        "existing": {
+                            "id": existing.id,
+                            "display_name": existing.display_name,
+                            "birth_year": existing.birth_year,
+                            "position": existing.position,
+                            "country": existing.country,
+                            "city": existing.city,
+                            "status": existing.status,
+                        },
+                    }
+                ),
+                409,
+            )
+
+        player = LocalPlayer(
+            display_name=display_name,
+            birth_year=birth_year,
+            position=position,
+            country=country,
+            city=city,
+            status="pending",
+            provenance="user",
+            created_by_user_id=user.id,
+        )
+        db.session.add(player)
+        db.session.flush()
+        claim = PlayerProfileClaim(
+            player_api_id=None,
+            local_player_id=player.id,
+            user_account_id=user.id,
+            relationship_type=relationship_type,
+            status="pending",
+            verification_code=_mint_verification_code(),
+            verification_status="unverified",
+        )
+        db.session.add(claim)
+        db.session.commit()
+        return jsonify({"player": _local_player_public_dict(player), "claim": _profile_claim_dict(claim)}), 201
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in create_local_player: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to create local player")), 500
+
+
 # ---------------------------------------------------------------------------
 # Public
 # ---------------------------------------------------------------------------
+
+
+def _subject_showcase_payload(subject: ShowcaseSubject, *, auth_context=None) -> dict:
+    """Compose the shared showcase contract for an explicit subject."""
+    if auth_context is None:
+        auth_context = _optional_authenticated_context()
+    authenticated = auth_context is not None
+    auth_user = auth_context["user"] if auth_context else None
+    is_owner = bool(auth_user and _has_approved_subject_claim(subject, auth_user.id))
+    profile_row = PlayerShowcaseProfile.query.filter(*_subject_filters(PlayerShowcaseProfile, subject)).first()
+    if profile_row and profile_row.status == "approved":
+        profile = profile_row.public_dict(include_agent_contact=authenticated)
+    elif profile_row and is_owner and profile_row.status == "pending":
+        profile = profile_row.owner_dict()
+    else:
+        profile = None
+
+    claimed = (
+        PlayerProfileClaim.query.filter(
+            *_subject_filters(PlayerProfileClaim, subject),
+            PlayerProfileClaim.status == "approved",
+        ).first()
+        is not None
+    )
+    payload = {
+        "profile": profile,
+        "reel": _subject_highlight_reel(subject, include_pending=is_owner),
+        "photos": _subject_photos(subject, include_unapproved=is_owner),
+        "affiliations": _subject_affiliations(subject, include_private=is_owner),
+        "verified_footage": [] if subject.is_local else _verified_footage(subject.player_api_id),
+        "claim_status": "claimed" if claimed else "unclaimed",
+    }
+    if subject.is_local:
+        return {"local_player_id": subject.local_player_id, **payload}
+    return {"player_api_id": subject.player_api_id, **payload}
+
+
+def _local_player_visible_to_context(player: LocalPlayer, auth_context) -> bool:
+    if player.status == "approved":
+        return True
+    user = auth_context["user"] if auth_context else None
+    return bool(user and _has_visible_local_claim(player.id, user.id))
+
+
+@showcase_bp.route("/local-players/<int:lp_id>", methods=["GET"])
+def get_local_player(lp_id: int):
+    """Public local-player identity, with claimant-only pending visibility."""
+    try:
+        player, merged_into = _resolved_local_player(lp_id)
+        if player is None:
+            return jsonify({"error": "local player not found"}), 404
+        auth_context = _optional_authenticated_context()
+        if not _local_player_visible_to_context(player, auth_context):
+            return jsonify({"error": "local player not found"}), 404
+        payload = {"player": _local_player_public_dict(player)}
+        if merged_into is not None:
+            payload["merged_into"] = merged_into
+        return jsonify(payload)
+    except Exception as e:
+        logger.error("Error in get_local_player: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to load local player")), 500
+
+
+@showcase_bp.route("/local-players/<int:lp_id>/showcase", methods=["GET"])
+def get_local_player_showcase(lp_id: int):
+    """Showcase-only local profile; local subjects never have Film Room evidence."""
+    try:
+        player, _ = _resolved_local_player(lp_id)
+        if player is None:
+            return jsonify({"error": "local player not found"}), 404
+        auth_context = _optional_authenticated_context()
+        if not _local_player_visible_to_context(player, auth_context):
+            return jsonify({"error": "local player not found"}), 404
+        return jsonify(_subject_showcase_payload(_local_subject(player.id), auth_context=auth_context))
+    except Exception as e:
+        logger.error("Error in get_local_player_showcase: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to load showcase")), 500
 
 
 @showcase_bp.route("/players/<int:player_api_id>/showcase", methods=["GET"])
@@ -841,38 +1216,7 @@ def get_player_showcase(player_api_id: int):
     or bad-token callers get the approved-only public view — never a 401.
     """
     try:
-        auth_context = _optional_authenticated_context()
-        authenticated = auth_context is not None
-        auth_user = auth_context["user"] if auth_context else None
-        is_owner = bool(auth_user and _has_approved_claim(player_api_id, auth_user.id))
-        profile_row = PlayerShowcaseProfile.query.filter_by(player_api_id=player_api_id).first()
-        if profile_row and profile_row.status == "approved":
-            profile = profile_row.public_dict(include_agent_contact=authenticated)
-        elif profile_row and is_owner and profile_row.status == "pending":
-            # Owner sees their unpublished draft with its status; public does not.
-            profile = profile_row.owner_dict()
-        else:
-            profile = None
-
-        reel = _highlight_reel(player_api_id, include_pending=is_owner)
-        photos = _player_photos(player_api_id, include_unapproved=is_owner)
-
-        claimed = PlayerProfileClaim.query.filter_by(player_api_id=player_api_id, status="approved").first() is not None
-
-        return jsonify(
-            {
-                "player_api_id": player_api_id,
-                "profile": profile,
-                "reel": reel,
-                "photos": photos,
-                "affiliations": _player_affiliations(
-                    player_api_id,
-                    include_private=is_owner,
-                ),
-                "verified_footage": _verified_footage(player_api_id),
-                "claim_status": "claimed" if claimed else "unclaimed",
-            }
-        )
+        return jsonify(_subject_showcase_payload(_api_subject(player_api_id)))
     except Exception as e:
         logger.error("Error in get_player_showcase: %s", e)
         return jsonify(_safe_error_payload(e, "Failed to load showcase")), 500
@@ -1022,8 +1366,11 @@ def my_claims():
             db.session.commit()
         out = []
         for claim in claims:
-            payload = claim.to_dict()
-            payload["player_name"] = _resolve_player_name(claim.player_api_id)
+            payload = _profile_claim_dict(claim, include_null_local_id=True)
+            payload["player_name"] = _resolve_claim_player_name(claim)
+            if claim.local_player_id is not None:
+                local_player = db.session.get(LocalPlayer, claim.local_player_id)
+                payload["local_player"] = _local_player_mini_dict(local_player) if local_player else None
             out.append(payload)
         return jsonify({"claims": out})
     except Exception as e:
@@ -1060,7 +1407,7 @@ def verify_my_claim(claim_id: int):
             claim.verification_code = _mint_verification_code()
         _run_claim_proof_check(claim, proof_url)
         db.session.commit()
-        return jsonify({"claim": claim.to_dict()})
+        return jsonify({"claim": _profile_claim_dict(claim)})
     except Exception as e:
         db.session.rollback()
         logger.error("Error in verify_my_claim: %s", e)
@@ -1231,12 +1578,28 @@ def my_club():
                 official_claim,
                 exclude_rejected=True,
             )
-            player_ids = {affiliation.player_api_id for affiliation in eligible_affiliations}
+            player_ids = {
+                affiliation.player_api_id for affiliation in eligible_affiliations if affiliation.player_api_id
+            }
+            local_player_ids = {
+                affiliation.local_player_id for affiliation in eligible_affiliations if affiliation.local_player_id
+            }
+            subject_predicates = []
             if player_ids:
+                subject_predicates.append(
+                    (PlayerProfileClaim.player_api_id.in_(sorted(player_ids)))
+                    & PlayerProfileClaim.local_player_id.is_(None)
+                )
+            if local_player_ids:
+                subject_predicates.append(
+                    (PlayerProfileClaim.local_player_id.in_(sorted(local_player_ids)))
+                    & PlayerProfileClaim.player_api_id.is_(None)
+                )
+            if subject_predicates:
                 player_claims = (
                     PlayerProfileClaim.query.filter(
                         PlayerProfileClaim.status == "pending",
-                        PlayerProfileClaim.player_api_id.in_(sorted(player_ids)),
+                        or_(*subject_predicates),
                     )
                     .order_by(PlayerProfileClaim.created_at.asc(), PlayerProfileClaim.id.asc())
                     .all()
@@ -1344,9 +1707,10 @@ def vouch_for_player_claim(claim_id: int):
         official_claims = _approved_official_claims(user.id)
         if not official_claims:
             return jsonify({"error": "You do not have an approved club-official claim"}), 403
+        subject = _claim_subject(player_claim)
         affiliations = (
             PlayerClubAffiliation.query.filter(
-                PlayerClubAffiliation.player_api_id == player_claim.player_api_id,
+                *_subject_filters(PlayerClubAffiliation, subject),
                 PlayerClubAffiliation.status != "rejected",
             )
             .order_by(PlayerClubAffiliation.created_at.asc(), PlayerClubAffiliation.id.asc())
@@ -1392,8 +1756,19 @@ def vouch_for_player_claim(claim_id: int):
 @limiter.limit("10 per hour", key_func=_user_rate_limit_key)
 def create_player_affiliation(player_api_id: int):
     """Submit one pre-moderated self-reported club affiliation."""
+    return _create_subject_affiliation(_api_subject(player_api_id))
+
+
+@showcase_bp.route("/local-players/<int:lp_id>/showcase/affiliations", methods=["POST"])
+@require_user_auth
+@limiter.limit("10 per hour", key_func=_user_rate_limit_key)
+def create_local_player_affiliation(lp_id: int):
+    return _create_subject_affiliation(_local_subject(lp_id))
+
+
+def _create_subject_affiliation(subject: ShowcaseSubject):
     try:
-        user, error = _approved_claim_or_403(player_api_id)
+        user, error = _approved_subject_claim_or_403(subject)
         if error:
             return error
 
@@ -1427,9 +1802,9 @@ def create_player_affiliation(player_api_id: int):
             if season is not None and len(season) > MAX_AFFILIATION_SEASON_LENGTH:
                 return jsonify({"error": "season must be a string of at most 20 characters"}), 400
 
-        _lock_affiliation_cap(player_api_id)
+        _lock_affiliation_cap_subject(subject)
         duplicate_query = PlayerClubAffiliation.query.filter(
-            PlayerClubAffiliation.player_api_id == player_api_id,
+            *_subject_filters(PlayerClubAffiliation, subject),
             PlayerClubAffiliation.status != "rejected",
         )
         if has_local_club:
@@ -1440,14 +1815,14 @@ def create_player_affiliation(player_api_id: int):
             return jsonify({"error": "This club affiliation has already been submitted"}), 409
 
         active_count = PlayerClubAffiliation.query.filter(
-            PlayerClubAffiliation.player_api_id == player_api_id,
+            *_subject_filters(PlayerClubAffiliation, subject),
             PlayerClubAffiliation.status != "rejected",
         ).count()
         if active_count >= MAX_AFFILIATIONS:
             return jsonify({"error": f"affiliation limit reached ({MAX_AFFILIATIONS})"}), 409
 
         affiliation = PlayerClubAffiliation(
-            player_api_id=player_api_id,
+            **_subject_values(subject),
             local_club_id=local_club_id if has_local_club else None,
             team_api_id=team_api_id if has_api_team else None,
             season=season,
@@ -1470,11 +1845,27 @@ def create_player_affiliation(player_api_id: int):
 @require_user_auth
 def delete_player_affiliation(player_api_id: int, aff_id: int):
     """Delete an affiliation belonging to a player whose profile the caller owns."""
+    return _delete_subject_affiliation(_api_subject(player_api_id), aff_id)
+
+
+@showcase_bp.route(
+    "/local-players/<int:lp_id>/showcase/affiliations/<int:aff_id>",
+    methods=["DELETE"],
+)
+@require_user_auth
+def delete_local_player_affiliation(lp_id: int, aff_id: int):
+    return _delete_subject_affiliation(_local_subject(lp_id), aff_id)
+
+
+def _delete_subject_affiliation(subject: ShowcaseSubject, aff_id: int):
     try:
-        _, error = _approved_claim_or_403(player_api_id)
+        _, error = _approved_subject_claim_or_403(subject)
         if error:
             return error
-        affiliation = PlayerClubAffiliation.query.filter_by(id=aff_id, player_api_id=player_api_id).first()
+        affiliation = PlayerClubAffiliation.query.filter(
+            PlayerClubAffiliation.id == aff_id,
+            *_subject_filters(PlayerClubAffiliation, subject),
+        ).first()
         if affiliation is None:
             return jsonify({"error": "affiliation not found"}), 404
         db.session.delete(affiliation)
@@ -1492,8 +1883,19 @@ def delete_player_affiliation(player_api_id: int, aff_id: int):
 def upsert_showcase_profile(player_api_id: int):
     """Upsert the self-reported profile card. Any edit reverts to pending
     (hidden from public until an admin re-approves)."""
+    return _upsert_subject_showcase_profile(_api_subject(player_api_id))
+
+
+@showcase_bp.route("/local-players/<int:lp_id>/showcase/profile", methods=["PUT"])
+@require_user_auth
+@limiter.limit("20 per hour", key_func=_user_rate_limit_key)
+def upsert_local_showcase_profile(lp_id: int):
+    return _upsert_subject_showcase_profile(_local_subject(lp_id))
+
+
+def _upsert_subject_showcase_profile(subject: ShowcaseSubject):
     try:
-        user, error = _approved_claim_or_403(player_api_id)
+        user, error = _approved_subject_claim_or_403(subject)
         if error:
             return error
 
@@ -1553,9 +1955,9 @@ def upsert_showcase_profile(player_api_id: int):
         nationality_secondary = _clean_optional_text(payload.get("nationality_secondary"), MAX_NATIONALITY_LENGTH)
         languages = _clean_optional_text(payload.get("languages"), MAX_LANGUAGES_LENGTH)
 
-        profile = PlayerShowcaseProfile.query.filter_by(player_api_id=player_api_id).first()
+        profile = PlayerShowcaseProfile.query.filter(*_subject_filters(PlayerShowcaseProfile, subject)).first()
         if profile is None:
-            profile = PlayerShowcaseProfile(player_api_id=player_api_id)
+            profile = PlayerShowcaseProfile(**_subject_values(subject))
             db.session.add(profile)
         profile.bio = bio
         profile.positions = positions
@@ -1583,8 +1985,19 @@ def upsert_showcase_profile(player_api_id: int):
 @limiter.limit("20 per hour", key_func=_user_rate_limit_key)
 def create_showcase_photo(player_api_id: int):
     """Create a private pending-upload row and mint a direct browser PUT URL."""
+    return _create_subject_showcase_photo(_api_subject(player_api_id))
+
+
+@showcase_bp.route("/local-players/<int:lp_id>/showcase/photos", methods=["POST"])
+@require_user_auth
+@limiter.limit("20 per hour", key_func=_user_rate_limit_key)
+def create_local_showcase_photo(lp_id: int):
+    return _create_subject_showcase_photo(_local_subject(lp_id))
+
+
+def _create_subject_showcase_photo(subject: ShowcaseSubject):
     try:
-        user, error = _approved_claim_or_403(player_api_id)
+        user, error = _approved_subject_claim_or_403(subject)
         if error:
             return error
         if not showcase_media_storage.is_configured():
@@ -1605,9 +2018,9 @@ def create_showcase_photo(player_api_id: int):
         if size_bytes > max_bytes:
             return jsonify({"error": f"photo exceeds the {max_bytes // (1024**2)}MB limit"}), 400
 
-        _lock_photo_cap(player_api_id)
+        _lock_photo_cap_subject(subject)
         active_count = PlayerShowcaseMedia.query.filter(
-            PlayerShowcaseMedia.player_api_id == player_api_id,
+            *_subject_filters(PlayerShowcaseMedia, subject),
             PlayerShowcaseMedia.kind == "photo",
             PlayerShowcaseMedia.status != "rejected",
         ).count()
@@ -1615,7 +2028,7 @@ def create_showcase_photo(player_api_id: int):
             return jsonify({"error": f"photo limit reached ({MAX_PHOTOS})"}), 409
 
         media = PlayerShowcaseMedia(
-            player_api_id=player_api_id,
+            **_subject_values(subject),
             kind="photo",
             blob_path="pending",
             content_type=content_type,
@@ -1626,7 +2039,13 @@ def create_showcase_photo(player_api_id: int):
         )
         db.session.add(media)
         db.session.flush()
-        upload = showcase_media_storage.mint_upload(player_api_id, media.id, content_type)
+        path_prefix = f"local-players/{subject.local_player_id}" if subject.is_local else None
+        upload = showcase_media_storage.mint_upload(
+            subject.subject_id,
+            media.id,
+            content_type,
+            path_prefix=path_prefix,
+        )
         media.blob_path = upload["blob_path"]
         db.session.commit()
         return (
@@ -1659,12 +2078,30 @@ def create_showcase_photo(player_api_id: int):
 @limiter.limit("30 per hour", key_func=_user_rate_limit_key)
 def complete_showcase_photo(player_api_id: int, media_id: int):
     """Verify a direct upload and move it into the private moderation queue."""
+    return _complete_subject_showcase_photo(_api_subject(player_api_id), media_id)
+
+
+@showcase_bp.route(
+    "/local-players/<int:lp_id>/showcase/photos/<int:media_id>/complete",
+    methods=["POST"],
+)
+@require_user_auth
+@limiter.limit("30 per hour", key_func=_user_rate_limit_key)
+def complete_local_showcase_photo(lp_id: int, media_id: int):
+    return _complete_subject_showcase_photo(_local_subject(lp_id), media_id)
+
+
+def _complete_subject_showcase_photo(subject: ShowcaseSubject, media_id: int):
     try:
-        _, error = _approved_claim_or_403(player_api_id)
+        _, error = _approved_subject_claim_or_403(subject)
         if error:
             return error
         media = (
-            PlayerShowcaseMedia.query.filter_by(id=media_id, player_api_id=player_api_id, kind="photo")
+            PlayerShowcaseMedia.query.filter(
+                PlayerShowcaseMedia.id == media_id,
+                *_subject_filters(PlayerShowcaseMedia, subject),
+                PlayerShowcaseMedia.kind == "photo",
+            )
             .with_for_update()
             .first()
         )
@@ -1703,8 +2140,19 @@ def complete_showcase_photo(player_api_id: int, media_id: int):
 @limiter.limit("30 per hour", key_func=_user_rate_limit_key)
 def reorder_showcase_photos(player_api_id: int):
     """Reorder approved photos; pending/rejected/foreign ids are ignored."""
+    return _reorder_subject_showcase_photos(_api_subject(player_api_id))
+
+
+@showcase_bp.route("/local-players/<int:lp_id>/showcase/photos/order", methods=["PATCH"])
+@require_user_auth
+@limiter.limit("30 per hour", key_func=_user_rate_limit_key)
+def reorder_local_showcase_photos(lp_id: int):
+    return _reorder_subject_showcase_photos(_local_subject(lp_id))
+
+
+def _reorder_subject_showcase_photos(subject: ShowcaseSubject):
     try:
-        _, error = _approved_claim_or_403(player_api_id)
+        _, error = _approved_subject_claim_or_403(subject)
         if error:
             return error
         payload, payload_error = _json_object_or_400()
@@ -1715,7 +2163,11 @@ def reorder_showcase_photos(player_api_id: int):
             return jsonify({"error": "ordered_ids must be a list"}), 400
 
         approved = (
-            PlayerShowcaseMedia.query.filter_by(player_api_id=player_api_id, kind="photo", status="approved")
+            PlayerShowcaseMedia.query.filter(
+                *_subject_filters(PlayerShowcaseMedia, subject),
+                PlayerShowcaseMedia.kind == "photo",
+                PlayerShowcaseMedia.status == "approved",
+            )
             .order_by(PlayerShowcaseMedia.sort_order.asc(), PlayerShowcaseMedia.id.asc())
             .all()
         )
@@ -1745,8 +2197,19 @@ def reorder_showcase_photos(player_api_id: int):
 @limiter.limit("30 per hour", key_func=_user_rate_limit_key)
 def set_primary_showcase_photo(player_api_id: int, media_id: int):
     """Set one approved photo as primary, clearing every prior primary."""
+    return _set_primary_subject_showcase_photo(_api_subject(player_api_id), media_id)
+
+
+@showcase_bp.route("/local-players/<int:lp_id>/showcase/photos/<int:media_id>", methods=["PATCH"])
+@require_user_auth
+@limiter.limit("30 per hour", key_func=_user_rate_limit_key)
+def set_primary_local_showcase_photo(lp_id: int, media_id: int):
+    return _set_primary_subject_showcase_photo(_local_subject(lp_id), media_id)
+
+
+def _set_primary_subject_showcase_photo(subject: ShowcaseSubject, media_id: int):
     try:
-        _, error = _approved_claim_or_403(player_api_id)
+        _, error = _approved_subject_claim_or_403(subject)
         if error:
             return error
         payload, payload_error = _json_object_or_400()
@@ -1755,7 +2218,11 @@ def set_primary_showcase_photo(player_api_id: int, media_id: int):
         if payload.get("is_primary") is not True:
             return jsonify({"error": "is_primary must be true"}), 400
         media = (
-            PlayerShowcaseMedia.query.filter_by(id=media_id, player_api_id=player_api_id, kind="photo")
+            PlayerShowcaseMedia.query.filter(
+                PlayerShowcaseMedia.id == media_id,
+                *_subject_filters(PlayerShowcaseMedia, subject),
+                PlayerShowcaseMedia.kind == "photo",
+            )
             .with_for_update()
             .first()
         )
@@ -1764,9 +2231,10 @@ def set_primary_showcase_photo(player_api_id: int, media_id: int):
         if media.status != "approved":
             return jsonify({"error": "only approved photos can be primary"}), 409
 
-        PlayerShowcaseMedia.query.filter_by(player_api_id=player_api_id, kind="photo").update(
-            {PlayerShowcaseMedia.is_primary: False}, synchronize_session=False
-        )
+        PlayerShowcaseMedia.query.filter(
+            *_subject_filters(PlayerShowcaseMedia, subject),
+            PlayerShowcaseMedia.kind == "photo",
+        ).update({PlayerShowcaseMedia.is_primary: False}, synchronize_session=False)
         media.is_primary = True
         db.session.commit()
         return jsonify({"media": _media_dict(media)})
@@ -1781,12 +2249,27 @@ def set_primary_showcase_photo(player_api_id: int, media_id: int):
 @limiter.limit("30 per hour", key_func=_user_rate_limit_key)
 def delete_showcase_photo(player_api_id: int, media_id: int):
     """Delete a photo row and both its private and published blob representations."""
+    return _delete_subject_showcase_photo(_api_subject(player_api_id), media_id)
+
+
+@showcase_bp.route("/local-players/<int:lp_id>/showcase/photos/<int:media_id>", methods=["DELETE"])
+@require_user_auth
+@limiter.limit("30 per hour", key_func=_user_rate_limit_key)
+def delete_local_showcase_photo(lp_id: int, media_id: int):
+    return _delete_subject_showcase_photo(_local_subject(lp_id), media_id)
+
+
+def _delete_subject_showcase_photo(subject: ShowcaseSubject, media_id: int):
     try:
-        _, error = _approved_claim_or_403(player_api_id)
+        _, error = _approved_subject_claim_or_403(subject)
         if error:
             return error
         media = (
-            PlayerShowcaseMedia.query.filter_by(id=media_id, player_api_id=player_api_id, kind="photo")
+            PlayerShowcaseMedia.query.filter(
+                PlayerShowcaseMedia.id == media_id,
+                *_subject_filters(PlayerShowcaseMedia, subject),
+                PlayerShowcaseMedia.kind == "photo",
+            )
             .with_for_update()
             .first()
         )
@@ -1815,8 +2298,19 @@ def delete_showcase_photo(player_api_id: int, media_id: int):
 @limiter.limit("30 per hour", key_func=_user_rate_limit_key)
 def add_reel_item(player_api_id: int):
     """Add a pending YouTube highlight to the player's reel (goes to moderation)."""
+    return _add_subject_reel_item(_api_subject(player_api_id))
+
+
+@showcase_bp.route("/local-players/<int:lp_id>/showcase/reel", methods=["POST"])
+@require_user_auth
+@limiter.limit("30 per hour", key_func=_user_rate_limit_key)
+def add_local_reel_item(lp_id: int):
+    return _add_subject_reel_item(_local_subject(lp_id))
+
+
+def _add_subject_reel_item(subject: ShowcaseSubject):
     try:
-        user, error = _approved_claim_or_403(player_api_id)
+        user, error = _approved_subject_claim_or_403(subject)
         if error:
             return error
 
@@ -1831,12 +2325,15 @@ def add_reel_item(player_api_id: int):
         title = _clean_optional_text(payload.get("title"), MAX_TITLE_LENGTH)
 
         # Cap the whole player's reel (any status) so pending submissions can't grow unbounded.
-        count = PlayerLink.query.filter_by(player_id=player_api_id, link_type="highlight").count()
+        count = PlayerLink.query.filter(
+            *_subject_filters(PlayerLink, subject, api_field="player_id"),
+            PlayerLink.link_type == "highlight",
+        ).count()
         if count >= MAX_REEL_ITEMS:
             return jsonify({"error": f"reel limit reached ({MAX_REEL_ITEMS})"}), 400
 
         link = PlayerLink(
-            player_id=player_api_id,
+            **_subject_values(subject, api_field="player_id"),
             user_id=user.id,
             url=raw_url,
             title=title,
@@ -1860,8 +2357,19 @@ def reorder_reel(player_api_id: int):
     """Set sort_order from an ordered id list. Only integer PlayerLink ids that
     belong to this player and are highlights apply; foreign and synthetic
     ``yt-*`` ids are ignored."""
+    return _reorder_subject_reel(_api_subject(player_api_id))
+
+
+@showcase_bp.route("/local-players/<int:lp_id>/showcase/reel/order", methods=["PATCH"])
+@require_user_auth
+@limiter.limit("30 per hour", key_func=_user_rate_limit_key)
+def reorder_local_reel(lp_id: int):
+    return _reorder_subject_reel(_local_subject(lp_id))
+
+
+def _reorder_subject_reel(subject: ShowcaseSubject):
     try:
-        user, error = _approved_claim_or_403(player_api_id)
+        _, error = _approved_subject_claim_or_403(subject)
         if error:
             return error
 
@@ -1871,7 +2379,11 @@ def reorder_reel(player_api_id: int):
             return jsonify({"error": "ordered_ids must be a list"}), 400
 
         own_links = {
-            link.id: link for link in PlayerLink.query.filter_by(player_id=player_api_id, link_type="highlight").all()
+            link.id: link
+            for link in PlayerLink.query.filter(
+                *_subject_filters(PlayerLink, subject, api_field="player_id"),
+                PlayerLink.link_type == "highlight",
+            ).all()
         }
         position = 0
         for link_id in ordered_ids:
@@ -1883,7 +2395,7 @@ def reorder_reel(player_api_id: int):
             link.sort_order = position
             position += 1
         db.session.commit()
-        return jsonify({"reel": _highlight_reel(player_api_id, include_pending=True)})
+        return jsonify({"reel": _subject_highlight_reel(subject, include_pending=True)})
     except Exception as e:
         db.session.rollback()
         logger.error("Error in reorder_reel: %s", e)
@@ -1896,14 +2408,29 @@ def reorder_reel(player_api_id: int):
 def delete_reel_item(player_api_id: int, link_id: int):
     """Delete a reel item — only the submitter or an approved owner of the player.
     Synthetic ``yt-*`` ids never match this integer route (not deletable)."""
+    return _delete_subject_reel_item(_api_subject(player_api_id), link_id)
+
+
+@showcase_bp.route("/local-players/<int:lp_id>/showcase/reel/<int:link_id>", methods=["DELETE"])
+@require_user_auth
+@limiter.limit("30 per hour", key_func=_user_rate_limit_key)
+def delete_local_reel_item(lp_id: int, link_id: int):
+    return _delete_subject_reel_item(_local_subject(lp_id), link_id)
+
+
+def _delete_subject_reel_item(subject: ShowcaseSubject, link_id: int):
     try:
         user = _current_user_account()
         if user is None:
             return jsonify({"error": "auth context missing email"}), 401
-        link = PlayerLink.query.filter_by(id=link_id, player_id=player_api_id, link_type="highlight").first()
+        link = PlayerLink.query.filter(
+            PlayerLink.id == link_id,
+            *_subject_filters(PlayerLink, subject, api_field="player_id"),
+            PlayerLink.link_type == "highlight",
+        ).first()
         if link is None:
             return jsonify({"error": "reel item not found"}), 404
-        if link.user_id != user.id and not _has_approved_claim(player_api_id, user.id):
+        if link.user_id != user.id and not _has_approved_subject_claim(subject, user.id):
             return jsonify({"error": "You are not permitted to delete this reel item"}), 403
         db.session.delete(link)
         db.session.commit()
@@ -2135,6 +2662,323 @@ def admin_link_local_club_api(club_id: int):
         return jsonify(_safe_error_payload(e, "Failed to link local club")), 500
 
 
+@showcase_bp.route("/admin/local-players", methods=["GET"])
+@require_api_key
+def admin_list_local_players():
+    """List local identities with creator email and full moderation metadata."""
+    try:
+        status = (request.args.get("status") or "").strip().lower()
+        query = LocalPlayer.query
+        if status:
+            if status not in LOCAL_PLAYER_STATUSES:
+                return jsonify({"error": f"invalid status; one of {sorted(LOCAL_PLAYER_STATUSES)}"}), 400
+            query = query.filter(LocalPlayer.status == status)
+        players = query.order_by(LocalPlayer.created_at.desc(), LocalPlayer.id.desc()).all()
+        out = []
+        for player in players:
+            payload = _local_player_admin_dict(player)
+            creator = db.session.get(UserAccount, player.created_by_user_id) if player.created_by_user_id else None
+            payload["created_by_email"] = creator.email if creator else None
+            out.append(payload)
+        return jsonify({"players": out})
+    except Exception as e:
+        logger.error("Error in admin_list_local_players: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to load local players")), 500
+
+
+@showcase_bp.route("/admin/local-players/<int:lp_id>/review", methods=["POST"])
+@require_api_key
+def admin_review_local_player(lp_id: int):
+    """Approve or reject a pending local identity."""
+    try:
+        player = LocalPlayer.query.filter_by(id=lp_id).with_for_update().first()
+        if player is None:
+            return jsonify({"error": "local player not found"}), 404
+        payload, payload_error = _json_object_or_400()
+        if payload_error:
+            return payload_error
+        raw_action = payload.get("action")
+        action = raw_action.strip().lower() if isinstance(raw_action, str) else ""
+        if action not in ("approve", "reject"):
+            return jsonify({"error": "action must be approve or reject"}), 400
+        if player.status != "pending":
+            return jsonify({"error": f"cannot {action} a {player.status} local player"}), 409
+
+        now = datetime.now(UTC)
+        player.status = "approved" if action == "approve" else "rejected"
+        player.review_note = _clean_optional_text(payload.get("note"), MAX_REVIEW_NOTE_LENGTH)
+        player.reviewed_by = getattr(g, "user_email", None)
+        player.reviewed_at = now
+        player.updated_at = now
+        db.session.commit()
+        return jsonify({"player": _local_player_admin_dict(player)})
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in admin_review_local_player: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to review local player")), 500
+
+
+_PROFILE_MERGE_FIELDS = (
+    "bio",
+    "positions",
+    "preferred_foot",
+    "height_cm",
+    "contract_status",
+    "contract_until",
+    "availability",
+    "agent_name",
+    "agent_contact_email",
+    "nationality_secondary",
+    "languages",
+)
+_CLAIM_MERGE_STATUS_RANK = {
+    "pending": 0,
+    "approved": 1,
+    "rejected": 2,
+    "revoked": 3,
+}
+_CLAIM_EVIDENCE_STATUS_RANK = {
+    "unverified": 0,
+    "code_not_found": 1,
+    "code_found": 2,
+}
+
+
+def _merge_local_player_claims(source_id: int, target_id: int) -> int:
+    """Move claims while retaining one canonical row per claimant.
+
+    A user may have claimed both duplicate identities before an admin discovers
+    the duplicate. The target row survives. Explicit denial is precedence-safe
+    (revoked/rejected cannot be resurrected), while the strongest independent
+    social-proof evidence and club-vouch provenance are retained.
+    """
+    source_subject = _local_subject(source_id)
+    target_subject = _local_subject(target_id)
+    source_claims = (
+        PlayerProfileClaim.query.filter(*_subject_filters(PlayerProfileClaim, source_subject)).with_for_update().all()
+    )
+    if not source_claims:
+        return 0
+
+    target_claims = (
+        PlayerProfileClaim.query.filter(*_subject_filters(PlayerProfileClaim, target_subject)).with_for_update().all()
+    )
+    target_by_user = {claim.user_account_id: claim for claim in target_claims}
+    for source_claim in source_claims:
+        target_claim = target_by_user.get(source_claim.user_account_id)
+        if target_claim is None:
+            continue
+
+        source_rank = _CLAIM_MERGE_STATUS_RANK.get(source_claim.status, -1)
+        target_rank = _CLAIM_MERGE_STATUS_RANK.get(target_claim.status, -1)
+        source_status_wins = source_rank > target_rank
+        if source_rank == target_rank and source_claim.reviewed_at is not None:
+            source_status_wins = target_claim.reviewed_at is None or source_claim.reviewed_at > target_claim.reviewed_at
+        if source_status_wins:
+            for field in (
+                "relationship_type",
+                "status",
+                "message",
+                "reviewed_by",
+                "reviewed_at",
+            ):
+                setattr(target_claim, field, getattr(source_claim, field))
+        elif target_claim.message is None and source_claim.message is not None:
+            target_claim.message = source_claim.message
+
+        source_evidence_rank = _CLAIM_EVIDENCE_STATUS_RANK.get(source_claim.verification_status, -1)
+        target_evidence_rank = _CLAIM_EVIDENCE_STATUS_RANK.get(target_claim.verification_status, -1)
+        source_evidence_wins = source_evidence_rank > target_evidence_rank
+        if source_evidence_rank == target_evidence_rank:
+            if source_claim.verification_proof_url and not target_claim.verification_proof_url:
+                source_evidence_wins = True
+            elif source_claim.verification_checked_at is not None:
+                source_evidence_wins = (
+                    target_claim.verification_checked_at is None
+                    or source_claim.verification_checked_at > target_claim.verification_checked_at
+                )
+        if source_evidence_wins:
+            for field in (
+                "verification_code",
+                "verification_proof_url",
+                "verification_status",
+                "verification_checked_at",
+            ):
+                setattr(target_claim, field, getattr(source_claim, field))
+
+        if source_claim.verification_method == "vouch" or target_claim.verification_method == "vouch":
+            target_claim.verification_method = "vouch"
+        elif target_claim.verification_method is None:
+            target_claim.verification_method = source_claim.verification_method
+
+        target_note = target_claim.verification_note
+        source_note = source_claim.verification_note
+        if target_note and source_note and target_note != source_note:
+            delimiter = " | "
+            note_budget = VERIFICATION_NOTE_MAX_LENGTH - len(delimiter)
+            target_budget = note_budget // 2
+            target_claim.verification_note = (
+                f"{target_note[:target_budget]}{delimiter}{source_note[: note_budget - target_budget]}"
+            )
+        else:
+            target_claim.verification_note = (target_note or source_note or "")[:VERIFICATION_NOTE_MAX_LENGTH] or None
+
+        if source_claim.created_at and (
+            target_claim.created_at is None or source_claim.created_at < target_claim.created_at
+        ):
+            target_claim.created_at = source_claim.created_at
+        db.session.delete(source_claim)
+
+    # Flush duplicate removals before the bulk move meets the local claimant
+    # uniqueness constraint.
+    db.session.flush()
+    PlayerProfileClaim.query.filter(*_subject_filters(PlayerProfileClaim, source_subject)).update(
+        {PlayerProfileClaim.local_player_id: target_id},
+        synchronize_session=False,
+    )
+    return len(source_claims)
+
+
+def _merge_local_player_profiles(source_id: int, target_id: int, now: datetime) -> int:
+    """Move the source profile, consolidating a target collision safely."""
+    source_subject = _local_subject(source_id)
+    target_subject = _local_subject(target_id)
+    source_profile = (
+        PlayerShowcaseProfile.query.filter(*_subject_filters(PlayerShowcaseProfile, source_subject))
+        .with_for_update()
+        .first()
+    )
+    if source_profile is None:
+        return 0
+
+    target_profile = (
+        PlayerShowcaseProfile.query.filter(*_subject_filters(PlayerShowcaseProfile, target_subject))
+        .with_for_update()
+        .first()
+    )
+    if target_profile is None:
+        return PlayerShowcaseProfile.query.filter(PlayerShowcaseProfile.id == source_profile.id).update(
+            {
+                PlayerShowcaseProfile.local_player_id: target_id,
+                PlayerShowcaseProfile.updated_at: now,
+            },
+            synchronize_session=False,
+        )
+
+    changed = False
+    for field in _PROFILE_MERGE_FIELDS:
+        if getattr(target_profile, field) is None and getattr(source_profile, field) is not None:
+            setattr(target_profile, field, getattr(source_profile, field))
+            changed = True
+    if changed:
+        # Any source-authored material entering the canonical card must pass
+        # through pre-moderation again before becoming public.
+        target_profile.status = "pending"
+        target_profile.reviewed_by = None
+        target_profile.reviewed_at = None
+        target_profile.updated_by_user_id = source_profile.updated_by_user_id
+        target_profile.updated_at = now
+    db.session.delete(source_profile)
+    db.session.flush()
+    return 1
+
+
+@showcase_bp.route("/admin/local-players/<int:lp_id>/merge", methods=["POST"])
+@require_api_key
+def admin_merge_local_player(lp_id: int):
+    """Merge a duplicate and repoint every explicit local showcase key."""
+    try:
+        source = LocalPlayer.query.filter_by(id=lp_id).with_for_update().first()
+        if source is None:
+            return jsonify({"error": "local player not found"}), 404
+        payload, payload_error = _json_object_or_400()
+        if payload_error:
+            return payload_error
+        target_id = payload.get("into_local_player_id")
+        if isinstance(target_id, bool) or not isinstance(target_id, int) or target_id <= 0:
+            return jsonify({"error": "into_local_player_id must be a positive integer"}), 400
+        if target_id == source.id:
+            return jsonify({"error": "A local player cannot be merged into itself"}), 400
+        if source.status in ("merged", "rejected"):
+            return jsonify({"error": f"cannot merge a {source.status} local player"}), 409
+
+        target = LocalPlayer.query.filter_by(id=target_id).with_for_update().first()
+        if target is None or target.status in ("merged", "rejected"):
+            return jsonify({"error": "merge target must be an active local player"}), 400
+
+        now = datetime.now(UTC)
+        claims = _merge_local_player_claims(source.id, target.id)
+        profiles = _merge_local_player_profiles(source.id, target.id, now)
+        media = PlayerShowcaseMedia.query.filter(
+            *_subject_filters(PlayerShowcaseMedia, _local_subject(source.id))
+        ).update(
+            {
+                PlayerShowcaseMedia.local_player_id: target.id,
+                PlayerShowcaseMedia.updated_at: now,
+            },
+            synchronize_session=False,
+        )
+        affiliations = PlayerClubAffiliation.query.filter(
+            *_subject_filters(PlayerClubAffiliation, _local_subject(source.id))
+        ).update(
+            {
+                PlayerClubAffiliation.local_player_id: target.id,
+                PlayerClubAffiliation.updated_at: now,
+            },
+            synchronize_session=False,
+        )
+        links = PlayerLink.query.filter(
+            *_subject_filters(PlayerLink, _local_subject(source.id), api_field="player_id")
+        ).update({PlayerLink.local_player_id: target.id}, synchronize_session=False)
+
+        source.status = "merged"
+        source.merged_into_local_player_id = target.id
+        source.reviewed_by = getattr(g, "user_email", None)
+        source.reviewed_at = now
+        source.updated_at = now
+        db.session.commit()
+        return jsonify(
+            {
+                "player": _local_player_admin_dict(source),
+                "moved": {
+                    "claims": claims,
+                    "profiles": profiles,
+                    "media": media,
+                    "affiliations": affiliations,
+                    "links": links,
+                },
+            }
+        )
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in admin_merge_local_player: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to merge local player")), 500
+
+
+@showcase_bp.route("/admin/local-players/<int:lp_id>/link-api", methods=["POST"])
+@require_api_key
+def admin_link_local_player_api(lp_id: int):
+    """Store a future API-Football bridge without moving or syncing content."""
+    try:
+        player = db.session.get(LocalPlayer, lp_id)
+        if player is None:
+            return jsonify({"error": "local player not found"}), 404
+        payload, payload_error = _json_object_or_400()
+        if payload_error:
+            return payload_error
+        player_api_id = payload.get("player_api_id")
+        if isinstance(player_api_id, bool) or not isinstance(player_api_id, int) or player_api_id <= 0:
+            return jsonify({"error": "player_api_id must be a positive integer"}), 400
+        player.api_player_id = player_api_id
+        player.updated_at = datetime.now(UTC)
+        db.session.commit()
+        return jsonify({"player": _local_player_admin_dict(player)})
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in admin_link_local_player_api: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to link local player")), 500
+
+
 @showcase_bp.route("/admin/showcase/affiliations", methods=["GET"])
 @require_api_key
 def admin_list_affiliations():
@@ -2302,8 +3146,8 @@ def admin_list_claims():
         claims = query.order_by(PlayerProfileClaim.created_at.desc(), PlayerProfileClaim.id.desc()).all()
         out = []
         for claim in claims:
-            payload = claim.to_dict()
-            payload["player_name"] = _resolve_player_name(claim.player_api_id)
+            payload = _profile_claim_dict(claim)
+            payload["player_name"] = _resolve_claim_player_name(claim)
             payload["user_email"] = claim.user.email if claim.user else None
             out.append(payload)
         return jsonify({"claims": out})
@@ -2331,7 +3175,7 @@ def admin_recheck_claim(claim_id: int):
 
         _run_claim_proof_check(claim, proof_url)
         db.session.commit()
-        return jsonify({"claim": claim.to_dict()})
+        return jsonify({"claim": _profile_claim_dict(claim)})
     except Exception as e:
         db.session.rollback()
         logger.error("Error in admin_recheck_claim: %s", e)
@@ -2366,7 +3210,7 @@ def admin_review_claim(claim_id: int):
         claim.reviewed_by = getattr(g, "user_email", None)
         claim.reviewed_at = datetime.now(UTC)
         db.session.commit()
-        return jsonify({"claim": claim.to_dict()})
+        return jsonify({"claim": _profile_claim_dict(claim)})
     except Exception as e:
         db.session.rollback()
         logger.error("Error in admin_review_claim: %s", e)
@@ -2388,7 +3232,11 @@ def admin_list_profiles():
         out = []
         for profile in profiles:
             payload = profile.owner_dict()
-            payload["player_name"] = _resolve_player_name(profile.player_api_id)
+            if profile.local_player_id is not None:
+                local_player = db.session.get(LocalPlayer, profile.local_player_id)
+                payload["player_name"] = local_player.display_name if local_player else None
+            else:
+                payload["player_name"] = _resolve_player_name(profile.player_api_id)
             out.append(payload)
         return jsonify({"profiles": out})
     except Exception as e:
@@ -2400,8 +3248,19 @@ def admin_list_profiles():
 @require_api_key
 def admin_review_profile(player_api_id: int):
     """Approve (publish) or reject (keep hidden/pending) a showcase profile edit."""
+    return _admin_review_subject_profile(_api_subject(player_api_id))
+
+
+@showcase_bp.route("/admin/showcase/local-profiles/<int:lp_id>/review", methods=["POST"])
+@require_api_key
+def admin_review_local_profile(lp_id: int):
+    """Approve or hide a local-player profile edit."""
+    return _admin_review_subject_profile(_local_subject(lp_id))
+
+
+def _admin_review_subject_profile(subject: ShowcaseSubject):
     try:
-        profile = PlayerShowcaseProfile.query.filter_by(player_api_id=player_api_id).first()
+        profile = PlayerShowcaseProfile.query.filter(*_subject_filters(PlayerShowcaseProfile, subject)).first()
         if profile is None:
             return jsonify({"error": "profile not found"}), 404
         payload = request.get_json(silent=True) or {}

--- a/academy-watch-backend/src/routes/showcase.py
+++ b/academy-watch-backend/src/routes/showcase.py
@@ -20,6 +20,7 @@ Reuse decisions (see the build contract):
 
 import logging
 import re
+import secrets
 from datetime import UTC, date, datetime
 from urllib.parse import parse_qs, urlparse
 
@@ -38,7 +39,7 @@ from src.models.league import NewsletterPlayerYoutubeLink, PlayerLink, UserAccou
 from src.models.showcase import PlayerProfileClaim, PlayerShowcaseMedia, PlayerShowcaseProfile
 from src.models.tracked_player import TrackedPlayer
 from src.models.video import VideoMatch, VideoPlayerReport, VideoRosterEntry
-from src.services import showcase_media_storage
+from src.services import showcase_media_storage, social_proof
 from src.services.photo_processing import process_photo
 from src.utils.sanitize import is_safe_https_url, sanitize_plain_text
 
@@ -72,6 +73,8 @@ MIN_HEIGHT_CM = 100
 MAX_HEIGHT_CM = 260
 VERIFIED_FOOTAGE_CAP = 10
 PLAYER_SEARCH_CAP = 20
+VERIFICATION_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+VERIFICATION_NOTE_MAX_LENGTH = 500
 
 # The only identity gate strong enough for public display (see models/video.py).
 VERIFIED_IDENTITY = "human_confirmed"
@@ -183,6 +186,34 @@ def _clean_optional_text(value, max_len: int):
         return None
     cleaned = sanitize_plain_text(value).strip()
     return cleaned[:max_len] if cleaned else None
+
+
+def _mint_verification_code() -> str:
+    """Mint a short code without visually ambiguous 0/O/1/I characters."""
+    return "AW-" + "".join(secrets.choice(VERIFICATION_ALPHABET) for _ in range(8))
+
+
+def _proof_url_error():
+    allowed = ", ".join(social_proof.ALLOWED_SOCIAL_HOSTS)
+    return jsonify(
+        {
+            "error": (
+                "proof_url must be an HTTPS public profile URL on one of: "
+                f"{allowed}; IP addresses, userinfo, and explicit ports are not allowed"
+            )
+        }
+    ), 400
+
+
+def _run_claim_proof_check(claim: PlayerProfileClaim, proof_url: str) -> None:
+    """Apply one advisory social-profile check result to a claim row."""
+    result = social_proof.check_proof(proof_url, claim.verification_code)
+    found = bool(result.get("found"))
+    note = str(result.get("note") or "The public profile could not be checked.")
+    claim.verification_proof_url = proof_url
+    claim.verification_checked_at = datetime.now(UTC)
+    claim.verification_status = "code_found" if found else "code_not_found"
+    claim.verification_note = note[:VERIFICATION_NOTE_MAX_LENGTH]
 
 
 def _json_object_or_400():
@@ -561,6 +592,12 @@ def submit_profile_claim(player_api_id: int):
                 existing.reviewed_by = None
                 existing.reviewed_at = None
                 existing.created_at = datetime.now(UTC)
+                existing.verification_code = _mint_verification_code()
+                existing.verification_proof_url = None
+                existing.verification_status = "unverified"
+                existing.verification_checked_at = None
+                existing.verification_note = None
+                existing.verification_method = None
                 db.session.commit()
                 return jsonify({"claim": existing.to_dict()}), 201
             return jsonify(
@@ -573,6 +610,8 @@ def submit_profile_claim(player_api_id: int):
             relationship_type=relationship_type,
             message=message,
             status="pending",
+            verification_code=_mint_verification_code(),
+            verification_status="unverified",
         )
         db.session.add(claim)
         try:
@@ -607,6 +646,11 @@ def my_claims():
             .order_by(PlayerProfileClaim.created_at.desc(), PlayerProfileClaim.id.desc())
             .all()
         )
+        if any(claim.verification_code is None for claim in claims):
+            for claim in claims:
+                if claim.verification_code is None:
+                    claim.verification_code = _mint_verification_code()
+            db.session.commit()
         out = []
         for claim in claims:
             payload = claim.to_dict()
@@ -614,8 +658,44 @@ def my_claims():
             out.append(payload)
         return jsonify({"claims": out})
     except Exception as e:
+        db.session.rollback()
         logger.error("Error in my_claims: %s", e)
         return jsonify(_safe_error_payload(e, "Failed to load claims")), 500
+
+
+@showcase_bp.route("/me/claims/<int:claim_id>/verify", methods=["POST"])
+@require_user_auth
+@limiter.limit("6 per hour", key_func=_user_rate_limit_key)
+def verify_my_claim(claim_id: int):
+    """Run an advisory social-profile proof check for the caller's pending claim."""
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        claim = PlayerProfileClaim.query.filter_by(id=claim_id, user_account_id=user.id).first()
+        if claim is None:
+            return jsonify({"error": "claim not found"}), 404
+        if claim.status != "pending":
+            return jsonify({"error": f"cannot verify a {claim.status} claim"}), 409
+
+        payload, payload_error = _json_object_or_400()
+        if payload_error:
+            return payload_error
+        raw_proof_url = payload.get("proof_url")
+        proof_url = raw_proof_url.strip() if isinstance(raw_proof_url, str) else ""
+        valid, _ = social_proof.validate_proof_url(proof_url)
+        if not valid or len(proof_url) > MAX_URL_LENGTH:
+            return _proof_url_error()
+
+        if claim.verification_code is None:
+            claim.verification_code = _mint_verification_code()
+        _run_claim_proof_check(claim, proof_url)
+        db.session.commit()
+        return jsonify({"claim": claim.to_dict()})
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in verify_my_claim: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to verify claim proof")), 500
 
 
 # ---------------------------------------------------------------------------
@@ -1170,6 +1250,32 @@ def admin_list_claims():
     except Exception as e:
         logger.error("Error in admin_list_claims: %s", e)
         return jsonify(_safe_error_payload(e, "Failed to load claims")), 500
+
+
+@showcase_bp.route("/admin/showcase/claims/<int:claim_id>/recheck", methods=["POST"])
+@require_api_key
+def admin_recheck_claim(claim_id: int):
+    """Re-run the advisory check against a claim's stored social proof URL."""
+    try:
+        claim = db.session.get(PlayerProfileClaim, claim_id)
+        if claim is None:
+            return jsonify({"error": "claim not found"}), 404
+        proof_url = (claim.verification_proof_url or "").strip()
+        if not proof_url:
+            return jsonify({"error": "claim has no stored proof_url"}), 400
+        valid, _ = social_proof.validate_proof_url(proof_url)
+        if not valid or len(proof_url) > MAX_URL_LENGTH:
+            return _proof_url_error()
+        if claim.verification_code is None:
+            claim.verification_code = _mint_verification_code()
+
+        _run_claim_proof_check(claim, proof_url)
+        db.session.commit()
+        return jsonify({"claim": claim.to_dict()})
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in admin_recheck_claim: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to re-check claim proof")), 500
 
 
 @showcase_bp.route("/admin/showcase/claims/<int:claim_id>/review", methods=["POST"])

--- a/academy-watch-backend/src/routes/showcase.py
+++ b/academy-watch-backend/src/routes/showcase.py
@@ -20,11 +20,11 @@ Reuse decisions (see the build contract):
 
 import logging
 import re
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from urllib.parse import parse_qs, urlparse
 
-from flask import Blueprint, g, jsonify, request
-from sqlalchemy import func
+from flask import Blueprint, g, jsonify, request, send_file
+from sqlalchemy import func, text
 from sqlalchemy.exc import IntegrityError
 from src.auth import (
     _ensure_user_account,
@@ -35,9 +35,11 @@ from src.auth import (
 )
 from src.extensions import limiter
 from src.models.league import NewsletterPlayerYoutubeLink, PlayerLink, UserAccount, db
-from src.models.showcase import PlayerProfileClaim, PlayerShowcaseProfile
+from src.models.showcase import PlayerProfileClaim, PlayerShowcaseMedia, PlayerShowcaseProfile
 from src.models.tracked_player import TrackedPlayer
 from src.models.video import VideoMatch, VideoPlayerReport, VideoRosterEntry
+from src.services import showcase_media_storage
+from src.services.photo_processing import process_photo
 from src.utils.sanitize import is_safe_https_url, sanitize_plain_text
 
 logger = logging.getLogger(__name__)
@@ -47,7 +49,12 @@ showcase_bp = Blueprint("showcase", __name__)
 RELATIONSHIP_TYPES = {"player", "agent", "guardian", "club_official"}
 CLAIM_STATUSES = {"pending", "approved", "rejected", "revoked"}
 PROFILE_STATUSES = {"pending", "approved"}
+MEDIA_STATUSES = {"pending_upload", "pending", "approved", "rejected"}
 PREFERRED_FEET = {"left", "right", "both"}
+CONTRACT_STATUSES = {"under_contract", "expiring", "free_agent"}
+AVAILABILITY_STATUSES = {"open_to_moves", "not_looking", "trial_available"}
+PHOTO_CONTENT_TYPES = {"image/jpeg", "image/png", "image/webp"}
+EMAIL_PATTERN = re.compile(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
 
 MAX_BIO_LENGTH = 2000
 MAX_POSITIONS_LENGTH = 100
@@ -55,6 +62,12 @@ MAX_TITLE_LENGTH = 200
 MAX_MESSAGE_LENGTH = 1000
 MAX_URL_LENGTH = 500
 MAX_REEL_ITEMS = 20
+MAX_PHOTOS = 8
+MAX_AGENT_NAME_LENGTH = 200
+MAX_AGENT_EMAIL_LENGTH = 320
+MAX_NATIONALITY_LENGTH = 100
+MAX_LANGUAGES_LENGTH = 300
+MAX_REVIEW_NOTE_LENGTH = 2000
 MIN_HEIGHT_CM = 100
 MAX_HEIGHT_CM = 260
 VERIFIED_FOOTAGE_CAP = 10
@@ -99,13 +112,12 @@ def _has_approved_claim(player_api_id: int, user_id: int) -> bool:
     )
 
 
-def _optional_owner_user(player_api_id: int):
-    """The authenticated approved owner of this player, or None (optional auth).
+def _optional_authenticated_context():
+    """Best-effort optional Bearer auth for public showcase responses.
 
-    Parses the Bearer manually — mirroring ``require_user_auth`` internals — so a
-    missing / expired / malformed token DEGRADES to the public view instead of
-    401. Returns the UserAccount only when the token is valid AND that user holds
-    an approved claim on the player. Any error → None (never raise).
+    A missing, expired, or malformed token degrades to an anonymous response.
+    The account lookup is intentionally read-only: a public GET never creates a
+    UserAccount merely because a valid token was supplied.
     """
     try:
         auth = request.headers.get("Authorization", "")
@@ -118,7 +130,26 @@ def _optional_owner_user(player_api_id: int):
         email = (data or {}).get("email")
         if not email:
             return None
-        user = UserAccount.query.filter_by(email=email).first()
+        return {
+            "email": email,
+            "role": (data or {}).get("role"),
+            "user": UserAccount.query.filter_by(email=email).first(),
+        }
+    except Exception:
+        return None
+
+
+def _optional_owner_user(player_api_id: int):
+    """The authenticated approved owner of this player, or None (optional auth).
+
+    Parses the Bearer manually — mirroring ``require_user_auth`` internals — so a
+    missing / expired / malformed token DEGRADES to the public view instead of
+    401. Returns the UserAccount only when the token is valid AND that user holds
+    an approved claim on the player. Any error → None (never raise).
+    """
+    try:
+        context = _optional_authenticated_context()
+        user = context["user"] if context else None
         if user is None or not _has_approved_claim(player_api_id, user.id):
             return None
         return user
@@ -152,6 +183,18 @@ def _clean_optional_text(value, max_len: int):
         return None
     cleaned = sanitize_plain_text(value).strip()
     return cleaned[:max_len] if cleaned else None
+
+
+def _json_object_or_400():
+    """Return ``(object, None)`` or a consistent 400 for non-object JSON."""
+    payload = request.get_json(silent=True)
+    if payload is None:
+        if request.is_json and request.get_data(cache=True).strip():
+            return None, (jsonify({"error": "JSON body must be an object"}), 400)
+        return {}, None
+    if not isinstance(payload, dict):
+        return None, (jsonify({"error": "JSON body must be an object"}), 400)
+    return payload, None
 
 
 def _youtube_video_id(url: str) -> str | None:
@@ -205,6 +248,70 @@ def _link_dict(link: PlayerLink) -> dict:
         "source": "user",
         "created_at": link.created_at.isoformat() if link.created_at else None,
     }
+
+
+def _media_dict(media: PlayerShowcaseMedia, *, include_preview: bool = False) -> dict:
+    """Stable media JSON contract shared by public, owner, and admin routes."""
+    payload = {
+        "id": media.id,
+        "player_api_id": media.player_api_id,
+        "kind": media.kind,
+        "status": media.status,
+        "public_url": media.public_url,
+        "content_type": media.content_type,
+        "size_bytes": media.size_bytes,
+        "is_primary": bool(media.is_primary),
+        "sort_order": media.sort_order if media.sort_order is not None else 0,
+        "created_at": media.created_at.isoformat() if media.created_at else None,
+        "review_note": media.review_note,
+    }
+    if include_preview and media.status != "approved":
+        if media.status == "rejected":
+            payload["pending_preview_url"] = None
+        else:
+            try:
+                payload["pending_preview_url"] = showcase_media_storage.pending_preview_url(media.blob_path)
+            except Exception as exc:
+                logger.warning("Unable to mint pending preview for media %s: %s", media.id, exc)
+                payload["pending_preview_url"] = None
+    return payload
+
+
+def _lock_photo_cap(player_api_id: int) -> None:
+    """Serialize photo-row creation per player on PostgreSQL.
+
+    The eight-row cap is a conditional count and cannot be expressed as a
+    portable table constraint. A transaction-scoped advisory lock closes the
+    count-then-insert race in production; SQLite tests remain a no-op.
+    """
+    if db.session.get_bind().dialect.name == "postgresql":
+        db.session.execute(
+            text("SELECT pg_advisory_xact_lock(:namespace, :player_api_id)"),
+            {"namespace": 5_455_001, "player_api_id": player_api_id},
+        )
+
+
+def _cleanup_failed_publication(public_url: str | None, media_id: int) -> None:
+    """Compensate a published blob when moderation cannot commit approval."""
+    if not public_url:
+        return
+    try:
+        showcase_media_storage.delete_published(public_url)
+    except Exception as exc:
+        logger.error("Failed to compensate public blob for media %s: %s", media_id, exc)
+
+
+def _player_photos(player_api_id: int, *, include_unapproved: bool) -> list[dict]:
+    query = PlayerShowcaseMedia.query.filter_by(player_api_id=player_api_id, kind="photo")
+    if not include_unapproved:
+        query = query.filter(PlayerShowcaseMedia.status == "approved")
+    rows = query.order_by(
+        PlayerShowcaseMedia.is_primary.desc(),
+        PlayerShowcaseMedia.sort_order.asc(),
+        PlayerShowcaseMedia.created_at.asc(),
+        PlayerShowcaseMedia.id.asc(),
+    ).all()
+    return [_media_dict(row, include_preview=include_unapproved) for row in rows]
 
 
 def _highlight_reel(player_api_id: int, *, include_pending: bool) -> list[dict]:
@@ -337,11 +444,14 @@ def get_player_showcase(player_api_id: int):
     or bad-token callers get the approved-only public view — never a 401.
     """
     try:
-        is_owner = _optional_owner_user(player_api_id) is not None
+        auth_context = _optional_authenticated_context()
+        authenticated = auth_context is not None
+        auth_user = auth_context["user"] if auth_context else None
+        is_owner = bool(auth_user and _has_approved_claim(player_api_id, auth_user.id))
 
         profile_row = PlayerShowcaseProfile.query.filter_by(player_api_id=player_api_id).first()
         if profile_row and profile_row.status == "approved":
-            profile = profile_row.public_dict()
+            profile = profile_row.public_dict(include_agent_contact=authenticated)
         elif profile_row and is_owner and profile_row.status == "pending":
             # Owner sees their unpublished draft with its status; public does not.
             profile = profile_row.owner_dict()
@@ -349,6 +459,7 @@ def get_player_showcase(player_api_id: int):
             profile = None
 
         reel = _highlight_reel(player_api_id, include_pending=is_owner)
+        photos = _player_photos(player_api_id, include_unapproved=is_owner)
 
         claimed = PlayerProfileClaim.query.filter_by(player_api_id=player_api_id, status="approved").first() is not None
 
@@ -357,6 +468,7 @@ def get_player_showcase(player_api_id: int):
                 "player_api_id": player_api_id,
                 "profile": profile,
                 "reel": reel,
+                "photos": photos,
                 "verified_footage": _verified_footage(player_api_id),
                 "claim_status": "claimed" if claimed else "unclaimed",
             }
@@ -364,6 +476,57 @@ def get_player_showcase(player_api_id: int):
     except Exception as e:
         logger.error("Error in get_player_showcase: %s", e)
         return jsonify(_safe_error_payload(e, "Failed to load showcase")), 500
+
+
+# ---------------------------------------------------------------------------
+# Local development media transport (never active with Azure or in prod/stage)
+# ---------------------------------------------------------------------------
+
+
+@showcase_bp.route("/dev/showcase-media/<path:blob_path>", methods=["PUT"])
+def dev_put_showcase_media(blob_path: str):
+    """Local-dev stand-in for the browser's direct Azure BlockBlob PUT."""
+    if not showcase_media_storage.is_local_dev_enabled():
+        return jsonify({"error": "not found"}), 404
+    if blob_path.startswith("published/"):
+        return jsonify({"error": "invalid blob path"}), 400
+    if request.mimetype not in PHOTO_CONTENT_TYPES:
+        return jsonify({"error": f"Content-Type must be one of {sorted(PHOTO_CONTENT_TYPES)}"}), 400
+
+    max_bytes = showcase_media_storage.max_photo_bytes()
+    if request.content_length is not None and request.content_length > max_bytes:
+        return jsonify({"error": "photo exceeds the upload size limit"}), 413
+    raw = request.stream.read(max_bytes + 1)
+    if not raw:
+        return jsonify({"error": "photo upload is empty"}), 400
+    if len(raw) > max_bytes:
+        return jsonify({"error": "photo exceeds the upload size limit"}), 413
+    try:
+        path = showcase_media_storage.local_pending_path(blob_path, create_parent=True)
+        with path.open("xb") as pending_file:
+            pending_file.write(raw)
+    except FileExistsError:
+        return jsonify({"error": "pending upload already exists"}), 409
+    except (showcase_media_storage.InvalidBlobPathError, showcase_media_storage.StorageNotConfiguredError):
+        return jsonify({"error": "invalid blob path"}), 400
+    return "", 201
+
+
+@showcase_bp.route("/dev/showcase-media/<path:blob_path>", methods=["GET"])
+def dev_get_showcase_media(blob_path: str):
+    """Serve a private preview or approved local artifact during development."""
+    if not showcase_media_storage.is_local_dev_enabled():
+        return jsonify({"error": "not found"}), 404
+    try:
+        path = showcase_media_storage.local_serving_path(blob_path)
+    except (showcase_media_storage.InvalidBlobPathError, showcase_media_storage.StorageNotConfiguredError):
+        return jsonify({"error": "not found"}), 404
+    if not path.is_file():
+        return jsonify({"error": "not found"}), 404
+    response = send_file(path, conditional=True)
+    response.headers["Cache-Control"] = "private, no-store"
+    response.headers["Referrer-Policy"] = "no-referrer"
+    return response
 
 
 # ---------------------------------------------------------------------------
@@ -471,7 +634,9 @@ def upsert_showcase_profile(player_api_id: int):
         if error:
             return error
 
-        payload = request.get_json(silent=True) or {}
+        payload, payload_error = _json_object_or_400()
+        if payload_error:
+            return payload_error
         bio = _clean_optional_text(payload.get("bio"), MAX_BIO_LENGTH)
         positions = _clean_optional_text(payload.get("positions"), MAX_POSITIONS_LENGTH)
 
@@ -488,6 +653,43 @@ def upsert_showcase_profile(player_api_id: int):
             if height_cm < MIN_HEIGHT_CM or height_cm > MAX_HEIGHT_CM:
                 return jsonify({"error": f"height_cm must be between {MIN_HEIGHT_CM} and {MAX_HEIGHT_CM}"}), 400
 
+        contract_status = payload.get("contract_status")
+        if contract_status is not None:
+            contract_status = str(contract_status).strip().lower() or None
+            if contract_status and contract_status not in CONTRACT_STATUSES:
+                return jsonify({"error": f"contract_status must be one of {sorted(CONTRACT_STATUSES)}"}), 400
+
+        availability = payload.get("availability")
+        if availability is not None:
+            availability = str(availability).strip().lower() or None
+            if availability and availability not in AVAILABILITY_STATUSES:
+                return jsonify({"error": f"availability must be one of {sorted(AVAILABILITY_STATUSES)}"}), 400
+
+        contract_until = None
+        raw_contract_until = payload.get("contract_until")
+        if raw_contract_until not in (None, ""):
+            if not isinstance(raw_contract_until, str):
+                return jsonify({"error": "contract_until must be an ISO date (YYYY-MM-DD)"}), 400
+            try:
+                contract_until = date.fromisoformat(raw_contract_until.strip())
+            except ValueError:
+                return jsonify({"error": "contract_until must be an ISO date (YYYY-MM-DD)"}), 400
+
+        raw_agent_email = payload.get("agent_contact_email")
+        agent_contact_email = None
+        if raw_agent_email is not None:
+            if not isinstance(raw_agent_email, str):
+                return jsonify({"error": "agent_contact_email must be a valid email address"}), 400
+            agent_contact_email = sanitize_plain_text(raw_agent_email).strip() or None
+            if agent_contact_email and (
+                len(agent_contact_email) > MAX_AGENT_EMAIL_LENGTH or not EMAIL_PATTERN.fullmatch(agent_contact_email)
+            ):
+                return jsonify({"error": "agent_contact_email must be a valid email address"}), 400
+
+        agent_name = _clean_optional_text(payload.get("agent_name"), MAX_AGENT_NAME_LENGTH)
+        nationality_secondary = _clean_optional_text(payload.get("nationality_secondary"), MAX_NATIONALITY_LENGTH)
+        languages = _clean_optional_text(payload.get("languages"), MAX_LANGUAGES_LENGTH)
+
         profile = PlayerShowcaseProfile.query.filter_by(player_api_id=player_api_id).first()
         if profile is None:
             profile = PlayerShowcaseProfile(player_api_id=player_api_id)
@@ -496,6 +698,13 @@ def upsert_showcase_profile(player_api_id: int):
         profile.positions = positions
         profile.preferred_foot = preferred_foot
         profile.height_cm = height_cm
+        profile.contract_status = contract_status
+        profile.contract_until = contract_until
+        profile.availability = availability
+        profile.agent_name = agent_name
+        profile.agent_contact_email = agent_contact_email
+        profile.nationality_secondary = nationality_secondary
+        profile.languages = languages
         profile.status = "pending"  # owner edit → pending; hidden until re-approved
         profile.updated_by_user_id = user.id
         db.session.commit()
@@ -504,6 +713,238 @@ def upsert_showcase_profile(player_api_id: int):
         db.session.rollback()
         logger.error("Error in upsert_showcase_profile: %s", e)
         return jsonify(_safe_error_payload(e, "Failed to save profile")), 500
+
+
+@showcase_bp.route("/players/<int:player_api_id>/showcase/photos", methods=["POST"])
+@require_user_auth
+@limiter.limit("20 per hour", key_func=_user_rate_limit_key)
+def create_showcase_photo(player_api_id: int):
+    """Create a private pending-upload row and mint a direct browser PUT URL."""
+    try:
+        user, error = _approved_claim_or_403(player_api_id)
+        if error:
+            return error
+        if not showcase_media_storage.is_configured():
+            return jsonify({"error": "Showcase media storage is not configured"}), 503
+
+        payload, payload_error = _json_object_or_400()
+        if payload_error:
+            return payload_error
+        content_type = payload.get("content_type")
+        if not isinstance(content_type, str) or content_type.strip().lower() not in PHOTO_CONTENT_TYPES:
+            return jsonify({"error": f"content_type must be one of {sorted(PHOTO_CONTENT_TYPES)}"}), 400
+        content_type = content_type.strip().lower()
+
+        size_bytes = payload.get("size_bytes")
+        max_bytes = showcase_media_storage.max_photo_bytes()
+        if isinstance(size_bytes, bool) or not isinstance(size_bytes, int) or size_bytes <= 0:
+            return jsonify({"error": "size_bytes must be a positive integer"}), 400
+        if size_bytes > max_bytes:
+            return jsonify({"error": f"photo exceeds the {max_bytes // (1024**2)}MB limit"}), 400
+
+        _lock_photo_cap(player_api_id)
+        active_count = PlayerShowcaseMedia.query.filter(
+            PlayerShowcaseMedia.player_api_id == player_api_id,
+            PlayerShowcaseMedia.kind == "photo",
+            PlayerShowcaseMedia.status != "rejected",
+        ).count()
+        if active_count >= MAX_PHOTOS:
+            return jsonify({"error": f"photo limit reached ({MAX_PHOTOS})"}), 409
+
+        media = PlayerShowcaseMedia(
+            player_api_id=player_api_id,
+            kind="photo",
+            blob_path="pending",
+            content_type=content_type,
+            size_bytes=size_bytes,
+            status="pending_upload",
+            uploaded_by_user_id=user.id,
+            sort_order=active_count,
+        )
+        db.session.add(media)
+        db.session.flush()
+        upload = showcase_media_storage.mint_upload(player_api_id, media.id, content_type)
+        media.blob_path = upload["blob_path"]
+        db.session.commit()
+        return (
+            jsonify(
+                {
+                    "media": _media_dict(media, include_preview=True),
+                    "upload": {
+                        "url": upload["url"],
+                        "method": "PUT",
+                        "headers": upload["headers"],
+                    },
+                }
+            ),
+            201,
+        )
+    except showcase_media_storage.StorageNotConfiguredError:
+        db.session.rollback()
+        return jsonify({"error": "Showcase media storage is not configured"}), 503
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in create_showcase_photo: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to create photo upload")), 500
+
+
+@showcase_bp.route(
+    "/players/<int:player_api_id>/showcase/photos/<int:media_id>/complete",
+    methods=["POST"],
+)
+@require_user_auth
+@limiter.limit("30 per hour", key_func=_user_rate_limit_key)
+def complete_showcase_photo(player_api_id: int, media_id: int):
+    """Verify a direct upload and move it into the private moderation queue."""
+    try:
+        _, error = _approved_claim_or_403(player_api_id)
+        if error:
+            return error
+        media = (
+            PlayerShowcaseMedia.query.filter_by(id=media_id, player_api_id=player_api_id, kind="photo")
+            .with_for_update()
+            .first()
+        )
+        if media is None:
+            return jsonify({"error": "photo not found"}), 404
+        if media.status != "pending_upload":
+            return jsonify({"error": f"cannot complete a {media.status} photo"}), 409
+        if not showcase_media_storage.is_configured():
+            return jsonify({"error": "Showcase media storage is not configured"}), 503
+
+        verification = showcase_media_storage.verify_pending(media.blob_path)
+        if not verification.get("ok"):
+            return jsonify({"error": verification.get("error") or "pending upload could not be verified"}), 400
+        actual_size = verification.get("size_bytes")
+        if not isinstance(actual_size, int) or actual_size <= 0:
+            return jsonify({"error": "pending upload is empty or unreadable"}), 400
+        if actual_size > showcase_media_storage.max_photo_bytes():
+            return jsonify({"error": "pending upload exceeds the photo size limit"}), 400
+
+        media.size_bytes = actual_size
+        media.status = "pending"
+        media.updated_at = datetime.now(UTC)
+        db.session.commit()
+        return jsonify({"media": _media_dict(media, include_preview=True)})
+    except showcase_media_storage.StorageNotConfiguredError:
+        db.session.rollback()
+        return jsonify({"error": "Showcase media storage is not configured"}), 503
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in complete_showcase_photo: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to complete photo upload")), 500
+
+
+@showcase_bp.route("/players/<int:player_api_id>/showcase/photos/order", methods=["PATCH"])
+@require_user_auth
+@limiter.limit("30 per hour", key_func=_user_rate_limit_key)
+def reorder_showcase_photos(player_api_id: int):
+    """Reorder approved photos; pending/rejected/foreign ids are ignored."""
+    try:
+        _, error = _approved_claim_or_403(player_api_id)
+        if error:
+            return error
+        payload, payload_error = _json_object_or_400()
+        if payload_error:
+            return payload_error
+        ordered_ids = payload.get("ordered_ids")
+        if not isinstance(ordered_ids, list):
+            return jsonify({"error": "ordered_ids must be a list"}), 400
+
+        approved = (
+            PlayerShowcaseMedia.query.filter_by(player_api_id=player_api_id, kind="photo", status="approved")
+            .order_by(PlayerShowcaseMedia.sort_order.asc(), PlayerShowcaseMedia.id.asc())
+            .all()
+        )
+        by_id = {media.id: media for media in approved}
+        reordered = []
+        seen = set()
+        for media_id in ordered_ids:
+            if isinstance(media_id, bool) or not isinstance(media_id, int) or media_id in seen:
+                continue
+            media = by_id.get(media_id)
+            if media is not None:
+                reordered.append(media)
+                seen.add(media_id)
+        reordered.extend(media for media in approved if media.id not in seen)
+        for position, media in enumerate(reordered):
+            media.sort_order = position
+        db.session.commit()
+        return jsonify({"photos": [_media_dict(media) for media in reordered]})
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in reorder_showcase_photos: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to reorder photos")), 500
+
+
+@showcase_bp.route("/players/<int:player_api_id>/showcase/photos/<int:media_id>", methods=["PATCH"])
+@require_user_auth
+@limiter.limit("30 per hour", key_func=_user_rate_limit_key)
+def set_primary_showcase_photo(player_api_id: int, media_id: int):
+    """Set one approved photo as primary, clearing every prior primary."""
+    try:
+        _, error = _approved_claim_or_403(player_api_id)
+        if error:
+            return error
+        payload, payload_error = _json_object_or_400()
+        if payload_error:
+            return payload_error
+        if payload.get("is_primary") is not True:
+            return jsonify({"error": "is_primary must be true"}), 400
+        media = (
+            PlayerShowcaseMedia.query.filter_by(id=media_id, player_api_id=player_api_id, kind="photo")
+            .with_for_update()
+            .first()
+        )
+        if media is None:
+            return jsonify({"error": "photo not found"}), 404
+        if media.status != "approved":
+            return jsonify({"error": "only approved photos can be primary"}), 409
+
+        PlayerShowcaseMedia.query.filter_by(player_api_id=player_api_id, kind="photo").update(
+            {PlayerShowcaseMedia.is_primary: False}, synchronize_session=False
+        )
+        media.is_primary = True
+        db.session.commit()
+        return jsonify({"media": _media_dict(media)})
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in set_primary_showcase_photo: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to set primary photo")), 500
+
+
+@showcase_bp.route("/players/<int:player_api_id>/showcase/photos/<int:media_id>", methods=["DELETE"])
+@require_user_auth
+@limiter.limit("30 per hour", key_func=_user_rate_limit_key)
+def delete_showcase_photo(player_api_id: int, media_id: int):
+    """Delete a photo row and both its private and published blob representations."""
+    try:
+        _, error = _approved_claim_or_403(player_api_id)
+        if error:
+            return error
+        media = (
+            PlayerShowcaseMedia.query.filter_by(id=media_id, player_api_id=player_api_id, kind="photo")
+            .with_for_update()
+            .first()
+        )
+        if media is None:
+            return jsonify({"error": "photo not found"}), 404
+        if not showcase_media_storage.is_configured():
+            return jsonify({"error": "Showcase media storage is not configured"}), 503
+
+        showcase_media_storage.delete_pending(media.blob_path)
+        if media.public_url:
+            showcase_media_storage.delete_published(media.public_url)
+        db.session.delete(media)
+        db.session.commit()
+        return jsonify({"deleted": True})
+    except showcase_media_storage.StorageNotConfiguredError:
+        db.session.rollback()
+        return jsonify({"error": "Showcase media storage is not configured"}), 503
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in delete_showcase_photo: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to delete photo")), 500
 
 
 @showcase_bp.route("/players/<int:player_api_id>/showcase/reel", methods=["POST"])
@@ -611,8 +1052,100 @@ def delete_reel_item(player_api_id: int, link_id: int):
 
 
 # ---------------------------------------------------------------------------
-# Admin — claim + profile review
+# Admin — media, claim + profile review
 # ---------------------------------------------------------------------------
+
+
+@showcase_bp.route("/admin/showcase/media", methods=["GET"])
+@require_api_key
+def admin_list_showcase_media():
+    """List showcase media, optionally filtered by lifecycle status."""
+    try:
+        status = (request.args.get("status") or "").strip().lower()
+        query = PlayerShowcaseMedia.query.filter_by(kind="photo")
+        if status:
+            if status not in MEDIA_STATUSES:
+                return jsonify({"error": f"invalid status; one of {sorted(MEDIA_STATUSES)}"}), 400
+            query = query.filter(PlayerShowcaseMedia.status == status)
+        rows = query.order_by(PlayerShowcaseMedia.created_at.desc(), PlayerShowcaseMedia.id.desc()).all()
+        return jsonify({"media": [_media_dict(row, include_preview=True) for row in rows]})
+    except Exception as e:
+        logger.error("Error in admin_list_showcase_media: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to load showcase media")), 500
+
+
+@showcase_bp.route("/admin/showcase/media/<int:media_id>/review", methods=["POST"])
+@require_api_key
+def admin_review_showcase_media(media_id: int):
+    """Approve a processed photo for publication or reject its pending blob."""
+    published_url = None
+    try:
+        media = PlayerShowcaseMedia.query.filter_by(id=media_id).with_for_update().first()
+        if media is None or media.kind != "photo":
+            return jsonify({"error": "photo not found"}), 404
+
+        payload, payload_error = _json_object_or_400()
+        if payload_error:
+            return payload_error
+        raw_action = payload.get("action")
+        action = raw_action.strip().lower() if isinstance(raw_action, str) else ""
+        if action not in ("approve", "reject"):
+            return jsonify({"error": "action must be approve or reject"}), 400
+        if media.status != "pending":
+            return jsonify({"error": f"cannot {action} a {media.status} photo"}), 409
+        note = _clean_optional_text(payload.get("note"), MAX_REVIEW_NOTE_LENGTH)
+        if not showcase_media_storage.is_configured():
+            return jsonify({"error": "Showcase media storage is not configured"}), 503
+
+        if action == "approve":
+            try:
+                raw = showcase_media_storage.read_pending_bytes(media.blob_path)
+                processed, content_type = process_photo(raw)
+                published_url = showcase_media_storage.publish(media.blob_path, processed, content_type)
+                # Approval is not durable until the original (which can carry
+                # minors' EXIF/GPS) is gone. A failure compensates the public
+                # write and leaves the row pending for a safe retry.
+                showcase_media_storage.delete_pending(media.blob_path)
+            except showcase_media_storage.StorageNotConfiguredError:
+                db.session.rollback()
+                _cleanup_failed_publication(published_url, media.id)
+                return jsonify({"error": "Showcase media storage is not configured"}), 503
+            except Exception as exc:
+                db.session.rollback()
+                _cleanup_failed_publication(published_url, media.id)
+                logger.warning("Photo processing/publish failed for media %s: %s", media.id, exc)
+                return jsonify({"error": "Photo could not be processed or published"}), 422
+
+            media.public_url = published_url
+            media.content_type = content_type
+            media.size_bytes = len(processed)
+            media.status = "approved"
+        else:
+            try:
+                showcase_media_storage.delete_pending(media.blob_path)
+            except showcase_media_storage.StorageNotConfiguredError:
+                db.session.rollback()
+                return jsonify({"error": "Showcase media storage is not configured"}), 503
+            except Exception as exc:
+                db.session.rollback()
+                logger.warning("Pending photo delete failed for rejected media %s: %s", media.id, exc)
+                return jsonify({"error": "Photo could not be rejected because its upload could not be deleted"}), 422
+            media.status = "rejected"
+            media.public_url = None
+            media.is_primary = False
+
+        media.review_note = note
+        media.reviewed_by = getattr(g, "user_email", None)
+        media.reviewed_at = datetime.now(UTC)
+        media.updated_at = datetime.now(UTC)
+        db.session.commit()
+        published_url = None
+        return jsonify({"media": _media_dict(media, include_preview=action == "reject")})
+    except Exception as e:
+        db.session.rollback()
+        _cleanup_failed_publication(published_url, media_id)
+        logger.error("Error in admin_review_showcase_media: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to review showcase media")), 500
 
 
 @showcase_bp.route("/admin/showcase/claims", methods=["GET"])

--- a/academy-watch-backend/src/routes/showcase.py
+++ b/academy-watch-backend/src/routes/showcase.py
@@ -37,6 +37,7 @@ from src.auth import (
 from src.extensions import limiter
 from src.models.league import NewsletterPlayerYoutubeLink, PlayerLink, Team, UserAccount, db
 from src.models.showcase import (
+    ClubOfficialClaim,
     LocalClub,
     PlayerClubAffiliation,
     PlayerProfileClaim,
@@ -55,6 +56,7 @@ showcase_bp = Blueprint("showcase", __name__)
 
 RELATIONSHIP_TYPES = {"player", "agent", "guardian", "club_official"}
 CLAIM_STATUSES = {"pending", "approved", "rejected", "revoked"}
+CLUB_OFFICIAL_CLAIM_STATUSES = {"pending", "approved", "rejected", "revoked"}
 PROFILE_STATUSES = {"pending", "approved"}
 MEDIA_STATUSES = {"pending_upload", "pending", "approved", "rejected"}
 PREFERRED_FEET = {"left", "right", "both"}
@@ -90,6 +92,7 @@ MAX_LOCAL_CLUB_COUNTRY_LENGTH = 100
 MAX_LOCAL_CLUB_CITY_LENGTH = 120
 MAX_AFFILIATION_SEASON_LENGTH = 20
 MAX_AFFILIATIONS = 5
+MAX_CLUB_ROLE_TITLE_LENGTH = 100
 
 # The only identity gate strong enough for public display (see models/video.py).
 VERIFIED_IDENTITY = "human_confirmed"
@@ -234,7 +237,7 @@ def _proof_url_error():
     ), 400
 
 
-def _run_claim_proof_check(claim: PlayerProfileClaim, proof_url: str) -> None:
+def _run_claim_proof_check(claim: PlayerProfileClaim | ClubOfficialClaim, proof_url: str) -> None:
     """Apply one advisory social-profile check result to a claim row."""
     result = social_proof.check_proof(proof_url, claim.verification_code)
     found = bool(result.get("found"))
@@ -371,18 +374,125 @@ def _local_club_search_dict(club: LocalClub) -> dict:
     }
 
 
+def _latest_team_name(team_api_id: int | None) -> str | None:
+    """Resolve an API-Football team's latest-season display name."""
+    if team_api_id is None:
+        return None
+    team = Team.query.filter_by(team_id=team_api_id).order_by(Team.season.desc(), Team.id.desc()).first()
+    return team.name if team else None
+
+
+def _resolved_local_club(local_club_id: int | None) -> LocalClub | None:
+    """Resolve one local-club merge hop for display and matching."""
+    club = db.session.get(LocalClub, local_club_id) if local_club_id else None
+    if club and club.status == "merged" and club.merged_into_local_club_id:
+        return db.session.get(LocalClub, club.merged_into_local_club_id) or club
+    return club
+
+
+def _club_reference_name(*, team_api_id: int | None, local_club_id: int | None) -> str | None:
+    if team_api_id is not None:
+        return _latest_team_name(team_api_id)
+    club = _resolved_local_club(local_club_id)
+    return club.name if club else None
+
+
+def _club_claim_dict(claim: ClubOfficialClaim, *, include_verification_code: bool = True) -> dict:
+    """Serialize an official claim while making code exposure explicit."""
+    payload = claim.to_dict()
+    if not include_verification_code:
+        payload.pop("verification_code", None)
+    payload["club_name"] = _club_reference_name(
+        team_api_id=claim.team_api_id,
+        local_club_id=claim.local_club_id,
+    )
+    return payload
+
+
+def _player_claim_for_official_dict(claim: PlayerProfileClaim) -> dict:
+    """Cross-user claim shape: verification result is visible, secret code is not."""
+    payload = claim.to_dict()
+    payload.pop("verification_code", None)
+    payload["player_name"] = _resolve_player_name(claim.player_api_id)
+    return payload
+
+
+def _local_club_match_ids(local_club_id: int | None) -> set[int]:
+    """Ids equivalent to a local club under the single-hop merge rule."""
+    if local_club_id is None:
+        return set()
+    original = db.session.get(LocalClub, local_club_id)
+    canonical_id = local_club_id
+    if original and original.status == "merged" and original.merged_into_local_club_id:
+        canonical_id = original.merged_into_local_club_id
+
+    ids = {local_club_id, canonical_id}
+    merged_sources = (
+        db.session.query(LocalClub.id)
+        .filter(
+            LocalClub.status == "merged",
+            LocalClub.merged_into_local_club_id == canonical_id,
+        )
+        .all()
+    )
+    ids.update(row[0] for row in merged_sources)
+    return ids
+
+
+def _club_claim_matches_affiliation(claim: ClubOfficialClaim, affiliation: PlayerClubAffiliation) -> bool:
+    """Whether an approved official claim covers an affiliation's club."""
+    if claim.team_api_id is not None:
+        return affiliation.team_api_id == claim.team_api_id
+    if claim.local_club_id is None or affiliation.local_club_id is None:
+        return False
+    return affiliation.local_club_id in _local_club_match_ids(claim.local_club_id)
+
+
+def _approved_official_claims(user_id: int) -> list[ClubOfficialClaim]:
+    return (
+        ClubOfficialClaim.query.filter_by(user_account_id=user_id, status="approved")
+        .order_by(ClubOfficialClaim.created_at.asc(), ClubOfficialClaim.id.asc())
+        .all()
+    )
+
+
+def _matching_approved_official_claim(
+    user_id: int,
+    affiliation: PlayerClubAffiliation,
+) -> ClubOfficialClaim | None:
+    for claim in _approved_official_claims(user_id):
+        if _club_claim_matches_affiliation(claim, affiliation):
+            return claim
+    return None
+
+
+def _affiliations_for_club_claim(
+    claim: ClubOfficialClaim,
+    *,
+    statuses: set[str] | None = None,
+    exclude_rejected: bool = False,
+) -> list[PlayerClubAffiliation]:
+    query = PlayerClubAffiliation.query
+    if claim.team_api_id is not None:
+        query = query.filter(PlayerClubAffiliation.team_api_id == claim.team_api_id)
+    elif claim.local_club_id is not None:
+        match_ids = sorted(_local_club_match_ids(claim.local_club_id))
+        query = query.filter(PlayerClubAffiliation.local_club_id.in_(match_ids))
+    else:
+        return []
+    if statuses is not None:
+        query = query.filter(PlayerClubAffiliation.status.in_(statuses))
+    elif exclude_rejected:
+        query = query.filter(PlayerClubAffiliation.status != "rejected")
+    return query.order_by(PlayerClubAffiliation.created_at.asc(), PlayerClubAffiliation.id.asc()).all()
+
+
 def _affiliation_club_name(affiliation: PlayerClubAffiliation) -> str | None:
     """Resolve the display club, following one local-club merge hop."""
-    if affiliation.team_api_id is not None:
-        team = (
-            Team.query.filter_by(team_id=affiliation.team_api_id).order_by(Team.season.desc(), Team.id.desc()).first()
-        )
-        return team.name if team else None
-
-    club = db.session.get(LocalClub, affiliation.local_club_id) if affiliation.local_club_id else None
-    if club and club.status == "merged" and club.merged_into_local_club_id:
-        club = db.session.get(LocalClub, club.merged_into_local_club_id) or club
-    return club.name if club else None
+    return _club_reference_name(
+        team_api_id=affiliation.team_api_id,
+        local_club_id=affiliation.local_club_id,
+    )
 
 
 def _affiliation_dict(affiliation: PlayerClubAffiliation, *, include_review_note: bool = False) -> dict:
@@ -430,6 +540,15 @@ def _lock_affiliation_cap(player_api_id: int) -> None:
         db.session.execute(
             text("SELECT pg_advisory_xact_lock(:namespace, :player_api_id)"),
             {"namespace": 5_455_002, "player_api_id": player_api_id},
+        )
+
+
+def _lock_club_claims(user_id: int) -> None:
+    """Serialize active-club duplicate checks per claimant on PostgreSQL."""
+    if db.session.get_bind().dialect.name == "postgresql":
+        db.session.execute(
+            text("SELECT pg_advisory_xact_lock(:namespace, :user_id)"),
+            {"namespace": 5_455_003, "user_id": user_id},
         )
 
 
@@ -946,6 +1065,321 @@ def verify_my_claim(claim_id: int):
         db.session.rollback()
         logger.error("Error in verify_my_claim: %s", e)
         return jsonify(_safe_error_payload(e, "Failed to verify claim proof")), 500
+
+
+# ---------------------------------------------------------------------------
+# User-authed — club-official claims and My Club trust actions
+# ---------------------------------------------------------------------------
+
+
+@showcase_bp.route("/clubs/claim", methods=["POST"])
+@require_user_auth
+@limiter.limit("5 per hour", key_func=_user_rate_limit_key)
+def submit_club_official_claim():
+    """Submit a pending claim to represent one API team or local club."""
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+
+        payload, payload_error = _json_object_or_400()
+        if payload_error:
+            return payload_error
+
+        local_club_id = payload.get("local_club_id")
+        team_api_id = payload.get("team_api_id")
+        has_local_club = local_club_id is not None
+        has_api_team = team_api_id is not None
+        if has_local_club == has_api_team:
+            return jsonify({"error": "exactly one of local_club_id or team_api_id is required"}), 400
+
+        if has_local_club:
+            if isinstance(local_club_id, bool) or not isinstance(local_club_id, int) or local_club_id <= 0:
+                return jsonify({"error": "local_club_id must reference an active local club"}), 400
+            local_club = db.session.get(LocalClub, local_club_id)
+            if local_club is None or local_club.status in ("merged", "rejected"):
+                return jsonify({"error": "local_club_id must reference an active local club"}), 400
+        elif isinstance(team_api_id, bool) or not isinstance(team_api_id, int) or team_api_id <= 0:
+            return jsonify({"error": "team_api_id must be a positive integer"}), 400
+
+        raw_role_title = payload.get("role_title")
+        if not isinstance(raw_role_title, str):
+            return jsonify({"error": "role_title is required and must be a string"}), 400
+        role_title = _sanitize_text(raw_role_title).strip()
+        if not 2 <= len(role_title) <= MAX_CLUB_ROLE_TITLE_LENGTH:
+            return jsonify({"error": "role_title must be between 2 and 100 characters"}), 400
+
+        raw_message = payload.get("message")
+        if raw_message is not None and not isinstance(raw_message, str):
+            return jsonify({"error": "message must be a string of at most 1000 characters"}), 400
+        message = _sanitize_text(raw_message).strip() if isinstance(raw_message, str) else None
+        message = message or None
+        if message is not None and len(message) > MAX_MESSAGE_LENGTH:
+            return jsonify({"error": "message must be a string of at most 1000 characters"}), 400
+
+        _lock_club_claims(user.id)
+        duplicate_query = ClubOfficialClaim.query.filter(
+            ClubOfficialClaim.user_account_id == user.id,
+            ClubOfficialClaim.status.in_(("pending", "approved")),
+        )
+        if has_local_club:
+            duplicate_query = duplicate_query.filter(
+                ClubOfficialClaim.local_club_id.in_(sorted(_local_club_match_ids(local_club_id)))
+            )
+        else:
+            duplicate_query = duplicate_query.filter(ClubOfficialClaim.team_api_id == team_api_id)
+        if duplicate_query.first() is not None:
+            return jsonify({"error": "You already have an active claim for this club"}), 409
+
+        claim = ClubOfficialClaim(
+            user_account_id=user.id,
+            team_api_id=team_api_id if has_api_team else None,
+            local_club_id=local_club_id if has_local_club else None,
+            role_title=role_title,
+            message=message,
+            status="pending",
+            verification_code=_mint_verification_code(),
+            verification_status="unverified",
+        )
+        db.session.add(claim)
+        db.session.commit()
+        return jsonify({"claim": _club_claim_dict(claim)}), 201
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in submit_club_official_claim: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to submit club-official claim")), 500
+
+
+@showcase_bp.route("/me/club-claims", methods=["GET"])
+@require_user_auth
+def my_club_claims():
+    """The caller's club-official claims, including their own verification codes."""
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        claims = (
+            ClubOfficialClaim.query.filter_by(user_account_id=user.id)
+            .order_by(ClubOfficialClaim.created_at.desc(), ClubOfficialClaim.id.desc())
+            .all()
+        )
+        if any(claim.verification_code is None for claim in claims):
+            for claim in claims:
+                if claim.verification_code is None:
+                    claim.verification_code = _mint_verification_code()
+                    claim.updated_at = datetime.now(UTC)
+            db.session.commit()
+        return jsonify({"claims": [_club_claim_dict(claim) for claim in claims]})
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in my_club_claims: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to load club-official claims")), 500
+
+
+@showcase_bp.route("/me/club-claims/<int:claim_id>/verify", methods=["POST"])
+@require_user_auth
+@limiter.limit("6 per hour", key_func=_user_rate_limit_key)
+def verify_my_club_claim(claim_id: int):
+    """Run an advisory social-profile proof check for the caller's club claim."""
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        claim = ClubOfficialClaim.query.filter_by(id=claim_id, user_account_id=user.id).first()
+        if claim is None:
+            return jsonify({"error": "club-official claim not found"}), 404
+        if claim.status != "pending":
+            return jsonify({"error": f"cannot verify a {claim.status} club-official claim"}), 409
+
+        payload, payload_error = _json_object_or_400()
+        if payload_error:
+            return payload_error
+        raw_proof_url = payload.get("proof_url")
+        proof_url = raw_proof_url.strip() if isinstance(raw_proof_url, str) else ""
+        valid, _ = social_proof.validate_proof_url(proof_url)
+        if not valid or len(proof_url) > MAX_URL_LENGTH:
+            return _proof_url_error()
+
+        if claim.verification_code is None:
+            claim.verification_code = _mint_verification_code()
+        _run_claim_proof_check(claim, proof_url)
+        claim.updated_at = datetime.now(UTC)
+        db.session.commit()
+        return jsonify({"claim": _club_claim_dict(claim, include_verification_code=False)})
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in verify_my_club_claim: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to verify club-official claim proof")), 500
+
+
+@showcase_bp.route("/me/club", methods=["GET"])
+@require_user_auth
+def my_club():
+    """Approved club workspaces with affiliation review and vouch candidates."""
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+
+        clubs = []
+        for official_claim in _approved_official_claims(user.id):
+            pending_affiliations = _affiliations_for_club_claim(
+                official_claim,
+                statuses={"pending", "self_reported"},
+            )
+            eligible_affiliations = _affiliations_for_club_claim(
+                official_claim,
+                exclude_rejected=True,
+            )
+            player_ids = {affiliation.player_api_id for affiliation in eligible_affiliations}
+            if player_ids:
+                player_claims = (
+                    PlayerProfileClaim.query.filter(
+                        PlayerProfileClaim.status == "pending",
+                        PlayerProfileClaim.player_api_id.in_(sorted(player_ids)),
+                    )
+                    .order_by(PlayerProfileClaim.created_at.asc(), PlayerProfileClaim.id.asc())
+                    .all()
+                )
+            else:
+                player_claims = []
+
+            club_name = _club_reference_name(
+                team_api_id=official_claim.team_api_id,
+                local_club_id=official_claim.local_club_id,
+            )
+            clubs.append(
+                {
+                    # This workspace is caller-owned but not one of the explicit
+                    # claim-code surfaces; keep exposure narrowly allowlisted.
+                    "claim": _club_claim_dict(official_claim, include_verification_code=False),
+                    "club_name": club_name,
+                    "pending_affiliations": [
+                        _affiliation_dict(affiliation, include_review_note=True) for affiliation in pending_affiliations
+                    ],
+                    "vouchable_player_claims": [_player_claim_for_official_dict(claim) for claim in player_claims],
+                }
+            )
+        return jsonify({"clubs": clubs})
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in my_club: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to load club workspace")), 500
+
+
+def _official_affiliation_action(aff_id: int, *, target_status: str, note: str | None = None):
+    """Apply a club-confirm/reject transition after the shared official gate."""
+    user = _current_user_account()
+    if user is None:
+        return jsonify({"error": "auth context missing email"}), 401
+    affiliation = PlayerClubAffiliation.query.filter_by(id=aff_id).with_for_update().first()
+    if affiliation is None:
+        return jsonify({"error": "affiliation not found"}), 404
+    if _matching_approved_official_claim(user.id, affiliation) is None:
+        return jsonify({"error": "You are not an approved official for this club"}), 403
+    if affiliation.status not in ("pending", "self_reported"):
+        action = "confirm" if target_status == "club_confirmed" else "reject"
+        return jsonify({"error": f"cannot {action} a {affiliation.status} affiliation"}), 409
+
+    now = datetime.now(UTC)
+    affiliation.status = target_status
+    if target_status == "rejected":
+        affiliation.review_note = note
+    affiliation.reviewed_by = getattr(g, "user_email", None)
+    affiliation.reviewed_at = now
+    affiliation.updated_at = now
+    db.session.commit()
+    return jsonify({"affiliation": _affiliation_dict(affiliation, include_review_note=True)})
+
+
+@showcase_bp.route("/me/club/affiliations/<int:aff_id>/confirm", methods=["POST"])
+@require_user_auth
+@limiter.limit("30 per hour", key_func=_user_rate_limit_key)
+def confirm_club_affiliation(aff_id: int):
+    """Confirm a pending/self-reported affiliation for the caller's club."""
+    try:
+        return _official_affiliation_action(aff_id, target_status="club_confirmed")
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in confirm_club_affiliation: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to confirm affiliation")), 500
+
+
+@showcase_bp.route("/me/club/affiliations/<int:aff_id>/reject", methods=["POST"])
+@require_user_auth
+@limiter.limit("30 per hour", key_func=_user_rate_limit_key)
+def reject_club_affiliation(aff_id: int):
+    """Reject a pending/self-reported affiliation for the caller's club."""
+    try:
+        payload, payload_error = _json_object_or_400()
+        if payload_error:
+            return payload_error
+        note = _clean_optional_text(payload.get("note"), MAX_REVIEW_NOTE_LENGTH)
+        return _official_affiliation_action(aff_id, target_status="rejected", note=note)
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in reject_club_affiliation: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to reject affiliation")), 500
+
+
+@showcase_bp.route("/me/club/player-claims/<int:claim_id>/vouch", methods=["POST"])
+@require_user_auth
+@limiter.limit("10 per hour", key_func=_user_rate_limit_key)
+def vouch_for_player_claim(claim_id: int):
+    """Approve a player's IDENTITY via a verified club official.
+
+    Vouching never approves profile content: every owner-authored bio, reel item,
+    photo, and other showcase content remains pre-moderated.
+    """
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        player_claim = PlayerProfileClaim.query.filter_by(id=claim_id).with_for_update().first()
+        if player_claim is None:
+            return jsonify({"error": "player claim not found"}), 404
+        if player_claim.status != "pending":
+            return jsonify({"error": f"cannot vouch for a {player_claim.status} player claim"}), 409
+
+        official_claims = _approved_official_claims(user.id)
+        if not official_claims:
+            return jsonify({"error": "You do not have an approved club-official claim"}), 403
+        affiliations = (
+            PlayerClubAffiliation.query.filter(
+                PlayerClubAffiliation.player_api_id == player_claim.player_api_id,
+                PlayerClubAffiliation.status != "rejected",
+            )
+            .order_by(PlayerClubAffiliation.created_at.asc(), PlayerClubAffiliation.id.asc())
+            .all()
+        )
+        matching_official = next(
+            (
+                official
+                for official in official_claims
+                if any(_club_claim_matches_affiliation(official, affiliation) for affiliation in affiliations)
+            ),
+            None,
+        )
+        if matching_official is None:
+            return jsonify({"error": "The player has no eligible affiliation with one of your clubs"}), 403
+
+        club_name = _club_reference_name(
+            team_api_id=matching_official.team_api_id,
+            local_club_id=matching_official.local_club_id,
+        )
+        descriptor = f"{club_name} " if club_name else ""
+        now = datetime.now(UTC)
+        player_claim.status = "approved"
+        player_claim.verification_method = "vouch"
+        player_claim.verification_note = f"Vouched by a verified {descriptor}official"[:VERIFICATION_NOTE_MAX_LENGTH]
+        player_claim.reviewed_by = getattr(g, "user_email", None)
+        player_claim.reviewed_at = now
+        db.session.commit()
+        return jsonify({"claim": _player_claim_for_official_dict(player_claim)})
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in vouch_for_player_claim: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to vouch for player claim")), 500
 
 
 # ---------------------------------------------------------------------------
@@ -1481,8 +1915,97 @@ def delete_reel_item(player_api_id: int, link_id: int):
 
 
 # ---------------------------------------------------------------------------
-# Admin — local clubs + affiliation review
+# Admin — club-official claims, local clubs + affiliation review
 # ---------------------------------------------------------------------------
+
+
+@showcase_bp.route("/admin/club-claims", methods=["GET"])
+@require_api_key
+def admin_list_club_claims():
+    """List club-official claims, optionally filtered by lifecycle status."""
+    try:
+        status = (request.args.get("status") or "").strip().lower()
+        query = ClubOfficialClaim.query
+        if status:
+            if status not in CLUB_OFFICIAL_CLAIM_STATUSES:
+                return jsonify({"error": f"invalid status; one of {sorted(CLUB_OFFICIAL_CLAIM_STATUSES)}"}), 400
+            query = query.filter(ClubOfficialClaim.status == status)
+        claims = query.order_by(ClubOfficialClaim.created_at.desc(), ClubOfficialClaim.id.desc()).all()
+        out = []
+        for claim in claims:
+            payload = _club_claim_dict(claim)
+            payload["user_email"] = claim.user.email if claim.user else None
+            out.append(payload)
+        return jsonify({"claims": out})
+    except Exception as e:
+        logger.error("Error in admin_list_club_claims: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to load club-official claims")), 500
+
+
+@showcase_bp.route("/admin/club-claims/<int:claim_id>/review", methods=["POST"])
+@require_api_key
+def admin_review_club_claim(claim_id: int):
+    """Approve/reject a pending official claim, or revoke an approved one."""
+    try:
+        claim = ClubOfficialClaim.query.filter_by(id=claim_id).with_for_update().first()
+        if claim is None:
+            return jsonify({"error": "club-official claim not found"}), 404
+
+        payload, payload_error = _json_object_or_400()
+        if payload_error:
+            return payload_error
+        raw_action = payload.get("action")
+        action = raw_action.strip().lower() if isinstance(raw_action, str) else ""
+        transitions = {
+            "approve": ({"pending"}, "approved"),
+            "reject": ({"pending"}, "rejected"),
+            "revoke": ({"approved"}, "revoked"),
+        }
+        if action not in transitions:
+            return jsonify({"error": "action must be approve, reject, or revoke"}), 400
+        allowed_from, target = transitions[action]
+        if claim.status not in allowed_from:
+            return jsonify({"error": f"cannot {action} a {claim.status} club-official claim"}), 409
+
+        now = datetime.now(UTC)
+        claim.status = target
+        claim.review_note = _clean_optional_text(payload.get("note"), MAX_REVIEW_NOTE_LENGTH)
+        claim.reviewed_by = getattr(g, "user_email", None)
+        claim.reviewed_at = now
+        claim.updated_at = now
+        db.session.commit()
+        return jsonify({"claim": _club_claim_dict(claim, include_verification_code=False)})
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in admin_review_club_claim: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to review club-official claim")), 500
+
+
+@showcase_bp.route("/admin/club-claims/<int:claim_id>/recheck", methods=["POST"])
+@require_api_key
+def admin_recheck_club_claim(claim_id: int):
+    """Re-run social proof against a club claim's stored proof URL."""
+    try:
+        claim = db.session.get(ClubOfficialClaim, claim_id)
+        if claim is None:
+            return jsonify({"error": "club-official claim not found"}), 404
+        proof_url = (claim.verification_proof_url or "").strip()
+        if not proof_url:
+            return jsonify({"error": "club-official claim has no stored proof_url"}), 400
+        valid, _ = social_proof.validate_proof_url(proof_url)
+        if not valid or len(proof_url) > MAX_URL_LENGTH:
+            return _proof_url_error()
+        if claim.verification_code is None:
+            claim.verification_code = _mint_verification_code()
+
+        _run_claim_proof_check(claim, proof_url)
+        claim.updated_at = datetime.now(UTC)
+        db.session.commit()
+        return jsonify({"claim": _club_claim_dict(claim, include_verification_code=False)})
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Error in admin_recheck_club_claim: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to re-check club-official claim proof")), 500
 
 
 @showcase_bp.route("/admin/local-clubs", methods=["GET"])

--- a/academy-watch-backend/src/routes/showcase.py
+++ b/academy-watch-backend/src/routes/showcase.py
@@ -23,7 +23,7 @@ import re
 import secrets
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, unquote, urlparse
 
 from flask import Blueprint, g, jsonify, request, send_file
 from sqlalchemy import func, or_, text
@@ -49,7 +49,7 @@ from src.models.showcase import (
 from src.models.tracked_player import TrackedPlayer
 from src.models.video import VideoMatch, VideoPlayerReport, VideoRosterEntry
 from src.services import showcase_media_storage, social_proof
-from src.services.photo_processing import process_photo
+from src.services.photo_processing import process_photo, validate_photo
 from src.utils.sanitize import is_safe_https_url, sanitize_plain_text
 
 logger = logging.getLogger(__name__)
@@ -103,6 +103,9 @@ MAX_LOCAL_PLAYER_COUNTRY_LENGTH = 100
 MAX_LOCAL_PLAYER_CITY_LENGTH = 120
 MIN_LOCAL_PLAYER_BIRTH_YEAR = 1950
 MAX_LOCAL_PLAYER_BIRTH_YEAR = 2020
+MAX_PENDING_LOCAL_PLAYERS_PER_USER = 10
+MAX_PENDING_LOCAL_CLUBS_PER_USER = 10
+MAX_PENDING_CLUB_CLAIMS_PER_USER = 5
 
 # The only identity gate strong enough for public display (see models/video.py).
 VERIFIED_IDENTITY = "human_confirmed"
@@ -309,6 +312,11 @@ def _normalize_local_player_name(value: str) -> str:
     return LocalPlayer.normalize_name(value)
 
 
+def _escape_like_literal(value: str) -> str:
+    """Escape SQL LIKE metacharacters so a search term stays literal."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 def _mint_verification_code() -> str:
     """Mint a short code without visually ambiguous 0/O/1/I characters."""
     return "AW-" + "".join(secrets.choice(VERIFICATION_ALPHABET) for _ in range(8))
@@ -324,6 +332,25 @@ def _proof_url_error():
             )
         }
     ), 400
+
+
+def _proof_url_contains_verification_code(proof_url: str, verification_code: str | None) -> bool:
+    """Reject search/result URLs that can merely reflect the claimant's code."""
+    if not isinstance(proof_url, str) or not isinstance(verification_code, str):
+        return False
+    code = verification_code.strip().casefold()
+    if not code:
+        return False
+
+    decoded = proof_url
+    # Decode a small, fixed number of layers so percent-encoding cannot hide a
+    # reflected code without allowing attacker input to drive unbounded work.
+    for _ in range(3):
+        next_decoded = unquote(decoded)
+        if next_decoded == decoded:
+            break
+        decoded = next_decoded
+    return code in decoded.casefold()
 
 
 def _run_claim_proof_check(claim: PlayerProfileClaim | ClubOfficialClaim, proof_url: str) -> None:
@@ -449,14 +476,20 @@ def _local_player_public_dict(player: LocalPlayer) -> dict:
         "birth_year": player.birth_year,
         "position": player.position,
         "country": player.country,
-        "city": player.city,
         "status": player.status,
         "api_player_id": player.api_player_id,
     }
 
 
-def _local_player_admin_dict(player: LocalPlayer) -> dict:
+def _local_player_owner_dict(player: LocalPlayer) -> dict:
+    """Identity fields visible to the claimant, including precise locality."""
     payload = _local_player_public_dict(player)
+    payload["city"] = player.city
+    return payload
+
+
+def _local_player_admin_dict(player: LocalPlayer) -> dict:
+    payload = _local_player_owner_dict(player)
     payload.update(
         {
             "normalized_name": player.normalized_name,
@@ -596,6 +629,15 @@ def _club_claim_matches_affiliation(claim: ClubOfficialClaim, affiliation: Playe
         return affiliation.team_api_id == claim.team_api_id
     if claim.local_club_id is None or affiliation.local_club_id is None:
         return False
+    claimed_club = _resolved_local_club(claim.local_club_id)
+    affiliated_club = _resolved_local_club(affiliation.local_club_id)
+    if (
+        claimed_club is None
+        or claimed_club.status != "verified"
+        or affiliated_club is None
+        or affiliated_club.status != "verified"
+    ):
+        return False
     return affiliation.local_club_id in _local_club_match_ids(claim.local_club_id)
 
 
@@ -638,22 +680,36 @@ def _affiliations_for_club_claim(
     return query.order_by(PlayerClubAffiliation.created_at.asc(), PlayerClubAffiliation.id.asc()).all()
 
 
-def _affiliation_club_name(affiliation: PlayerClubAffiliation) -> str | None:
+def _affiliation_club_name(
+    affiliation: PlayerClubAffiliation,
+    *,
+    include_unverified_local_name: bool = False,
+) -> str | None:
     """Resolve the display club, following one local-club merge hop."""
-    return _club_reference_name(
-        team_api_id=affiliation.team_api_id,
-        local_club_id=affiliation.local_club_id,
-    )
+    if affiliation.team_api_id is not None:
+        return _latest_team_name(affiliation.team_api_id)
+    club = _resolved_local_club(affiliation.local_club_id)
+    if club is None or (not include_unverified_local_name and club.status != "verified"):
+        return None
+    return club.name
 
 
-def _affiliation_dict(affiliation: PlayerClubAffiliation, *, include_review_note: bool = False) -> dict:
+def _affiliation_dict(
+    affiliation: PlayerClubAffiliation,
+    *,
+    include_review_note: bool = False,
+    include_unverified_local_name: bool = False,
+) -> dict:
     """Stable affiliation contract shared by showcase and admin responses."""
     payload = {
         "id": affiliation.id,
         "player_api_id": affiliation.player_api_id,
         "team_api_id": affiliation.team_api_id,
         "local_club_id": affiliation.local_club_id,
-        "club_name": _affiliation_club_name(affiliation),
+        "club_name": _affiliation_club_name(
+            affiliation,
+            include_unverified_local_name=include_unverified_local_name,
+        ),
         "season": affiliation.season,
         "status": affiliation.status,
         "created_at": affiliation.created_at.isoformat() if affiliation.created_at else None,
@@ -670,7 +726,14 @@ def _subject_affiliations(subject: ShowcaseSubject, *, include_private: bool) ->
     if not include_private:
         query = query.filter(PlayerClubAffiliation.status.in_(PUBLIC_AFFILIATION_STATUSES))
     rows = query.order_by(PlayerClubAffiliation.created_at.asc(), PlayerClubAffiliation.id.asc()).all()
-    return [_affiliation_dict(row, include_review_note=include_private) for row in rows]
+    return [
+        _affiliation_dict(
+            row,
+            include_review_note=include_private,
+            include_unverified_local_name=include_private,
+        )
+        for row in rows
+    ]
 
 
 def _player_affiliations(player_api_id: int, *, include_private: bool) -> list[dict]:
@@ -723,6 +786,15 @@ def _lock_club_claims(user_id: int) -> None:
         )
 
 
+def _lock_pending_quota(user_id: int, *, namespace: int) -> None:
+    """Serialize each per-account pending count in production."""
+    if db.session.get_bind().dialect.name == "postgresql":
+        db.session.execute(
+            text("SELECT pg_advisory_xact_lock(:namespace, :user_id)"),
+            {"namespace": namespace, "user_id": user_id},
+        )
+
+
 def _cleanup_failed_publication(public_url: str | None, media_id: int) -> None:
     """Compensate a published blob when moderation cannot commit approval."""
     if not public_url:
@@ -731,6 +803,14 @@ def _cleanup_failed_publication(public_url: str | None, media_id: int) -> None:
         showcase_media_storage.delete_published(public_url)
     except Exception as exc:
         logger.error("Failed to compensate public blob for media %s: %s", media_id, exc)
+
+
+def _cleanup_failed_pending_upload(blob_path: str, media_id: int) -> None:
+    """Best-effort terminal cleanup for an upload that failed completion."""
+    try:
+        showcase_media_storage.delete_pending(blob_path)
+    except Exception as exc:
+        logger.warning("Failed to delete invalid pending blob for media %s: %s", media_id, exc)
 
 
 def _subject_photos(subject: ShowcaseSubject, *, include_unapproved: bool) -> list[dict]:
@@ -897,14 +977,19 @@ def _verified_footage(player_api_id: int) -> list[dict]:
 
 @showcase_bp.route("/clubs/search", methods=["GET"])
 @require_user_auth
+@limiter.limit("30 per minute", key_func=_user_rate_limit_key)
 def search_clubs():
     """Search API-synced teams and the isolated self-reported club layer."""
     try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
         raw_q = request.args.get("q")
         q = _sanitize_text(raw_q).strip() if isinstance(raw_q, str) else ""
         q = re.sub(r"\s+", " ", q)
         if len(q) < 2:
             return jsonify({"error": "q must be at least 2 characters"}), 400
+        like_pattern = f"%{_escape_like_literal(q)}%"
 
         ranked_teams = (
             db.session.query(
@@ -918,7 +1003,7 @@ def search_clubs():
                 )
                 .label("row_number"),
             )
-            .filter(Team.name.ilike(f"%{q}%"))
+            .filter(Team.name.ilike(like_pattern, escape="\\"))
             .subquery()
         )
         teams = (
@@ -934,8 +1019,11 @@ def search_clubs():
         )
         local_clubs = (
             LocalClub.query.filter(
-                LocalClub.name.ilike(f"%{q}%"),
-                LocalClub.status.in_(("pending", "verified")),
+                LocalClub.name.ilike(like_pattern, escape="\\"),
+                or_(
+                    LocalClub.status == "verified",
+                    (LocalClub.status == "pending") & (LocalClub.created_by_user_id == user.id),
+                ),
             )
             .order_by(LocalClub.name.asc(), LocalClub.id.asc())
             .limit(10)
@@ -988,6 +1076,7 @@ def create_local_club():
             return jsonify({"error": f"level must be one of {sorted(LOCAL_CLUB_LEVELS)}"}), 400
 
         normalized_name = _normalize_club_name(name)
+        _lock_pending_quota(user.id, namespace=5_455_004)
         existing = (
             LocalClub.query.filter(
                 LocalClub.normalized_name == normalized_name,
@@ -998,14 +1087,24 @@ def create_local_club():
             .first()
         )
         if existing is not None:
+            body = {"error": "A local club with this name and country already exists"}
+            if existing.status == "verified" or existing.created_by_user_id == user.id:
+                body["existing"] = {
+                    "id": existing.id,
+                    "name": existing.name,
+                    "country": existing.country,
+                    "status": existing.status,
+                }
+            return jsonify(body), 409
+
+        pending_count = LocalClub.query.filter_by(
+            created_by_user_id=user.id,
+            status="pending",
+        ).count()
+        if pending_count >= MAX_PENDING_LOCAL_CLUBS_PER_USER:
             return (
-                jsonify(
-                    {
-                        "error": "A local club with this name and country already exists",
-                        "existing": _local_club_search_dict(existing),
-                    }
-                ),
-                409,
+                jsonify({"error": (f"pending local club limit reached ({MAX_PENDING_LOCAL_CLUBS_PER_USER})")}),
+                429,
             )
 
         club = LocalClub(
@@ -1066,6 +1165,7 @@ def create_local_player():
                 400,
             )
 
+        _lock_pending_quota(user.id, namespace=5_455_005)
         duplicate_query = LocalPlayer.query.filter(
             LocalPlayer.normalized_name == _normalize_local_player_name(display_name),
             LocalPlayer.status.notin_(("rejected", "merged")),
@@ -1076,22 +1176,23 @@ def create_local_player():
             duplicate_query = duplicate_query.filter(LocalPlayer.birth_year == birth_year)
         existing = duplicate_query.order_by(LocalPlayer.id.asc()).first()
         if existing is not None:
+            body = {"error": "A local player with this name and birth year already exists"}
+            if existing.status == "approved" or existing.created_by_user_id == user.id:
+                body["existing"] = {
+                    "id": existing.id,
+                    "display_name": existing.display_name,
+                    "status": existing.status,
+                }
+            return jsonify(body), 409
+
+        pending_count = LocalPlayer.query.filter_by(
+            created_by_user_id=user.id,
+            status="pending",
+        ).count()
+        if pending_count >= MAX_PENDING_LOCAL_PLAYERS_PER_USER:
             return (
-                jsonify(
-                    {
-                        "error": "A local player with this name and birth year already exists",
-                        "existing": {
-                            "id": existing.id,
-                            "display_name": existing.display_name,
-                            "birth_year": existing.birth_year,
-                            "position": existing.position,
-                            "country": existing.country,
-                            "city": existing.city,
-                            "status": existing.status,
-                        },
-                    }
-                ),
-                409,
+                jsonify({"error": (f"pending local player limit reached ({MAX_PENDING_LOCAL_PLAYERS_PER_USER})")}),
+                429,
             )
 
         player = LocalPlayer(
@@ -1117,7 +1218,7 @@ def create_local_player():
         )
         db.session.add(claim)
         db.session.commit()
-        return jsonify({"player": _local_player_public_dict(player), "claim": _profile_claim_dict(claim)}), 201
+        return jsonify({"player": _local_player_owner_dict(player), "claim": _profile_claim_dict(claim)}), 201
     except Exception as e:
         db.session.rollback()
         logger.error("Error in create_local_player: %s", e)
@@ -1181,7 +1282,10 @@ def get_local_player(lp_id: int):
         auth_context = _optional_authenticated_context()
         if not _local_player_visible_to_context(player, auth_context):
             return jsonify({"error": "local player not found"}), 404
-        payload = {"player": _local_player_public_dict(player)}
+        auth_user = auth_context["user"] if auth_context else None
+        is_owner = bool(auth_user and _has_visible_local_claim(player.id, auth_user.id))
+        player_payload = _local_player_owner_dict(player) if is_owner else _local_player_public_dict(player)
+        payload = {"player": player_payload}
         if merged_into is not None:
             payload["merged_into"] = merged_into
         return jsonify(payload)
@@ -1405,6 +1509,8 @@ def verify_my_claim(claim_id: int):
 
         if claim.verification_code is None:
             claim.verification_code = _mint_verification_code()
+        if _proof_url_contains_verification_code(proof_url, claim.verification_code):
+            return _proof_url_error()
         _run_claim_proof_check(claim, proof_url)
         db.session.commit()
         return jsonify({"claim": _profile_claim_dict(claim)})
@@ -1478,6 +1584,16 @@ def submit_club_official_claim():
         if duplicate_query.first() is not None:
             return jsonify({"error": "You already have an active claim for this club"}), 409
 
+        pending_count = ClubOfficialClaim.query.filter_by(
+            user_account_id=user.id,
+            status="pending",
+        ).count()
+        if pending_count >= MAX_PENDING_CLUB_CLAIMS_PER_USER:
+            return (
+                jsonify({"error": (f"pending club-official claim limit reached ({MAX_PENDING_CLUB_CLAIMS_PER_USER})")}),
+                429,
+            )
+
         claim = ClubOfficialClaim(
             user_account_id=user.id,
             team_api_id=team_api_id if has_api_team else None,
@@ -1549,6 +1665,8 @@ def verify_my_club_claim(claim_id: int):
 
         if claim.verification_code is None:
             claim.verification_code = _mint_verification_code()
+        if _proof_url_contains_verification_code(proof_url, claim.verification_code):
+            return _proof_url_error()
         _run_claim_proof_check(claim, proof_url)
         claim.updated_at = datetime.now(UTC)
         db.session.commit()
@@ -1618,7 +1736,12 @@ def my_club():
                     "claim": _club_claim_dict(official_claim, include_verification_code=False),
                     "club_name": club_name,
                     "pending_affiliations": [
-                        _affiliation_dict(affiliation, include_review_note=True) for affiliation in pending_affiliations
+                        _affiliation_dict(
+                            affiliation,
+                            include_review_note=True,
+                            include_unverified_local_name=True,
+                        )
+                        for affiliation in pending_affiliations
                     ],
                     "vouchable_player_claims": [_player_claim_for_official_dict(claim) for claim in player_claims],
                 }
@@ -1630,7 +1753,12 @@ def my_club():
         return jsonify(_safe_error_payload(e, "Failed to load club workspace")), 500
 
 
-def _official_affiliation_action(aff_id: int, *, target_status: str, note: str | None = None):
+def _official_affiliation_action(
+    aff_id: int,
+    *,
+    target_status: str,
+    parse_rejection_note: bool = False,
+):
     """Apply a club-confirm/reject transition after the shared official gate."""
     user = _current_user_account()
     if user is None:
@@ -1639,10 +1767,17 @@ def _official_affiliation_action(aff_id: int, *, target_status: str, note: str |
     if affiliation is None:
         return jsonify({"error": "affiliation not found"}), 404
     if _matching_approved_official_claim(user.id, affiliation) is None:
-        return jsonify({"error": "You are not an approved official for this club"}), 403
+        return jsonify({"error": "affiliation not found"}), 404
     if affiliation.status not in ("pending", "self_reported"):
         action = "confirm" if target_status == "club_confirmed" else "reject"
         return jsonify({"error": f"cannot {action} a {affiliation.status} affiliation"}), 409
+
+    note = None
+    if parse_rejection_note:
+        payload, payload_error = _json_object_or_400()
+        if payload_error:
+            return payload_error
+        note = _clean_optional_text(payload.get("note"), MAX_REVIEW_NOTE_LENGTH)
 
     now = datetime.now(UTC)
     affiliation.status = target_status
@@ -1652,7 +1787,15 @@ def _official_affiliation_action(aff_id: int, *, target_status: str, note: str |
     affiliation.reviewed_at = now
     affiliation.updated_at = now
     db.session.commit()
-    return jsonify({"affiliation": _affiliation_dict(affiliation, include_review_note=True)})
+    return jsonify(
+        {
+            "affiliation": _affiliation_dict(
+                affiliation,
+                include_review_note=True,
+                include_unverified_local_name=True,
+            )
+        }
+    )
 
 
 @showcase_bp.route("/me/club/affiliations/<int:aff_id>/confirm", methods=["POST"])
@@ -1674,11 +1817,11 @@ def confirm_club_affiliation(aff_id: int):
 def reject_club_affiliation(aff_id: int):
     """Reject a pending/self-reported affiliation for the caller's club."""
     try:
-        payload, payload_error = _json_object_or_400()
-        if payload_error:
-            return payload_error
-        note = _clean_optional_text(payload.get("note"), MAX_REVIEW_NOTE_LENGTH)
-        return _official_affiliation_action(aff_id, target_status="rejected", note=note)
+        return _official_affiliation_action(
+            aff_id,
+            target_status="rejected",
+            parse_rejection_note=True,
+        )
     except Exception as e:
         db.session.rollback()
         logger.error("Error in reject_club_affiliation: %s", e)
@@ -1701,12 +1844,8 @@ def vouch_for_player_claim(claim_id: int):
         player_claim = PlayerProfileClaim.query.filter_by(id=claim_id).with_for_update().first()
         if player_claim is None:
             return jsonify({"error": "player claim not found"}), 404
-        if player_claim.status != "pending":
-            return jsonify({"error": f"cannot vouch for a {player_claim.status} player claim"}), 409
 
         official_claims = _approved_official_claims(user.id)
-        if not official_claims:
-            return jsonify({"error": "You do not have an approved club-official claim"}), 403
         subject = _claim_subject(player_claim)
         affiliations = (
             PlayerClubAffiliation.query.filter(
@@ -1725,7 +1864,9 @@ def vouch_for_player_claim(claim_id: int):
             None,
         )
         if matching_official is None:
-            return jsonify({"error": "The player has no eligible affiliation with one of your clubs"}), 403
+            return jsonify({"error": "player claim not found"}), 404
+        if player_claim.status != "pending":
+            return jsonify({"error": f"cannot vouch for a {player_claim.status} player claim"}), 409
 
         club_name = _club_reference_name(
             team_api_id=matching_official.team_api_id,
@@ -1831,7 +1972,18 @@ def _create_subject_affiliation(subject: ShowcaseSubject):
         )
         db.session.add(affiliation)
         db.session.commit()
-        return jsonify({"affiliation": _affiliation_dict(affiliation, include_review_note=True)}), 201
+        return (
+            jsonify(
+                {
+                    "affiliation": _affiliation_dict(
+                        affiliation,
+                        include_review_note=True,
+                        include_unverified_local_name=True,
+                    )
+                }
+            ),
+            201,
+        )
     except Exception as e:
         db.session.rollback()
         logger.error("Error in create_player_affiliation: %s", e)
@@ -2114,14 +2266,25 @@ def _complete_subject_showcase_photo(subject: ShowcaseSubject, media_id: int):
 
         verification = showcase_media_storage.verify_pending(media.blob_path)
         if not verification.get("ok"):
+            _cleanup_failed_pending_upload(media.blob_path, media.id)
             return jsonify({"error": verification.get("error") or "pending upload could not be verified"}), 400
         actual_size = verification.get("size_bytes")
         if not isinstance(actual_size, int) or actual_size <= 0:
+            _cleanup_failed_pending_upload(media.blob_path, media.id)
             return jsonify({"error": "pending upload is empty or unreadable"}), 400
         if actual_size > showcase_media_storage.max_photo_bytes():
+            _cleanup_failed_pending_upload(media.blob_path, media.id)
             return jsonify({"error": "pending upload exceeds the photo size limit"}), 400
 
-        media.size_bytes = actual_size
+        try:
+            raw = showcase_media_storage.read_pending_bytes(media.blob_path)
+            validate_photo(raw)
+        except Exception as exc:
+            _cleanup_failed_pending_upload(media.blob_path, media.id)
+            logger.warning("Photo validation failed during completion for media %s: %s", media.id, exc)
+            return jsonify({"error": "Photo could not be validated"}), 422
+
+        media.size_bytes = len(raw)
         media.status = "pending"
         media.updated_at = datetime.now(UTC)
         db.session.commit()
@@ -2524,6 +2687,8 @@ def admin_recheck_club_claim(claim_id: int):
             return _proof_url_error()
         if claim.verification_code is None:
             claim.verification_code = _mint_verification_code()
+        if _proof_url_contains_verification_code(proof_url, claim.verification_code):
+            return _proof_url_error()
 
         _run_claim_proof_check(claim, proof_url)
         claim.updated_at = datetime.now(UTC)
@@ -2995,7 +3160,16 @@ def admin_list_affiliations():
             PlayerClubAffiliation.id.desc(),
         ).all()
         return jsonify(
-            {"affiliations": [_affiliation_dict(affiliation, include_review_note=True) for affiliation in affiliations]}
+            {
+                "affiliations": [
+                    _affiliation_dict(
+                        affiliation,
+                        include_review_note=True,
+                        include_unverified_local_name=True,
+                    )
+                    for affiliation in affiliations
+                ]
+            }
         )
     except Exception as e:
         logger.error("Error in admin_list_affiliations: %s", e)
@@ -3028,7 +3202,15 @@ def admin_review_affiliation(aff_id: int):
         affiliation.reviewed_at = now
         affiliation.updated_at = now
         db.session.commit()
-        return jsonify({"affiliation": _affiliation_dict(affiliation, include_review_note=True)})
+        return jsonify(
+            {
+                "affiliation": _affiliation_dict(
+                    affiliation,
+                    include_review_note=True,
+                    include_unverified_local_name=True,
+                )
+            }
+        )
     except Exception as e:
         db.session.rollback()
         logger.error("Error in admin_review_affiliation: %s", e)
@@ -3172,6 +3354,8 @@ def admin_recheck_claim(claim_id: int):
             return _proof_url_error()
         if claim.verification_code is None:
             claim.verification_code = _mint_verification_code()
+        if _proof_url_contains_verification_code(proof_url, claim.verification_code):
+            return _proof_url_error()
 
         _run_claim_proof_check(claim, proof_url)
         db.session.commit()

--- a/academy-watch-backend/src/services/photo_processing.py
+++ b/academy-watch-backend/src/services/photo_processing.py
@@ -1,0 +1,84 @@
+"""Safeguarding-oriented processing for player showcase photos."""
+
+import warnings
+from io import BytesIO
+
+from PIL import Image, ImageOps, UnidentifiedImageError
+
+ALLOWED_FORMATS = {"JPEG", "PNG", "WEBP"}
+MAX_SOURCE_PIXELS = 40_000_000
+MAX_LONG_EDGE = 1600
+JPEG_QUALITY = 85
+
+
+class PhotoProcessingError(ValueError):
+    """Raised when an uploaded photo cannot be safely normalized."""
+
+
+def _normalized_rgb(image: Image.Image) -> Image.Image:
+    """Apply orientation, flatten transparency, and detach all metadata."""
+    image = ImageOps.exif_transpose(image)
+    if image.mode in {"RGBA", "LA"} or (image.mode == "P" and "transparency" in image.info):
+        rgba = image.convert("RGBA")
+        background = Image.new("RGBA", rgba.size, (255, 255, 255, 255))
+        background.alpha_composite(rgba)
+        return background.convert("RGB")
+    return image.convert("RGB")
+
+
+def process_photo(raw: bytes) -> tuple[bytes, str]:
+    """Normalize JPEG/PNG/WEBP bytes to a metadata-free, bounded JPEG.
+
+    Pillow's decompression-bomb warning is promoted to an error and a stricter
+    explicit source-pixel cap is applied before decoding the full image.
+    """
+    if not isinstance(raw, bytes) or not raw:
+        raise PhotoProcessingError("photo is empty")
+
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", Image.DecompressionBombWarning)
+            with Image.open(BytesIO(raw)) as source:
+                if source.format not in ALLOWED_FORMATS:
+                    raise PhotoProcessingError("photo must be JPEG, PNG, or WEBP")
+                width, height = source.size
+                if width <= 0 or height <= 0 or width * height > MAX_SOURCE_PIXELS:
+                    raise PhotoProcessingError("photo dimensions are too large")
+                source.seek(0)
+                source.load()
+                normalized = _normalized_rgb(source)
+    except PhotoProcessingError:
+        raise
+    except (Image.DecompressionBombError, Image.DecompressionBombWarning) as exc:
+        raise PhotoProcessingError("photo dimensions are too large") from exc
+    except (UnidentifiedImageError, OSError, SyntaxError, ValueError) as exc:
+        raise PhotoProcessingError("photo is invalid or corrupt") from exc
+
+    if max(normalized.size) > MAX_LONG_EDGE:
+        normalized.thumbnail((MAX_LONG_EDGE, MAX_LONG_EDGE), Image.Resampling.LANCZOS)
+
+    # Pillow's JPEG writer falls back to ``Image.info`` for COM comments and
+    # other encoder metadata. Clear the decoded image's metadata wholesale so
+    # location text outside EXIF cannot survive the re-encode either.
+    normalized.info.clear()
+
+    output = BytesIO()
+    try:
+        # No exif/icc_profile/comment kwargs are supplied: only decoded pixels
+        # survive into the approved artifact.
+        normalized.save(
+            output,
+            format="JPEG",
+            quality=JPEG_QUALITY,
+            optimize=True,
+            progressive=True,
+        )
+    except OSError as exc:
+        raise PhotoProcessingError("photo could not be encoded") from exc
+    finally:
+        normalized.close()
+
+    processed = output.getvalue()
+    if not processed:
+        raise PhotoProcessingError("photo could not be encoded")
+    return processed, "image/jpeg"

--- a/academy-watch-backend/src/services/photo_processing.py
+++ b/academy-watch-backend/src/services/photo_processing.py
@@ -1,6 +1,8 @@
 """Safeguarding-oriented processing for player showcase photos."""
 
 import warnings
+from collections.abc import Iterator
+from contextlib import contextmanager
 from io import BytesIO
 
 from PIL import Image, ImageOps, UnidentifiedImageError
@@ -13,6 +15,38 @@ JPEG_QUALITY = 85
 
 class PhotoProcessingError(ValueError):
     """Raised when an uploaded photo cannot be safely normalized."""
+
+
+@contextmanager
+def _validated_source(raw: bytes) -> Iterator[Image.Image]:
+    """Open and fully decode an allowed photo within the source-pixel cap."""
+    if not isinstance(raw, bytes) or not raw:
+        raise PhotoProcessingError("photo is empty")
+
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", Image.DecompressionBombWarning)
+            with Image.open(BytesIO(raw)) as source:
+                if source.format not in ALLOWED_FORMATS:
+                    raise PhotoProcessingError("photo must be JPEG, PNG, or WEBP")
+                width, height = source.size
+                if width <= 0 or height <= 0 or width * height > MAX_SOURCE_PIXELS:
+                    raise PhotoProcessingError("photo dimensions are too large")
+                source.seek(0)
+                source.load()
+                yield source
+    except PhotoProcessingError:
+        raise
+    except (Image.DecompressionBombError, Image.DecompressionBombWarning) as exc:
+        raise PhotoProcessingError("photo dimensions are too large") from exc
+    except (UnidentifiedImageError, OSError, SyntaxError, ValueError) as exc:
+        raise PhotoProcessingError("photo is invalid or corrupt") from exc
+
+
+def validate_photo(raw: bytes) -> None:
+    """Validate uploaded bytes without transforming or publishing them."""
+    with _validated_source(raw):
+        pass
 
 
 def _normalized_rgb(image: Image.Image) -> Image.Image:
@@ -32,27 +66,8 @@ def process_photo(raw: bytes) -> tuple[bytes, str]:
     Pillow's decompression-bomb warning is promoted to an error and a stricter
     explicit source-pixel cap is applied before decoding the full image.
     """
-    if not isinstance(raw, bytes) or not raw:
-        raise PhotoProcessingError("photo is empty")
-
-    try:
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", Image.DecompressionBombWarning)
-            with Image.open(BytesIO(raw)) as source:
-                if source.format not in ALLOWED_FORMATS:
-                    raise PhotoProcessingError("photo must be JPEG, PNG, or WEBP")
-                width, height = source.size
-                if width <= 0 or height <= 0 or width * height > MAX_SOURCE_PIXELS:
-                    raise PhotoProcessingError("photo dimensions are too large")
-                source.seek(0)
-                source.load()
-                normalized = _normalized_rgb(source)
-    except PhotoProcessingError:
-        raise
-    except (Image.DecompressionBombError, Image.DecompressionBombWarning) as exc:
-        raise PhotoProcessingError("photo dimensions are too large") from exc
-    except (UnidentifiedImageError, OSError, SyntaxError, ValueError) as exc:
-        raise PhotoProcessingError("photo is invalid or corrupt") from exc
+    with _validated_source(raw) as source:
+        normalized = _normalized_rgb(source)
 
     if max(normalized.size) > MAX_LONG_EDGE:
         normalized.thumbnail((MAX_LONG_EDGE, MAX_LONG_EDGE), Image.Resampling.LANCZOS)

--- a/academy-watch-backend/src/services/showcase_media_storage.py
+++ b/academy-watch-backend/src/services/showcase_media_storage.py
@@ -1,0 +1,424 @@
+"""Storage abstraction for pre-moderated player showcase photos.
+
+In Azure, browsers upload directly to the private pending container with a
+short-lived write SAS. The Flask app only verifies and moderates that upload;
+approved, EXIF-stripped bytes are written to the public container.
+
+When Azure is not configured, non-production environments use a local
+filesystem backend with the same contract. Production and staging never fall
+back to local storage.
+
+Env:
+  AZURE_STORAGE_CONNECTION_STRING  Azure storage account connection string
+  SHOWCASE_MEDIA_PENDING_CONTAINER private pending container (default
+                                   ``showcase-media-pending``)
+  SHOWCASE_MEDIA_CONTAINER         public approved container (default
+                                   ``showcase-media``)
+  SHOWCASE_PHOTO_MAX_MB            upload cap in MiB (default ``8``)
+  SHOWCASE_MEDIA_LOCAL_DIR         local-dev root (default under ``/tmp``)
+"""
+
+import logging
+import math
+import os
+import re
+import tempfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from urllib.parse import quote, unquote, urlparse
+from uuid import uuid4
+
+logger = logging.getLogger(__name__)
+
+try:
+    from azure.core.exceptions import ResourceNotFoundError
+    from azure.storage.blob import (
+        BlobSasPermissions,
+        BlobServiceClient,
+        ContentSettings,
+        generate_blob_sas,
+    )
+
+    _AZURE_AVAILABLE = True
+except ImportError:  # keep the app and local tests importable without Azure
+    ResourceNotFoundError = None
+    _AZURE_AVAILABLE = False
+
+UPLOAD_SAS_MINUTES = 15
+PREVIEW_SAS_MINUTES = 15
+DEFAULT_MAX_PHOTO_MB = 8
+DEV_ROUTE_PREFIX = "/api/dev/showcase-media"
+
+_CONTENT_TYPE_EXTENSIONS = {
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/webp": "webp",
+}
+_SAFE_PATH_PART = re.compile(r"[A-Za-z0-9._-]+")
+_PRODUCTION_ENVS = {"prod", "production", "stage", "staging"}
+_LOCAL_DEV_ENVS = {"dev", "development", "local", "test", "testing"}
+
+
+class StorageNotConfiguredError(RuntimeError):
+    """Raised when neither Azure nor the local-dev backend may be used."""
+
+
+class InvalidBlobPathError(ValueError):
+    """Raised when a blob path could escape the configured storage root."""
+
+
+class StoredMediaError(RuntimeError):
+    """Raised when stored media cannot safely be read or published."""
+
+
+def _pending_container() -> str:
+    return os.getenv("SHOWCASE_MEDIA_PENDING_CONTAINER", "showcase-media-pending")
+
+
+def _public_container() -> str:
+    return os.getenv("SHOWCASE_MEDIA_CONTAINER", "showcase-media")
+
+
+def max_photo_bytes() -> int:
+    """Configured photo upload cap in bytes."""
+    raw_value = os.getenv("SHOWCASE_PHOTO_MAX_MB", str(DEFAULT_MAX_PHOTO_MB))
+    try:
+        megabytes = float(raw_value)
+    except (TypeError, ValueError):
+        logger.warning("invalid SHOWCASE_PHOTO_MAX_MB=%r; using %s", raw_value, DEFAULT_MAX_PHOTO_MB)
+        megabytes = DEFAULT_MAX_PHOTO_MB
+    if not math.isfinite(megabytes) or megabytes <= 0:
+        logger.warning("invalid/non-positive SHOWCASE_PHOTO_MAX_MB=%r; using %s", raw_value, DEFAULT_MAX_PHOTO_MB)
+        megabytes = DEFAULT_MAX_PHOTO_MB
+    return int(megabytes * 1024**2)
+
+
+def _environment_markers() -> set[str]:
+    return {
+        value.strip().lower()
+        for value in (os.getenv("ENV"), os.getenv("FLASK_ENV"), os.getenv("APP_ENV"))
+        if value and value.strip()
+    }
+
+
+def is_azure_configured() -> bool:
+    """Whether the Azure SDK and connection string are both available."""
+    return _AZURE_AVAILABLE and bool(os.getenv("AZURE_STORAGE_CONNECTION_STRING"))
+
+
+def is_local_dev_enabled() -> bool:
+    """Whether the local fallback is allowed for this process.
+
+    This mirrors the Film Room development posture (local artifacts only when
+    Azure is absent) while adding an explicit production/staging fail-closed
+    gate for user-uploaded media.
+    """
+    if is_azure_configured():
+        return False
+    markers = _environment_markers()
+    if markers & _PRODUCTION_ENVS:
+        return False
+    # Fail closed when deployment markers are absent/unknown. An explicitly
+    # configured local root is also a deliberate test/dev opt-in.
+    return bool(markers & _LOCAL_DEV_ENVS) or (not markers and bool(os.getenv("SHOWCASE_MEDIA_LOCAL_DIR")))
+
+
+def is_configured() -> bool:
+    """Whether uploads can be served by Azure or the local-dev backend."""
+    return is_azure_configured() or is_local_dev_enabled()
+
+
+def _require_configured() -> None:
+    if not is_configured():
+        raise StorageNotConfiguredError("showcase media storage is not configured")
+
+
+def _service_client() -> "BlobServiceClient":
+    if not _AZURE_AVAILABLE:
+        raise StorageNotConfiguredError("azure-storage-blob is not installed")
+    connection_string = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
+    if not connection_string:
+        raise StorageNotConfiguredError("AZURE_STORAGE_CONNECTION_STRING is not configured")
+    return BlobServiceClient.from_connection_string(connection_string)
+
+
+def _account_key(client: "BlobServiceClient") -> str:
+    key = getattr(getattr(client, "credential", None), "account_key", None)
+    if not key:
+        raise StorageNotConfiguredError("Azure connection string must include an account key")
+    return key
+
+
+def _mint_sas(container: str, blob_path: str, permission: "BlobSasPermissions", expiry: datetime) -> str:
+    client = _service_client()
+    return generate_blob_sas(
+        account_name=client.account_name,
+        container_name=container,
+        blob_name=blob_path,
+        account_key=_account_key(client),
+        permission=permission,
+        expiry=expiry,
+    )
+
+
+def _validate_blob_path(blob_path: str) -> str:
+    if not isinstance(blob_path, str) or not blob_path or "\\" in blob_path or "\x00" in blob_path:
+        raise InvalidBlobPathError("invalid showcase media blob path")
+    if blob_path.startswith("/"):
+        raise InvalidBlobPathError("showcase media blob path must be relative")
+    parts = blob_path.split("/")
+    if any(not part or part in {".", ".."} or not _SAFE_PATH_PART.fullmatch(part) for part in parts):
+        raise InvalidBlobPathError("invalid showcase media blob path")
+    return "/".join(parts)
+
+
+def _extension_for(content_type: str) -> str:
+    try:
+        return _CONTENT_TYPE_EXTENSIONS[content_type]
+    except KeyError:
+        raise ValueError("unsupported showcase photo content type")
+
+
+def _pending_blob_path(player_api_id: int, media_id: int, content_type: str) -> str:
+    if player_api_id <= 0 or media_id <= 0:
+        raise ValueError("player_api_id and media_id must be positive")
+    extension = _extension_for(content_type)
+    return f"players/{player_api_id}/{media_id}/{uuid4().hex}.{extension}"
+
+
+def _published_blob_path(blob_path: str) -> str:
+    safe_path = _validate_blob_path(blob_path)
+    stem, separator, _extension = safe_path.rpartition(".")
+    return f"{stem}.jpg" if separator else f"{safe_path}.jpg"
+
+
+def _quoted_dev_url(route_blob_path: str) -> str:
+    return f"{DEV_ROUTE_PREFIX}/{quote(route_blob_path, safe='/')}"
+
+
+def mint_upload(player_api_id: int, media_id: int, content_type: str) -> dict:
+    """Mint a direct single-shot BlockBlob PUT for a new pending photo."""
+    _require_configured()
+    blob_path = _pending_blob_path(player_api_id, media_id, content_type)
+    expiry = datetime.now(UTC) + timedelta(minutes=UPLOAD_SAS_MINUTES)
+    headers = {"x-ms-blob-type": "BlockBlob", "Content-Type": content_type}
+
+    if is_azure_configured():
+        sas = _mint_sas(
+            _pending_container(),
+            blob_path,
+            # A single-shot upload only needs create permission. Omitting
+            # ``write`` prevents the same SAS from overwriting the blob after
+            # /complete or after an admin has previewed it.
+            BlobSasPermissions(create=True),
+            expiry,
+        )
+        blob = _service_client().get_blob_client(_pending_container(), blob_path)
+        url = f"{blob.url}?{sas}"
+    else:
+        url = _quoted_dev_url(blob_path)
+
+    return {
+        "blob_path": blob_path,
+        "url": url,
+        "method": "PUT",
+        "headers": headers,
+        "expires_at": expiry.isoformat(),
+    }
+
+
+def verify_pending(blob_path: str) -> dict:
+    """Verify that a pending upload exists, is non-empty, and is within cap."""
+    _require_configured()
+    blob_path = _validate_blob_path(blob_path)
+    try:
+        if is_azure_configured():
+            blob = _service_client().get_blob_client(_pending_container(), blob_path)
+            size_bytes = int(blob.get_blob_properties().size)
+        else:
+            path = local_pending_path(blob_path)
+            if not path.is_file():
+                return {"ok": False, "error": "pending upload not found"}
+            size_bytes = path.stat().st_size
+    except Exception as exc:  # missing blob, network, or auth all mean unverified
+        logger.warning("showcase pending blob verify failed for %s: %s", blob_path, exc)
+        return {"ok": False, "error": "pending upload not found or unreadable"}
+
+    if size_bytes <= 0:
+        return {"ok": False, "error": "uploaded photo is empty", "size_bytes": size_bytes}
+    if size_bytes > max_photo_bytes():
+        return {
+            "ok": False,
+            "error": f"uploaded photo exceeds {max_photo_bytes() // 1024**2}MB cap",
+            "size_bytes": size_bytes,
+        }
+    return {"ok": True, "size_bytes": size_bytes}
+
+
+def read_pending_bytes(blob_path: str) -> bytes:
+    """Read a verified-size pending upload for the moderation processor."""
+    check = verify_pending(blob_path)
+    if not check["ok"]:
+        raise StoredMediaError(check["error"])
+    blob_path = _validate_blob_path(blob_path)
+
+    if is_azure_configured():
+        blob = _service_client().get_blob_client(_pending_container(), blob_path)
+        # Keep memory bounded even if external state changes after verification.
+        raw = blob.download_blob(offset=0, length=max_photo_bytes() + 1, max_concurrency=1).readall()
+    else:
+        raw = local_pending_path(blob_path).read_bytes()
+
+    # Defend against a blob swap or local-file growth between verify and read.
+    if not raw or len(raw) > max_photo_bytes():
+        raise StoredMediaError("pending upload changed during moderation")
+    return raw
+
+
+def publish(blob_path: str, processed_bytes: bytes, content_type: str = "image/jpeg") -> str:
+    """Write processed bytes to the public container and return its public URL."""
+    _require_configured()
+    if content_type != "image/jpeg":
+        raise ValueError("approved showcase photos must be JPEG")
+    if not processed_bytes:
+        raise StoredMediaError("processed photo is empty")
+
+    public_blob_path = _published_blob_path(blob_path)
+    if is_azure_configured():
+        blob = _service_client().get_blob_client(_public_container(), public_blob_path)
+        blob.upload_blob(
+            processed_bytes,
+            overwrite=True,
+            content_settings=ContentSettings(content_type=content_type),
+        )
+        return blob.url
+
+    path = local_public_path(public_blob_path, create_parent=True)
+    temporary_path = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+    try:
+        temporary_path.write_bytes(processed_bytes)
+        os.replace(temporary_path, path)
+    finally:
+        try:
+            temporary_path.unlink()
+        except FileNotFoundError:
+            pass
+    return _quoted_dev_url(f"published/{public_blob_path}")
+
+
+def delete_pending(blob_path: str) -> None:
+    """Idempotently delete a pending upload."""
+    _require_configured()
+    blob_path = _validate_blob_path(blob_path)
+    if is_azure_configured():
+        blob = _service_client().get_blob_client(_pending_container(), blob_path)
+        try:
+            blob.delete_blob(delete_snapshots="include")
+        except Exception as exc:
+            if ResourceNotFoundError is not None and isinstance(exc, ResourceNotFoundError):
+                return
+            raise
+        return
+    try:
+        local_pending_path(blob_path).unlink()
+    except FileNotFoundError:
+        pass
+
+
+def _public_blob_path_from_reference(public_url_or_blob_path: str) -> str:
+    if not isinstance(public_url_or_blob_path, str) or not public_url_or_blob_path:
+        raise InvalidBlobPathError("invalid published media reference")
+
+    parsed = urlparse(public_url_or_blob_path)
+    path = unquote(parsed.path)
+    dev_prefix = f"{DEV_ROUTE_PREFIX}/published/"
+    if path.startswith(dev_prefix):
+        return _validate_blob_path(path[len(dev_prefix) :])
+
+    public_prefix = f"/{_public_container()}/"
+    if path.startswith(public_prefix):
+        return _validate_blob_path(path[len(public_prefix) :])
+
+    plain_path = public_url_or_blob_path
+    if plain_path.startswith("published/"):
+        plain_path = plain_path[len("published/") :]
+    safe_path = _validate_blob_path(plain_path)
+    return _published_blob_path(safe_path)
+
+
+def delete_published(public_url_or_blob_path: str) -> None:
+    """Idempotently delete an approved blob by its public URL or source path."""
+    _require_configured()
+    public_blob_path = _public_blob_path_from_reference(public_url_or_blob_path)
+    if is_azure_configured():
+        blob = _service_client().get_blob_client(_public_container(), public_blob_path)
+        try:
+            blob.delete_blob(delete_snapshots="include")
+        except Exception as exc:
+            if ResourceNotFoundError is not None and isinstance(exc, ResourceNotFoundError):
+                return
+            raise
+        return
+    try:
+        local_public_path(public_blob_path).unlink()
+    except FileNotFoundError:
+        pass
+
+
+def pending_preview_url(blob_path: str) -> str:
+    """Return a short-lived read URL for a non-public pending upload."""
+    _require_configured()
+    blob_path = _validate_blob_path(blob_path)
+    if not is_azure_configured():
+        return _quoted_dev_url(blob_path)
+
+    expiry = datetime.now(UTC) + timedelta(minutes=PREVIEW_SAS_MINUTES)
+    sas = _mint_sas(
+        _pending_container(),
+        blob_path,
+        BlobSasPermissions(read=True),
+        expiry,
+    )
+    blob = _service_client().get_blob_client(_pending_container(), blob_path)
+    return f"{blob.url}?{sas}"
+
+
+def _local_root() -> Path:
+    configured = os.getenv("SHOWCASE_MEDIA_LOCAL_DIR")
+    root = Path(configured) if configured else Path(tempfile.gettempdir()) / "academy-watch-showcase-media"
+    return root.expanduser().resolve()
+
+
+def _local_path(base: Path, blob_path: str, create_parent: bool) -> Path:
+    _require_configured()
+    if not is_local_dev_enabled():
+        raise StorageNotConfiguredError("local showcase media storage is disabled")
+    blob_path = _validate_blob_path(blob_path)
+    resolved_base = base.resolve()
+    path = (resolved_base / Path(*blob_path.split("/"))).resolve()
+    if path != resolved_base and resolved_base not in path.parents:
+        raise InvalidBlobPathError("showcase media path escapes local storage root")
+    if create_parent:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def local_pending_path(blob_path: str, create_parent: bool = False) -> Path:
+    """Resolve a pending blob within the local-dev root."""
+    return _local_path(_local_root() / "pending", blob_path, create_parent)
+
+
+def local_public_path(blob_path: str, create_parent: bool = False) -> Path:
+    """Resolve an approved blob within the local-dev root."""
+    return _local_path(_local_root() / "public", blob_path, create_parent)
+
+
+def local_serving_path(route_blob_path: str) -> Path:
+    """Resolve a dev GET route path to pending or approved local storage.
+
+    ``published/`` is a route-only namespace. PUT handlers should use
+    :func:`local_pending_path` so an upload can never write to the public area.
+    """
+    if route_blob_path.startswith("published/"):
+        return local_public_path(route_blob_path[len("published/") :])
+    return local_pending_path(route_blob_path)

--- a/academy-watch-backend/src/services/showcase_media_storage.py
+++ b/academy-watch-backend/src/services/showcase_media_storage.py
@@ -179,11 +179,18 @@ def _extension_for(content_type: str) -> str:
         raise ValueError("unsupported showcase photo content type")
 
 
-def _pending_blob_path(player_api_id: int, media_id: int, content_type: str) -> str:
+def _pending_blob_path(
+    player_api_id: int,
+    media_id: int,
+    content_type: str,
+    *,
+    path_prefix: str | None = None,
+) -> str:
     if player_api_id <= 0 or media_id <= 0:
         raise ValueError("player_api_id and media_id must be positive")
     extension = _extension_for(content_type)
-    return f"players/{player_api_id}/{media_id}/{uuid4().hex}.{extension}"
+    prefix = _validate_blob_path(path_prefix) if path_prefix is not None else f"players/{player_api_id}"
+    return f"{prefix}/{media_id}/{uuid4().hex}.{extension}"
 
 
 def _published_blob_path(blob_path: str) -> str:
@@ -196,10 +203,26 @@ def _quoted_dev_url(route_blob_path: str) -> str:
     return f"{DEV_ROUTE_PREFIX}/{quote(route_blob_path, safe='/')}"
 
 
-def mint_upload(player_api_id: int, media_id: int, content_type: str) -> dict:
-    """Mint a direct single-shot BlockBlob PUT for a new pending photo."""
+def mint_upload(
+    player_api_id: int,
+    media_id: int,
+    content_type: str,
+    *,
+    path_prefix: str | None = None,
+) -> dict:
+    """Mint a direct single-shot BlockBlob PUT for a new pending photo.
+
+    ``path_prefix`` lets local subjects use an explicit namespace such as
+    ``local-players/<id>``. Omitting it preserves the existing
+    ``players/<api-id>`` layout and call contract.
+    """
     _require_configured()
-    blob_path = _pending_blob_path(player_api_id, media_id, content_type)
+    blob_path = _pending_blob_path(
+        player_api_id,
+        media_id,
+        content_type,
+        path_prefix=path_prefix,
+    )
     expiry = datetime.now(UTC) + timedelta(minutes=UPLOAD_SAS_MINUTES)
     headers = {"x-ms-blob-type": "BlockBlob", "Content-Type": content_type}
 

--- a/academy-watch-backend/src/services/social_proof.py
+++ b/academy-watch-backend/src/services/social_proof.py
@@ -1,0 +1,193 @@
+"""Best-effort verification of one-time codes on public social profiles.
+
+This checker is deliberately advisory: a successful lookup helps an admin
+review a claim, but it never approves one. The request path is tightly scoped
+to known social hosts and manually controlled redirects to keep user-supplied
+URLs away from internal services.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from urllib.parse import urljoin, urlparse
+
+import requests
+from src.utils.sanitize import is_safe_https_url
+
+ALLOWED_SOCIAL_HOSTS = (
+    "instagram.com",
+    "tiktok.com",
+    "x.com",
+    "twitter.com",
+    "facebook.com",
+    "youtube.com",
+)
+
+_BODY_LIMIT_BYTES = 2 * 1024 * 1024
+_MAX_REDIRECTS = 3
+_REDIRECT_STATUSES = {301, 302, 303, 307, 308}
+_USER_AGENT = "The Academy Watch social-profile verifier/1.0"
+
+
+def _allowed_hostname(hostname: str) -> bool:
+    host = hostname.lower()
+    return any(host == allowed or host.endswith(f".{allowed}") for allowed in ALLOWED_SOCIAL_HOSTS)
+
+
+def validate_proof_url(url: str) -> tuple[bool, str]:
+    """Validate a proof URL without performing DNS or network access."""
+    if not is_safe_https_url(url):
+        return False, "URL must be an absolute HTTPS URL."
+    try:
+        parsed = urlparse(url.strip())
+        hostname = parsed.hostname
+        # Accessing parsed.port can itself raise for malformed ports.
+        parsed_port = parsed.port
+    except (TypeError, ValueError):
+        return False, "URL is malformed."
+
+    if parsed.username is not None or parsed.password is not None or "@" in parsed.netloc:
+        return False, "URL must not contain user information."
+    if parsed_port is not None or ":" in parsed.netloc:
+        return False, "URL must not contain an explicit port."
+    if not hostname:
+        return False, "URL must include a hostname."
+
+    try:
+        ipaddress.ip_address(hostname)
+    except ValueError:
+        pass
+    else:
+        return False, "IP-address hosts are not allowed."
+
+    if not _allowed_hostname(hostname):
+        return False, "URL hostname is not an allowed social-profile host."
+    return True, ""
+
+
+def _read_capped_body(response) -> bytes:
+    """Read at most two decoded-megabytes from a streamed response."""
+    body = bytearray()
+    for chunk in response.iter_content(chunk_size=64 * 1024, decode_unicode=False):
+        if not chunk:
+            continue
+        remaining = _BODY_LIMIT_BYTES - len(body)
+        if remaining <= 0:
+            break
+        body.extend(chunk[:remaining])
+        if len(body) >= _BODY_LIMIT_BYTES:
+            break
+    return bytes(body)
+
+
+def _decode_body(body: bytes, encoding: str | None) -> str:
+    try:
+        return body.decode(encoding or "utf-8", errors="replace")
+    except (LookupError, TypeError):
+        return body.decode("utf-8", errors="replace")
+
+
+def _close_quietly(resource) -> None:
+    """Close a response/session without letting cleanup violate no-raise."""
+    close = getattr(resource, "close", None)
+    if not callable(close):
+        return
+    try:
+        close()
+    except Exception:
+        pass
+
+
+def check_proof(url: str, code: str) -> dict:
+    """Check whether ``code`` appears in the capped public profile response.
+
+    Every failure is represented as ``found=False``; callers never need to
+    handle a networking or parsing exception from this advisory service.
+    """
+    valid, reason = validate_proof_url(url)
+    if not valid:
+        return {"found": False, "note": f"Proof URL was refused: {reason}"}
+    if not isinstance(code, str) or not code.strip():
+        return {"found": False, "note": "The claim has no verification code to check."}
+
+    current_url = url.strip()
+    session = None
+    try:
+        session = requests.Session()
+        # Do not consult .netrc/proxy environment state or retain response
+        # cookies between manually followed hops.
+        session.trust_env = False
+        session.auth = None
+        session.cookies.clear()
+
+        for redirect_count in range(_MAX_REDIRECTS + 1):
+            session.cookies.clear()
+            response = session.get(
+                current_url,
+                headers={"User-Agent": _USER_AGENT},
+                timeout=(3.05, 6),
+                allow_redirects=False,
+                stream=True,
+            )
+            try:
+                if response.status_code in _REDIRECT_STATUSES:
+                    if redirect_count >= _MAX_REDIRECTS:
+                        return {
+                            "found": False,
+                            "note": "Profile check stopped after the maximum of 3 redirects.",
+                        }
+                    location = response.headers.get("Location")
+                    if not location:
+                        return {
+                            "found": False,
+                            "note": "Profile check stopped because a redirect had no destination.",
+                        }
+                    next_url = urljoin(current_url, location)
+                    redirect_valid, redirect_reason = validate_proof_url(next_url)
+                    if not redirect_valid:
+                        return {
+                            "found": False,
+                            "note": f"Profile redirect was refused: {redirect_reason}",
+                        }
+
+                    current_host = (urlparse(current_url).hostname or "").lower()
+                    next_host = (urlparse(next_url).hostname or "").lower()
+                    if next_host != current_host:
+                        return {
+                            "found": False,
+                            "note": "Profile redirect was refused because it changed hostname.",
+                        }
+                    current_url = next_url
+                    continue
+
+                if not 200 <= response.status_code < 300:
+                    return {
+                        "found": False,
+                        "note": f"Public profile returned HTTP {response.status_code}; no code was confirmed.",
+                    }
+
+                body = _read_capped_body(response)
+                text = _decode_body(body, getattr(response, "encoding", None))
+                found = code.casefold() in text.casefold()
+                if found:
+                    return {
+                        "found": True,
+                        "note": "Verification code found on the public profile.",
+                    }
+                return {
+                    "found": False,
+                    "note": "Verification code was not found in the first 2 MB of the public profile.",
+                }
+            finally:
+                _close_quietly(response)
+        return {"found": False, "note": "Profile check stopped before a response could be checked."}
+    except requests.RequestException:
+        return {"found": False, "note": "A network error prevented the public profile check."}
+    except Exception:
+        return {"found": False, "note": "The public profile could not be checked."}
+    finally:
+        if session is not None:
+            _close_quietly(session)
+
+
+__all__ = ["ALLOWED_SOCIAL_HOSTS", "check_proof", "validate_proof_url"]

--- a/academy-watch-backend/tests/test_claim_verification.py
+++ b/academy-watch-backend/tests/test_claim_verification.py
@@ -1,0 +1,426 @@
+"""Tests for the advisory social-profile claim verification ladder.
+
+Network access is always replaced at the ``social_proof.requests`` boundary.
+The automated result helps an admin review a claim; it never approves one.
+"""
+
+import json
+import re
+from io import BytesIO
+
+import pytest
+from flask import Flask
+from src.auth import _ensure_user_account, issue_user_token
+from src.models.league import db
+from src.models.showcase import PlayerProfileClaim
+from src.services import social_proof
+
+ADMIN_KEY = "test-admin-key"
+PLAYER_ID = 5001
+CODE_PATTERN = re.compile(r"^AW-[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$")
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("SKIP_API_HANDSHAKE", "1")
+    monkeypatch.setenv("API_USE_STUB_DATA", "true")
+    monkeypatch.setenv("ADMIN_API_KEY", ADMIN_KEY)
+    monkeypatch.setenv("ADMIN_IP_WHITELIST", "")
+
+    from src.routes.showcase import showcase_bp
+
+    flask_app = Flask(__name__)
+    flask_app.config.update(
+        TESTING=True,
+        SECRET_KEY="test-secret-key",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        RATELIMIT_ENABLED=False,
+    )
+
+    db.init_app(flask_app)
+    flask_app.register_blueprint(showcase_bp, url_prefix="/api")
+
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+class FakeResponse:
+    """Small requests.Response stand-in supporting streaming and redirect tests."""
+
+    def __init__(self, body=b"", *, status_code=200, headers=None, encoding="utf-8"):
+        self._body = body
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.encoding = encoding
+        self.raw = BytesIO(body)
+        self.closed = False
+
+    @property
+    def content(self):
+        return self._body
+
+    @property
+    def text(self):
+        return self._body.decode(self.encoding or "utf-8", errors="replace")
+
+    def iter_content(self, chunk_size=1, decode_unicode=False):
+        del decode_unicode
+        for start in range(0, len(self._body), chunk_size):
+            yield self._body[start : start + chunk_size]
+
+    def close(self):
+        self.closed = True
+
+
+def _user_headers(email):
+    token = issue_user_token(email)["token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _admin_headers():
+    token = issue_user_token("admin@test.com", role="admin")["token"]
+    return {"Authorization": f"Bearer {token}", "X-API-Key": ADMIN_KEY}
+
+
+def _make_user(email):
+    user = _ensure_user_account(email)
+    db.session.commit()
+    return user
+
+
+def _seed_claim(
+    email="owner@example.com",
+    *,
+    status="pending",
+    code="AW-ABCDEFGH",
+    proof_url=None,
+    verification_status="unverified",
+):
+    user = _make_user(email)
+    claim = PlayerProfileClaim(
+        player_api_id=PLAYER_ID,
+        user_account_id=user.id,
+        relationship_type="player",
+        status=status,
+        verification_code=code,
+        verification_proof_url=proof_url,
+        verification_status=verification_status,
+    )
+    db.session.add(claim)
+    db.session.commit()
+    return user, claim
+
+
+def _fake_get(monkeypatch, responses):
+    """Patch requests.Session with an ordered response queue and return calls."""
+    queued = list(responses)
+    calls = []
+
+    class FakeCookies:
+        def clear(self):
+            return None
+
+    class FakeSession:
+        def __init__(self):
+            self.trust_env = True
+            self.cookies = FakeCookies()
+            self.headers = {}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            self.close()
+
+        def get(self, url, **kwargs):
+            calls.append((url, kwargs | {"session_headers": dict(self.headers), "trust_env": self.trust_env}))
+            if not queued:
+                raise AssertionError("unexpected network fetch")
+            response = queued.pop(0)
+            if isinstance(response, Exception):
+                raise response
+            return response
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(social_proof.requests, "Session", FakeSession)
+    return calls
+
+
+def _forbid_fetch(monkeypatch):
+    class ForbiddenSession:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError(f"unexpected network session: {args!r} {kwargs!r}")
+
+    monkeypatch.setattr(social_proof.requests, "Session", ForbiddenSession)
+
+
+class TestClaimCodeLifecycle:
+    def test_creation_mints_code_and_returns_full_verification_shape(self, client):
+        response = client.post(
+            f"/api/players/{PLAYER_ID}/claim",
+            json={"relationship_type": "player", "message": "This is me"},
+            headers=_user_headers("owner@example.com"),
+        )
+
+        assert response.status_code == 201, response.get_json()
+        claim = response.get_json()["claim"]
+        assert CODE_PATTERN.fullmatch(claim["verification_code"])
+        assert {
+            key: claim[key]
+            for key in (
+                "verification_proof_url",
+                "verification_status",
+                "verification_checked_at",
+                "verification_note",
+                "verification_method",
+            )
+        } == {
+            "verification_proof_url": None,
+            "verification_status": "unverified",
+            "verification_checked_at": None,
+            "verification_note": None,
+            "verification_method": None,
+        }
+
+    def test_me_claims_lazily_mints_and_persists_legacy_code(self, app, client):
+        with app.app_context():
+            _, claim = _seed_claim(code=None)
+            claim_id = claim.id
+
+        response = client.get("/api/me/claims", headers=_user_headers("owner@example.com"))
+
+        assert response.status_code == 200, response.get_json()
+        claims = response.get_json()["claims"]
+        assert len(claims) == 1
+        legacy_claim = claims[0]
+        assert CODE_PATTERN.fullmatch(legacy_claim["verification_code"])
+        assert legacy_claim["verification_proof_url"] is None
+        assert legacy_claim["verification_status"] == "unverified"
+        assert legacy_claim["verification_checked_at"] is None
+        assert legacy_claim["verification_note"] is None
+        assert legacy_claim["verification_method"] is None
+        with app.app_context():
+            assert db.session.get(PlayerProfileClaim, claim_id).verification_code == claims[0]["verification_code"]
+
+
+class TestProofUrlBoundary:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://instagram.com/academy-player",
+            "https://example.com/academy-player",
+            "https://127.0.0.1/academy-player",
+            "https://instagram.com:443/academy-player",
+            "https://claimant@instagram.com/academy-player",
+        ],
+    )
+    def test_invalid_url_is_400_before_fetch(self, app, client, monkeypatch, url):
+        with app.app_context():
+            _, claim = _seed_claim()
+            claim_id = claim.id
+        _forbid_fetch(monkeypatch)
+
+        response = client.post(
+            f"/api/me/claims/{claim_id}/verify",
+            json={"proof_url": url},
+            headers=_user_headers("owner@example.com"),
+        )
+
+        assert response.status_code == 400, response.get_json()
+        error = response.get_json()["error"]
+        assert "instagram.com" in error
+        assert "youtube.com" in error
+
+    def test_cross_host_redirect_is_refused_even_when_both_hosts_are_allowed(self, monkeypatch):
+        calls = _fake_get(
+            monkeypatch,
+            [
+                FakeResponse(
+                    status_code=302,
+                    headers={"Location": "https://tiktok.com/@academy-player"},
+                )
+            ],
+        )
+
+        result = social_proof.check_proof("https://instagram.com/academy-player", "AW-ABCDEFGH")
+
+        assert result["found"] is False
+        assert "redirect" in result["note"].lower()
+        assert len(calls) == 1
+
+    def test_body_is_capped_at_two_megabytes(self, monkeypatch):
+        code = "AW-ABCDEFGH"
+        body = (b"x" * (2 * 1024 * 1024)) + code.lower().encode()
+        calls = _fake_get(monkeypatch, [FakeResponse(body)])
+
+        result = social_proof.check_proof("https://instagram.com/academy-player", code)
+
+        assert result["found"] is False
+        assert code not in result["note"]
+        assert len(calls) == 1
+        _, kwargs = calls[0]
+        assert kwargs["timeout"] == (3.05, 6)
+        assert kwargs["allow_redirects"] is False
+        assert kwargs["stream"] is True
+        request_headers = kwargs.get("headers", {}) | kwargs.get("session_headers", {})
+        assert request_headers.get("User-Agent")
+        assert not {"Authorization", "Cookie"}.intersection(request_headers)
+        assert kwargs["trust_env"] is False
+
+    def test_network_errors_are_returned_as_advisory_notes(self, monkeypatch):
+        _fake_get(monkeypatch, [RuntimeError("simulated timeout")])
+
+        result = social_proof.check_proof("https://instagram.com/academy-player", "AW-ABCDEFGH")
+
+        assert result["found"] is False
+        assert result["note"]
+
+
+class TestClaimantVerification:
+    def test_code_found_updates_advisory_status(self, app, client, monkeypatch):
+        code = "AW-ABCDEFGH"
+        with app.app_context():
+            _, claim = _seed_claim(code=code)
+            claim_id = claim.id
+        calls = _fake_get(monkeypatch, [FakeResponse(f"Public bio: {code.lower()}".encode())])
+
+        response = client.post(
+            f"/api/me/claims/{claim_id}/verify",
+            json={"proof_url": "https://instagram.com/academy-player"},
+            headers=_user_headers("owner@example.com"),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        claim = response.get_json()["claim"]
+        assert claim["status"] == "pending"
+        assert claim["verification_status"] == "code_found"
+        assert claim["verification_checked_at"]
+        assert claim["verification_note"]
+        assert claim["verification_proof_url"] == "https://instagram.com/academy-player"
+        assert len(calls) == 1
+        with app.app_context():
+            stored = db.session.get(PlayerProfileClaim, claim_id)
+            assert stored.status == "pending"
+            assert stored.verification_status == "code_found"
+
+    def test_code_not_found_is_normal_200_outcome(self, app, client, monkeypatch):
+        with app.app_context():
+            _, claim = _seed_claim()
+            claim_id = claim.id
+        _fake_get(monkeypatch, [FakeResponse(b"A public profile without the verification token")])
+
+        response = client.post(
+            f"/api/me/claims/{claim_id}/verify",
+            json={"proof_url": "https://x.com/academy-player"},
+            headers=_user_headers("owner@example.com"),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        claim = response.get_json()["claim"]
+        assert claim["verification_status"] == "code_not_found"
+        assert claim["verification_checked_at"]
+        assert claim["verification_note"]
+
+    def test_non_owner_cannot_verify(self, app, client, monkeypatch):
+        with app.app_context():
+            _, claim = _seed_claim()
+            claim_id = claim.id
+        _forbid_fetch(monkeypatch)
+
+        response = client.post(
+            f"/api/me/claims/{claim_id}/verify",
+            json={"proof_url": "https://instagram.com/academy-player"},
+            headers=_user_headers("stranger@example.com"),
+        )
+
+        assert response.status_code in (403, 404), response.get_json()
+
+    def test_non_pending_claim_returns_409(self, app, client, monkeypatch):
+        with app.app_context():
+            _, claim = _seed_claim(status="approved")
+            claim_id = claim.id
+        _forbid_fetch(monkeypatch)
+
+        response = client.post(
+            f"/api/me/claims/{claim_id}/verify",
+            json={"proof_url": "https://instagram.com/academy-player"},
+            headers=_user_headers("owner@example.com"),
+        )
+
+        assert response.status_code == 409, response.get_json()
+
+
+class TestAdminRecheck:
+    def test_recheck_uses_stored_url_and_updates_result(self, app, client, monkeypatch):
+        code = "AW-ABCDEFGH"
+        proof_url = "https://youtube.com/@academy-player"
+        with app.app_context():
+            _, claim = _seed_claim(code=code, proof_url=proof_url, verification_status="code_not_found")
+            claim_id = claim.id
+        calls = _fake_get(monkeypatch, [FakeResponse(f"About {code}".encode())])
+
+        response = client.post(
+            f"/api/admin/showcase/claims/{claim_id}/recheck",
+            headers=_admin_headers(),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        claim = response.get_json()["claim"]
+        assert claim["verification_status"] == "code_found"
+        assert claim["verification_checked_at"]
+        assert calls[0][0] == proof_url
+
+    def test_recheck_without_stored_url_is_400_without_fetch(self, app, client, monkeypatch):
+        with app.app_context():
+            _, claim = _seed_claim(proof_url=None)
+            claim_id = claim.id
+        _forbid_fetch(monkeypatch)
+
+        response = client.post(
+            f"/api/admin/showcase/claims/{claim_id}/recheck",
+            headers=_admin_headers(),
+        )
+
+        assert response.status_code == 400, response.get_json()
+
+    def test_admin_list_includes_verification_fields(self, app, client):
+        with app.app_context():
+            _seed_claim(proof_url="https://facebook.com/academy-player")
+
+        response = client.get("/api/admin/showcase/claims", headers=_admin_headers())
+
+        assert response.status_code == 200, response.get_json()
+        claim = response.get_json()["claims"][0]
+        assert {
+            "verification_code",
+            "verification_proof_url",
+            "verification_status",
+            "verification_checked_at",
+            "verification_note",
+            "verification_method",
+        }.issubset(claim)
+
+
+def test_verification_code_never_appears_in_public_showcase(app, client):
+    code = "AW-ABCDEFGH"
+    with app.app_context():
+        _seed_claim(status="approved", code=code, verification_status="code_found")
+
+    response = client.get(f"/api/players/{PLAYER_ID}/showcase")
+
+    assert response.status_code == 200, response.get_json()
+    assert response.get_json()["claim_status"] == "claimed"
+    serialized = json.dumps(response.get_json())
+    assert "verification_code" not in serialized
+    assert code not in serialized

--- a/academy-watch-backend/tests/test_claim_verification.py
+++ b/academy-watch-backend/tests/test_claim_verification.py
@@ -158,11 +158,15 @@ def _fake_get(monkeypatch, responses):
 
 
 def _forbid_fetch(monkeypatch):
+    attempts = []
+
     class ForbiddenSession:
         def __init__(self, *args, **kwargs):
+            attempts.append((args, kwargs))
             raise AssertionError(f"unexpected network session: {args!r} {kwargs!r}")
 
     monkeypatch.setattr(social_proof.requests, "Session", ForbiddenSession)
+    return attempts
 
 
 class TestClaimCodeLifecycle:
@@ -241,6 +245,35 @@ class TestProofUrlBoundary:
         error = response.get_json()["error"]
         assert "instagram.com" in error
         assert "youtube.com" in error
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://youtube.com/results?search_query=aw-abcdefgh",
+            ("https://youtube.com/results?search_query=%41%57%2D%41%42%43%44%45%46%47%48"),
+        ],
+    )
+    def test_reflected_code_url_is_400_before_fetch(self, app, client, monkeypatch, url):
+        with app.app_context():
+            _, claim = _seed_claim(code="AW-ABCDEFGH")
+            claim_id = claim.id
+        fetch_attempts = _forbid_fetch(monkeypatch)
+
+        response = client.post(
+            f"/api/me/claims/{claim_id}/verify",
+            json={"proof_url": url},
+            headers=_user_headers("owner@example.com"),
+        )
+        standard_error = client.post(
+            f"/api/me/claims/{claim_id}/verify",
+            json={"proof_url": "https://example.com/academy-player"},
+            headers=_user_headers("owner@example.com"),
+        )
+
+        assert response.status_code == 400, response.get_json()
+        assert standard_error.status_code == 400, standard_error.get_json()
+        assert response.get_json() == standard_error.get_json()
+        assert fetch_attempts == []
 
     def test_cross_host_redirect_is_refused_even_when_both_hosts_are_allowed(self, monkeypatch):
         calls = _fake_get(
@@ -393,6 +426,30 @@ class TestAdminRecheck:
         )
 
         assert response.status_code == 400, response.get_json()
+
+    def test_recheck_rejects_stored_reflected_code_url_before_fetch(self, app, client, monkeypatch):
+        proof_url = "https://youtube.com/results?search_query=aw%2Dabcdefgh"
+        with app.app_context():
+            _, claim = _seed_claim(
+                code="AW-ABCDEFGH",
+                proof_url=proof_url,
+                verification_status="code_not_found",
+            )
+            claim_id = claim.id
+        fetch_attempts = _forbid_fetch(monkeypatch)
+
+        response = client.post(
+            f"/api/admin/showcase/claims/{claim_id}/recheck",
+            headers=_admin_headers(),
+        )
+
+        assert response.status_code == 400, response.get_json()
+        assert response.get_json()["error"].startswith("proof_url must be an HTTPS public profile URL")
+        assert fetch_attempts == []
+        with app.app_context():
+            stored = db.session.get(PlayerProfileClaim, claim_id)
+            assert stored.verification_status == "code_not_found"
+            assert stored.verification_checked_at is None
 
     def test_admin_list_includes_verification_fields(self, app, client):
         with app.app_context():

--- a/academy-watch-backend/tests/test_club_officials.py
+++ b/academy-watch-backend/tests/test_club_officials.py
@@ -1,0 +1,872 @@
+"""Tests for club-official claims, affiliation decisions, and player vouching.
+
+The module owns an isolated in-memory SQLite app. Social-proof HTTP is always
+replaced at the ``social_proof.requests`` boundary, so these tests never make a
+real network request.
+"""
+
+import json
+import re
+from datetime import UTC, datetime
+from io import BytesIO
+
+import pytest
+from flask import Flask
+from src.auth import _ensure_user_account, issue_user_token
+from src.models.league import League, Team, db
+from src.models.showcase import (
+    ClubOfficialClaim,
+    LocalClub,
+    PlayerClubAffiliation,
+    PlayerProfileClaim,
+    PlayerShowcaseProfile,
+)
+from src.services import social_proof
+
+ADMIN_KEY = "test-admin-key"
+PLAYER_ID = 5001
+OTHER_PLAYER_ID = 5002
+TEAM_ID = 4401
+OTHER_TEAM_ID = 4402
+CODE_PATTERN = re.compile(r"^AW-[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$")
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("SKIP_API_HANDSHAKE", "1")
+    monkeypatch.setenv("API_USE_STUB_DATA", "true")
+    monkeypatch.setenv("ADMIN_API_KEY", ADMIN_KEY)
+    monkeypatch.setenv("ADMIN_IP_WHITELIST", "")
+
+    from src.routes.showcase import showcase_bp
+
+    flask_app = Flask(__name__)
+    flask_app.config.update(
+        TESTING=True,
+        SECRET_KEY="test-secret-key",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        RATELIMIT_ENABLED=False,
+    )
+
+    db.init_app(flask_app)
+    flask_app.register_blueprint(showcase_bp, url_prefix="/api")
+
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+class FakeResponse:
+    """Small streaming ``requests.Response`` stand-in."""
+
+    def __init__(self, body=b"", *, status_code=200, headers=None, encoding="utf-8"):
+        self._body = body
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.encoding = encoding
+        self.raw = BytesIO(body)
+        self.closed = False
+
+    @property
+    def content(self):
+        return self._body
+
+    @property
+    def text(self):
+        return self._body.decode(self.encoding or "utf-8", errors="replace")
+
+    def iter_content(self, chunk_size=1, decode_unicode=False):
+        del decode_unicode
+        for start in range(0, len(self._body), chunk_size):
+            yield self._body[start : start + chunk_size]
+
+    def close(self):
+        self.closed = True
+
+
+def _fake_get(monkeypatch, responses):
+    """Patch ``requests.Session`` with an ordered response queue."""
+    queued = list(responses)
+    calls = []
+
+    class FakeCookies:
+        def clear(self):
+            return None
+
+    class FakeSession:
+        def __init__(self):
+            self.trust_env = True
+            self.cookies = FakeCookies()
+            self.headers = {}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            self.close()
+
+        def get(self, url, **kwargs):
+            calls.append((url, kwargs | {"session_headers": dict(self.headers), "trust_env": self.trust_env}))
+            if not queued:
+                raise AssertionError("unexpected network fetch")
+            response = queued.pop(0)
+            if isinstance(response, Exception):
+                raise response
+            return response
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(social_proof.requests, "Session", FakeSession)
+    return calls
+
+
+def _forbid_fetch(monkeypatch):
+    class ForbiddenSession:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError(f"unexpected network session: {args!r} {kwargs!r}")
+
+    monkeypatch.setattr(social_proof.requests, "Session", ForbiddenSession)
+
+
+def _user_headers(email):
+    token = issue_user_token(email)["token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _admin_headers():
+    token = issue_user_token("admin@test.com", role="admin")["token"]
+    return {"Authorization": f"Bearer {token}", "X-API-Key": ADMIN_KEY}
+
+
+def _make_user(email):
+    user = _ensure_user_account(email)
+    db.session.commit()
+    return user
+
+
+def _seed_team(team_id=TEAM_ID, name="Northbridge United", *, season=2025):
+    league = League.query.filter_by(league_id=39).first()
+    if league is None:
+        league = League(league_id=39, name="Premier League", country="England", season=2025)
+        db.session.add(league)
+        db.session.flush()
+    team = Team(
+        team_id=team_id,
+        name=name,
+        country="England",
+        season=season,
+        league_id=league.id,
+        is_active=True,
+    )
+    db.session.add(team)
+    db.session.flush()
+    return team
+
+
+def _seed_local_club(
+    name="Northside Juniors",
+    *,
+    status="verified",
+    merged_into_local_club_id=None,
+):
+    club = LocalClub(
+        name=name,
+        normalized_name=LocalClub.normalize_name(name),
+        country="England",
+        city="Leeds",
+        level="youth",
+        status=status,
+        provenance="user",
+        merged_into_local_club_id=merged_into_local_club_id,
+    )
+    db.session.add(club)
+    db.session.flush()
+    return club
+
+
+def _seed_official_claim(
+    email="official@example.com",
+    *,
+    team_api_id=None,
+    local_club_id=None,
+    status="pending",
+    code="AW-CLUBCODE",
+    proof_url=None,
+    verification_status="unverified",
+):
+    user = _make_user(email)
+    claim = ClubOfficialClaim(
+        user_account_id=user.id,
+        team_api_id=team_api_id,
+        local_club_id=local_club_id,
+        role_title="Academy Director",
+        message="I manage the academy.",
+        status=status,
+        verification_code=code,
+        verification_proof_url=proof_url,
+        verification_status=verification_status,
+    )
+    db.session.add(claim)
+    db.session.commit()
+    return user, claim
+
+
+def _seed_player_claim(
+    *,
+    player_api_id=PLAYER_ID,
+    email="player@example.com",
+    status="pending",
+    code="AW-PLAYERCODE",
+    verification_status="unverified",
+    verification_checked_at=None,
+):
+    user = _make_user(email)
+    claim = PlayerProfileClaim(
+        player_api_id=player_api_id,
+        user_account_id=user.id,
+        relationship_type="player",
+        status=status,
+        verification_code=code,
+        verification_status=verification_status,
+        verification_checked_at=verification_checked_at,
+    )
+    db.session.add(claim)
+    db.session.commit()
+    return user, claim
+
+
+def _seed_affiliation(
+    *,
+    player_api_id=PLAYER_ID,
+    team_api_id=None,
+    local_club_id=None,
+    status="pending",
+    review_note=None,
+):
+    affiliation = PlayerClubAffiliation(
+        player_api_id=player_api_id,
+        team_api_id=team_api_id,
+        local_club_id=local_club_id,
+        season="2025/26",
+        status=status,
+        review_note=review_note,
+    )
+    db.session.add(affiliation)
+    db.session.commit()
+    return affiliation
+
+
+class TestClubClaimSubmission:
+    def test_requires_auth(self, client):
+        response = client.post(
+            "/api/clubs/claim",
+            json={"team_api_id": TEAM_ID, "role_title": "Academy Director"},
+        )
+
+        assert response.status_code == 401
+
+    def test_team_claim_sanitizes_fields_and_resolves_latest_name(self, app, client):
+        with app.app_context():
+            _seed_team(name="Northbridge Old Name", season=2024)
+            _seed_team(name="Northbridge United", season=2025)
+            db.session.commit()
+
+        response = client.post(
+            "/api/clubs/claim",
+            json={
+                "team_api_id": TEAM_ID,
+                "role_title": " <b>Academy Director</b> ",
+                "message": f"<script>{'M' * 900}</script>",
+            },
+            headers=_user_headers("official@example.com"),
+        )
+
+        assert response.status_code == 201, response.get_json()
+        claim = response.get_json()["claim"]
+        assert claim["team_api_id"] == TEAM_ID
+        assert claim["local_club_id"] is None
+        assert claim["club_name"] == "Northbridge United"
+        assert claim["role_title"] == "Academy Director"
+        assert claim["message"] == "M" * 900
+        assert claim["status"] == "pending"
+        assert CODE_PATTERN.fullmatch(claim["verification_code"])
+        assert claim["verification_status"] == "unverified"
+
+    def test_reference_xor_and_active_local_club_validation(self, app, client):
+        with app.app_context():
+            active = _seed_local_club("Active Club", status="pending")
+            merged = _seed_local_club("Merged Club", status="merged")
+            rejected = _seed_local_club("Rejected Club", status="rejected")
+            db.session.commit()
+            active_id = active.id
+            invalid_local_ids = (merged.id, rejected.id, 999999)
+
+        payloads = [
+            {"role_title": "Coach"},
+            {"team_api_id": TEAM_ID, "local_club_id": active_id, "role_title": "Coach"},
+            {"team_api_id": 0, "role_title": "Coach"},
+            {"team_api_id": -1, "role_title": "Coach"},
+            {"team_api_id": "4401", "role_title": "Coach"},
+            {"team_api_id": True, "role_title": "Coach"},
+            *({"local_club_id": club_id, "role_title": "Coach"} for club_id in invalid_local_ids),
+        ]
+        headers = _user_headers("official@example.com")
+
+        for payload in payloads:
+            response = client.post("/api/clubs/claim", json=payload, headers=headers)
+            assert response.status_code == 400, (payload, response.get_json())
+
+        with app.app_context():
+            assert ClubOfficialClaim.query.count() == 0
+
+    def test_role_title_is_required_and_bounded_after_sanitizing(self, client):
+        headers = _user_headers("official@example.com")
+        for role_title in (None, "x", "x" * 101, 123):
+            payload = {"team_api_id": TEAM_ID}
+            if role_title is not None:
+                payload["role_title"] = role_title
+            response = client.post("/api/clubs/claim", json=payload, headers=headers)
+            assert response.status_code == 400, (role_title, response.get_json())
+
+        too_long_message = client.post(
+            "/api/clubs/claim",
+            json={"team_api_id": TEAM_ID, "role_title": "Coach", "message": "x" * 1001},
+            headers=headers,
+        )
+        assert too_long_message.status_code == 400, too_long_message.get_json()
+
+    @pytest.mark.parametrize("status", ["pending", "approved"])
+    def test_active_duplicate_is_409(self, app, client, status):
+        with app.app_context():
+            _seed_official_claim(team_api_id=TEAM_ID, status=status)
+
+        response = client.post(
+            "/api/clubs/claim",
+            json={"team_api_id": TEAM_ID, "role_title": "Head Coach"},
+            headers=_user_headers("official@example.com"),
+        )
+
+        assert response.status_code == 409, response.get_json()
+
+    def test_active_duplicate_follows_one_local_merge_hop(self, app, client):
+        with app.app_context():
+            canonical = _seed_local_club("Canonical Academy", status="verified")
+            merged = _seed_local_club(
+                "Former Academy Name",
+                status="merged",
+                merged_into_local_club_id=canonical.id,
+            )
+            db.session.commit()
+            canonical_id = canonical.id
+            _seed_official_claim(local_club_id=merged.id, status="approved")
+
+        response = client.post(
+            "/api/clubs/claim",
+            json={"local_club_id": canonical_id, "role_title": "Head Coach"},
+            headers=_user_headers("official@example.com"),
+        )
+
+        assert response.status_code == 409, response.get_json()
+
+
+class TestClubClaimVerification:
+    def test_me_claims_is_owner_scoped_and_lazily_mints_code(self, app, client):
+        with app.app_context():
+            _seed_team()
+            _, own = _seed_official_claim(team_api_id=TEAM_ID, code=None)
+            _seed_official_claim(
+                email="other-official@example.com",
+                team_api_id=OTHER_TEAM_ID,
+                code="AW-OTHERCODE",
+            )
+            own_id = own.id
+
+        response = client.get(
+            "/api/me/club-claims",
+            headers=_user_headers("official@example.com"),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        claims = response.get_json()["claims"]
+        assert len(claims) == 1
+        claim = claims[0]
+        assert claim["id"] == own_id
+        assert claim["club_name"] == "Northbridge United"
+        assert CODE_PATTERN.fullmatch(claim["verification_code"])
+        assert {
+            "verification_proof_url",
+            "verification_status",
+            "verification_checked_at",
+            "verification_note",
+            "verification_method",
+        }.issubset(claim)
+        with app.app_context():
+            assert CODE_PATTERN.fullmatch(db.session.get(ClubOfficialClaim, own_id).verification_code)
+
+    def test_code_found_updates_advisory_status(self, app, client, monkeypatch):
+        code = "AW-ABCDEFGH"
+        with app.app_context():
+            _seed_team()
+            _, claim = _seed_official_claim(team_api_id=TEAM_ID, code=code)
+            claim_id = claim.id
+        calls = _fake_get(monkeypatch, [FakeResponse(f"Public club bio: {code.lower()}".encode())])
+
+        response = client.post(
+            f"/api/me/club-claims/{claim_id}/verify",
+            json={"proof_url": "https://instagram.com/northbridge-united"},
+            headers=_user_headers("official@example.com"),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        verified = response.get_json()["claim"]
+        assert verified["status"] == "pending"
+        assert verified["verification_status"] == "code_found"
+        assert verified["verification_checked_at"]
+        assert verified["verification_note"]
+        assert verified["verification_proof_url"] == "https://instagram.com/northbridge-united"
+        assert verified["club_name"] == "Northbridge United"
+        assert "verification_code" not in verified
+        assert len(calls) == 1
+
+    def test_code_not_found_is_a_normal_200_result(self, app, client, monkeypatch):
+        with app.app_context():
+            _, claim = _seed_official_claim(team_api_id=TEAM_ID, code="AW-ABCDEFGH")
+            claim_id = claim.id
+        _fake_get(monkeypatch, [FakeResponse(b"A public club profile without the token")])
+
+        response = client.post(
+            f"/api/me/club-claims/{claim_id}/verify",
+            json={"proof_url": "https://x.com/northbridge-united"},
+            headers=_user_headers("official@example.com"),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        verified = response.get_json()["claim"]
+        assert verified["verification_status"] == "code_not_found"
+        assert verified["verification_checked_at"]
+        assert verified["verification_note"]
+
+    def test_invalid_proof_url_is_rejected_before_fetch(self, app, client, monkeypatch):
+        with app.app_context():
+            _, claim = _seed_official_claim(team_api_id=TEAM_ID)
+            claim_id = claim.id
+        _forbid_fetch(monkeypatch)
+
+        response = client.post(
+            f"/api/me/club-claims/{claim_id}/verify",
+            json={"proof_url": "https://example.com/northbridge"},
+            headers=_user_headers("official@example.com"),
+        )
+
+        assert response.status_code == 400, response.get_json()
+
+    def test_non_owner_gets_404_without_fetch(self, app, client, monkeypatch):
+        with app.app_context():
+            _, claim = _seed_official_claim(team_api_id=TEAM_ID)
+            claim_id = claim.id
+        _forbid_fetch(monkeypatch)
+
+        response = client.post(
+            f"/api/me/club-claims/{claim_id}/verify",
+            json={"proof_url": "https://instagram.com/northbridge"},
+            headers=_user_headers("stranger@example.com"),
+        )
+
+        assert response.status_code == 404, response.get_json()
+
+    def test_non_pending_claim_is_409_without_fetch(self, app, client, monkeypatch):
+        with app.app_context():
+            _, claim = _seed_official_claim(team_api_id=TEAM_ID, status="approved")
+            claim_id = claim.id
+        _forbid_fetch(monkeypatch)
+
+        response = client.post(
+            f"/api/me/club-claims/{claim_id}/verify",
+            json={"proof_url": "https://instagram.com/northbridge"},
+            headers=_user_headers("official@example.com"),
+        )
+
+        assert response.status_code == 409, response.get_json()
+
+
+class TestMyClubDashboard:
+    def test_shape_merge_hop_matching_and_player_code_stripping(self, app, client):
+        checked_at = datetime(2026, 7, 14, 10, 0, tzinfo=UTC)
+        with app.app_context():
+            canonical = _seed_local_club("Northside Academy", status="verified")
+            merged = _seed_local_club(
+                "Northside Juniors Old",
+                status="merged",
+                merged_into_local_club_id=canonical.id,
+            )
+            other = _seed_local_club("Other Academy", status="verified")
+            db.session.commit()
+            canonical_id = canonical.id
+            merged_id = merged.id
+            other_id = other.id
+
+            _, official_claim = _seed_official_claim(
+                local_club_id=canonical_id,
+                status="approved",
+                code="AW-OFFICIALSECRET",
+            )
+            pending_affiliation = _seed_affiliation(
+                player_api_id=PLAYER_ID,
+                local_club_id=merged_id,
+                status="pending",
+                review_note="Awaiting the club",
+            )
+            self_reported_affiliation = _seed_affiliation(
+                player_api_id=OTHER_PLAYER_ID,
+                local_club_id=canonical_id,
+                status="self_reported",
+                review_note="Admin accepted the report",
+            )
+            _seed_affiliation(
+                player_api_id=5003,
+                local_club_id=merged_id,
+                status="rejected",
+                review_note="Rejected report",
+            )
+            _seed_affiliation(player_api_id=5004, local_club_id=other_id, status="pending")
+
+            _, first_player_claim = _seed_player_claim(
+                player_api_id=PLAYER_ID,
+                email="first-player@example.com",
+                code="AW-FIRSTPLAYERSECRET",
+                verification_status="code_found",
+                verification_checked_at=checked_at,
+            )
+            _, second_player_claim = _seed_player_claim(
+                player_api_id=OTHER_PLAYER_ID,
+                email="second-player@example.com",
+                code="AW-SECONDPLAYERSECRET",
+            )
+            _seed_player_claim(player_api_id=5003, email="rejected-aff-player@example.com")
+            _seed_player_claim(player_api_id=5004, email="other-club-player@example.com")
+            _seed_player_claim(
+                player_api_id=PLAYER_ID,
+                email="already-approved@example.com",
+                status="approved",
+            )
+            official_claim_id = official_claim.id
+            expected_affiliation_ids = {pending_affiliation.id, self_reported_affiliation.id}
+            expected_player_claim_ids = {first_player_claim.id, second_player_claim.id}
+
+        response = client.get("/api/me/club", headers=_user_headers("official@example.com"))
+
+        assert response.status_code == 200, response.get_json()
+        clubs = response.get_json()["clubs"]
+        assert len(clubs) == 1
+        club = clubs[0]
+        assert club["claim"]["id"] == official_claim_id
+        assert club["club_name"] == "Northside Academy"
+        assert {item["id"] for item in club["pending_affiliations"]} == expected_affiliation_ids
+        assert {item["status"] for item in club["pending_affiliations"]} == {"pending", "self_reported"}
+        assert all("review_note" in item for item in club["pending_affiliations"])
+
+        player_claims = club["vouchable_player_claims"]
+        assert {item["id"] for item in player_claims} == expected_player_claim_ids
+        assert all("verification_code" not in item for item in player_claims)
+        first = next(item for item in player_claims if item["id"] == first_player_claim.id)
+        assert first["verification_status"] == "code_found"
+        assert first["verification_checked_at"]
+
+        serialized = json.dumps(response.get_json())
+        assert "verification_code" not in serialized
+        assert "AW-OFFICIALSECRET" not in serialized
+        assert "AW-FIRSTPLAYERSECRET" not in serialized
+        assert "AW-SECONDPLAYERSECRET" not in serialized
+
+
+class TestClubAffiliationDecisions:
+    def test_confirm_marks_pending_affiliation_club_confirmed(self, app, client):
+        with app.app_context():
+            _seed_team()
+            _seed_official_claim(team_api_id=TEAM_ID, status="approved")
+            affiliation = _seed_affiliation(team_api_id=TEAM_ID, status="pending")
+            affiliation_id = affiliation.id
+
+        response = client.post(
+            f"/api/me/club/affiliations/{affiliation_id}/confirm",
+            headers=_user_headers("official@example.com"),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        assert response.get_json()["affiliation"]["status"] == "club_confirmed"
+        with app.app_context():
+            stored = db.session.get(PlayerClubAffiliation, affiliation_id)
+            assert stored.status == "club_confirmed"
+            assert stored.reviewed_by == "official@example.com"
+            assert stored.reviewed_at is not None
+
+    def test_reject_allows_self_reported_and_sanitizes_note(self, app, client):
+        with app.app_context():
+            _seed_official_claim(team_api_id=TEAM_ID, status="approved")
+            affiliation = _seed_affiliation(team_api_id=TEAM_ID, status="self_reported")
+            affiliation_id = affiliation.id
+
+        response = client.post(
+            f"/api/me/club/affiliations/{affiliation_id}/reject",
+            json={"note": " <b>Player is not registered here</b> "},
+            headers=_user_headers("official@example.com"),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        rejected = response.get_json()["affiliation"]
+        assert rejected["status"] == "rejected"
+        assert rejected["review_note"] == "Player is not registered here"
+        with app.app_context():
+            stored = db.session.get(PlayerClubAffiliation, affiliation_id)
+            assert stored.reviewed_by == "official@example.com"
+            assert stored.reviewed_at is not None
+
+    def test_wrong_club_official_cannot_decide_affiliation(self, app, client):
+        with app.app_context():
+            _seed_official_claim(team_api_id=OTHER_TEAM_ID, status="approved")
+            affiliation = _seed_affiliation(team_api_id=TEAM_ID, status="pending")
+            affiliation_id = affiliation.id
+
+        response = client.post(
+            f"/api/me/club/affiliations/{affiliation_id}/confirm",
+            headers=_user_headers("official@example.com"),
+        )
+
+        assert response.status_code in (403, 404), response.get_json()
+        with app.app_context():
+            assert db.session.get(PlayerClubAffiliation, affiliation_id).status == "pending"
+
+    @pytest.mark.parametrize(
+        ("action", "status"),
+        [("confirm", "club_confirmed"), ("reject", "rejected")],
+    )
+    def test_non_reviewable_affiliation_is_409(self, app, client, action, status):
+        with app.app_context():
+            _seed_official_claim(team_api_id=TEAM_ID, status="approved")
+            affiliation = _seed_affiliation(team_api_id=TEAM_ID, status=status)
+            affiliation_id = affiliation.id
+
+        response = client.post(
+            f"/api/me/club/affiliations/{affiliation_id}/{action}",
+            json={} if action == "reject" else None,
+            headers=_user_headers("official@example.com"),
+        )
+
+        assert response.status_code == 409, response.get_json()
+
+
+class TestPlayerClaimVouching:
+    def test_vouch_approves_identity_but_leaves_content_pending(self, app, client):
+        with app.app_context():
+            canonical = _seed_local_club("Northside Academy", status="verified")
+            merged = _seed_local_club(
+                "Old Northside Academy",
+                status="merged",
+                merged_into_local_club_id=canonical.id,
+            )
+            db.session.commit()
+            canonical_id = canonical.id
+            merged_id = merged.id
+            _seed_official_claim(local_club_id=canonical_id, status="approved")
+            _seed_affiliation(local_club_id=merged_id, status="pending")
+            _, player_claim = _seed_player_claim(code="AW-PLAYERSECRET")
+            profile = PlayerShowcaseProfile(
+                player_api_id=PLAYER_ID,
+                bio="Pending owner content",
+                status="pending",
+            )
+            db.session.add(profile)
+            db.session.commit()
+            player_claim_id = player_claim.id
+
+        response = client.post(
+            f"/api/me/club/player-claims/{player_claim_id}/vouch",
+            headers=_user_headers("official@example.com"),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        vouched = response.get_json()["claim"]
+        assert vouched["status"] == "approved"
+        assert vouched["verification_method"] == "vouch"
+        assert vouched["verification_note"] == "Vouched by a verified Northside Academy official"
+        assert vouched["reviewed_by"] == "official@example.com"
+        assert vouched["reviewed_at"]
+        assert "verification_code" not in vouched
+        assert "AW-PLAYERSECRET" not in json.dumps(response.get_json())
+
+        with app.app_context():
+            stored_claim = db.session.get(PlayerProfileClaim, player_claim_id)
+            assert stored_claim.status == "approved"
+            assert stored_claim.verification_code == "AW-PLAYERSECRET"
+            assert PlayerShowcaseProfile.query.filter_by(player_api_id=PLAYER_ID).one().status == "pending"
+
+        public = client.get(f"/api/players/{PLAYER_ID}/showcase")
+        assert public.status_code == 200, public.get_json()
+        assert public.get_json()["claim_status"] == "claimed"
+        assert public.get_json()["profile"] is None
+
+    def test_ineligible_player_is_rejected_without_changing_claim(self, app, client):
+        with app.app_context():
+            _seed_official_claim(team_api_id=TEAM_ID, status="approved")
+            _seed_affiliation(team_api_id=OTHER_TEAM_ID, status="pending")
+            _, player_claim = _seed_player_claim()
+            player_claim_id = player_claim.id
+
+        response = client.post(
+            f"/api/me/club/player-claims/{player_claim_id}/vouch",
+            headers=_user_headers("official@example.com"),
+        )
+
+        assert 400 <= response.status_code < 500, response.get_json()
+        assert response.status_code != 409
+        with app.app_context():
+            assert db.session.get(PlayerProfileClaim, player_claim_id).status == "pending"
+
+    def test_non_pending_player_claim_is_409(self, app, client):
+        with app.app_context():
+            _seed_official_claim(team_api_id=TEAM_ID, status="approved")
+            _seed_affiliation(team_api_id=TEAM_ID, status="club_confirmed")
+            _, player_claim = _seed_player_claim(status="approved")
+            player_claim_id = player_claim.id
+
+        response = client.post(
+            f"/api/me/club/player-claims/{player_claim_id}/vouch",
+            headers=_user_headers("official@example.com"),
+        )
+
+        assert response.status_code == 409, response.get_json()
+
+
+class TestAdminClubClaims:
+    def test_list_filters_status_and_includes_club_name_and_code(self, app, client):
+        with app.app_context():
+            _seed_team()
+            _, pending = _seed_official_claim(team_api_id=TEAM_ID, code="AW-ADMINVISIBLE")
+            _seed_official_claim(
+                email="approved-official@example.com",
+                team_api_id=OTHER_TEAM_ID,
+                status="approved",
+            )
+            pending_id = pending.id
+
+        response = client.get(
+            "/api/admin/club-claims?status=pending",
+            headers=_admin_headers(),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        claims = response.get_json()["claims"]
+        assert [claim["id"] for claim in claims] == [pending_id]
+        assert claims[0]["club_name"] == "Northbridge United"
+        assert claims[0]["verification_code"] == "AW-ADMINVISIBLE"
+
+    @pytest.mark.parametrize(
+        ("starting_status", "action", "expected_status"),
+        [
+            ("pending", "approve", "approved"),
+            ("pending", "reject", "rejected"),
+            ("approved", "revoke", "revoked"),
+        ],
+    )
+    def test_review_transitions(self, app, client, starting_status, action, expected_status):
+        with app.app_context():
+            _, claim = _seed_official_claim(team_api_id=TEAM_ID, status=starting_status)
+            claim_id = claim.id
+
+        response = client.post(
+            f"/api/admin/club-claims/{claim_id}/review",
+            json={"action": action, "note": "<b>Checked by operations</b>"},
+            headers=_admin_headers(),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        reviewed = response.get_json()["claim"]
+        assert reviewed["status"] == expected_status
+        assert reviewed["reviewed_by"] == "admin@test.com"
+        assert reviewed["reviewed_at"]
+        assert "verification_code" not in reviewed
+        with app.app_context():
+            stored = db.session.get(ClubOfficialClaim, claim_id)
+            assert stored.status == expected_status
+            assert stored.review_note == "Checked by operations"
+
+    @pytest.mark.parametrize(
+        ("starting_status", "action"),
+        [("approved", "approve"), ("approved", "reject"), ("pending", "revoke")],
+    )
+    def test_review_rejects_invalid_transition(self, app, client, starting_status, action):
+        with app.app_context():
+            _, claim = _seed_official_claim(team_api_id=TEAM_ID, status=starting_status)
+            claim_id = claim.id
+
+        response = client.post(
+            f"/api/admin/club-claims/{claim_id}/review",
+            json={"action": action},
+            headers=_admin_headers(),
+        )
+
+        assert response.status_code == 409, response.get_json()
+
+    def test_recheck_uses_stored_proof_url(self, app, client, monkeypatch):
+        code = "AW-ABCDEFGH"
+        proof_url = "https://youtube.com/@northbridge"
+        with app.app_context():
+            _, claim = _seed_official_claim(
+                team_api_id=TEAM_ID,
+                code=code,
+                proof_url=proof_url,
+                verification_status="code_not_found",
+            )
+            claim_id = claim.id
+        calls = _fake_get(monkeypatch, [FakeResponse(f"About the club {code}".encode())])
+
+        response = client.post(
+            f"/api/admin/club-claims/{claim_id}/recheck",
+            headers=_admin_headers(),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        checked = response.get_json()["claim"]
+        assert checked["verification_status"] == "code_found"
+        assert checked["verification_checked_at"]
+        assert "verification_code" not in checked
+        assert calls[0][0] == proof_url
+
+    def test_recheck_without_proof_url_is_400_without_fetch(self, app, client, monkeypatch):
+        with app.app_context():
+            _, claim = _seed_official_claim(team_api_id=TEAM_ID, proof_url=None)
+            claim_id = claim.id
+        _forbid_fetch(monkeypatch)
+
+        response = client.post(
+            f"/api/admin/club-claims/{claim_id}/recheck",
+            headers=_admin_headers(),
+        )
+
+        assert response.status_code == 400, response.get_json()
+
+
+def test_club_claim_code_never_appears_in_public_showcase(app, client):
+    club_secret = "AW-CLUBPUBLICSECRET"
+    player_secret = "AW-PLAYERPUBLICSECRET"
+    with app.app_context():
+        _seed_official_claim(team_api_id=TEAM_ID, status="approved", code=club_secret)
+        _seed_player_claim(status="approved", code=player_secret)
+        _seed_affiliation(team_api_id=TEAM_ID, status="club_confirmed")
+
+    response = client.get(f"/api/players/{PLAYER_ID}/showcase")
+
+    assert response.status_code == 200, response.get_json()
+    serialized = json.dumps(response.get_json())
+    assert "verification_code" not in serialized
+    assert club_secret not in serialized
+    assert player_secret not in serialized

--- a/academy-watch-backend/tests/test_club_officials.py
+++ b/academy-watch-backend/tests/test_club_officials.py
@@ -377,6 +377,29 @@ class TestClubClaimSubmission:
 
         assert response.status_code == 409, response.get_json()
 
+    def test_pending_claim_quota_rejects_sixth_outstanding_claim(self, app, client):
+        with app.app_context():
+            for offset in range(5):
+                _seed_official_claim(team_api_id=10_000 + offset)
+
+        response = client.post(
+            "/api/clubs/claim",
+            json={"team_api_id": 20_000, "role_title": "Head Coach"},
+            headers=_user_headers("official@example.com"),
+        )
+
+        assert response.status_code == 429, response.get_json()
+        assert response.get_json() == {"error": "pending club-official claim limit reached (5)"}
+        with app.app_context():
+            user = _ensure_user_account("official@example.com")
+            assert (
+                ClubOfficialClaim.query.filter_by(
+                    user_account_id=user.id,
+                    status="pending",
+                ).count()
+                == 5
+            )
+
 
 class TestClubClaimVerification:
     def test_me_claims_is_owner_scoped_and_lazily_mints_code(self, app, client):
@@ -630,18 +653,69 @@ class TestClubAffiliationDecisions:
             assert stored.reviewed_by == "official@example.com"
             assert stored.reviewed_at is not None
 
-    def test_wrong_club_official_cannot_decide_affiliation(self, app, client):
+    @pytest.mark.parametrize("action", ["confirm", "reject"])
+    def test_absent_and_unauthorized_affiliation_are_uniform_404(self, app, client, action):
         with app.app_context():
             _seed_official_claim(team_api_id=OTHER_TEAM_ID, status="approved")
-            affiliation = _seed_affiliation(team_api_id=TEAM_ID, status="pending")
+            affiliation = _seed_affiliation(team_api_id=TEAM_ID, status="club_confirmed")
             affiliation_id = affiliation.id
 
-        response = client.post(
-            f"/api/me/club/affiliations/{affiliation_id}/confirm",
+        unauthorized = client.post(
+            f"/api/me/club/affiliations/{affiliation_id}/{action}",
+            headers=_user_headers("official@example.com"),
+        )
+        absent = client.post(
+            f"/api/me/club/affiliations/999999/{action}",
             headers=_user_headers("official@example.com"),
         )
 
-        assert response.status_code in (403, 404), response.get_json()
+        assert unauthorized.status_code == absent.status_code == 404
+        assert unauthorized.get_json() == absent.get_json() == {"error": "affiliation not found"}
+        with app.app_context():
+            assert db.session.get(PlayerClubAffiliation, affiliation_id).status == "club_confirmed"
+
+    @pytest.mark.parametrize(
+        ("action", "expected_status"),
+        [("confirm", "club_confirmed"), ("reject", "rejected")],
+    )
+    def test_verified_local_club_official_can_decide_affiliation(
+        self,
+        app,
+        client,
+        action,
+        expected_status,
+    ):
+        with app.app_context():
+            club = _seed_local_club(status="verified")
+            _seed_official_claim(local_club_id=club.id, status="approved")
+            affiliation = _seed_affiliation(local_club_id=club.id, status="pending")
+            affiliation_id = affiliation.id
+
+        response = client.post(
+            f"/api/me/club/affiliations/{affiliation_id}/{action}",
+            json={} if action == "reject" else None,
+            headers=_user_headers("official@example.com"),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        assert response.get_json()["affiliation"]["status"] == expected_status
+
+    @pytest.mark.parametrize("action", ["confirm", "reject"])
+    def test_pending_local_club_official_cannot_decide_affiliation(self, app, client, action):
+        with app.app_context():
+            club = _seed_local_club(status="pending")
+            _seed_official_claim(local_club_id=club.id, status="approved")
+            affiliation = _seed_affiliation(local_club_id=club.id, status="pending")
+            affiliation_id = affiliation.id
+
+        response = client.post(
+            f"/api/me/club/affiliations/{affiliation_id}/{action}",
+            json={} if action == "reject" else None,
+            headers=_user_headers("official@example.com"),
+        )
+
+        assert response.status_code == 404, response.get_json()
+        assert response.get_json() == {"error": "affiliation not found"}
         with app.app_context():
             assert db.session.get(PlayerClubAffiliation, affiliation_id).status == "pending"
 
@@ -714,10 +788,10 @@ class TestPlayerClaimVouching:
         assert public.get_json()["claim_status"] == "claimed"
         assert public.get_json()["profile"] is None
 
-    def test_ineligible_player_is_rejected_without_changing_claim(self, app, client):
+    def test_api_team_official_can_vouch_for_player_claim(self, app, client):
         with app.app_context():
             _seed_official_claim(team_api_id=TEAM_ID, status="approved")
-            _seed_affiliation(team_api_id=OTHER_TEAM_ID, status="pending")
+            _seed_affiliation(team_api_id=TEAM_ID, status="pending")
             _, player_claim = _seed_player_claim()
             player_claim_id = player_claim.id
 
@@ -726,10 +800,47 @@ class TestPlayerClaimVouching:
             headers=_user_headers("official@example.com"),
         )
 
-        assert 400 <= response.status_code < 500, response.get_json()
-        assert response.status_code != 409
+        assert response.status_code == 200, response.get_json()
+        assert response.get_json()["claim"]["status"] == "approved"
+
+    def test_pending_local_club_official_cannot_vouch_for_player_claim(self, app, client):
+        with app.app_context():
+            club = _seed_local_club(status="pending")
+            _seed_official_claim(local_club_id=club.id, status="approved")
+            _seed_affiliation(local_club_id=club.id, status="pending")
+            _, player_claim = _seed_player_claim()
+            player_claim_id = player_claim.id
+
+        response = client.post(
+            f"/api/me/club/player-claims/{player_claim_id}/vouch",
+            headers=_user_headers("official@example.com"),
+        )
+
+        assert response.status_code == 404, response.get_json()
+        assert response.get_json() == {"error": "player claim not found"}
         with app.app_context():
             assert db.session.get(PlayerProfileClaim, player_claim_id).status == "pending"
+
+    def test_absent_and_unauthorized_player_claim_are_uniform_404(self, app, client):
+        with app.app_context():
+            _seed_official_claim(team_api_id=TEAM_ID, status="approved")
+            _seed_affiliation(team_api_id=OTHER_TEAM_ID, status="pending")
+            _, player_claim = _seed_player_claim(status="approved")
+            player_claim_id = player_claim.id
+
+        unauthorized = client.post(
+            f"/api/me/club/player-claims/{player_claim_id}/vouch",
+            headers=_user_headers("official@example.com"),
+        )
+        absent = client.post(
+            "/api/me/club/player-claims/999999/vouch",
+            headers=_user_headers("official@example.com"),
+        )
+
+        assert unauthorized.status_code == absent.status_code == 404
+        assert unauthorized.get_json() == absent.get_json() == {"error": "player claim not found"}
+        with app.app_context():
+            assert db.session.get(PlayerProfileClaim, player_claim_id).status == "approved"
 
     def test_non_pending_player_claim_is_409(self, app, client):
         with app.app_context():

--- a/academy-watch-backend/tests/test_local_clubs.py
+++ b/academy-watch-backend/tests/test_local_clubs.py
@@ -110,6 +110,7 @@ def _seed_local_club(
     status="pending",
     normalized_name=None,
     merged_into_local_club_id=None,
+    created_by_user_id=None,
 ):
     club = LocalClub(
         name=name,
@@ -120,6 +121,7 @@ def _seed_local_club(
         status=status,
         provenance="user",
         merged_into_local_club_id=merged_into_local_club_id,
+        created_by_user_id=created_by_user_id,
     )
     db.session.add(club)
     db.session.flush()
@@ -205,16 +207,17 @@ class TestLocalClubCreation:
         with app.app_context():
             assert LocalClub.query.count() == 0
 
-    @pytest.mark.parametrize("existing_status", ["pending", "verified", "merged"])
-    def test_duplicate_non_rejected_echoes_existing(self, app, client, existing_status):
+    @pytest.mark.parametrize("existing_status", ["pending", "merged"])
+    def test_duplicate_other_users_nonpublic_club_is_generic(self, app, client, existing_status):
         with app.app_context():
+            other_user = _make_user("other@example.com")
             existing = _seed_local_club(
                 "North Star FC",
                 country="England",
                 status=existing_status,
+                created_by_user_id=other_user.id,
             )
             db.session.commit()
-            existing_id = existing.id
 
         response = client.post(
             "/api/local-clubs",
@@ -223,13 +226,51 @@ class TestLocalClubCreation:
         )
 
         assert response.status_code == 409, response.get_json()
-        body = response.get_json()
-        assert body["error"]
-        assert body["existing"]["id"] == existing_id
-        assert body["existing"]["name"] == "North Star FC"
-        assert set(body["existing"]) == {"id", "name", "country", "city", "level", "status"}
+        assert response.get_json() == {"error": "A local club with this name and country already exists"}
         with app.app_context():
             assert LocalClub.query.count() == 1
+
+    @pytest.mark.parametrize(
+        ("existing_status", "same_creator"),
+        [("verified", False), ("pending", True), ("merged", True)],
+    )
+    def test_duplicate_public_or_caller_created_club_returns_minimal_existing(
+        self,
+        app,
+        client,
+        existing_status,
+        same_creator,
+    ):
+        with app.app_context():
+            caller = _make_user("creator@example.com")
+            other_user = _make_user("other@example.com")
+            existing = _seed_local_club(
+                "North Star FC",
+                country="England",
+                city="Private City",
+                level="academy",
+                status=existing_status,
+                created_by_user_id=caller.id if same_creator else other_user.id,
+            )
+            db.session.commit()
+            expected = {
+                "id": existing.id,
+                "name": "North Star FC",
+                "country": "England",
+                "status": existing_status,
+            }
+
+        response = client.post(
+            "/api/local-clubs",
+            json={"name": " NORTH\n  star fc ", "country": "eNgLaNd"},
+            headers=_user_headers("creator@example.com"),
+        )
+
+        assert response.status_code == 409, response.get_json()
+        assert response.get_json() == {
+            "error": "A local club with this name and country already exists",
+            "existing": expected,
+        }
 
     def test_rejected_duplicate_can_be_recreated(self, app, client):
         with app.app_context():
@@ -255,15 +296,22 @@ class TestClubSearch:
 
     def test_returns_api_and_visible_local_groups(self, app, client):
         with app.app_context():
+            other_user = _make_user("other@example.com")
             team = _seed_team(team_id=4401, name="Northbridge United")
             _seed_team(team_id=4401, name="Northbridge United", season=2024)
-            pending = _seed_local_club("Northbridge Juniors", status="pending")
+            other_pending = _seed_local_club(
+                "Northbridge Secret Juniors",
+                city="Private Town",
+                status="pending",
+                created_by_user_id=other_user.id,
+            )
             verified = _seed_local_club("Northbridge Academy", status="verified")
             _seed_local_club("Northbridge Old Name", status="merged")
             _seed_local_club("Northbridge Rejected", status="rejected")
             db.session.commit()
             team_id = team.team_id
-            visible_ids = {pending.id, verified.id}
+            visible_ids = {verified.id}
+            hidden_id = other_pending.id
 
         response = client.get(
             "/api/clubs/search?q=NoRtHbRiDgE",
@@ -274,14 +322,63 @@ class TestClubSearch:
         body = response.get_json()
         assert body["api_teams"] == [{"team_api_id": team_id, "name": "Northbridge United", "country": "England"}]
         assert {club["id"] for club in body["local_clubs"]} == visible_ids
+        assert hidden_id not in {club["id"] for club in body["local_clubs"]}
+        assert "Northbridge Secret Juniors" not in response.get_data(as_text=True)
+        assert "Private Town" not in response.get_data(as_text=True)
         assert all(set(club) == {"id", "name", "country", "city", "level", "status"} for club in body["local_clubs"])
-        assert {club["status"] for club in body["local_clubs"]} == {"pending", "verified"}
+        assert {club["status"] for club in body["local_clubs"]} == {"verified"}
+
+    def test_returns_callers_own_pending_local_club(self, app, client):
+        with app.app_context():
+            searcher = _make_user("searcher@example.com")
+            own_pending = _seed_local_club(
+                "Northbridge Juniors",
+                status="pending",
+                created_by_user_id=searcher.id,
+            )
+            db.session.commit()
+            own_pending_id = own_pending.id
+
+        response = client.get(
+            "/api/clubs/search?q=NoRtHbRiDgE",
+            headers=_user_headers("searcher@example.com"),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        assert [club["id"] for club in response.get_json()["local_clubs"]] == [own_pending_id]
+        assert response.get_json()["local_clubs"][0]["status"] == "pending"
+
+    def test_treats_percent_and_underscore_as_literal_search_text(self, app, client):
+        with app.app_context():
+            literal_team = _seed_team(team_id=4401, name="Literal %_ United")
+            _seed_team(team_id=4402, name="Ordinary United")
+            literal_club = _seed_local_club("Literal %_ Juniors", status="verified")
+            _seed_local_club("Ordinary Juniors", status="verified")
+            db.session.commit()
+            literal_team_id = literal_team.team_id
+            literal_club_id = literal_club.id
+
+        response = client.get(
+            "/api/clubs/search",
+            query_string={"q": "%_"},
+            headers=_user_headers("searcher@example.com"),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        assert response.get_json()["api_teams"] == [
+            {
+                "team_api_id": literal_team_id,
+                "name": "Literal %_ United",
+                "country": "England",
+            }
+        ]
+        assert [club["id"] for club in response.get_json()["local_clubs"]] == [literal_club_id]
 
     def test_caps_each_result_group_at_ten(self, app, client):
         with app.app_context():
             for index in range(12):
                 _seed_team(team_id=7000 + index, name=f"Search Team {index}")
-                _seed_local_club(f"Search Local {index}", status="pending")
+                _seed_local_club(f"Search Local {index}", status="verified")
             db.session.commit()
 
         response = client.get(
@@ -574,6 +671,67 @@ class TestAffiliationVisibility:
         }
         assert all(item["created_at"] for item in owner_view)
         assert all("review_note" in item for item in owner_view)
+
+    def test_public_hides_unverified_local_names_owner_and_admin_keep_them(self, app, client):
+        with app.app_context():
+            owner, _ = _approved_claim()
+            pending = _seed_local_club("Pending Private Club", status="pending")
+            rejected = _seed_local_club("Rejected Private Club", status="rejected")
+            pending_merge_target = _seed_local_club("Pending Merge Target", status="pending")
+            merged_source = _seed_local_club(
+                "Old Merged Club",
+                status="merged",
+                merged_into_local_club_id=pending_merge_target.id,
+            )
+            affiliations = [
+                _seed_affiliation(
+                    local_club_id=pending.id,
+                    status="self_reported",
+                    created_by_user_id=owner.id,
+                ),
+                _seed_affiliation(
+                    local_club_id=rejected.id,
+                    status="self_reported",
+                    created_by_user_id=owner.id,
+                ),
+                _seed_affiliation(
+                    local_club_id=merged_source.id,
+                    status="self_reported",
+                    created_by_user_id=owner.id,
+                ),
+            ]
+            db.session.commit()
+            expected_private_names = {
+                affiliations[0].id: "Pending Private Club",
+                affiliations[1].id: "Rejected Private Club",
+                affiliations[2].id: "Pending Merge Target",
+            }
+
+        public_response = client.get(f"/api/players/{PLAYER_ID}/showcase")
+
+        assert public_response.status_code == 200, public_response.get_json()
+        public_affiliations = public_response.get_json()["affiliations"]
+        assert {item["id"] for item in public_affiliations} == set(expected_private_names)
+        assert all(item["club_name"] is None for item in public_affiliations)
+        assert all(name not in public_response.get_data(as_text=True) for name in expected_private_names.values())
+
+        owner_response = client.get(
+            f"/api/players/{PLAYER_ID}/showcase",
+            headers=_user_headers("owner@example.com"),
+        )
+        assert owner_response.status_code == 200, owner_response.get_json()
+        assert {
+            item["id"]: item["club_name"] for item in owner_response.get_json()["affiliations"]
+        } == expected_private_names
+
+        admin_response = client.get(
+            "/api/admin/showcase/affiliations?status=self_reported",
+            headers=_admin_headers(),
+        )
+        assert admin_response.status_code == 200, admin_response.get_json()
+        assert {
+            item["id"]: item["club_name"] for item in admin_response.get_json()["affiliations"]
+        } == expected_private_names
 
     def test_merged_local_club_name_follows_one_hop(self, app, client):
         with app.app_context():

--- a/academy-watch-backend/tests/test_local_clubs.py
+++ b/academy-watch-backend/tests/test_local_clubs.py
@@ -1,0 +1,792 @@
+"""Tests for showcase-local clubs and pre-moderated affiliations.
+
+Local clubs are deliberately separate from API-Football ``Team`` rows.  The
+tests seed both stores directly and exercise only the showcase blueprint so a
+regression cannot accidentally rely on journey, sync, crawl, or scout code.
+"""
+
+import pytest
+from flask import Flask
+from src.auth import _ensure_user_account, issue_user_token
+from src.models.league import League, Team, db
+from src.models.showcase import LocalClub, PlayerClubAffiliation, PlayerProfileClaim
+
+ADMIN_KEY = "test-admin-key"
+PLAYER_ID = 5001
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("SKIP_API_HANDSHAKE", "1")
+    monkeypatch.setenv("API_USE_STUB_DATA", "true")
+    monkeypatch.setenv("ADMIN_API_KEY", ADMIN_KEY)
+    monkeypatch.setenv("ADMIN_IP_WHITELIST", "")
+
+    from src.routes.showcase import showcase_bp
+
+    flask_app = Flask(__name__)
+    flask_app.config.update(
+        TESTING=True,
+        SECRET_KEY="test-secret-key",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        RATELIMIT_ENABLED=False,
+    )
+
+    db.init_app(flask_app)
+    flask_app.register_blueprint(showcase_bp, url_prefix="/api")
+
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _user_headers(email):
+    token = issue_user_token(email)["token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _admin_headers():
+    token = issue_user_token("admin@test.com", role="admin")["token"]
+    return {"Authorization": f"Bearer {token}", "X-API-Key": ADMIN_KEY}
+
+
+def _make_user(email):
+    user = _ensure_user_account(email)
+    db.session.commit()
+    return user
+
+
+def _approved_claim(player_api_id=PLAYER_ID, email="owner@example.com"):
+    user = _make_user(email)
+    claim = PlayerProfileClaim(
+        player_api_id=player_api_id,
+        user_account_id=user.id,
+        relationship_type="player",
+        status="approved",
+    )
+    db.session.add(claim)
+    db.session.commit()
+    return user, claim
+
+
+def _seed_team(team_id=33, name="Manchester United", country="England", season=2025):
+    league = League.query.filter_by(league_id=39).first()
+    if league is None:
+        league = League(league_id=39, name="Premier League", country="England", season=2025)
+        db.session.add(league)
+        db.session.flush()
+    team = Team(
+        team_id=team_id,
+        name=name,
+        country=country,
+        season=season,
+        league_id=league.id,
+        is_active=True,
+    )
+    db.session.add(team)
+    db.session.flush()
+    return team
+
+
+def _seed_local_club(
+    name="Northside Juniors",
+    *,
+    country="England",
+    city="Leeds",
+    level="youth",
+    status="pending",
+    normalized_name=None,
+    merged_into_local_club_id=None,
+):
+    club = LocalClub(
+        name=name,
+        normalized_name=normalized_name or " ".join(name.lower().split()),
+        country=country,
+        city=city,
+        level=level,
+        status=status,
+        provenance="user",
+        merged_into_local_club_id=merged_into_local_club_id,
+    )
+    db.session.add(club)
+    db.session.flush()
+    return club
+
+
+def _seed_affiliation(
+    *,
+    player_api_id=PLAYER_ID,
+    local_club_id=None,
+    team_api_id=None,
+    season="2025/26",
+    status="pending",
+    created_by_user_id=None,
+    review_note=None,
+):
+    affiliation = PlayerClubAffiliation(
+        player_api_id=player_api_id,
+        local_club_id=local_club_id,
+        team_api_id=team_api_id,
+        season=season,
+        status=status,
+        created_by_user_id=created_by_user_id,
+        review_note=review_note,
+    )
+    db.session.add(affiliation)
+    db.session.flush()
+    return affiliation
+
+
+# --------------------------------------------------------------------------- #
+# Local-club creation and search
+# --------------------------------------------------------------------------- #
+
+
+class TestLocalClubCreation:
+    def test_requires_auth(self, client):
+        response = client.post("/api/local-clubs", json={"name": "Northside Juniors"})
+
+        assert response.status_code == 401
+
+    def test_create_sanitizes_caps_and_normalizes(self, app, client):
+        response = client.post(
+            "/api/local-clubs",
+            json={
+                "name": " <b>North   Star FC</b> ",
+                "country": f"<script>{'E' * 110}</script>",
+                "city": f"<i>{'C' * 130}</i>",
+                "level": "academy",
+            },
+            headers=_user_headers("creator@example.com"),
+        )
+
+        assert response.status_code == 201, response.get_json()
+        club = response.get_json()["club"]
+        assert club["name"] == "North   Star FC"
+        assert club["country"] == "E" * 100
+        assert club["city"] == "C" * 120
+        assert club["level"] == "academy"
+        assert club["status"] == "pending"
+        with app.app_context():
+            stored = db.session.get(LocalClub, club["id"])
+            assert stored.normalized_name == "north star fc"
+            assert stored.provenance == "user"
+            assert stored.created_by_user_id == _make_user("creator@example.com").id
+            stored.name = "  Renamed\n  North Star  "
+            db.session.flush()
+            assert stored.normalized_name == "renamed north star"
+
+    def test_name_and_level_validation(self, app, client):
+        headers = _user_headers("creator@example.com")
+        invalid_payloads = [
+            {},
+            {"name": "x"},
+            {"name": "x" * 201},
+            {"name": "Valid Club", "level": "elite"},
+        ]
+
+        for payload in invalid_payloads:
+            response = client.post("/api/local-clubs", json=payload, headers=headers)
+            assert response.status_code == 400, (payload, response.get_json())
+
+        with app.app_context():
+            assert LocalClub.query.count() == 0
+
+    @pytest.mark.parametrize("existing_status", ["pending", "verified", "merged"])
+    def test_duplicate_non_rejected_echoes_existing(self, app, client, existing_status):
+        with app.app_context():
+            existing = _seed_local_club(
+                "North Star FC",
+                country="England",
+                status=existing_status,
+            )
+            db.session.commit()
+            existing_id = existing.id
+
+        response = client.post(
+            "/api/local-clubs",
+            json={"name": " NORTH\n  star fc ", "country": "eNgLaNd"},
+            headers=_user_headers("creator@example.com"),
+        )
+
+        assert response.status_code == 409, response.get_json()
+        body = response.get_json()
+        assert body["error"]
+        assert body["existing"]["id"] == existing_id
+        assert body["existing"]["name"] == "North Star FC"
+        assert set(body["existing"]) == {"id", "name", "country", "city", "level", "status"}
+        with app.app_context():
+            assert LocalClub.query.count() == 1
+
+    def test_rejected_duplicate_can_be_recreated(self, app, client):
+        with app.app_context():
+            rejected = _seed_local_club("North Star FC", country="England", status="rejected")
+            db.session.commit()
+            rejected_id = rejected.id
+
+        response = client.post(
+            "/api/local-clubs",
+            json={"name": "north star fc", "country": "ENGLAND"},
+            headers=_user_headers("creator@example.com"),
+        )
+
+        assert response.status_code == 201, response.get_json()
+        assert response.get_json()["club"]["id"] != rejected_id
+
+
+class TestClubSearch:
+    def test_requires_auth_and_two_character_query(self, client):
+        assert client.get("/api/clubs/search?q=north").status_code == 401
+        response = client.get("/api/clubs/search?q=n", headers=_user_headers("searcher@example.com"))
+        assert response.status_code == 400
+
+    def test_returns_api_and_visible_local_groups(self, app, client):
+        with app.app_context():
+            team = _seed_team(team_id=4401, name="Northbridge United")
+            _seed_team(team_id=4401, name="Northbridge United", season=2024)
+            pending = _seed_local_club("Northbridge Juniors", status="pending")
+            verified = _seed_local_club("Northbridge Academy", status="verified")
+            _seed_local_club("Northbridge Old Name", status="merged")
+            _seed_local_club("Northbridge Rejected", status="rejected")
+            db.session.commit()
+            team_id = team.team_id
+            visible_ids = {pending.id, verified.id}
+
+        response = client.get(
+            "/api/clubs/search?q=NoRtHbRiDgE",
+            headers=_user_headers("searcher@example.com"),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        body = response.get_json()
+        assert body["api_teams"] == [{"team_api_id": team_id, "name": "Northbridge United", "country": "England"}]
+        assert {club["id"] for club in body["local_clubs"]} == visible_ids
+        assert all(set(club) == {"id", "name", "country", "city", "level", "status"} for club in body["local_clubs"])
+        assert {club["status"] for club in body["local_clubs"]} == {"pending", "verified"}
+
+    def test_caps_each_result_group_at_ten(self, app, client):
+        with app.app_context():
+            for index in range(12):
+                _seed_team(team_id=7000 + index, name=f"Search Team {index}")
+                _seed_local_club(f"Search Local {index}", status="pending")
+            db.session.commit()
+
+        response = client.get(
+            "/api/clubs/search?q=search",
+            headers=_user_headers("searcher@example.com"),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        assert len(response.get_json()["api_teams"]) == 10
+        assert len(response.get_json()["local_clubs"]) == 10
+
+
+# --------------------------------------------------------------------------- #
+# Owner affiliation lifecycle
+# --------------------------------------------------------------------------- #
+
+
+class TestAffiliationCreation:
+    def test_requires_exactly_one_club_reference(self, app, client):
+        with app.app_context():
+            _approved_claim()
+            local = _seed_local_club(status="verified")
+            db.session.commit()
+            local_id = local.id
+        headers = _user_headers("owner@example.com")
+
+        for payload in ({}, {"local_club_id": local_id, "team_api_id": 33}):
+            response = client.post(
+                f"/api/players/{PLAYER_ID}/showcase/affiliations",
+                json=payload,
+                headers=headers,
+            )
+            assert response.status_code == 400, (payload, response.get_json())
+
+    def test_non_owner_is_forbidden(self, app, client):
+        with app.app_context():
+            _approved_claim()
+
+        response = client.post(
+            f"/api/players/{PLAYER_ID}/showcase/affiliations",
+            json={"team_api_id": 33},
+            headers=_user_headers("stranger@example.com"),
+        )
+
+        assert response.status_code == 403
+
+    def test_positive_team_id_and_sanitized_season(self, app, client):
+        with app.app_context():
+            owner, _ = _approved_claim()
+            owner_id = owner.id
+
+        response = client.post(
+            f"/api/players/{PLAYER_ID}/showcase/affiliations",
+            json={"team_api_id": 987654, "season": " <b>2025/26</b> "},
+            headers=_user_headers("owner@example.com"),
+        )
+
+        assert response.status_code == 201, response.get_json()
+        affiliation = response.get_json()["affiliation"]
+        assert affiliation["player_api_id"] == PLAYER_ID
+        assert affiliation["team_api_id"] == 987654
+        assert affiliation["local_club_id"] is None
+        assert affiliation["season"] == "2025/26"
+        assert affiliation["status"] == "pending"
+        with app.app_context():
+            stored = db.session.get(PlayerClubAffiliation, affiliation["id"])
+            assert stored.created_by_user_id == owner_id
+
+    def test_team_id_and_season_validation(self, app, client):
+        with app.app_context():
+            _approved_claim()
+        headers = _user_headers("owner@example.com")
+
+        for team_api_id in (0, -1, "33", True):
+            response = client.post(
+                f"/api/players/{PLAYER_ID}/showcase/affiliations",
+                json={"team_api_id": team_api_id},
+                headers=headers,
+            )
+            assert response.status_code == 400, (team_api_id, response.get_json())
+
+        response = client.post(
+            f"/api/players/{PLAYER_ID}/showcase/affiliations",
+            json={"team_api_id": 33, "season": "x" * 21},
+            headers=headers,
+        )
+        assert response.status_code == 400, response.get_json()
+
+    def test_local_reference_must_be_active(self, app, client):
+        with app.app_context():
+            _approved_claim()
+            merged = _seed_local_club("Merged Club", status="merged")
+            rejected = _seed_local_club("Rejected Club", status="rejected")
+            db.session.commit()
+            invalid_ids = [merged.id, rejected.id, 999999]
+        headers = _user_headers("owner@example.com")
+
+        for local_club_id in invalid_ids:
+            response = client.post(
+                f"/api/players/{PLAYER_ID}/showcase/affiliations",
+                json={"local_club_id": local_club_id},
+                headers=headers,
+            )
+            assert response.status_code == 400, (local_club_id, response.get_json())
+
+    def test_five_non_rejected_cap_but_rejected_does_not_count(self, app, client):
+        with app.app_context():
+            owner, _ = _approved_claim()
+            for index in range(4):
+                _seed_affiliation(team_api_id=1000 + index, created_by_user_id=owner.id)
+            _seed_affiliation(team_api_id=1999, status="rejected", created_by_user_id=owner.id)
+            db.session.commit()
+        headers = _user_headers("owner@example.com")
+
+        fifth = client.post(
+            f"/api/players/{PLAYER_ID}/showcase/affiliations",
+            json={"team_api_id": 2000},
+            headers=headers,
+        )
+        assert fifth.status_code == 201, fifth.get_json()
+
+        sixth = client.post(
+            f"/api/players/{PLAYER_ID}/showcase/affiliations",
+            json={"team_api_id": 2001},
+            headers=headers,
+        )
+        assert sixth.status_code == 409, sixth.get_json()
+
+    def test_duplicate_local_and_team_references_are_409(self, app, client):
+        with app.app_context():
+            owner, _ = _approved_claim()
+            local = _seed_local_club(status="verified")
+            _seed_affiliation(local_club_id=local.id, created_by_user_id=owner.id)
+            _seed_affiliation(team_api_id=33, status="self_reported", created_by_user_id=owner.id)
+            db.session.commit()
+            local_id = local.id
+        headers = _user_headers("owner@example.com")
+
+        for payload in ({"local_club_id": local_id}, {"team_api_id": 33}):
+            response = client.post(
+                f"/api/players/{PLAYER_ID}/showcase/affiliations",
+                json=payload,
+                headers=headers,
+            )
+            assert response.status_code == 409, (payload, response.get_json())
+
+    def test_rejected_duplicate_can_be_resubmitted(self, app, client):
+        with app.app_context():
+            owner, _ = _approved_claim()
+            _seed_affiliation(team_api_id=33, status="rejected", created_by_user_id=owner.id)
+            db.session.commit()
+
+        response = client.post(
+            f"/api/players/{PLAYER_ID}/showcase/affiliations",
+            json={"team_api_id": 33},
+            headers=_user_headers("owner@example.com"),
+        )
+
+        assert response.status_code == 201, response.get_json()
+
+
+class TestAffiliationDelete:
+    def test_owner_deletes_player_row(self, app, client):
+        with app.app_context():
+            owner, _ = _approved_claim()
+            affiliation = _seed_affiliation(team_api_id=33, created_by_user_id=owner.id)
+            db.session.commit()
+            affiliation_id = affiliation.id
+
+        response = client.delete(
+            f"/api/players/{PLAYER_ID}/showcase/affiliations/{affiliation_id}",
+            headers=_user_headers("owner@example.com"),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        assert response.get_json() == {"deleted": True}
+        with app.app_context():
+            assert db.session.get(PlayerClubAffiliation, affiliation_id) is None
+
+    def test_non_owner_cannot_delete_and_wrong_player_row_is_not_found(self, app, client):
+        with app.app_context():
+            owner, _ = _approved_claim()
+            affiliation = _seed_affiliation(player_api_id=9999, team_api_id=33, created_by_user_id=owner.id)
+            db.session.commit()
+            affiliation_id = affiliation.id
+
+        stranger = client.delete(
+            f"/api/players/{PLAYER_ID}/showcase/affiliations/{affiliation_id}",
+            headers=_user_headers("stranger@example.com"),
+        )
+        assert stranger.status_code == 403
+
+        wrong_player = client.delete(
+            f"/api/players/{PLAYER_ID}/showcase/affiliations/{affiliation_id}",
+            headers=_user_headers("owner@example.com"),
+        )
+        assert wrong_player.status_code == 404
+        with app.app_context():
+            assert db.session.get(PlayerClubAffiliation, affiliation_id) is not None
+
+
+# --------------------------------------------------------------------------- #
+# Showcase visibility and club-name resolution
+# --------------------------------------------------------------------------- #
+
+
+class TestAffiliationVisibility:
+    def test_public_sees_approved_states_owner_sees_all_with_notes(self, app, client):
+        with app.app_context():
+            owner, _ = _approved_claim()
+            local = _seed_local_club("Northside Juniors", status="verified")
+            _seed_team(team_id=33, name="Manchester United")
+            _seed_affiliation(
+                local_club_id=local.id,
+                status="pending",
+                created_by_user_id=owner.id,
+                review_note="Awaiting review",
+            )
+            _seed_affiliation(
+                team_api_id=33,
+                status="rejected",
+                created_by_user_id=owner.id,
+                review_note="Wrong club",
+            )
+            _seed_affiliation(
+                team_api_id=33,
+                status="self_reported",
+                created_by_user_id=owner.id,
+                review_note="Approved by admin",
+            )
+            _seed_affiliation(
+                local_club_id=local.id,
+                status="club_confirmed",
+                created_by_user_id=owner.id,
+                review_note="Confirmed by official",
+            )
+            db.session.commit()
+
+        public_response = client.get(f"/api/players/{PLAYER_ID}/showcase")
+        assert public_response.status_code == 200, public_response.get_json()
+        public = public_response.get_json()["affiliations"]
+        assert {item["status"] for item in public} == {"self_reported", "club_confirmed"}
+        assert {item["club_name"] for item in public} == {"Manchester United", "Northside Juniors"}
+        assert all("review_note" not in item for item in public)
+        assert all(
+            set(item)
+            == {
+                "id",
+                "player_api_id",
+                "team_api_id",
+                "local_club_id",
+                "club_name",
+                "season",
+                "status",
+                "created_at",
+            }
+            for item in public
+        )
+
+        stranger = client.get(
+            f"/api/players/{PLAYER_ID}/showcase",
+            headers=_user_headers("stranger@example.com"),
+        ).get_json()["affiliations"]
+        assert {item["status"] for item in stranger} == {"self_reported", "club_confirmed"}
+        assert all("review_note" not in item for item in stranger)
+
+        admin_bearer_only = client.get(
+            f"/api/players/{PLAYER_ID}/showcase",
+            headers={"Authorization": f"Bearer {issue_user_token('admin@test.com', role='admin')['token']}"},
+        ).get_json()["affiliations"]
+        assert {item["status"] for item in admin_bearer_only} == {"self_reported", "club_confirmed"}
+        assert all("review_note" not in item for item in admin_bearer_only)
+
+        owner_view = client.get(
+            f"/api/players/{PLAYER_ID}/showcase",
+            headers=_user_headers("owner@example.com"),
+        ).get_json()["affiliations"]
+        assert {item["status"] for item in owner_view} == {
+            "pending",
+            "rejected",
+            "self_reported",
+            "club_confirmed",
+        }
+        notes = {item["status"]: item["review_note"] for item in owner_view}
+        assert notes == {
+            "pending": "Awaiting review",
+            "rejected": "Wrong club",
+            "self_reported": "Approved by admin",
+            "club_confirmed": "Confirmed by official",
+        }
+        assert all(item["created_at"] for item in owner_view)
+        assert all("review_note" in item for item in owner_view)
+
+    def test_merged_local_club_name_follows_one_hop(self, app, client):
+        with app.app_context():
+            target = _seed_local_club("Current Club Name", status="verified")
+            source = _seed_local_club(
+                "Old Club Name",
+                status="merged",
+                merged_into_local_club_id=target.id,
+            )
+            affiliation = _seed_affiliation(local_club_id=source.id, status="self_reported")
+            db.session.commit()
+            affiliation_id = affiliation.id
+
+        response = client.get(f"/api/players/{PLAYER_ID}/showcase")
+
+        assert response.status_code == 200, response.get_json()
+        affiliations = response.get_json()["affiliations"]
+        assert [(item["id"], item["club_name"]) for item in affiliations] == [(affiliation_id, "Current Club Name")]
+
+
+# --------------------------------------------------------------------------- #
+# Admin local-club moderation, merge, and API bridge
+# --------------------------------------------------------------------------- #
+
+
+class TestAdminLocalClubs:
+    def test_list_filters_by_status(self, app, client):
+        with app.app_context():
+            pending = _seed_local_club("Pending Club", status="pending")
+            _seed_local_club("Verified Club", status="verified")
+            db.session.commit()
+            pending_id = pending.id
+
+        response = client.get("/api/admin/local-clubs?status=pending", headers=_admin_headers())
+
+        assert response.status_code == 200, response.get_json()
+        assert [club["id"] for club in response.get_json()["clubs"]] == [pending_id]
+
+    @pytest.mark.parametrize(
+        ("action", "expected_status"),
+        [("verify", "verified"), ("reject", "rejected")],
+    )
+    def test_review_pending_then_blocks_second_review(self, app, client, action, expected_status):
+        with app.app_context():
+            club = _seed_local_club(status="pending")
+            db.session.commit()
+            club_id = club.id
+
+        response = client.post(
+            f"/api/admin/local-clubs/{club_id}/review",
+            json={"action": action, "note": "<b>Reviewed safely</b>"},
+            headers=_admin_headers(),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        reviewed = response.get_json()["club"]
+        assert reviewed["status"] == expected_status
+        assert reviewed["review_note"] == "Reviewed safely"
+        assert reviewed["reviewed_by"] == "admin@test.com"
+        assert reviewed["reviewed_at"]
+
+        second = client.post(
+            f"/api/admin/local-clubs/{club_id}/review",
+            json={"action": action},
+            headers=_admin_headers(),
+        )
+        assert second.status_code == 409, second.get_json()
+
+    def test_merge_repoints_all_affiliations(self, app, client):
+        with app.app_context():
+            source = _seed_local_club("Duplicate Juniors", status="pending")
+            target = _seed_local_club("Canonical Juniors", status="verified")
+            first = _seed_affiliation(local_club_id=source.id, status="pending")
+            second = _seed_affiliation(player_api_id=5002, local_club_id=source.id, status="self_reported")
+            db.session.commit()
+            source_id = source.id
+            target_id = target.id
+            affiliation_ids = [first.id, second.id]
+
+        response = client.post(
+            f"/api/admin/local-clubs/{source_id}/merge",
+            json={"into_local_club_id": target_id},
+            headers=_admin_headers(),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        assert response.get_json()["moved_affiliations"] == 2
+        merged = response.get_json()["club"]
+        assert merged["status"] == "merged"
+        assert merged["merged_into_local_club_id"] == target_id
+        with app.app_context():
+            source_row = db.session.get(LocalClub, source_id)
+            assert source_row.status == "merged"
+            assert source_row.merged_into_local_club_id == target_id
+            moved = db.session.query(PlayerClubAffiliation).filter(PlayerClubAffiliation.id.in_(affiliation_ids)).all()
+            assert {row.local_club_id for row in moved} == {target_id}
+
+    def test_merge_blocks_self_missing_and_inactive_targets(self, app, client):
+        with app.app_context():
+            source = _seed_local_club("Source Club", status="pending")
+            merged_target = _seed_local_club("Merged Target", status="merged")
+            rejected_target = _seed_local_club("Rejected Target", status="rejected")
+            db.session.commit()
+            source_id = source.id
+            invalid_target_ids = [source.id, merged_target.id, rejected_target.id, 999999]
+
+        for target_id in invalid_target_ids:
+            response = client.post(
+                f"/api/admin/local-clubs/{source_id}/merge",
+                json={"into_local_club_id": target_id},
+                headers=_admin_headers(),
+            )
+            assert response.status_code == 400, (target_id, response.get_json())
+
+        with app.app_context():
+            source = db.session.get(LocalClub, source_id)
+            assert source.status == "pending"
+            assert source.merged_into_local_club_id is None
+
+    def test_link_api_validates_positive_integer_and_never_writes_teams(self, app, client):
+        with app.app_context():
+            club = _seed_local_club(status="verified")
+            db.session.commit()
+            club_id = club.id
+            assert Team.query.count() == 0
+
+        for invalid in (0, -1, "33", True):
+            response = client.post(
+                f"/api/admin/local-clubs/{club_id}/link-api",
+                json={"team_api_id": invalid},
+                headers=_admin_headers(),
+            )
+            assert response.status_code == 400, (invalid, response.get_json())
+
+        linked = client.post(
+            f"/api/admin/local-clubs/{club_id}/link-api",
+            json={"team_api_id": 987654},
+            headers=_admin_headers(),
+        )
+        assert linked.status_code == 200, linked.get_json()
+        assert linked.get_json()["club"]["api_team_id"] == 987654
+        with app.app_context():
+            assert db.session.get(LocalClub, club_id).api_team_id == 987654
+            assert Team.query.count() == 0
+
+
+# --------------------------------------------------------------------------- #
+# Admin affiliation moderation
+# --------------------------------------------------------------------------- #
+
+
+class TestAdminAffiliations:
+    def test_list_filters_and_resolves_both_club_kinds(self, app, client):
+        with app.app_context():
+            local = _seed_local_club("Northside Juniors", status="verified")
+            _seed_team(team_id=33, name="Manchester United")
+            local_affiliation = _seed_affiliation(
+                local_club_id=local.id,
+                status="pending",
+                review_note="Local note",
+            )
+            team_affiliation = _seed_affiliation(
+                player_api_id=5002,
+                team_api_id=33,
+                status="pending",
+                review_note="Team note",
+            )
+            _seed_affiliation(player_api_id=5003, team_api_id=44, status="rejected")
+            db.session.commit()
+            expected = {
+                local_affiliation.id: ("Northside Juniors", "Local note"),
+                team_affiliation.id: ("Manchester United", "Team note"),
+            }
+
+        response = client.get(
+            "/api/admin/showcase/affiliations?status=pending",
+            headers=_admin_headers(),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        affiliations = response.get_json()["affiliations"]
+        assert {item["id"] for item in affiliations} == set(expected)
+        assert {item["id"]: (item["club_name"], item["review_note"]) for item in affiliations} == expected
+
+    @pytest.mark.parametrize(
+        ("action", "expected_status"),
+        [("approve", "self_reported"), ("reject", "rejected")],
+    )
+    def test_review_pending_then_blocks_second_review(self, app, client, action, expected_status):
+        with app.app_context():
+            affiliation = _seed_affiliation(team_api_id=33, status="pending")
+            db.session.commit()
+            affiliation_id = affiliation.id
+
+        response = client.post(
+            f"/api/admin/showcase/affiliations/{affiliation_id}/review",
+            json={"action": action, "note": "<i>Moderator note</i>"},
+            headers=_admin_headers(),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        reviewed = response.get_json()["affiliation"]
+        assert reviewed["status"] == expected_status
+        assert reviewed["review_note"] == "Moderator note"
+        with app.app_context():
+            stored = db.session.get(PlayerClubAffiliation, affiliation_id)
+            assert stored.status == expected_status
+            assert stored.reviewed_by == "admin@test.com"
+            assert stored.reviewed_at is not None
+
+        second = client.post(
+            f"/api/admin/showcase/affiliations/{affiliation_id}/review",
+            json={"action": action},
+            headers=_admin_headers(),
+        )
+        assert second.status_code == 409, second.get_json()

--- a/academy-watch-backend/tests/test_local_players.py
+++ b/academy-watch-backend/tests/test_local_players.py
@@ -431,16 +431,45 @@ class TestLocalPlayerCreation:
         assert response.status_code == 409, response.get_json()
         body = response.get_json()
         assert body["error"]
-        assert body["existing"]["id"] == existing_id
-        assert set(body["existing"]) == {
-            "id",
-            "display_name",
-            "birth_year",
-            "position",
-            "country",
-            "city",
-            "status",
+        if existing_status == "approved":
+            assert body["existing"] == {
+                "id": existing_id,
+                "display_name": "North Star Prospect",
+                "status": "approved",
+            }
+            assert not {"city", "birth_year", "position", "country"} & body["existing"].keys()
+        else:
+            assert "existing" not in body
+        with app.app_context():
+            assert LocalPlayer.query.count() == 1
+
+    def test_caller_owned_pending_duplicate_echoes_limited_existing(self, app, client):
+        with app.app_context():
+            creator = _make_user("creator@example.com")
+            existing = _seed_local_player(
+                "North Star Prospect",
+                birth_year=2008,
+                status="pending",
+                created_by_user_id=creator.id,
+            )
+            db.session.commit()
+            existing_id = existing.id
+
+        response = client.post(
+            "/api/local-players",
+            json={"display_name": " NORTH\n star prospect ", "birth_year": 2008},
+            headers=_user_headers("creator@example.com"),
+        )
+
+        assert response.status_code == 409, response.get_json()
+        body = response.get_json()
+        assert body["error"]
+        assert body["existing"] == {
+            "id": existing_id,
+            "display_name": "North Star Prospect",
+            "status": "pending",
         }
+        assert not {"city", "birth_year", "position", "country"} & body["existing"].keys()
         with app.app_context():
             assert LocalPlayer.query.count() == 1
 

--- a/academy-watch-backend/tests/test_local_players.py
+++ b/academy-watch-backend/tests/test_local_players.py
@@ -1,0 +1,1574 @@
+"""Tests for showcase-only local player identities.
+
+Local players never enter API-Football tracking, stats, journeys, Scout, or
+Film Room. These tests exercise the explicit local subject columns, claimant
+visibility, owner curation, moderation, merge tooling, and collision isolation
+from an API player that happens to have the same positive integer id.
+"""
+
+import re
+from datetime import UTC, datetime
+from io import BytesIO
+from urllib.parse import urlsplit
+
+import pytest
+from flask import Flask
+from PIL import Image
+from src.auth import _ensure_user_account, issue_user_token
+from src.models.league import PlayerLink, db
+from src.models.showcase import (
+    LocalClub,
+    LocalPlayer,
+    PlayerClubAffiliation,
+    PlayerProfileClaim,
+    PlayerShowcaseMedia,
+    PlayerShowcaseProfile,
+)
+from src.models.tracked_player import TrackedPlayer
+from src.services import social_proof
+
+ADMIN_KEY = "test-admin-key"
+CODE_PATTERN = re.compile(r"^AW-[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$")
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    monkeypatch.setenv("SKIP_API_HANDSHAKE", "1")
+    monkeypatch.setenv("API_USE_STUB_DATA", "true")
+    monkeypatch.setenv("ADMIN_API_KEY", ADMIN_KEY)
+    monkeypatch.setenv("ADMIN_IP_WHITELIST", "")
+    monkeypatch.setenv("ENV", "development")
+    monkeypatch.setenv("FLASK_ENV", "development")
+    monkeypatch.setenv("APP_ENV", "development")
+    monkeypatch.setenv("SHOWCASE_MEDIA_LOCAL_DIR", str(tmp_path / "showcase-media"))
+    monkeypatch.delenv("AZURE_STORAGE_CONNECTION_STRING", raising=False)
+
+    from src.routes.showcase import showcase_bp
+
+    flask_app = Flask(__name__)
+    flask_app.config.update(
+        TESTING=True,
+        SECRET_KEY="test-secret-key",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        RATELIMIT_ENABLED=False,
+    )
+
+    db.init_app(flask_app)
+    flask_app.register_blueprint(showcase_bp, url_prefix="/api")
+
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+class FakeResponse:
+    """Small streaming response used at the social-proof HTTP boundary."""
+
+    def __init__(self, body=b"", *, status_code=200, headers=None, encoding="utf-8"):
+        self._body = body
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.encoding = encoding
+        self.raw = BytesIO(body)
+        self.closed = False
+
+    @property
+    def content(self):
+        return self._body
+
+    @property
+    def text(self):
+        return self._body.decode(self.encoding or "utf-8", errors="replace")
+
+    def iter_content(self, chunk_size=1, decode_unicode=False):
+        del decode_unicode
+        for start in range(0, len(self._body), chunk_size):
+            yield self._body[start : start + chunk_size]
+
+    def close(self):
+        self.closed = True
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _user_headers(email):
+    token = issue_user_token(email)["token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _admin_headers():
+    token = issue_user_token("admin@test.com", role="admin")["token"]
+    return {"Authorization": f"Bearer {token}", "X-API-Key": ADMIN_KEY}
+
+
+def _make_user(email):
+    user = _ensure_user_account(email)
+    db.session.commit()
+    return user
+
+
+def _seed_local_player(
+    display_name="Northside Prospect",
+    *,
+    birth_year=2008,
+    position="Midfielder",
+    country="England",
+    city="Leeds",
+    status="pending",
+    api_player_id=None,
+    merged_into_local_player_id=None,
+    created_by_user_id=None,
+):
+    player = LocalPlayer(
+        display_name=display_name,
+        normalized_name=LocalPlayer.normalize_name(display_name),
+        birth_year=birth_year,
+        position=position,
+        country=country,
+        city=city,
+        status=status,
+        api_player_id=api_player_id,
+        merged_into_local_player_id=merged_into_local_player_id,
+        provenance="user",
+        created_by_user_id=created_by_user_id,
+    )
+    db.session.add(player)
+    db.session.flush()
+    return player
+
+
+def _seed_claim(
+    email="owner@example.com",
+    *,
+    player_api_id=None,
+    local_player_id=None,
+    status="approved",
+    relationship_type="player",
+    code="AW-ABCDEFGH",
+):
+    user = _make_user(email)
+    claim = PlayerProfileClaim(
+        player_api_id=player_api_id,
+        local_player_id=local_player_id,
+        user_account_id=user.id,
+        relationship_type=relationship_type,
+        status=status,
+        verification_code=code,
+        verification_status="unverified",
+    )
+    db.session.add(claim)
+    db.session.commit()
+    return user, claim
+
+
+def _seed_local_club(name="Northside Juniors", *, status="verified"):
+    club = LocalClub(
+        name=name,
+        normalized_name=LocalClub.normalize_name(name),
+        country="England",
+        city="Leeds",
+        level="youth",
+        status=status,
+        provenance="user",
+    )
+    db.session.add(club)
+    db.session.flush()
+    return club
+
+
+def _seed_media(
+    *,
+    player_api_id=None,
+    local_player_id=None,
+    user_id=None,
+    status="approved",
+    sort_order=0,
+    suffix="photo",
+):
+    subject_path = f"local-players/{local_player_id}" if local_player_id is not None else f"players/{player_api_id}"
+    media = PlayerShowcaseMedia(
+        player_api_id=player_api_id,
+        local_player_id=local_player_id,
+        kind="photo",
+        blob_path=f"{subject_path}/{suffix}.jpg",
+        public_url=f"/api/dev/showcase-media/published/{subject_path}/{suffix}.jpg",
+        content_type="image/jpeg",
+        size_bytes=1024,
+        status=status,
+        sort_order=sort_order,
+        uploaded_by_user_id=user_id,
+    )
+    db.session.add(media)
+    db.session.flush()
+    return media
+
+
+def _create_local_player(client, email="creator@example.com", **overrides):
+    payload = {
+        "display_name": "Northside Prospect",
+        "birth_year": 2008,
+        "position": "Midfielder",
+        "country": "England",
+        "city": "Leeds",
+    }
+    payload.update(overrides)
+    response = client.post("/api/local-players", json=payload, headers=_user_headers(email))
+    assert response.status_code == 201, response.get_json()
+    return response.get_json()
+
+
+def _jpeg_bytes() -> bytes:
+    image = Image.new("RGB", (48, 32), "#4f7d63")
+    output = BytesIO()
+    image.save(output, "JPEG", quality=90)
+    return output.getvalue()
+
+
+def _url_path(url):
+    parsed = urlsplit(url)
+    return parsed.path or url
+
+
+def _create_complete_local_photo(client, lp_id, headers, raw):
+    created = client.post(
+        f"/api/local-players/{lp_id}/showcase/photos",
+        json={"content_type": "image/jpeg", "size_bytes": len(raw)},
+        headers=headers,
+    )
+    assert created.status_code == 201, created.get_json()
+    body = created.get_json()
+    upload = body["upload"]
+    uploaded = client.put(_url_path(upload["url"]), data=raw, headers=upload["headers"])
+    assert uploaded.status_code in (200, 201, 204), uploaded.get_json(silent=True)
+    media_id = body["media"]["id"]
+    completed = client.post(
+        f"/api/local-players/{lp_id}/showcase/photos/{media_id}/complete",
+        headers=headers,
+    )
+    assert completed.status_code == 200, completed.get_json()
+    assert completed.get_json()["media"]["status"] == "pending"
+    return body, completed.get_json()["media"]
+
+
+def _fake_get(monkeypatch, responses):
+    queued = list(responses)
+
+    class FakeCookies:
+        def clear(self):
+            return None
+
+    class FakeSession:
+        def __init__(self):
+            self.trust_env = True
+            self.cookies = FakeCookies()
+            self.headers = {}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            self.close()
+
+        def get(self, _url, **_kwargs):
+            if not queued:
+                raise AssertionError("unexpected network fetch")
+            response = queued.pop(0)
+            if isinstance(response, Exception):
+                raise response
+            return response
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(social_proof.requests, "Session", FakeSession)
+
+
+# --------------------------------------------------------------------------- #
+# Creation, validation, and duplicates
+# --------------------------------------------------------------------------- #
+
+
+class TestLocalPlayerCreation:
+    def test_requires_auth(self, client):
+        response = client.post("/api/local-players", json={"display_name": "Northside Prospect"})
+
+        assert response.status_code == 401
+
+    def test_create_sanitizes_normalizes_and_auto_claims(self, app, client):
+        response = client.post(
+            "/api/local-players",
+            json={
+                "display_name": " <b>North   Star Prospect</b> ",
+                "birth_year": 2009,
+                "position": f"<i>{'M' * 60}</i>",
+                "country": f"<script>{'E' * 110}</script>",
+                "city": f"<b>{'C' * 130}</b>",
+                "birth_date": "2009-04-03",
+            },
+            headers=_user_headers("creator@example.com"),
+        )
+
+        assert response.status_code == 201, response.get_json()
+        body = response.get_json()
+        player = body["player"]
+        assert set(player) == {
+            "id",
+            "display_name",
+            "birth_year",
+            "position",
+            "country",
+            "city",
+            "status",
+            "api_player_id",
+        }
+        assert player == {
+            "id": player["id"],
+            "display_name": "North   Star Prospect",
+            "birth_year": 2009,
+            "position": "M" * 50,
+            "country": "E" * 100,
+            "city": "C" * 120,
+            "status": "pending",
+            "api_player_id": None,
+        }
+        assert "birth_date" not in player
+
+        claim = body["claim"]
+        assert claim["player_api_id"] is None
+        assert claim["local_player_id"] == player["id"]
+        assert claim["relationship_type"] == "player"
+        assert claim["status"] == "pending"
+        assert CODE_PATTERN.fullmatch(claim["verification_code"])
+        assert claim["verification_status"] == "unverified"
+
+        with app.app_context():
+            stored = db.session.get(LocalPlayer, player["id"])
+            creator = _make_user("creator@example.com")
+            assert stored.normalized_name == "north star prospect"
+            assert stored.created_by_user_id == creator.id
+            assert stored.provenance == "user"
+            assert not hasattr(stored, "birth_date")
+            stored.display_name = "  Renamed\n  Prospect  "
+            db.session.flush()
+            assert stored.normalized_name == "renamed prospect"
+
+    @pytest.mark.parametrize("relationship_type", ["agent", "guardian"])
+    def test_supported_relationship_types_round_trip(self, client, relationship_type):
+        body = _create_local_player(
+            client,
+            display_name=f"{relationship_type.title()} Prospect",
+            relationship_type=relationship_type,
+        )
+
+        assert body["claim"]["relationship_type"] == relationship_type
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {},
+            {"display_name": "x"},
+            {"display_name": "x" * 201},
+            {"display_name": 123},
+            {"display_name": "Valid Prospect", "relationship_type": "club_official"},
+            {"display_name": "Valid Prospect", "relationship_type": 1},
+        ],
+    )
+    def test_name_and_relationship_validation(self, app, client, payload):
+        response = client.post("/api/local-players", json=payload, headers=_user_headers("creator@example.com"))
+
+        assert response.status_code == 400, (payload, response.get_json())
+        with app.app_context():
+            assert LocalPlayer.query.count() == 0
+            assert PlayerProfileClaim.query.count() == 0
+
+    @pytest.mark.parametrize("birth_year", [1949, 2021, "2008", 2008.0, True, False])
+    def test_birth_year_validation(self, app, client, birth_year):
+        response = client.post(
+            "/api/local-players",
+            json={"display_name": "Valid Prospect", "birth_year": birth_year},
+            headers=_user_headers("creator@example.com"),
+        )
+
+        assert response.status_code == 400, (birth_year, response.get_json())
+        with app.app_context():
+            assert LocalPlayer.query.count() == 0
+
+    @pytest.mark.parametrize("birth_year", [None, 1950, 2020])
+    def test_birth_year_boundaries(self, client, birth_year):
+        response = client.post(
+            "/api/local-players",
+            json={"display_name": f"Boundary Prospect {birth_year}", "birth_year": birth_year},
+            headers=_user_headers("creator@example.com"),
+        )
+
+        assert response.status_code == 201, response.get_json()
+        assert response.get_json()["player"]["birth_year"] == birth_year
+
+    @pytest.mark.parametrize("existing_status", ["pending", "approved"])
+    def test_active_duplicate_echoes_existing(self, app, client, existing_status):
+        with app.app_context():
+            existing = _seed_local_player("North Star Prospect", birth_year=2008, status=existing_status)
+            db.session.commit()
+            existing_id = existing.id
+
+        response = client.post(
+            "/api/local-players",
+            json={"display_name": " NORTH\n star prospect ", "birth_year": 2008},
+            headers=_user_headers("creator@example.com"),
+        )
+
+        assert response.status_code == 409, response.get_json()
+        body = response.get_json()
+        assert body["error"]
+        assert body["existing"]["id"] == existing_id
+        assert set(body["existing"]) == {
+            "id",
+            "display_name",
+            "birth_year",
+            "position",
+            "country",
+            "city",
+            "status",
+        }
+        with app.app_context():
+            assert LocalPlayer.query.count() == 1
+
+    def test_duplicate_without_birth_year_uses_null_safe_match(self, app, client):
+        with app.app_context():
+            _seed_local_player("No Birth Year Prospect", birth_year=None, status="pending")
+            db.session.commit()
+
+        response = client.post(
+            "/api/local-players",
+            json={"display_name": " no  birth year prospect "},
+            headers=_user_headers("creator@example.com"),
+        )
+
+        assert response.status_code == 409, response.get_json()
+
+    @pytest.mark.parametrize("existing_status", ["rejected", "merged"])
+    def test_inactive_duplicate_can_be_recreated(self, app, client, existing_status):
+        with app.app_context():
+            existing = _seed_local_player("Recreated Prospect", status=existing_status)
+            db.session.commit()
+            existing_id = existing.id
+
+        body = _create_local_player(client, display_name=" recreated prospect ")
+
+        assert body["player"]["id"] != existing_id
+
+
+# --------------------------------------------------------------------------- #
+# Identity visibility and public showcase
+# --------------------------------------------------------------------------- #
+
+
+class TestLocalPlayerVisibility:
+    def test_pending_is_claimant_only_until_admin_approval(self, app, client):
+        with app.app_context():
+            player = _seed_local_player(status="pending")
+            db.session.commit()
+            player_id = player.id
+            _, claim = _seed_claim(local_player_id=player_id, status="pending")
+            claim_id = claim.id
+
+        assert client.get(f"/api/local-players/{player_id}").status_code == 404
+        assert (
+            client.get(
+                f"/api/local-players/{player_id}",
+                headers=_user_headers("stranger@example.com"),
+            ).status_code
+            == 404
+        )
+        assert (
+            client.get(
+                f"/api/local-players/{player_id}",
+                headers={"Authorization": "Bearer not.a.real.token"},
+            ).status_code
+            == 404
+        )
+
+        owner = client.get(
+            f"/api/local-players/{player_id}",
+            headers=_user_headers("owner@example.com"),
+        )
+        assert owner.status_code == 200, owner.get_json()
+        assert owner.get_json()["player"]["status"] == "pending"
+
+        approved = client.post(
+            f"/api/admin/local-players/{player_id}/review",
+            json={"action": "approve", "note": "Identity checked"},
+            headers=_admin_headers(),
+        )
+        assert approved.status_code == 200, approved.get_json()
+        assert approved.get_json()["player"]["status"] == "approved"
+        public = client.get(f"/api/local-players/{player_id}")
+        assert public.status_code == 200, public.get_json()
+        assert public.get_json()["player"]["id"] == player_id
+
+        with app.app_context():
+            # Identity approval does not silently approve the ownership claim.
+            assert db.session.get(PlayerProfileClaim, claim_id).status == "pending"
+
+    def test_rejected_player_remains_visible_to_its_claimant_only(self, app, client):
+        with app.app_context():
+            player = _seed_local_player(status="pending")
+            db.session.commit()
+            player_id = player.id
+            _seed_claim(local_player_id=player_id, status="pending")
+
+        rejected = client.post(
+            f"/api/admin/local-players/{player_id}/review",
+            json={"action": "reject"},
+            headers=_admin_headers(),
+        )
+        assert rejected.status_code == 200, rejected.get_json()
+        assert client.get(f"/api/local-players/{player_id}").status_code == 404
+        owner = client.get(
+            f"/api/local-players/{player_id}",
+            headers=_user_headers("owner@example.com"),
+        )
+        assert owner.status_code == 200
+        assert owner.get_json()["player"]["status"] == "rejected"
+
+    def test_merged_player_follows_exactly_one_hop(self, app, client):
+        with app.app_context():
+            target = _seed_local_player("Canonical Prospect", status="approved")
+            source = _seed_local_player(
+                "Duplicate Prospect",
+                status="merged",
+                merged_into_local_player_id=target.id,
+            )
+            db.session.commit()
+            source_id = source.id
+            target_id = target.id
+
+        response = client.get(f"/api/local-players/{source_id}")
+
+        assert response.status_code == 200, response.get_json()
+        assert set(response.get_json()) == {"player", "merged_into"}
+        assert response.get_json()["merged_into"] == target_id
+        assert response.get_json()["player"]["id"] == target_id
+        assert response.get_json()["player"]["display_name"] == "Canonical Prospect"
+
+    def test_showcase_shape_and_film_room_are_local_only(self, app, client, monkeypatch):
+        with app.app_context():
+            player = _seed_local_player(status="approved", api_player_id=987654)
+            db.session.commit()
+            player_id = player.id
+            _seed_claim(local_player_id=player_id, status="pending")
+
+        from src.routes import showcase as showcase_routes
+
+        def _film_room_must_not_run(_player_api_id):
+            raise AssertionError("local showcase attempted to load Film Room")
+
+        monkeypatch.setattr(showcase_routes, "_verified_footage", _film_room_must_not_run)
+        response = client.get(f"/api/local-players/{player_id}/showcase")
+
+        assert response.status_code == 200, response.get_json()
+        body = response.get_json()
+        assert set(body) == {
+            "local_player_id",
+            "profile",
+            "photos",
+            "reel",
+            "affiliations",
+            "verified_footage",
+            "claim_status",
+        }
+        assert body == {
+            "local_player_id": player_id,
+            "profile": None,
+            "photos": [],
+            "reel": [],
+            "affiliations": [],
+            "verified_footage": [],
+            "claim_status": "unclaimed",
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Owner curation
+# --------------------------------------------------------------------------- #
+
+
+class TestLocalOwnerGate:
+    def test_pending_claim_can_view_but_cannot_curate(self, app, client):
+        with app.app_context():
+            player = _seed_local_player(status="pending")
+            db.session.commit()
+            player_id = player.id
+            _seed_claim(local_player_id=player_id, status="pending")
+        headers = _user_headers("owner@example.com")
+
+        assert client.get(f"/api/local-players/{player_id}/showcase", headers=headers).status_code == 200
+        response = client.put(
+            f"/api/local-players/{player_id}/showcase/profile",
+            json={"bio": "Draft"},
+            headers=headers,
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.parametrize(
+        ("method", "suffix", "payload"),
+        [
+            ("PUT", "profile", {"bio": "No"}),
+            ("POST", "reel", {"url": "https://youtu.be/nope123"}),
+            ("POST", "photos", {"content_type": "image/jpeg", "size_bytes": 100}),
+            ("POST", "affiliations", {"team_api_id": 33}),
+        ],
+    )
+    def test_non_owner_cannot_curate_any_local_content(self, app, client, method, suffix, payload):
+        with app.app_context():
+            player = _seed_local_player(status="approved")
+            db.session.commit()
+            player_id = player.id
+            _seed_claim(local_player_id=player_id, status="approved")
+
+        response = client.open(
+            f"/api/local-players/{player_id}/showcase/{suffix}",
+            method=method,
+            json=payload,
+            headers=_user_headers("stranger@example.com"),
+        )
+
+        assert response.status_code == 403, response.get_json()
+
+    def test_api_claim_with_same_integer_does_not_grant_local_ownership(self, app, client):
+        with app.app_context():
+            player = _seed_local_player(status="approved")
+            db.session.commit()
+            player_id = player.id
+            _seed_claim(email="api-owner@example.com", player_api_id=player_id, status="approved")
+
+        denied = client.put(
+            f"/api/local-players/{player_id}/showcase/profile",
+            json={"bio": "Crossed subject"},
+            headers=_user_headers("api-owner@example.com"),
+        )
+
+        assert denied.status_code == 403, denied.get_json()
+
+
+class TestLocalProfileCuration:
+    def test_profile_owner_draft_and_local_admin_moderation(self, app, client):
+        with app.app_context():
+            player = _seed_local_player(status="approved")
+            db.session.commit()
+            player_id = player.id
+            _seed_claim(local_player_id=player_id, status="approved")
+        headers = _user_headers("owner@example.com")
+
+        saved = client.put(
+            f"/api/local-players/{player_id}/showcase/profile",
+            json={
+                "bio": "Community academy prospect",
+                "positions": "CM",
+                "preferred_foot": "right",
+                "height_cm": 174,
+            },
+            headers=headers,
+        )
+        assert saved.status_code == 200, saved.get_json()
+        profile = saved.get_json()["profile"]
+        assert profile["player_api_id"] is None
+        assert profile["local_player_id"] == player_id
+        assert profile["status"] == "pending"
+
+        assert client.get(f"/api/local-players/{player_id}/showcase").get_json()["profile"] is None
+        owner = client.get(f"/api/local-players/{player_id}/showcase", headers=headers).get_json()["profile"]
+        assert owner["bio"] == "Community academy prospect"
+        assert owner["status"] == "pending"
+        assert owner["local_player_id"] == player_id
+
+        approved = client.post(
+            f"/api/admin/showcase/local-profiles/{player_id}/review",
+            json={"action": "approve"},
+            headers=_admin_headers(),
+        )
+        assert approved.status_code == 200, approved.get_json()
+        assert approved.get_json()["profile"]["status"] == "approved"
+        public = client.get(f"/api/local-players/{player_id}/showcase").get_json()["profile"]
+        assert public["bio"] == "Community academy prospect"
+        assert public["local_player_id"] == player_id
+        assert public["self_reported"] is True
+
+
+class TestLocalReelCuration:
+    def test_add_reorder_and_delete_local_reel_without_api_collision(self, app, client):
+        with app.app_context():
+            player = _seed_local_player(status="approved")
+            db.session.commit()
+            player_id = player.id
+            _seed_claim(local_player_id=player_id, status="approved")
+        headers = _user_headers("owner@example.com")
+
+        first = client.post(
+            f"/api/local-players/{player_id}/showcase/reel",
+            json={"url": "https://youtu.be/local-a", "title": "First"},
+            headers=headers,
+        )
+        second = client.post(
+            f"/api/local-players/{player_id}/showcase/reel",
+            json={"url": "https://youtu.be/local-b", "title": "Second"},
+            headers=headers,
+        )
+        assert first.status_code == 201, first.get_json()
+        assert second.status_code == 201, second.get_json()
+        for response in (first, second):
+            link = response.get_json()["link"]
+            assert link["player_id"] is None
+            assert link["local_player_id"] == player_id
+            assert link["status"] == "pending"
+        first_id = first.get_json()["link"]["id"]
+        second_id = second.get_json()["link"]["id"]
+
+        with app.app_context():
+            db.session.get(PlayerLink, first_id).status = "approved"
+            db.session.get(PlayerLink, second_id).status = "approved"
+            foreign = PlayerLink(
+                player_id=player_id,
+                local_player_id=None,
+                url="https://youtu.be/api-foreign",
+                link_type="highlight",
+                status="approved",
+                sort_order=77,
+            )
+            db.session.add(foreign)
+            db.session.commit()
+            foreign_id = foreign.id
+
+        reordered = client.patch(
+            f"/api/local-players/{player_id}/showcase/reel/order",
+            json={"ordered_ids": [second_id, foreign_id, "yt-1", first_id]},
+            headers=headers,
+        )
+        assert reordered.status_code == 200, reordered.get_json()
+        with app.app_context():
+            assert db.session.get(PlayerLink, second_id).sort_order == 0
+            assert db.session.get(PlayerLink, first_id).sort_order == 1
+            assert db.session.get(PlayerLink, foreign_id).sort_order == 77
+
+        public = client.get(f"/api/local-players/{player_id}/showcase").get_json()["reel"]
+        assert [item["url"] for item in public] == ["https://youtu.be/local-b", "https://youtu.be/local-a"]
+        assert all(item["local_player_id"] == player_id for item in public)
+
+        deleted = client.delete(
+            f"/api/local-players/{player_id}/showcase/reel/{first_id}",
+            headers=headers,
+        )
+        assert deleted.status_code == 200, deleted.get_json()
+        with app.app_context():
+            assert db.session.get(PlayerLink, first_id) is None
+            assert db.session.get(PlayerLink, foreign_id) is not None
+
+
+class TestLocalPhotoCuration:
+    def test_local_photo_full_owner_lifecycle_and_namespace(self, app, client):
+        raw = _jpeg_bytes()
+        with app.app_context():
+            player = _seed_local_player(status="approved")
+            db.session.commit()
+            player_id = player.id
+            _seed_claim(local_player_id=player_id, status="approved")
+        headers = _user_headers("owner@example.com")
+
+        first_created, first_pending = _create_complete_local_photo(client, player_id, headers, raw)
+        second_created, second_pending = _create_complete_local_photo(client, player_id, headers, raw)
+        assert f"/local-players/{player_id}/" in _url_path(first_created["upload"]["url"])
+        assert f"/local-players/{player_id}/" in _url_path(second_created["upload"]["url"])
+        assert first_pending["player_api_id"] is None
+        assert first_pending["local_player_id"] == player_id
+
+        owner_pending = client.get(
+            f"/api/local-players/{player_id}/showcase",
+            headers=headers,
+        ).get_json()["photos"]
+        assert {item["id"] for item in owner_pending} == {first_pending["id"], second_pending["id"]}
+        assert client.get(f"/api/local-players/{player_id}/showcase").get_json()["photos"] == []
+
+        for media_id in (first_pending["id"], second_pending["id"]):
+            reviewed = client.post(
+                f"/api/admin/showcase/media/{media_id}/review",
+                json={"action": "approve"},
+                headers=_admin_headers(),
+            )
+            assert reviewed.status_code == 200, reviewed.get_json()
+            assert reviewed.get_json()["media"]["local_player_id"] == player_id
+
+        reordered = client.patch(
+            f"/api/local-players/{player_id}/showcase/photos/order",
+            json={"ordered_ids": [second_pending["id"], first_pending["id"]]},
+            headers=headers,
+        )
+        assert reordered.status_code == 200, reordered.get_json()
+        assert [item["id"] for item in reordered.get_json()["photos"]] == [
+            second_pending["id"],
+            first_pending["id"],
+        ]
+
+        primary = client.patch(
+            f"/api/local-players/{player_id}/showcase/photos/{first_pending['id']}",
+            json={"is_primary": True},
+            headers=headers,
+        )
+        assert primary.status_code == 200, primary.get_json()
+        assert primary.get_json()["media"]["is_primary"] is True
+        assert primary.get_json()["media"]["local_player_id"] == player_id
+
+        deleted = client.delete(
+            f"/api/local-players/{player_id}/showcase/photos/{second_pending['id']}",
+            headers=headers,
+        )
+        assert deleted.status_code == 200, deleted.get_json()
+        public = client.get(f"/api/local-players/{player_id}/showcase").get_json()["photos"]
+        assert [item["id"] for item in public] == [first_pending["id"]]
+
+
+class TestLocalAffiliationCuration:
+    def test_create_moderate_publish_and_delete_local_affiliation(self, app, client):
+        with app.app_context():
+            player = _seed_local_player(status="approved")
+            club = _seed_local_club()
+            db.session.commit()
+            player_id = player.id
+            club_id = club.id
+            _seed_claim(local_player_id=player_id, status="approved")
+        headers = _user_headers("owner@example.com")
+
+        created = client.post(
+            f"/api/local-players/{player_id}/showcase/affiliations",
+            json={"local_club_id": club_id, "season": " <b>2025/26</b> "},
+            headers=headers,
+        )
+        assert created.status_code == 201, created.get_json()
+        affiliation = created.get_json()["affiliation"]
+        assert affiliation["player_api_id"] is None
+        assert affiliation["local_player_id"] == player_id
+        assert affiliation["local_club_id"] == club_id
+        assert affiliation["season"] == "2025/26"
+        assert affiliation["status"] == "pending"
+        assert client.get(f"/api/local-players/{player_id}/showcase").get_json()["affiliations"] == []
+
+        reviewed = client.post(
+            f"/api/admin/showcase/affiliations/{affiliation['id']}/review",
+            json={"action": "approve"},
+            headers=_admin_headers(),
+        )
+        assert reviewed.status_code == 200, reviewed.get_json()
+        public = client.get(f"/api/local-players/{player_id}/showcase").get_json()["affiliations"]
+        assert len(public) == 1
+        assert public[0]["local_player_id"] == player_id
+        assert public[0]["club_name"] == "Northside Juniors"
+        assert public[0]["status"] == "self_reported"
+
+        deleted = client.delete(
+            f"/api/local-players/{player_id}/showcase/affiliations/{affiliation['id']}",
+            headers=headers,
+        )
+        assert deleted.status_code == 200, deleted.get_json()
+        with app.app_context():
+            assert db.session.get(PlayerClubAffiliation, affiliation["id"]) is None
+
+
+def test_api_rows_with_same_numeric_id_do_not_consume_local_caps(app, client):
+    with app.app_context():
+        player = _seed_local_player(status="approved")
+        db.session.commit()
+        player_id = player.id
+        owner, _ = _seed_claim(local_player_id=player_id, status="approved")
+        for index in range(20):
+            db.session.add(
+                PlayerLink(
+                    player_id=player_id,
+                    local_player_id=None,
+                    url=f"https://youtu.be/api-{index}",
+                    link_type="highlight",
+                    status="approved",
+                )
+            )
+        for index in range(8):
+            _seed_media(player_api_id=player_id, user_id=owner.id, status="pending", suffix=f"api-{index}")
+        for index in range(5):
+            db.session.add(
+                PlayerClubAffiliation(
+                    player_api_id=player_id,
+                    local_player_id=None,
+                    team_api_id=1000 + index,
+                    status="pending",
+                )
+            )
+        db.session.commit()
+    headers = _user_headers("owner@example.com")
+
+    reel = client.post(
+        f"/api/local-players/{player_id}/showcase/reel",
+        json={"url": "https://youtu.be/local-cap"},
+        headers=headers,
+    )
+    photo = client.post(
+        f"/api/local-players/{player_id}/showcase/photos",
+        json={"content_type": "image/jpeg", "size_bytes": 100},
+        headers=headers,
+    )
+    affiliation = client.post(
+        f"/api/local-players/{player_id}/showcase/affiliations",
+        json={"team_api_id": 999999},
+        headers=headers,
+    )
+
+    assert reel.status_code == 201, reel.get_json()
+    assert photo.status_code == 201, photo.get_json()
+    assert affiliation.status_code == 201, affiliation.get_json()
+
+
+# --------------------------------------------------------------------------- #
+# Subject collision and claim verification
+# --------------------------------------------------------------------------- #
+
+
+class TestSubjectIsolation:
+    def test_local_and_api_payloads_do_not_cross_on_equal_ids(self, app, client):
+        with app.app_context():
+            player = _seed_local_player(status="approved")
+            db.session.commit()
+            player_id = player.id
+
+            db.session.add_all(
+                [
+                    PlayerShowcaseProfile(
+                        player_api_id=None,
+                        local_player_id=player_id,
+                        bio="Local profile",
+                        status="approved",
+                    ),
+                    PlayerShowcaseProfile(
+                        player_api_id=player_id,
+                        local_player_id=None,
+                        bio="API profile",
+                        status="approved",
+                    ),
+                    PlayerLink(
+                        player_id=None,
+                        local_player_id=player_id,
+                        url="https://youtu.be/local-only",
+                        link_type="highlight",
+                        status="approved",
+                    ),
+                    PlayerLink(
+                        player_id=player_id,
+                        local_player_id=None,
+                        url="https://youtu.be/api-only",
+                        link_type="highlight",
+                        status="approved",
+                    ),
+                    PlayerClubAffiliation(
+                        player_api_id=None,
+                        local_player_id=player_id,
+                        team_api_id=101,
+                        season="local-season",
+                        status="self_reported",
+                    ),
+                    PlayerClubAffiliation(
+                        player_api_id=player_id,
+                        local_player_id=None,
+                        team_api_id=202,
+                        season="api-season",
+                        status="self_reported",
+                    ),
+                ]
+            )
+            local_media = _seed_media(local_player_id=player_id, suffix="local-only")
+            api_media = _seed_media(player_api_id=player_id, suffix="api-only")
+            db.session.commit()
+            local_media_id = local_media.id
+            api_media_id = api_media.id
+
+        local = client.get(f"/api/local-players/{player_id}/showcase")
+        api = client.get(f"/api/players/{player_id}/showcase")
+
+        assert local.status_code == 200, local.get_json()
+        assert api.status_code == 200, api.get_json()
+        local_body = local.get_json()
+        api_body = api.get_json()
+        assert local_body["profile"]["bio"] == "Local profile"
+        assert local_body["profile"]["local_player_id"] == player_id
+        assert [item["url"] for item in local_body["reel"]] == ["https://youtu.be/local-only"]
+        assert [item["id"] for item in local_body["photos"]] == [local_media_id]
+        assert [item["season"] for item in local_body["affiliations"]] == ["local-season"]
+
+        assert api_body["profile"]["bio"] == "API profile"
+        assert "local_player_id" not in api_body["profile"]
+        assert [item["url"] for item in api_body["reel"]] == ["https://youtu.be/api-only"]
+        assert [item["id"] for item in api_body["photos"]] == [api_media_id]
+        assert [item["season"] for item in api_body["affiliations"]] == ["api-season"]
+        assert all("local_player_id" not in item for item in api_body["reel"])
+        assert all("local_player_id" not in item for item in api_body["photos"])
+        assert all("local_player_id" not in item for item in api_body["affiliations"])
+
+    def test_local_player_is_absent_from_club_and_admin_player_search(self, app, client):
+        with app.app_context():
+            _seed_local_player("Unique Northbridge Prospect", status="approved")
+            db.session.commit()
+
+        clubs = client.get(
+            "/api/clubs/search?q=northbridge",
+            headers=_user_headers("searcher@example.com"),
+        )
+        players = client.get(
+            "/api/admin/showcase/player-search?q=northbridge",
+            headers=_admin_headers(),
+        )
+
+        assert clubs.status_code == 200, clubs.get_json()
+        assert clubs.get_json() == {"api_teams": [], "local_clubs": []}
+        assert players.status_code == 200, players.get_json()
+        assert players.get_json() == {"players": []}
+
+
+class TestLocalClaims:
+    def test_claim_model_enforces_exactly_one_subject(self, app):
+        with app.app_context():
+            user = _make_user("owner@example.com")
+            both = PlayerProfileClaim(
+                player_api_id=5001,
+                local_player_id=1,
+                user_account_id=user.id,
+                relationship_type="player",
+                status="pending",
+            )
+            db.session.add(both)
+            with pytest.raises(ValueError, match="exactly one"):
+                db.session.flush()
+            db.session.rollback()
+
+            neither = PlayerProfileClaim(
+                player_api_id=None,
+                local_player_id=None,
+                user_account_id=user.id,
+                relationship_type="player",
+                status="pending",
+            )
+            db.session.add(neither)
+            with pytest.raises(ValueError, match="exactly one"):
+                db.session.flush()
+            db.session.rollback()
+
+    def test_me_claims_includes_local_mini_dict_and_null_local_id_for_api_claim(self, app, client):
+        with app.app_context():
+            player = _seed_local_player("Academy Prospect", status="pending")
+            db.session.commit()
+            player_id = player.id
+            user = _make_user("owner@example.com")
+            local_claim = PlayerProfileClaim(
+                player_api_id=None,
+                local_player_id=player_id,
+                user_account_id=user.id,
+                relationship_type="player",
+                status="pending",
+                verification_code=None,
+                verification_status="unverified",
+            )
+            api_claim = PlayerProfileClaim(
+                player_api_id=5001,
+                local_player_id=None,
+                user_account_id=user.id,
+                relationship_type="agent",
+                status="pending",
+                verification_code=None,
+                verification_status="unverified",
+            )
+            db.session.add_all([local_claim, api_claim])
+            db.session.commit()
+            local_claim_id = local_claim.id
+            api_claim_id = api_claim.id
+
+        response = client.get("/api/me/claims", headers=_user_headers("owner@example.com"))
+
+        assert response.status_code == 200, response.get_json()
+        by_id = {claim["id"]: claim for claim in response.get_json()["claims"]}
+        local = by_id[local_claim_id]
+        api = by_id[api_claim_id]
+        assert local["player_api_id"] is None
+        assert local["local_player_id"] == player_id
+        assert local["local_player"] == {
+            "id": player_id,
+            "display_name": "Academy Prospect",
+            "status": "pending",
+        }
+        assert local["player_name"] == "Academy Prospect"
+        assert CODE_PATTERN.fullmatch(local["verification_code"])
+
+        assert api["player_api_id"] == 5001
+        assert api["local_player_id"] is None
+        assert "local_player" not in api
+        assert CODE_PATTERN.fullmatch(api["verification_code"])
+
+    def test_existing_verify_endpoint_updates_local_claim(self, app, client, monkeypatch):
+        code = "AW-ABCDEFGH"
+        with app.app_context():
+            player = _seed_local_player(status="pending")
+            db.session.commit()
+            player_id = player.id
+            _, claim = _seed_claim(
+                local_player_id=player_id,
+                status="pending",
+                code=code,
+            )
+            claim_id = claim.id
+        _fake_get(monkeypatch, [FakeResponse(f"Player bio {code.lower()}".encode())])
+
+        response = client.post(
+            f"/api/me/claims/{claim_id}/verify",
+            json={"proof_url": "https://instagram.com/academy-prospect"},
+            headers=_user_headers("owner@example.com"),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        verified = response.get_json()["claim"]
+        assert verified["player_api_id"] is None
+        assert verified["local_player_id"] == player_id
+        assert verified["status"] == "pending"
+        assert verified["verification_status"] == "code_found"
+        assert verified["verification_checked_at"]
+        with app.app_context():
+            stored = db.session.get(PlayerProfileClaim, claim_id)
+            assert stored.player_api_id is None
+            assert stored.local_player_id == player_id
+            assert stored.verification_status == "code_found"
+
+
+# --------------------------------------------------------------------------- #
+# Admin moderation, merge, and API bridge
+# --------------------------------------------------------------------------- #
+
+
+class TestAdminLocalPlayers:
+    @pytest.mark.parametrize(
+        ("action", "expected_status"),
+        [("approve", "approved"), ("reject", "rejected")],
+    )
+    def test_list_creator_email_and_pending_only_review(self, client, action, expected_status):
+        created = _create_local_player(
+            client,
+            email="creator@example.com",
+            display_name=f"{action.title()} Prospect",
+        )
+        player_id = created["player"]["id"]
+
+        listing = client.get("/api/admin/local-players?status=pending", headers=_admin_headers())
+        assert listing.status_code == 200, listing.get_json()
+        assert [player["id"] for player in listing.get_json()["players"]] == [player_id]
+        listed = listing.get_json()["players"][0]
+        assert listed["created_by_email"] == "creator@example.com"
+        assert listed["normalized_name"] == f"{action} prospect"
+        assert listed["provenance"] == "user"
+
+        reviewed = client.post(
+            f"/api/admin/local-players/{player_id}/review",
+            json={"action": action, "note": " <b>Reviewed safely</b> "},
+            headers=_admin_headers(),
+        )
+        assert reviewed.status_code == 200, reviewed.get_json()
+        player = reviewed.get_json()["player"]
+        assert player["status"] == expected_status
+        assert player["review_note"] == "Reviewed safely"
+        assert player["reviewed_by"] == "admin@test.com"
+        assert player["reviewed_at"]
+
+        second = client.post(
+            f"/api/admin/local-players/{player_id}/review",
+            json={"action": action},
+            headers=_admin_headers(),
+        )
+        assert second.status_code == 409, second.get_json()
+
+    def test_merge_repoints_every_local_subject_with_exact_counts(self, app, client):
+        with app.app_context():
+            source = _seed_local_player("Duplicate Prospect", status="pending")
+            target = _seed_local_player("Canonical Prospect", status="approved")
+            db.session.commit()
+            source_id = source.id
+            target_id = target.id
+
+            first_user = _make_user("first@example.com")
+            second_user = _make_user("second@example.com")
+            api_user = _make_user("api@example.com")
+            local_claims = [
+                PlayerProfileClaim(
+                    player_api_id=None,
+                    local_player_id=source_id,
+                    user_account_id=user.id,
+                    relationship_type="player",
+                    status="pending",
+                )
+                for user in (first_user, second_user)
+            ]
+            api_claim = PlayerProfileClaim(
+                player_api_id=source_id,
+                local_player_id=None,
+                user_account_id=api_user.id,
+                relationship_type="player",
+                status="pending",
+            )
+            local_profile = PlayerShowcaseProfile(
+                player_api_id=None,
+                local_player_id=source_id,
+                bio="Move me",
+                status="pending",
+            )
+            api_profile = PlayerShowcaseProfile(
+                player_api_id=source_id,
+                local_player_id=None,
+                bio="Leave API row",
+                status="pending",
+            )
+            local_media = [_seed_media(local_player_id=source_id, suffix=f"local-{index}") for index in range(2)]
+            api_media = _seed_media(player_api_id=source_id, suffix="api")
+            local_affiliations = [
+                PlayerClubAffiliation(
+                    player_api_id=None,
+                    local_player_id=source_id,
+                    team_api_id=100 + index,
+                    status="pending",
+                )
+                for index in range(2)
+            ]
+            api_affiliation = PlayerClubAffiliation(
+                player_api_id=source_id,
+                local_player_id=None,
+                team_api_id=999,
+                status="pending",
+            )
+            local_links = [
+                PlayerLink(
+                    player_id=None,
+                    local_player_id=source_id,
+                    url=f"https://youtu.be/local-{index}",
+                    link_type="highlight",
+                    status="pending",
+                )
+                for index in range(2)
+            ]
+            api_link = PlayerLink(
+                player_id=source_id,
+                local_player_id=None,
+                url="https://youtu.be/api-row",
+                link_type="highlight",
+                status="pending",
+            )
+            db.session.add_all(
+                [
+                    *local_claims,
+                    api_claim,
+                    local_profile,
+                    api_profile,
+                    *local_affiliations,
+                    api_affiliation,
+                    *local_links,
+                    api_link,
+                ]
+            )
+            db.session.commit()
+            local_claim_ids = [row.id for row in local_claims]
+            local_profile_id = local_profile.id
+            local_media_ids = [row.id for row in local_media]
+            local_affiliation_ids = [row.id for row in local_affiliations]
+            local_link_ids = [row.id for row in local_links]
+            api_ids = {
+                "claim": api_claim.id,
+                "profile": api_profile.id,
+                "media": api_media.id,
+                "affiliation": api_affiliation.id,
+                "link": api_link.id,
+            }
+
+        response = client.post(
+            f"/api/admin/local-players/{source_id}/merge",
+            json={"into_local_player_id": target_id},
+            headers=_admin_headers(),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        assert response.get_json()["moved"] == {
+            "claims": 2,
+            "profiles": 1,
+            "media": 2,
+            "affiliations": 2,
+            "links": 2,
+        }
+        assert response.get_json()["player"]["status"] == "merged"
+        assert response.get_json()["player"]["merged_into_local_player_id"] == target_id
+
+        with app.app_context():
+            db.session.expire_all()
+            source = db.session.get(LocalPlayer, source_id)
+            assert source.status == "merged"
+            assert source.merged_into_local_player_id == target_id
+            assert {db.session.get(PlayerProfileClaim, row_id).local_player_id for row_id in local_claim_ids} == {
+                target_id
+            }
+            assert db.session.get(PlayerShowcaseProfile, local_profile_id).local_player_id == target_id
+            assert {db.session.get(PlayerShowcaseMedia, row_id).local_player_id for row_id in local_media_ids} == {
+                target_id
+            }
+            assert {
+                db.session.get(PlayerClubAffiliation, row_id).local_player_id for row_id in local_affiliation_ids
+            } == {target_id}
+            assert {db.session.get(PlayerLink, row_id).local_player_id for row_id in local_link_ids} == {target_id}
+
+            assert db.session.get(PlayerProfileClaim, api_ids["claim"]).player_api_id == source_id
+            assert db.session.get(PlayerProfileClaim, api_ids["claim"]).local_player_id is None
+            assert db.session.get(PlayerShowcaseProfile, api_ids["profile"]).player_api_id == source_id
+            assert db.session.get(PlayerShowcaseMedia, api_ids["media"]).player_api_id == source_id
+            assert db.session.get(PlayerClubAffiliation, api_ids["affiliation"]).player_api_id == source_id
+            assert db.session.get(PlayerLink, api_ids["link"]).player_id == source_id
+            assert db.session.get(PlayerLink, api_ids["link"]).local_player_id is None
+
+    def test_merge_consolidates_profile_collision_and_returns_card_to_moderation(self, app, client):
+        with app.app_context():
+            source = _seed_local_player("Duplicate Profile", status="approved")
+            target = _seed_local_player("Canonical Profile", status="approved")
+            db.session.commit()
+            source_id = source.id
+            target_id = target.id
+            source_profile = PlayerShowcaseProfile(
+                player_api_id=None,
+                local_player_id=source_id,
+                bio="Source biography",
+                positions="CM",
+                status="approved",
+            )
+            target_profile = PlayerShowcaseProfile(
+                player_api_id=None,
+                local_player_id=target_id,
+                bio="Canonical biography",
+                status="approved",
+                reviewed_by="original-reviewer@example.com",
+                reviewed_at=datetime.now(UTC),
+            )
+            db.session.add_all([source_profile, target_profile])
+            db.session.commit()
+            source_profile_id = source_profile.id
+            target_profile_id = target_profile.id
+
+        response = client.post(
+            f"/api/admin/local-players/{source_id}/merge",
+            json={"into_local_player_id": target_id},
+            headers=_admin_headers(),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        assert response.get_json()["moved"]["profiles"] == 1
+        with app.app_context():
+            profiles = PlayerShowcaseProfile.query.filter_by(local_player_id=target_id).all()
+            assert [profile.id for profile in profiles] == [target_profile_id]
+            assert profiles[0].bio == "Canonical biography"
+            assert profiles[0].positions == "CM"
+            assert profiles[0].status == "pending"
+            assert profiles[0].reviewed_by is None
+            assert profiles[0].reviewed_at is None
+            assert db.session.get(PlayerShowcaseProfile, source_profile_id) is None
+
+    def test_merge_consolidates_same_users_claim_and_preserves_approval(self, app, client):
+        with app.app_context():
+            source = _seed_local_player("Duplicate Claim", status="approved")
+            target = _seed_local_player("Canonical Claim", status="approved")
+            db.session.commit()
+            source_id = source.id
+            target_id = target.id
+            user = _make_user("same-owner@example.com")
+            source_claim = PlayerProfileClaim(
+                player_api_id=None,
+                local_player_id=source_id,
+                user_account_id=user.id,
+                relationship_type="player",
+                status="approved",
+                verification_code="AW-ABCDEFGH",
+                verification_status="code_found",
+            )
+            target_claim = PlayerProfileClaim(
+                player_api_id=None,
+                local_player_id=target_id,
+                user_account_id=user.id,
+                relationship_type="guardian",
+                status="pending",
+                verification_code="AW-HGFEDCBA",
+                verification_status="unverified",
+            )
+            db.session.add_all([source_claim, target_claim])
+            db.session.commit()
+            source_claim_id = source_claim.id
+            target_claim_id = target_claim.id
+            user_id = user.id
+
+        response = client.post(
+            f"/api/admin/local-players/{source_id}/merge",
+            json={"into_local_player_id": target_id},
+            headers=_admin_headers(),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        assert response.get_json()["moved"]["claims"] == 1
+        with app.app_context():
+            claims = PlayerProfileClaim.query.filter_by(
+                local_player_id=target_id,
+                user_account_id=user_id,
+            ).all()
+            assert [claim.id for claim in claims] == [target_claim_id]
+            assert claims[0].status == "approved"
+            assert claims[0].relationship_type == "player"
+            assert claims[0].verification_code == "AW-ABCDEFGH"
+            assert claims[0].verification_status == "code_found"
+            assert db.session.get(PlayerProfileClaim, source_claim_id) is None
+
+    def test_merge_claim_collision_is_denial_safe_and_preserves_independent_evidence(self, app, client):
+        with app.app_context():
+            source = _seed_local_player("Approved Duplicate", status="approved")
+            target = _seed_local_player("Revoked Canonical", status="approved")
+            db.session.commit()
+            source_id = source.id
+            target_id = target.id
+            user = _make_user("reviewed-owner@example.com")
+            source_claim = PlayerProfileClaim(
+                player_api_id=None,
+                local_player_id=source_id,
+                user_account_id=user.id,
+                relationship_type="player",
+                status="approved",
+                verification_code="AW-ABCDEFGH",
+                verification_proof_url="https://instagram.com/reviewed-owner",
+                verification_status="code_found",
+                verification_note="social code found",
+                reviewed_by="source-reviewer@example.com",
+                reviewed_at=datetime.now(UTC),
+            )
+            target_claim = PlayerProfileClaim(
+                player_api_id=None,
+                local_player_id=target_id,
+                user_account_id=user.id,
+                relationship_type="guardian",
+                status="revoked",
+                verification_code="AW-HGFEDCBA",
+                verification_status="unverified",
+                verification_note="official vouched previously",
+                verification_method="vouch",
+                reviewed_by="revoking-admin@example.com",
+                reviewed_at=datetime.now(UTC),
+            )
+            db.session.add_all([source_claim, target_claim])
+            db.session.commit()
+            target_claim_id = target_claim.id
+
+        response = client.post(
+            f"/api/admin/local-players/{source_id}/merge",
+            json={"into_local_player_id": target_id},
+            headers=_admin_headers(),
+        )
+
+        assert response.status_code == 200, response.get_json()
+        with app.app_context():
+            claim = db.session.get(PlayerProfileClaim, target_claim_id)
+            assert claim.status == "revoked"
+            assert claim.relationship_type == "guardian"
+            assert claim.reviewed_by == "revoking-admin@example.com"
+            assert claim.verification_status == "code_found"
+            assert claim.verification_proof_url == "https://instagram.com/reviewed-owner"
+            assert claim.verification_method == "vouch"
+            assert "social code found" in claim.verification_note
+            assert "official vouched previously" in claim.verification_note
+
+    def test_merge_rejects_self_missing_and_inactive_targets(self, app, client):
+        with app.app_context():
+            source = _seed_local_player("Source Prospect", status="pending")
+            merged = _seed_local_player("Merged Target", status="merged")
+            rejected = _seed_local_player("Rejected Target", status="rejected")
+            db.session.commit()
+            source_id = source.id
+            invalid_targets = [source.id, merged.id, rejected.id, 999999]
+
+        for target_id in invalid_targets:
+            response = client.post(
+                f"/api/admin/local-players/{source_id}/merge",
+                json={"into_local_player_id": target_id},
+                headers=_admin_headers(),
+            )
+            assert response.status_code == 400, (target_id, response.get_json())
+
+        with app.app_context():
+            source = db.session.get(LocalPlayer, source_id)
+            assert source.status == "pending"
+            assert source.merged_into_local_player_id is None
+
+    @pytest.mark.parametrize("source_status", ["merged", "rejected"])
+    def test_merge_rejects_inactive_source(self, app, client, source_status):
+        with app.app_context():
+            source = _seed_local_player("Inactive Source", status=source_status)
+            target = _seed_local_player("Active Target", status="approved")
+            db.session.commit()
+            source_id = source.id
+            target_id = target.id
+
+        response = client.post(
+            f"/api/admin/local-players/{source_id}/merge",
+            json={"into_local_player_id": target_id},
+            headers=_admin_headers(),
+        )
+
+        assert response.status_code == 409, response.get_json()
+
+    def test_link_api_validates_and_never_repoints_or_tracks_content(self, app, client):
+        with app.app_context():
+            player = _seed_local_player("Bridge Prospect", status="approved")
+            db.session.commit()
+            player_id = player.id
+            local_link = PlayerLink(
+                player_id=None,
+                local_player_id=player_id,
+                url="https://youtu.be/stays-local",
+                link_type="highlight",
+                status="approved",
+            )
+            db.session.add(local_link)
+            db.session.commit()
+            local_link_id = local_link.id
+            assert TrackedPlayer.query.count() == 0
+
+        for invalid in (0, -1, "5001", True):
+            response = client.post(
+                f"/api/admin/local-players/{player_id}/link-api",
+                json={"player_api_id": invalid},
+                headers=_admin_headers(),
+            )
+            assert response.status_code == 400, (invalid, response.get_json())
+
+        linked = client.post(
+            f"/api/admin/local-players/{player_id}/link-api",
+            json={"player_api_id": 5001},
+            headers=_admin_headers(),
+        )
+        assert linked.status_code == 200, linked.get_json()
+        assert linked.get_json()["player"]["api_player_id"] == 5001
+
+        local_showcase = client.get(f"/api/local-players/{player_id}/showcase").get_json()
+        api_showcase = client.get("/api/players/5001/showcase").get_json()
+        assert [item["url"] for item in local_showcase["reel"]] == ["https://youtu.be/stays-local"]
+        assert local_showcase["verified_footage"] == []
+        assert api_showcase["reel"] == []
+        with app.app_context():
+            assert db.session.get(LocalPlayer, player_id).api_player_id == 5001
+            assert db.session.get(PlayerLink, local_link_id).local_player_id == player_id
+            assert db.session.get(PlayerLink, local_link_id).player_id is None
+            assert TrackedPlayer.query.count() == 0

--- a/academy-watch-backend/tests/test_season_data_sea01.py
+++ b/academy-watch-backend/tests/test_season_data_sea01.py
@@ -1,21 +1,24 @@
 """D2 season-data (sea01) pinning tests — proposal §2 / §3 / §7 D2.
 
-Locks the four load-bearing guarantees of the PR2 (`sea01`) work:
+Locks six load-bearing migration and season-data guarantees:
 
-1. **Migration head stays single** and is `sea01` (chained off `aw23`) — a second
-   head would make `flask db upgrade` ambiguous on deploy.
-2. **`sea01` is idempotent** — every DDL is guarded, so a re-applied or
+1. **Migration head stays single** and is `shp05`, with the showcase chain
+   descending linearly from `sea01` (which remains chained off `aw23`) — a
+   second head would make `flask db upgrade` ambiguous on deploy.
+2. **Showcase downgrades protect blobs** — non-empty blob-owning tables stop a
+   downgrade, while an already-absent table remains a no-op.
+3. **`sea01` is idempotent** — every DDL is guarded, so a re-applied or
    partially-applied upgrade is a pure no-op (migrations do NOT auto-run on
    deploy; prod schema has drifted out-of-band, invariants §8).
-3. **Rich extraction** — `_create_entry_from_stat` banks the full API-Football
+4. **Rich extraction** — `_create_entry_from_stat` banks the full API-Football
    per-season statistics block into the sea01 columns with
    ``stats_source='journey-api'`` while the basic 4 fields stay byte-identical to
    the pre-sea01 behavior; a sparse/null payload yields NULL rich columns and
    never crashes (missing ≠ observed-zero).
-4. **Duplicate-merge survival** — after a club-ID correction produces a duplicate,
+5. **Duplicate-merge survival** — after a club-ID correction produces a duplicate,
    the merged survivor keeps its rich fields (journey-api / newer-synced wins the
    tie), and the primary "more appearances" rule is untouched.
-5. **Backfill endpoint** — `POST /api/admin/journeys/backfill-entry-player-ids`
+6. **Backfill endpoint** — `POST /api/admin/journeys/backfill-entry-player-ids`
    fills only NULL `player_api_id` rows, converges to zero in bounded batches,
    is idempotent on re-run, never clobbers a set value, clamps its batch bound,
    and 401s without admin auth.
@@ -49,10 +52,10 @@ def _script_directory():
 
 
 class TestMigrationHead:
-    def test_single_head_is_sea01(self):
-        """The whole chain resolves to exactly one head, and it is sea01."""
+    def test_single_head_is_shp05(self):
+        """The whole chain resolves to exactly one head, and it is shp05."""
         heads = _script_directory().get_heads()
-        assert heads == ["sea01"], f"expected the single head to be sea01, got {heads}"
+        assert heads == ["shp05"], f"expected the single head to be shp05, got {heads}"
 
     def test_sea01_chains_off_aw23(self):
         """sea01 branches from the real prod tip (aw23), keeping the line linear."""
@@ -61,9 +64,22 @@ class TestMigrationHead:
         assert sea01.down_revision == "aw23"
         assert script.get_revision("aw23") is not None
 
+    def test_showcase_chain_descends_from_sea01(self):
+        """Every showcase migration extends sea01 in one linear chain."""
+        script = _script_directory()
+        expected_parents = {
+            "shp01": "sea01",
+            "shp02": "shp01",
+            "shp03": "shp02",
+            "shp04": "shp03",
+            "shp05": "shp04",
+        }
+        for revision, expected_parent in expected_parents.items():
+            assert script.get_revision(revision).down_revision == expected_parent
+
 
 # ---------------------------------------------------------------------------
-# (2) sea01 idempotency (guarded DDL runs twice cleanly under SQLite)
+# Shared SQLite migration-test helpers
 # ---------------------------------------------------------------------------
 
 
@@ -86,12 +102,81 @@ def _alembic_ops(engine):
 
 
 def _sqlite_column_exists(table, column):
-    return column in {c["name"] for c in sa.inspect(alembic_op.get_bind()).get_columns(table)}
+    inspector = sa.inspect(alembic_op.get_bind())
+    if table not in inspector.get_table_names():
+        return False
+    return column in {c["name"] for c in inspector.get_columns(table)}
+
+
+def _sqlite_table_exists(table):
+    return table in sa.inspect(alembic_op.get_bind()).get_table_names()
 
 
 def _sqlite_index_exists(name):
     inspector = sa.inspect(alembic_op.get_bind())
     return any(name in {ix["name"] for ix in inspector.get_indexes(t)} for t in inspector.get_table_names())
+
+
+def _migration_with_sqlite_guards(monkeypatch, module_name):
+    migration = importlib.import_module(module_name)
+    monkeypatch.setattr(migration, "column_exists", _sqlite_column_exists)
+    monkeypatch.setattr(migration, "index_exists", _sqlite_index_exists)
+    monkeypatch.setattr(migration, "table_exists", _sqlite_table_exists)
+    return migration
+
+
+# ---------------------------------------------------------------------------
+# (2) Showcase downgrade blob safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("module_name", "table_name"),
+    [
+        ("migrations.versions.shp01_showcase_media", "player_showcase_media"),
+        ("migrations.versions.shp05_local_players", "local_players"),
+    ],
+)
+def test_showcase_downgrade_rejects_nonempty_blob_owning_table(monkeypatch, module_name, table_name):
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(sa.text(f"CREATE TABLE {table_name} (id INTEGER PRIMARY KEY)"))
+        conn.execute(sa.text(f"INSERT INTO {table_name} (id) VALUES (1)"))
+    migration = _migration_with_sqlite_guards(monkeypatch, module_name)
+
+    try:
+        with pytest.raises(RuntimeError, match=r"(?i)reconcile.*purge.*blobs"):
+            with _alembic_ops(engine):
+                migration.downgrade()
+
+        assert table_name in sa.inspect(engine).get_table_names()
+        with engine.connect() as conn:
+            assert conn.execute(sa.text(f"SELECT COUNT(*) FROM {table_name}")).scalar_one() == 1
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "migrations.versions.shp01_showcase_media",
+        "migrations.versions.shp05_local_players",
+    ],
+)
+def test_showcase_downgrade_guard_noops_when_table_is_absent(monkeypatch, module_name):
+    engine = sa.create_engine("sqlite:///:memory:")
+    migration = _migration_with_sqlite_guards(monkeypatch, module_name)
+
+    try:
+        with _alembic_ops(engine):
+            migration.downgrade()
+    finally:
+        engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# (3) sea01 idempotency (guarded DDL runs twice cleanly under SQLite)
+# ---------------------------------------------------------------------------
 
 
 # The FULL 28-column contract sea01 adds to player_journey_entries (27 rich
@@ -290,7 +375,7 @@ class TestSea01Idempotency:
 
 
 # ---------------------------------------------------------------------------
-# (3) Rich extraction from the API-Football statistics block
+# (4) Rich extraction from the API-Football statistics block
 # ---------------------------------------------------------------------------
 
 
@@ -452,7 +537,7 @@ class TestStatCoercionHelpers:
 
 
 # ---------------------------------------------------------------------------
-# (4) Duplicate-merge keeps rich fields
+# (5) Duplicate-merge keeps rich fields
 # ---------------------------------------------------------------------------
 
 
@@ -514,7 +599,7 @@ class TestMergeSurvivorKeepsRichData:
 
 
 # ---------------------------------------------------------------------------
-# (5) Backfill endpoint
+# (6) Backfill endpoint
 # ---------------------------------------------------------------------------
 
 ADMIN_KEY = "test-admin-key"

--- a/academy-watch-backend/tests/test_showcase.py
+++ b/academy-watch-backend/tests/test_showcase.py
@@ -505,8 +505,9 @@ class TestPublicPayload:
         resp = client.get("/api/players/5001/showcase")
         assert resp.status_code == 200
         data = resp.get_json()
-        assert set(data.keys()) == {"player_api_id", "profile", "reel", "verified_footage", "claim_status"}
+        assert set(data.keys()) == {"player_api_id", "profile", "photos", "reel", "verified_footage", "claim_status"}
         assert data["profile"] is None
+        assert data["photos"] == []
         assert data["reel"] == []
         assert data["verified_footage"] == []
         assert data["claim_status"] == "unclaimed"

--- a/academy-watch-backend/tests/test_showcase.py
+++ b/academy-watch-backend/tests/test_showcase.py
@@ -505,10 +505,19 @@ class TestPublicPayload:
         resp = client.get("/api/players/5001/showcase")
         assert resp.status_code == 200
         data = resp.get_json()
-        assert set(data.keys()) == {"player_api_id", "profile", "photos", "reel", "verified_footage", "claim_status"}
+        assert set(data.keys()) == {
+            "player_api_id",
+            "profile",
+            "photos",
+            "reel",
+            "affiliations",
+            "verified_footage",
+            "claim_status",
+        }
         assert data["profile"] is None
         assert data["photos"] == []
         assert data["reel"] == []
+        assert data["affiliations"] == []
         assert data["verified_footage"] == []
         assert data["claim_status"] == "unclaimed"
 

--- a/academy-watch-backend/tests/test_showcase_media.py
+++ b/academy-watch-backend/tests/test_showcase_media.py
@@ -5,6 +5,8 @@ visibility, gallery curation, profile validation/privacy, moderation rejection,
 and production storage degradation.
 """
 
+import struct
+import zlib
 from io import BytesIO
 from urllib.parse import urlsplit
 
@@ -120,24 +122,35 @@ def _gps_jpeg() -> bytes:
     return raw
 
 
+def _oversized_dimension_png() -> bytes:
+    """Tiny PNG container whose declared dimensions exceed the pixel cap."""
+
+    def chunk(kind, payload):
+        checksum = zlib.crc32(kind + payload) & 0xFFFFFFFF
+        return struct.pack(">I", len(payload)) + kind + payload + struct.pack(">I", checksum)
+
+    ihdr = struct.pack(">IIBBBBB", 8000, 5001, 8, 2, 0, 0, 0)
+    return b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr) + chunk(b"IEND", b"")
+
+
 def _url_path(url):
     parsed = urlsplit(url)
     return parsed.path or url
 
 
-def _create_photo(client, headers, raw):
+def _create_photo(client, headers, raw, *, content_type="image/jpeg"):
     response = client.post(
         f"/api/players/{PLAYER_ID}/showcase/photos",
-        json={"content_type": "image/jpeg", "size_bytes": len(raw)},
+        json={"content_type": content_type, "size_bytes": len(raw)},
         headers=headers,
     )
     assert response.status_code == 201, response.get_json()
     return response.get_json()
 
 
-def _upload_photo(client, upload, raw):
+def _upload_photo(client, upload, raw, *, content_type="image/jpeg"):
     assert upload["method"] == "PUT"
-    assert upload["headers"] == {"x-ms-blob-type": "BlockBlob", "Content-Type": "image/jpeg"}
+    assert upload["headers"] == {"x-ms-blob-type": "BlockBlob", "Content-Type": content_type}
     response = client.put(_url_path(upload["url"]), data=raw, headers=upload["headers"])
     assert response.status_code in (200, 201, 204), response.get_json(silent=True)
 
@@ -178,6 +191,86 @@ def _seed_media(player_api_id, user_id, *, status="approved", sort_order=0, suff
 
 
 class TestPhotoLifecycle:
+    def test_complete_rejects_oversized_dimensions_and_deletes_pending_blob(self, app, client):
+        raw = _oversized_dimension_png()
+        with app.app_context():
+            _approved_claim(PLAYER_ID, "owner@example.com")
+        headers = _user_headers("owner@example.com")
+
+        created = _create_photo(client, headers, raw, content_type="image/png")
+        _upload_photo(client, created["upload"], raw, content_type="image/png")
+        pending_path = _url_path(created["upload"]["url"])
+        media_id = created["media"]["id"]
+        assert len(raw) < 1024
+        assert client.get(pending_path).status_code == 200
+
+        completed = client.post(
+            f"/api/players/{PLAYER_ID}/showcase/photos/{media_id}/complete",
+            headers=headers,
+        )
+
+        assert completed.status_code == 422
+        assert client.get(pending_path).status_code == 404
+        with app.app_context():
+            row = db.session.get(PlayerShowcaseMedia, media_id)
+            assert row is None or row.status != "pending"
+
+    def test_failed_size_verification_deletes_pending_blob(self, app, client, monkeypatch):
+        from src.services import showcase_media_storage
+
+        raw = _gps_jpeg()
+        with app.app_context():
+            _approved_claim(PLAYER_ID, "owner@example.com")
+        headers = _user_headers("owner@example.com")
+
+        created = _create_photo(client, headers, raw)
+        _upload_photo(client, created["upload"], raw)
+        pending_path = _url_path(created["upload"]["url"])
+        media_id = created["media"]["id"]
+        monkeypatch.setattr(showcase_media_storage, "max_photo_bytes", lambda: len(raw) - 1)
+
+        completed = client.post(
+            f"/api/players/{PLAYER_ID}/showcase/photos/{media_id}/complete",
+            headers=headers,
+        )
+
+        assert completed.status_code == 400
+        assert client.get(pending_path).status_code == 404
+        with app.app_context():
+            row = db.session.get(PlayerShowcaseMedia, media_id)
+            assert row is None or row.status != "pending"
+
+    def test_invalid_completion_cleanup_failure_is_best_effort(self, app, client, monkeypatch):
+        from src.services import showcase_media_storage
+
+        raw = _oversized_dimension_png()
+        with app.app_context():
+            _approved_claim(PLAYER_ID, "owner@example.com")
+        headers = _user_headers("owner@example.com")
+
+        created = _create_photo(client, headers, raw, content_type="image/png")
+        _upload_photo(client, created["upload"], raw, content_type="image/png")
+        media_id = created["media"]["id"]
+        with app.app_context():
+            expected_blob_path = db.session.get(PlayerShowcaseMedia, media_id).blob_path
+        cleanup_attempts = []
+
+        def fail_cleanup(blob_path):
+            cleanup_attempts.append(blob_path)
+            raise OSError("simulated cleanup failure")
+
+        monkeypatch.setattr(showcase_media_storage, "delete_pending", fail_cleanup)
+        completed = client.post(
+            f"/api/players/{PLAYER_ID}/showcase/photos/{media_id}/complete",
+            headers=headers,
+        )
+
+        assert completed.status_code == 422
+        assert cleanup_attempts == [expected_blob_path]
+        with app.app_context():
+            row = db.session.get(PlayerShowcaseMedia, media_id)
+            assert row is None or row.status != "pending"
+
     def test_create_complete_approve_strips_gps_and_all_exif(self, app, client):
         raw = _gps_jpeg()
         with app.app_context():
@@ -256,23 +349,29 @@ class TestPhotoLifecycle:
         owner = client.get(f"/api/players/{PLAYER_ID}/showcase", headers=headers).get_json()
         assert [(item["id"], item["status"]) for item in owner["photos"]] == [(pending["id"], "rejected")]
 
-    def test_processing_failure_returns_422_and_stays_pending(self, app, client):
+    def test_invalid_bytes_fail_completion_and_delete_pending_blob(self, app, client):
         raw = b"not actually a jpeg"
         with app.app_context():
             _approved_claim(PLAYER_ID, "owner@example.com")
         headers = _user_headers("owner@example.com")
-        created, pending = _create_upload_complete(client, headers, raw)
+        created = _create_photo(client, headers, raw)
+        _upload_photo(client, created["upload"], raw)
+        media_id = created["media"]["id"]
+        pending_path = _url_path(created["upload"]["url"])
+        assert client.get(pending_path).status_code == 200
 
-        reviewed = client.post(
-            f"/api/admin/showcase/media/{pending['id']}/review",
-            json={"action": "approve"},
-            headers=_admin_headers(),
+        completed = client.post(
+            f"/api/players/{PLAYER_ID}/showcase/photos/{media_id}/complete",
+            headers=headers,
         )
-        assert reviewed.status_code == 422
-        assert client.get(_url_path(created["upload"]["url"])).status_code == 200
+
+        assert completed.status_code == 422
+        assert client.get(pending_path).status_code == 404
         with app.app_context():
-            row = db.session.get(PlayerShowcaseMedia, pending["id"])
-            assert row.status == "pending"
+            row = db.session.get(PlayerShowcaseMedia, media_id)
+            assert row is not None
+            assert row.status == "pending_upload"
+            assert row.status not in {"pending", "approved"}
             assert row.public_url is None
 
     def test_delete_removes_approved_row_and_public_blob(self, app, client):

--- a/academy-watch-backend/tests/test_showcase_media.py
+++ b/academy-watch-backend/tests/test_showcase_media.py
@@ -1,0 +1,542 @@
+"""Tests for Talent Showcase photo media and enriched profile fields.
+
+Covers the direct-upload lifecycle, EXIF/GPS stripping, owner and public
+visibility, gallery curation, profile validation/privacy, moderation rejection,
+and production storage degradation.
+"""
+
+from io import BytesIO
+from urllib.parse import urlsplit
+
+import pytest
+from flask import Flask
+from PIL import ExifTags, Image, TiffImagePlugin
+from src.auth import _ensure_user_account, issue_user_token
+from src.models.league import db
+from src.models.showcase import PlayerProfileClaim, PlayerShowcaseMedia
+
+ADMIN_KEY = "test-admin-key"
+PLAYER_ID = 5001
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    monkeypatch.setenv("SKIP_API_HANDSHAKE", "1")
+    monkeypatch.setenv("API_USE_STUB_DATA", "true")
+    monkeypatch.setenv("ADMIN_API_KEY", ADMIN_KEY)
+    monkeypatch.setenv("ADMIN_IP_WHITELIST", "")
+    monkeypatch.setenv("ENV", "development")
+    monkeypatch.setenv("FLASK_ENV", "development")
+    monkeypatch.setenv("APP_ENV", "development")
+    monkeypatch.setenv("SHOWCASE_MEDIA_LOCAL_DIR", str(tmp_path / "showcase-media"))
+    monkeypatch.delenv("AZURE_STORAGE_CONNECTION_STRING", raising=False)
+
+    from src.routes.showcase import showcase_bp
+
+    flask_app = Flask(__name__)
+    flask_app.config.update(
+        TESTING=True,
+        SECRET_KEY="test-secret-key",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        RATELIMIT_ENABLED=False,
+    )
+
+    db.init_app(flask_app)
+    flask_app.register_blueprint(showcase_bp, url_prefix="/api")
+
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _user_headers(email):
+    token = issue_user_token(email)["token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _admin_headers():
+    token = issue_user_token("admin@test.com", role="admin")["token"]
+    return {"Authorization": f"Bearer {token}", "X-API-Key": ADMIN_KEY}
+
+
+def _make_user(email):
+    user = _ensure_user_account(email)
+    db.session.commit()
+    return user
+
+
+def _approved_claim(player_api_id, email):
+    user = _make_user(email)
+    claim = PlayerProfileClaim(
+        player_api_id=player_api_id,
+        user_account_id=user.id,
+        relationship_type="player",
+        status="approved",
+    )
+    db.session.add(claim)
+    db.session.commit()
+    return user, claim
+
+
+def _gps_jpeg() -> bytes:
+    """A valid large JPEG carrying both generic EXIF and GPS coordinates."""
+    image = Image.new("RGB", (1800, 900), "#8fbc8f")
+    exif = Image.Exif()
+    exif[ExifTags.Base.ImageDescription] = "Safeguarding test location"
+    exif[ExifTags.Base.GPSInfo] = {
+        ExifTags.GPS.GPSLatitudeRef: "N",
+        ExifTags.GPS.GPSLatitude: (
+            TiffImagePlugin.IFDRational(51, 1),
+            TiffImagePlugin.IFDRational(30, 1),
+            TiffImagePlugin.IFDRational(0, 1),
+        ),
+        ExifTags.GPS.GPSLongitudeRef: "W",
+        ExifTags.GPS.GPSLongitude: (
+            TiffImagePlugin.IFDRational(0, 1),
+            TiffImagePlugin.IFDRational(7, 1),
+            TiffImagePlugin.IFDRational(0, 1),
+        ),
+    }
+    output = BytesIO()
+    image.save(output, "JPEG", quality=92, exif=exif, comment=b"GPS:51.5007,-0.1246")
+    raw = output.getvalue()
+
+    with Image.open(BytesIO(raw)) as source:
+        assert source.getexif().get_ifd(ExifTags.IFD.GPSInfo)
+        assert source.info["comment"] == b"GPS:51.5007,-0.1246"
+    return raw
+
+
+def _url_path(url):
+    parsed = urlsplit(url)
+    return parsed.path or url
+
+
+def _create_photo(client, headers, raw):
+    response = client.post(
+        f"/api/players/{PLAYER_ID}/showcase/photos",
+        json={"content_type": "image/jpeg", "size_bytes": len(raw)},
+        headers=headers,
+    )
+    assert response.status_code == 201, response.get_json()
+    return response.get_json()
+
+
+def _upload_photo(client, upload, raw):
+    assert upload["method"] == "PUT"
+    assert upload["headers"] == {"x-ms-blob-type": "BlockBlob", "Content-Type": "image/jpeg"}
+    response = client.put(_url_path(upload["url"]), data=raw, headers=upload["headers"])
+    assert response.status_code in (200, 201, 204), response.get_json(silent=True)
+
+
+def _create_upload_complete(client, headers, raw):
+    created = _create_photo(client, headers, raw)
+    _upload_photo(client, created["upload"], raw)
+    media_id = created["media"]["id"]
+    completed = client.post(
+        f"/api/players/{PLAYER_ID}/showcase/photos/{media_id}/complete",
+        headers=headers,
+    )
+    assert completed.status_code == 200, completed.get_json()
+    assert completed.get_json()["media"]["status"] == "pending"
+    return created, completed.get_json()["media"]
+
+
+def _seed_media(player_api_id, user_id, *, status="approved", sort_order=0, suffix="photo"):
+    media = PlayerShowcaseMedia(
+        player_api_id=player_api_id,
+        kind="photo",
+        blob_path=f"players/{player_api_id}/{suffix}.jpg",
+        public_url=f"/api/dev/showcase-media/published/players/{player_api_id}/{suffix}.jpg",
+        content_type="image/jpeg",
+        size_bytes=1024,
+        status=status,
+        sort_order=sort_order,
+        uploaded_by_user_id=user_id,
+    )
+    db.session.add(media)
+    db.session.flush()
+    return media
+
+
+# --------------------------------------------------------------------------- #
+# Upload + moderation lifecycle
+# --------------------------------------------------------------------------- #
+
+
+class TestPhotoLifecycle:
+    def test_create_complete_approve_strips_gps_and_all_exif(self, app, client):
+        raw = _gps_jpeg()
+        with app.app_context():
+            _approved_claim(PLAYER_ID, "owner@example.com")
+        headers = _user_headers("owner@example.com")
+
+        created, pending = _create_upload_complete(client, headers, raw)
+        assert created["media"]["status"] == "pending_upload"
+        assert pending["size_bytes"] == len(raw)
+        assert client.get(f"/api/players/{PLAYER_ID}/showcase").get_json()["photos"] == []
+        owner_pending = client.get(f"/api/players/{PLAYER_ID}/showcase", headers=headers).get_json()["photos"]
+        assert [(item["id"], item["status"]) for item in owner_pending] == [(pending["id"], "pending")]
+
+        # The dev transport mirrors create-only SAS semantics: completion cannot
+        # be followed by an overwrite that bypasses the admin's preview.
+        overwrite = client.put(_url_path(created["upload"]["url"]), data=raw, headers=created["upload"]["headers"])
+        assert overwrite.status_code == 409
+
+        queue = client.get("/api/admin/showcase/media?status=pending", headers=_admin_headers())
+        assert queue.status_code == 200
+        assert [item["id"] for item in queue.get_json()["media"]] == [pending["id"]]
+
+        reviewed = client.post(
+            f"/api/admin/showcase/media/{pending['id']}/review",
+            json={"action": "approve", "note": "Safe to publish"},
+            headers=_admin_headers(),
+        )
+        assert reviewed.status_code == 200, reviewed.get_json()
+        media = reviewed.get_json()["media"]
+        assert media["status"] == "approved"
+        assert media["content_type"] == "image/jpeg"
+        assert media["public_url"]
+        assert media["review_note"] == "Safe to publish"
+        assert client.get(_url_path(created["upload"]["url"])).status_code == 404
+
+        published = client.get(_url_path(media["public_url"]))
+        assert published.status_code == 200
+        with Image.open(BytesIO(published.data)) as processed:
+            assert processed.format == "JPEG"
+            assert max(processed.size) == 1600
+            assert not processed.getexif()
+            assert not processed.getexif().get_ifd(ExifTags.IFD.GPSInfo)
+            assert "comment" not in processed.info
+            assert b"GPS:51.5007,-0.1246" not in published.data
+
+        public = client.get(f"/api/players/{PLAYER_ID}/showcase").get_json()
+        assert [photo["id"] for photo in public["photos"]] == [pending["id"]]
+
+    def test_reject_deletes_pending_blob_but_keeps_row_and_note(self, app, client):
+        raw = _gps_jpeg()
+        with app.app_context():
+            _approved_claim(PLAYER_ID, "owner@example.com")
+        headers = _user_headers("owner@example.com")
+        created, pending = _create_upload_complete(client, headers, raw)
+        pending_path = _url_path(created["upload"]["url"])
+        assert client.get(pending_path).status_code == 200
+
+        reviewed = client.post(
+            f"/api/admin/showcase/media/{pending['id']}/review",
+            json={"action": "reject", "note": "Contains private contact details"},
+            headers=_admin_headers(),
+        )
+        assert reviewed.status_code == 200
+        media = reviewed.get_json()["media"]
+        assert media["status"] == "rejected"
+        assert media["review_note"] == "Contains private contact details"
+        assert media["pending_preview_url"] is None
+        assert client.get(pending_path).status_code == 404
+
+        with app.app_context():
+            row = db.session.get(PlayerShowcaseMedia, pending["id"])
+            assert row is not None
+            assert row.status == "rejected"
+
+        assert client.get(f"/api/players/{PLAYER_ID}/showcase").get_json()["photos"] == []
+        owner = client.get(f"/api/players/{PLAYER_ID}/showcase", headers=headers).get_json()
+        assert [(item["id"], item["status"]) for item in owner["photos"]] == [(pending["id"], "rejected")]
+
+    def test_processing_failure_returns_422_and_stays_pending(self, app, client):
+        raw = b"not actually a jpeg"
+        with app.app_context():
+            _approved_claim(PLAYER_ID, "owner@example.com")
+        headers = _user_headers("owner@example.com")
+        created, pending = _create_upload_complete(client, headers, raw)
+
+        reviewed = client.post(
+            f"/api/admin/showcase/media/{pending['id']}/review",
+            json={"action": "approve"},
+            headers=_admin_headers(),
+        )
+        assert reviewed.status_code == 422
+        assert client.get(_url_path(created["upload"]["url"])).status_code == 200
+        with app.app_context():
+            row = db.session.get(PlayerShowcaseMedia, pending["id"])
+            assert row.status == "pending"
+            assert row.public_url is None
+
+    def test_delete_removes_approved_row_and_public_blob(self, app, client):
+        raw = _gps_jpeg()
+        with app.app_context():
+            _approved_claim(PLAYER_ID, "owner@example.com")
+        headers = _user_headers("owner@example.com")
+        _, pending = _create_upload_complete(client, headers, raw)
+        approved = client.post(
+            f"/api/admin/showcase/media/{pending['id']}/review",
+            json={"action": "approve"},
+            headers=_admin_headers(),
+        ).get_json()["media"]
+        public_path = _url_path(approved["public_url"])
+        assert client.get(public_path).status_code == 200
+
+        deleted = client.delete(
+            f"/api/players/{PLAYER_ID}/showcase/photos/{pending['id']}",
+            headers=headers,
+        )
+        assert deleted.status_code == 200
+        assert client.get(public_path).status_code == 404
+        with app.app_context():
+            assert db.session.get(PlayerShowcaseMedia, pending["id"]) is None
+
+
+# --------------------------------------------------------------------------- #
+# Owner gate, cap, and visibility
+# --------------------------------------------------------------------------- #
+
+
+class TestPhotoPermissionsAndVisibility:
+    def test_non_owner_cannot_create_photo(self, app, client):
+        with app.app_context():
+            _approved_claim(PLAYER_ID, "owner@example.com")
+        response = client.post(
+            f"/api/players/{PLAYER_ID}/showcase/photos",
+            json={"content_type": "image/jpeg", "size_bytes": 100},
+            headers=_user_headers("stranger@example.com"),
+        )
+        assert response.status_code == 403
+
+    def test_eight_non_rejected_photos_enforces_cap(self, app, client):
+        with app.app_context():
+            owner, _ = _approved_claim(PLAYER_ID, "owner@example.com")
+            for index in range(8):
+                _seed_media(PLAYER_ID, owner.id, status="pending", sort_order=index, suffix=f"cap-{index}")
+            db.session.commit()
+
+        response = client.post(
+            f"/api/players/{PLAYER_ID}/showcase/photos",
+            json={"content_type": "image/jpeg", "size_bytes": 100},
+            headers=_user_headers("owner@example.com"),
+        )
+        assert response.status_code == 409
+
+    def test_public_sees_approved_owner_also_sees_pending(self, app, client):
+        with app.app_context():
+            owner, _ = _approved_claim(PLAYER_ID, "owner@example.com")
+            approved = _seed_media(PLAYER_ID, owner.id, suffix="approved")
+            db.session.commit()
+            approved_id = approved.id
+
+        headers = _user_headers("owner@example.com")
+        pending = _create_photo(client, headers, _gps_jpeg())["media"]
+
+        public = client.get(f"/api/players/{PLAYER_ID}/showcase").get_json()["photos"]
+        assert [item["id"] for item in public] == [approved_id]
+        assert all(item["status"] == "approved" for item in public)
+
+        owner_view = client.get(f"/api/players/{PLAYER_ID}/showcase", headers=headers).get_json()["photos"]
+        by_id = {item["id"]: item for item in owner_view}
+        assert set(by_id) == {approved_id, pending["id"]}
+        assert by_id[pending["id"]]["status"] == "pending_upload"
+        assert by_id[pending["id"]]["pending_preview_url"]
+
+        stranger = client.get(
+            f"/api/players/{PLAYER_ID}/showcase", headers=_user_headers("stranger@example.com")
+        ).get_json()["photos"]
+        assert [item["id"] for item in stranger] == [approved_id]
+
+
+# --------------------------------------------------------------------------- #
+# Gallery curation
+# --------------------------------------------------------------------------- #
+
+
+class TestPhotoCuration:
+    def test_reorder_and_set_primary_on_approved_photos(self, app, client):
+        with app.app_context():
+            owner, _ = _approved_claim(PLAYER_ID, "owner@example.com")
+            first = _seed_media(PLAYER_ID, owner.id, sort_order=0, suffix="first")
+            second = _seed_media(PLAYER_ID, owner.id, sort_order=1, suffix="second")
+            third = _seed_media(PLAYER_ID, owner.id, sort_order=2, suffix="third")
+            db.session.commit()
+            first_id, second_id, third_id = first.id, second.id, third.id
+
+        headers = _user_headers("owner@example.com")
+        reordered = client.patch(
+            f"/api/players/{PLAYER_ID}/showcase/photos/order",
+            json={"ordered_ids": [third_id, first_id, second_id]},
+            headers=headers,
+        )
+        assert reordered.status_code == 200, reordered.get_json()
+        assert [item["id"] for item in reordered.get_json()["photos"]] == [third_id, first_id, second_id]
+
+        primary = client.patch(
+            f"/api/players/{PLAYER_ID}/showcase/photos/{first_id}",
+            json={"is_primary": True},
+            headers=headers,
+        )
+        assert primary.status_code == 200, primary.get_json()
+        assert primary.get_json()["media"]["is_primary"] is True
+
+        with app.app_context():
+            rows = PlayerShowcaseMedia.query.filter_by(player_api_id=PLAYER_ID).all()
+            assert {row.id: row.sort_order for row in rows} == {
+                third_id: 0,
+                first_id: 1,
+                second_id: 2,
+            }
+            assert [row.id for row in rows if row.is_primary] == [first_id]
+
+
+# --------------------------------------------------------------------------- #
+# Enriched profile fields
+# --------------------------------------------------------------------------- #
+
+
+class TestEnrichedProfile:
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"contract_status": "retired"},
+            {"availability": "maybe"},
+            {"contract_until": "2026-02-30"},
+            {"agent_contact_email": "not-an-email"},
+        ],
+    )
+    def test_invalid_new_profile_fields_return_400(self, app, client, payload):
+        with app.app_context():
+            _approved_claim(PLAYER_ID, "owner@example.com")
+        response = client.put(
+            f"/api/players/{PLAYER_ID}/showcase/profile",
+            json=payload,
+            headers=_user_headers("owner@example.com"),
+        )
+        assert response.status_code == 400, (payload, response.get_json())
+
+    def test_valid_fields_round_trip_and_agent_email_requires_auth(self, app, client):
+        with app.app_context():
+            _approved_claim(PLAYER_ID, "owner@example.com")
+            _make_user("scout@example.com")
+
+        payload = {
+            "contract_status": "under_contract",
+            "contract_until": "2027-06-30",
+            "availability": "open_to_moves",
+            "agent_name": "Alex Agent",
+            "agent_contact_email": "alex.agent@example.com",
+            "nationality_secondary": "Irish",
+            "languages": "English, Spanish",
+        }
+        saved = client.put(
+            f"/api/players/{PLAYER_ID}/showcase/profile",
+            json=payload,
+            headers=_user_headers("owner@example.com"),
+        )
+        assert saved.status_code == 200, saved.get_json()
+        assert saved.get_json()["profile"]["status"] == "pending"
+
+        approved = client.post(
+            f"/api/admin/showcase/profiles/{PLAYER_ID}/review",
+            json={"action": "approve"},
+            headers=_admin_headers(),
+        )
+        assert approved.status_code == 200
+
+        anonymous = client.get(f"/api/players/{PLAYER_ID}/showcase").get_json()["profile"]
+        assert anonymous["agent_name"] == "Alex Agent"
+        assert anonymous["contract_until"] == "2027-06-30"
+        assert "agent_contact_email" not in anonymous
+
+        authenticated = client.get(
+            f"/api/players/{PLAYER_ID}/showcase", headers=_user_headers("scout@example.com")
+        ).get_json()["profile"]
+        assert authenticated["agent_contact_email"] == "alex.agent@example.com"
+
+    def test_non_object_json_uses_validation_envelopes(self, app, client):
+        with app.app_context():
+            owner, _ = _approved_claim(PLAYER_ID, "owner@example.com")
+            pending = _seed_media(PLAYER_ID, owner.id, status="pending", suffix="bad-action")
+            db.session.commit()
+            pending_id = pending.id
+        headers = _user_headers("owner@example.com")
+
+        profile = client.put(f"/api/players/{PLAYER_ID}/showcase/profile", json=["bad"], headers=headers)
+        assert profile.status_code == 400
+        null_profile = client.put(
+            f"/api/players/{PLAYER_ID}/showcase/profile",
+            data="null",
+            headers={**headers, "Content-Type": "application/json"},
+        )
+        assert null_profile.status_code == 400
+        create = client.post(f"/api/players/{PLAYER_ID}/showcase/photos", json=["bad"], headers=headers)
+        assert create.status_code == 400
+        review = client.post(
+            f"/api/admin/showcase/media/{pending_id}/review",
+            json={"action": 1},
+            headers=_admin_headers(),
+        )
+        assert review.status_code == 400
+
+
+# --------------------------------------------------------------------------- #
+# Graceful production degradation
+# --------------------------------------------------------------------------- #
+
+
+def test_prod_without_azure_returns_503(app, client, monkeypatch):
+    with app.app_context():
+        owner, _ = _approved_claim(PLAYER_ID, "owner@example.com")
+        pending = _seed_media(PLAYER_ID, owner.id, status="pending", suffix="prod-pending")
+        db.session.commit()
+        pending_id = pending.id
+
+    monkeypatch.setenv("ENV", "production")
+    monkeypatch.setenv("FLASK_ENV", "production")
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.delenv("AZURE_STORAGE_CONNECTION_STRING", raising=False)
+
+    response = client.post(
+        f"/api/players/{PLAYER_ID}/showcase/photos",
+        json={"content_type": "image/jpeg", "size_bytes": 100},
+        headers=_user_headers("owner@example.com"),
+    )
+    assert response.status_code == 503
+    assert "storage" in response.get_json()["error"].lower()
+
+    review = client.post(
+        f"/api/admin/showcase/media/{pending_id}/review",
+        json={"action": "reject"},
+        headers=_admin_headers(),
+    )
+    assert review.status_code == 503
+    with app.app_context():
+        assert db.session.get(PlayerShowcaseMedia, pending_id).status == "pending"
+
+
+def test_local_storage_gate_fails_closed(app, monkeypatch, tmp_path):
+    from src.services import showcase_media_storage
+
+    monkeypatch.delenv("AZURE_STORAGE_CONNECTION_STRING", raising=False)
+    for name in ("ENV", "FLASK_ENV", "APP_ENV", "SHOWCASE_MEDIA_LOCAL_DIR"):
+        monkeypatch.delenv(name, raising=False)
+    assert showcase_media_storage.is_local_dev_enabled() is False
+
+    monkeypatch.setenv("SHOWCASE_MEDIA_LOCAL_DIR", str(tmp_path / "explicit-local"))
+    assert showcase_media_storage.is_local_dev_enabled() is True
+
+    monkeypatch.setenv("ENV", "development")
+    monkeypatch.setenv("FLASK_ENV", "production")
+    assert showcase_media_storage.is_local_dev_enabled() is False
+
+    for value in ("nan", "inf", "-1"):
+        monkeypatch.setenv("SHOWCASE_PHOTO_MAX_MB", value)
+        assert showcase_media_storage.max_photo_bytes() == 8 * 1024**2

--- a/academy-watch-frontend/src/App.jsx
+++ b/academy-watch-frontend/src/App.jsx
@@ -83,6 +83,7 @@ import { AdminTools } from '@/pages/admin/AdminTools'
 import { AdminSandbox } from '@/pages/admin/AdminSandbox'
 import { AdminFormation } from '@/pages/admin/AdminFormation'
 import { AdminShowcase } from '@/pages/admin/AdminShowcase'
+import { AdminLocalClubs } from '@/pages/admin/AdminLocalClubs'
 import { HomePage } from '@/pages/HomePage'
 import { PublicFormationBuilder } from '@/pages/PublicFormationBuilder'
 import { CohortBrowser } from '@/pages/CohortBrowser'
@@ -4122,6 +4123,7 @@ function AppRoutes() {
         <Route path="video" element={<AdminVideo />} />
         <Route path="video/:matchId" element={<AdminVideoMatch />} />
         <Route path="showcase" element={<AdminShowcase />} />
+        <Route path="local-clubs" element={<AdminLocalClubs />} />
         <Route path="settings" element={<AdminSettings />} />
         <Route path="tools" element={<AdminTools />} />
         <Route path="sandbox" element={<AdminSandbox />} />

--- a/academy-watch-frontend/src/App.jsx
+++ b/academy-watch-frontend/src/App.jsx
@@ -91,6 +91,8 @@ import { ScoutPage } from '@/pages/ScoutPage'
 import { WatchlistPage } from '@/pages/WatchlistPage'
 import { ListsPage } from '@/pages/ListsPage'
 import { MyClub } from '@/pages/MyClub'
+import { LocalPlayerPage } from '@/pages/LocalPlayerPage'
+import { LocalPlayerCreate } from '@/pages/LocalPlayerCreate'
 import { PricingPage } from '@/pages/PricingPage'
 import { CohortDetail } from '@/pages/CohortDetail'
 import { CohortAnalytics } from '@/pages/CohortAnalytics'
@@ -4081,6 +4083,8 @@ function AppRoutes() {
       <Route path="/newsletters/historical" element={<HistoricalNewslettersPage />} />
       <Route path="/writeups/:commentaryId" element={<WriteupPage />} />
       <Route path="/players/:playerId" element={<PlayerPage />} />
+      <Route path="/local-players/new" element={<LocalPlayerCreate />} />
+      <Route path="/local-players/:localPlayerId" element={<LocalPlayerPage />} />
       <Route path="/journalists" element={<JournalistList apiService={APIService} />} />
       <Route
         path="/settings"

--- a/academy-watch-frontend/src/App.jsx
+++ b/academy-watch-frontend/src/App.jsx
@@ -90,6 +90,7 @@ import { CohortBrowser } from '@/pages/CohortBrowser'
 import { ScoutPage } from '@/pages/ScoutPage'
 import { WatchlistPage } from '@/pages/WatchlistPage'
 import { ListsPage } from '@/pages/ListsPage'
+import { MyClub } from '@/pages/MyClub'
 import { PricingPage } from '@/pages/PricingPage'
 import { CohortDetail } from '@/pages/CohortDetail'
 import { CohortAnalytics } from '@/pages/CohortAnalytics'
@@ -4099,6 +4100,7 @@ function AppRoutes() {
       <Route path="/scout" element={<ScoutPage />} />
       <Route path="/scout/watchlist" element={<WatchlistPage />} />
       <Route path="/scout/lists" element={<ListsPage />} />
+      <Route path="/my-club" element={<MyClub />} />
       <Route path="/pricing" element={<PricingPage />} />
       <Route path="/academy" element={<CohortBrowser />} />
       <Route path="/academy/cohorts/:cohortId" element={<CohortDetail />} />

--- a/academy-watch-frontend/src/components/ShowcaseSection.jsx
+++ b/academy-watch-frontend/src/components/ShowcaseSection.jsx
@@ -38,6 +38,7 @@ import {
   Star,
   Copy,
   Search,
+  Building2,
 } from 'lucide-react'
 import { APIService } from '@/lib/api'
 import { track } from '@/lib/track'
@@ -69,6 +70,19 @@ const AVAILABILITY_OPTIONS = [
   { value: 'not_looking', label: 'Not looking' },
   { value: 'trial_available', label: 'Available for trials' },
 ]
+
+const CLUB_LEVEL_OPTIONS = [
+  { value: 'grassroots', label: 'Grassroots' },
+  { value: 'academy', label: 'Academy' },
+  { value: 'youth', label: 'Youth' },
+  { value: 'semi_pro', label: 'Semi-professional' },
+  { value: 'professional', label: 'Professional' },
+  { value: 'other', label: 'Other' },
+]
+
+const EMPTY_CLUB_RESULTS = { api_teams: [], local_clubs: [] }
+const EMPTY_LOCAL_CLUB_FORM = { name: '', country: '', city: '', level: '' }
+const PUBLIC_AFFILIATION_STATUSES = new Set(['self_reported', 'club_confirmed'])
 
 const PHOTO_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp'])
 const PHOTO_MAX_BYTES = 8 * 1024 * 1024
@@ -165,6 +179,31 @@ function VerificationInstructions() {
   )
 }
 
+function AffiliationStatusBadge({ status }) {
+  if (status === 'club_confirmed') {
+    return (
+      <Badge variant="outline" className="border-emerald-200 bg-emerald-50 text-emerald-800">
+        Club-confirmed
+      </Badge>
+    )
+  }
+  if (status === 'pending') {
+    return (
+      <Badge variant="outline" className="border-amber-200 bg-amber-50 text-amber-800">
+        Pending review
+      </Badge>
+    )
+  }
+  if (status === 'rejected') {
+    return (
+      <Badge variant="outline" className="border-rose-200 bg-rose-50 text-rose-800">
+        Rejected
+      </Badge>
+    )
+  }
+  return <Badge variant="secondary">Self-reported</Badge>
+}
+
 export function ShowcaseSection({ playerApiId, playerName }) {
   const { token } = useAuth()
   const { openLoginModal } = useAuthUI()
@@ -215,6 +254,27 @@ export function ShowcaseSection({ playerApiId, playerName }) {
   const [photoActionCopy, setPhotoActionCopy] = useState({ title: 'Update photos', done: 'Photos updated' })
   const [photoDeleteTarget, setPhotoDeleteTarget] = useState(null)
 
+  // Club affiliation dialog + delete confirmation
+  const [clubOpen, setClubOpen] = useState(false)
+  const [clubSearch, setClubSearch] = useState('')
+  const [clubSearchBusy, setClubSearchBusy] = useState(false)
+  const [clubSearchComplete, setClubSearchComplete] = useState(false)
+  const [clubSearchError, setClubSearchError] = useState(null)
+  const [clubResults, setClubResults] = useState(EMPTY_CLUB_RESULTS)
+  const [selectedClub, setSelectedClub] = useState(null)
+  const [clubSeason, setClubSeason] = useState('')
+  const [createClubMode, setCreateClubMode] = useState(false)
+  const [localClubForm, setLocalClubForm] = useState(EMPTY_LOCAL_CLUB_FORM)
+  const [duplicateClub, setDuplicateClub] = useState(null)
+  const [clubBusy, setClubBusy] = useState(false)
+  const [clubDone, setClubDone] = useState(false)
+  const [clubError, setClubError] = useState(null)
+  const [clubDeleteOpen, setClubDeleteOpen] = useState(false)
+  const [clubDeleteTarget, setClubDeleteTarget] = useState(null)
+  const [clubDeleteBusy, setClubDeleteBusy] = useState(false)
+  const [clubDeleteDone, setClubDeleteDone] = useState(false)
+  const [clubDeleteError, setClubDeleteError] = useState(null)
+
   // Edit-profile dialog
   const [profileOpen, setProfileOpen] = useState(false)
   const [profileForm, setProfileForm] = useState({
@@ -251,6 +311,7 @@ export function ShowcaseSection({ playerApiId, playerName }) {
   const activePlayerRef = useRef(playerApiId)
   const previousPlayerRef = useRef(playerApiId)
   const closeTimersRef = useRef({})
+  const clubSearchRequestRef = useRef(0)
 
   const clearCloseTimer = useCallback((key) => {
     const timer = closeTimersRef.current[key]
@@ -310,6 +371,26 @@ export function ShowcaseSection({ playerApiId, playerName }) {
       setPhotoActionError(null)
       setPhotoDeleteTarget(null)
       setPhotoInputKey((key) => key + 1)
+      clubSearchRequestRef.current += 1
+      setClubOpen(false)
+      setClubSearch('')
+      setClubSearchBusy(false)
+      setClubSearchComplete(false)
+      setClubSearchError(null)
+      setClubResults(EMPTY_CLUB_RESULTS)
+      setSelectedClub(null)
+      setClubSeason('')
+      setCreateClubMode(false)
+      setLocalClubForm(EMPTY_LOCAL_CLUB_FORM)
+      setDuplicateClub(null)
+      setClubBusy(false)
+      setClubDone(false)
+      setClubError(null)
+      setClubDeleteOpen(false)
+      setClubDeleteTarget(null)
+      setClubDeleteBusy(false)
+      setClubDeleteDone(false)
+      setClubDeleteError(null)
       setProfileOpen(false)
       setProfileBusy(false)
       setReelBusy(false)
@@ -333,6 +414,43 @@ export function ShowcaseSection({ playerApiId, playerName }) {
       })
     return () => { cancelled = true }
   }, [clearAllCloseTimers, fetchData, playerApiId])
+
+  useEffect(() => {
+    const query = clubSearch.trim()
+    if (!clubOpen || createClubMode || query.length < 2) return undefined
+
+    const requestId = clubSearchRequestRef.current + 1
+    clubSearchRequestRef.current = requestId
+    const pid = playerApiId
+    const timer = setTimeout(async () => {
+      if (clubSearchRequestRef.current !== requestId || activePlayerRef.current !== pid) return
+      setClubSearchBusy(true)
+      setClubSearchError(null)
+      try {
+        const response = await APIService.searchClubs(query)
+        if (clubSearchRequestRef.current !== requestId || activePlayerRef.current !== pid) return
+        setClubResults({
+          api_teams: Array.isArray(response?.api_teams) ? response.api_teams : [],
+          local_clubs: Array.isArray(response?.local_clubs) ? response.local_clubs : [],
+        })
+        setClubSearchComplete(true)
+      } catch (err) {
+        if (clubSearchRequestRef.current !== requestId || activePlayerRef.current !== pid) return
+        setClubResults(EMPTY_CLUB_RESULTS)
+        setClubSearchComplete(false)
+        setClubSearchError(err.body?.error || err.message || 'Failed to search clubs')
+      } finally {
+        if (clubSearchRequestRef.current === requestId && activePlayerRef.current === pid) {
+          setClubSearchBusy(false)
+        }
+      }
+    }, 300)
+
+    return () => {
+      clearTimeout(timer)
+      if (clubSearchRequestRef.current === requestId) clubSearchRequestRef.current += 1
+    }
+  }, [clubOpen, clubSearch, createClubMode, playerApiId])
 
   const refresh = useCallback(async () => {
     const pid = playerApiId
@@ -365,12 +483,16 @@ export function ShowcaseSection({ playerApiId, playerName }) {
 
   const reel = Array.isArray(showcase.reel) ? showcase.reel : []
   const photos = Array.isArray(showcase.photos) ? showcase.photos : []
+  const affiliations = Array.isArray(showcase.affiliations) ? showcase.affiliations : []
   const profile = showcase.profile || null
   const verified = Array.isArray(showcase.verified_footage) ? showcase.verified_footage : []
   const claimStatus = showcase.claim_status // 'unclaimed' | 'claimed'
 
   const myClaim = myClaims.find((c) => Number(c.player_api_id) === Number(playerApiId))
   const isOwner = myClaim?.status === 'approved'
+  const visibleAffiliations = affiliations.filter(
+    (affiliation) => isOwner || PUBLIC_AFFILIATION_STATUSES.has(affiliation.status),
+  )
 
   const approvedPhotos = photos
     .filter((photo) => photo.status === 'approved')
@@ -393,7 +515,11 @@ export function ShowcaseSection({ playerApiId, playerName }) {
   // can still claim an unclaimed profile.
   const showClaimStrip = !isOwner && (myClaim ? true : claimStatus === 'unclaimed')
 
-  const hasContent = reel.length > 0 || visiblePhotos.length > 0 || profile || verified.length > 0
+  const hasContent = reel.length > 0
+    || visiblePhotos.length > 0
+    || visibleAffiliations.length > 0
+    || profile
+    || verified.length > 0
   if (!hasContent && !isOwner && !showClaimStrip) return null
 
   const reorderableIds = reel.filter((i) => !isSynthetic(i)).map((i) => i.id)
@@ -765,6 +891,160 @@ export function ShowcaseSection({ playerApiId, playerName }) {
     }
   }
 
+  const resetClubDialog = () => {
+    clubSearchRequestRef.current += 1
+    setClubSearch('')
+    setClubSearchBusy(false)
+    setClubSearchComplete(false)
+    setClubSearchError(null)
+    setClubResults(EMPTY_CLUB_RESULTS)
+    setSelectedClub(null)
+    setClubSeason('')
+    setCreateClubMode(false)
+    setLocalClubForm(EMPTY_LOCAL_CLUB_FORM)
+    setDuplicateClub(null)
+    setClubBusy(false)
+    setClubDone(false)
+    setClubError(null)
+  }
+
+  const openClubDialog = () => {
+    clearCloseTimer('clubAdd')
+    resetClubDialog()
+    setClubOpen(true)
+  }
+
+  const updateClubSearch = (value) => {
+    clubSearchRequestRef.current += 1
+    setClubSearch(value)
+    setClubSearchBusy(false)
+    setClubSearchComplete(false)
+    setClubSearchError(null)
+    setClubResults(EMPTY_CLUB_RESULTS)
+    setSelectedClub(null)
+    setDuplicateClub(null)
+    setClubError(null)
+  }
+
+  const chooseClub = (kind, club) => {
+    setSelectedClub({ kind, club })
+    setCreateClubMode(false)
+    setDuplicateClub(null)
+    setClubError(null)
+  }
+
+  const toggleCreateClub = () => {
+    const next = !createClubMode
+    clubSearchRequestRef.current += 1
+    setClubSearchBusy(false)
+    setCreateClubMode(next)
+    setSelectedClub(null)
+    setDuplicateClub(null)
+    setClubError(null)
+    if (next) {
+      setLocalClubForm({ ...EMPTY_LOCAL_CLUB_FORM, name: clubSearch.trim() })
+    }
+  }
+
+  const submitClub = async () => {
+    if (clubBusy) return
+    if (createClubMode && !localClubForm.name.trim()) {
+      setClubError('Enter the club name.')
+      return
+    }
+    if (!createClubMode && !selectedClub) {
+      setClubError('Select a club from the search results.')
+      return
+    }
+
+    const pid = playerApiId
+    let stage = createClubMode ? 'create' : 'affiliation'
+    setClubBusy(true)
+    setClubDone(false)
+    setClubError(null)
+    setDuplicateClub(null)
+    try {
+      let selection = selectedClub
+      if (createClubMode) {
+        const response = await APIService.createLocalClub({
+          name: localClubForm.name.trim(),
+          country: localClubForm.country.trim() || undefined,
+          city: localClubForm.city.trim() || undefined,
+          level: localClubForm.level || undefined,
+        })
+        const club = response?.club
+        if (!club?.id) throw new Error('The club was created without an id')
+        selection = { kind: 'local', club }
+        stage = 'affiliation'
+      }
+
+      const affiliationPayload = selection.kind === 'api'
+        ? { team_api_id: selection.club.team_api_id }
+        : { local_club_id: selection.club.id }
+      const season = clubSeason.trim()
+      await APIService.addPlayerAffiliation(pid, {
+        ...affiliationPayload,
+        season: season || undefined,
+      })
+      if (activePlayerRef.current === pid) setClubDone(true)
+      await refresh()
+      scheduleClose('clubAdd', pid, () => {
+        setClubOpen(false)
+        setClubDone(false)
+      })
+    } catch (err) {
+      if (activePlayerRef.current !== pid) return
+      if (stage === 'create' && err.status === 409 && err.body?.existing) {
+        setDuplicateClub(err.body.existing)
+        setClubError('A matching community club already exists. Use that club instead.')
+      } else {
+        setClubError(err.body?.error || err.message || 'Failed to add club')
+      }
+    } finally {
+      if (activePlayerRef.current === pid) setClubBusy(false)
+    }
+  }
+
+  const requestDeleteClub = (affiliation) => {
+    if (clubDeleteBusy) return
+    clearCloseTimer('clubDelete')
+    setClubDeleteTarget(affiliation)
+    setClubDeleteDone(false)
+    setClubDeleteError(null)
+    setClubDeleteOpen(true)
+  }
+
+  const deleteClub = async () => {
+    if (clubDeleteBusy || !clubDeleteTarget?.id) return
+    const pid = playerApiId
+    const affiliationId = clubDeleteTarget.id
+    setClubDeleteBusy(true)
+    setClubDeleteDone(false)
+    setClubDeleteError(null)
+    try {
+      await APIService.deletePlayerAffiliation(pid, affiliationId)
+      if (activePlayerRef.current === pid) setClubDeleteDone(true)
+      await refresh()
+      scheduleClose('clubDelete', pid, () => {
+        setClubDeleteOpen(false)
+        setClubDeleteDone(false)
+        setClubDeleteTarget(null)
+      })
+    } catch (err) {
+      if (activePlayerRef.current === pid) {
+        setClubDeleteError(err.body?.error || err.message || 'Failed to remove club')
+      }
+    } finally {
+      if (activePlayerRef.current === pid) setClubDeleteBusy(false)
+    }
+  }
+
+  const clubResultCount = clubResults.api_teams.length + clubResults.local_clubs.length
+  const canCreateClub = clubSearch.trim().length >= 2
+    && clubSearchComplete
+    && !clubSearchBusy
+    && clubResultCount === 0
+
   return (
     <Card>
       <CardContent className="space-y-8 py-6">
@@ -950,7 +1230,73 @@ export function ShowcaseSection({ playerApiId, playerName }) {
           </div>
         )}
 
-        {/* 2. Highlight reel */}
+        {/* 2. Clubs */}
+        {(visibleAffiliations.length > 0 || isOwner) && (
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <p className="inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                <Building2 className="h-3.5 w-3.5" />
+                Clubs
+              </p>
+              {isOwner && (
+                <Button variant="outline" size="sm" onClick={openClubDialog} disabled={clubBusy} className="gap-1.5">
+                  <Plus className="h-3.5 w-3.5" />
+                  Add club
+                </Button>
+              )}
+            </div>
+
+            {visibleAffiliations.length > 0 ? (
+              <div className="divide-y divide-border/60 overflow-hidden rounded-lg border border-border/70">
+                {visibleAffiliations.map((affiliation) => (
+                  <div key={affiliation.id} className="px-3 py-3">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="break-words text-sm font-semibold text-foreground">
+                          {affiliation.club_name || 'Club'}
+                        </p>
+                        {affiliation.season && (
+                          <p className="mt-0.5 text-xs text-muted-foreground">Season {affiliation.season}</p>
+                        )}
+                      </div>
+                      <div className="flex shrink-0 items-center gap-1.5">
+                        <AffiliationStatusBadge status={affiliation.status} />
+                        {isOwner && (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                            disabled={clubDeleteBusy}
+                            onClick={() => requestDeleteClub(affiliation)}
+                            aria-label={`Remove ${affiliation.club_name || 'club'}`}
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+                    {isOwner && affiliation.status === 'rejected' && affiliation.review_note && (
+                      <p className="mt-2 break-words text-xs leading-relaxed text-rose-700">
+                        Review note: {affiliation.review_note}
+                      </p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={openClubDialog}
+                className="flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-border py-6 text-sm text-muted-foreground transition-colors hover:border-primary/40 hover:bg-primary/5 hover:text-foreground"
+              >
+                <Plus className="h-4 w-4" />
+                Add your first club
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* 3. Highlight reel */}
         {reel.length > 0 && (
           <div className="space-y-3">
             <p className="inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
@@ -1020,7 +1366,7 @@ export function ShowcaseSection({ playerApiId, playerName }) {
           </div>
         )}
 
-        {/* 3. Self-reported profile */}
+        {/* 4. Self-reported profile */}
         {profile && (
           <div className="min-w-0 space-y-3 rounded-lg border border-border/70 bg-secondary/40 p-4">
             <div className="flex items-center gap-2">
@@ -1098,7 +1444,7 @@ export function ShowcaseSection({ playerApiId, playerName }) {
           </div>
         )}
 
-        {/* 4. Club-verified footage */}
+        {/* 5. Club-verified footage */}
         {verified.length > 0 && (
           <div className="space-y-3">
             <div className="flex flex-wrap items-center gap-2">
@@ -1141,7 +1487,7 @@ export function ShowcaseSection({ playerApiId, playerName }) {
           </div>
         )}
 
-        {/* 5. Claim strip */}
+        {/* 6. Claim strip */}
         {showClaimStrip && (
           <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border/70 pt-4">
             {myClaim ? (
@@ -1515,6 +1861,318 @@ export function ShowcaseSection({ playerApiId, playerName }) {
               )}
             </DialogFooter>
           )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Add-club affiliation dialog */}
+      <Dialog
+        open={clubOpen}
+        onOpenChange={(open) => {
+          if (clubBusy) return
+          setClubOpen(open)
+          if (!open) {
+            clearCloseTimer('clubAdd')
+            resetClubDialog()
+          }
+        }}
+      >
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
+          <DialogHeader>
+            <DialogTitle>Add a club</DialogTitle>
+            <DialogDescription>
+              Search official and community clubs first. New community clubs and affiliations are reviewed before appearing publicly.
+            </DialogDescription>
+          </DialogHeader>
+
+          {clubDone ? (
+            <div className="flex items-center gap-2 py-4 text-sm text-emerald-600" role="status" aria-live="polite">
+              <Check className="h-4 w-4" />
+              Submitted for review
+            </div>
+          ) : (
+            <div className="space-y-4 py-2">
+              <div className="space-y-2">
+                <Label htmlFor={`showcase-club-search-${playerApiId}`}>Search clubs</Label>
+                <div className="relative">
+                  <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    id={`showcase-club-search-${playerApiId}`}
+                    type="search"
+                    placeholder="Search by club name"
+                    value={clubSearch}
+                    onChange={(event) => updateClubSearch(event.target.value)}
+                    maxLength={200}
+                    disabled={clubBusy || createClubMode}
+                    className="pl-9"
+                    autoComplete="off"
+                  />
+                </div>
+                {clubSearch.trim().length > 0 && clubSearch.trim().length < 2 ? (
+                  <p className="text-xs text-muted-foreground">Enter at least 2 characters.</p>
+                ) : null}
+              </div>
+
+              {clubSearchBusy ? (
+                <div className="flex items-center gap-2 rounded-md bg-muted/50 px-3 py-2 text-sm text-muted-foreground" role="status">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Searching clubs…
+                </div>
+              ) : null}
+
+              {clubSearchError ? (
+                <p className="text-xs text-destructive" role="alert">{clubSearchError}</p>
+              ) : null}
+
+              {!clubSearchBusy && clubSearchComplete && clubResultCount > 0 && !createClubMode ? (
+                <div className="max-h-64 space-y-4 overflow-y-auto pr-1">
+                  {clubResults.api_teams.length > 0 ? (
+                    <div className="space-y-2">
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                        Official clubs
+                      </p>
+                      <div className="space-y-1" role="listbox" aria-label="Official clubs">
+                        {clubResults.api_teams.map((club) => {
+                          const selected = selectedClub?.kind === 'api'
+                            && Number(selectedClub.club.team_api_id) === Number(club.team_api_id)
+                          return (
+                            <button
+                              key={`api-${club.team_api_id}`}
+                              type="button"
+                              role="option"
+                              aria-selected={selected}
+                              onClick={() => chooseClub('api', club)}
+                              className={`flex w-full items-center justify-between gap-3 rounded-md border px-3 py-2 text-left transition-colors ${selected
+                                ? 'border-primary/50 bg-primary/5'
+                                : 'border-border/70 hover:border-primary/30 hover:bg-muted/50'}`}
+                            >
+                              <span className="min-w-0">
+                                <span className="block truncate text-sm font-medium text-foreground">{club.name}</span>
+                                {club.country ? (
+                                  <span className="block truncate text-xs text-muted-foreground">{club.country}</span>
+                                ) : null}
+                              </span>
+                              {selected ? <Check className="h-4 w-4 shrink-0 text-primary" /> : null}
+                            </button>
+                          )
+                        })}
+                      </div>
+                    </div>
+                  ) : null}
+
+                  {clubResults.local_clubs.length > 0 ? (
+                    <div className="space-y-2">
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                        Community clubs
+                      </p>
+                      <div className="space-y-1" role="listbox" aria-label="Community clubs">
+                        {clubResults.local_clubs.map((club) => {
+                          const selected = selectedClub?.kind === 'local'
+                            && Number(selectedClub.club.id) === Number(club.id)
+                          const location = [club.city, club.country].filter(Boolean).join(', ')
+                          const level = optionLabel(CLUB_LEVEL_OPTIONS, club.level)
+                          return (
+                            <button
+                              key={`local-${club.id}`}
+                              type="button"
+                              role="option"
+                              aria-selected={selected}
+                              onClick={() => chooseClub('local', club)}
+                              className={`flex w-full items-center justify-between gap-3 rounded-md border px-3 py-2 text-left transition-colors ${selected
+                                ? 'border-primary/50 bg-primary/5'
+                                : 'border-border/70 hover:border-primary/30 hover:bg-muted/50'}`}
+                            >
+                              <span className="min-w-0">
+                                <span className="block truncate text-sm font-medium text-foreground">{club.name}</span>
+                                {location || level ? (
+                                  <span className="block truncate text-xs text-muted-foreground">
+                                    {[location, level].filter(Boolean).join(' · ')}
+                                  </span>
+                                ) : null}
+                              </span>
+                              {selected ? <Check className="h-4 w-4 shrink-0 text-primary" /> : null}
+                            </button>
+                          )
+                        })}
+                      </div>
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
+
+              {canCreateClub || createClubMode ? (
+                <div className="rounded-lg border border-dashed border-border p-3">
+                  <Button type="button" variant="ghost" size="sm" onClick={toggleCreateClub} disabled={clubBusy}>
+                    {createClubMode ? 'Back to search' : "Can't find your club? Add it"}
+                  </Button>
+
+                  {createClubMode ? (
+                    <div className="mt-3 space-y-3 border-t border-border/70 pt-3">
+                      <div className="space-y-2">
+                        <Label htmlFor={`showcase-local-club-name-${playerApiId}`}>Club name</Label>
+                        <Input
+                          id={`showcase-local-club-name-${playerApiId}`}
+                          value={localClubForm.name}
+                          onChange={(event) => setLocalClubForm((form) => ({ ...form, name: event.target.value }))}
+                          maxLength={200}
+                          disabled={clubBusy}
+                        />
+                      </div>
+                      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                        <div className="space-y-2">
+                          <Label htmlFor={`showcase-local-club-country-${playerApiId}`}>Country (optional)</Label>
+                          <Input
+                            id={`showcase-local-club-country-${playerApiId}`}
+                            value={localClubForm.country}
+                            onChange={(event) => setLocalClubForm((form) => ({ ...form, country: event.target.value }))}
+                            maxLength={100}
+                            disabled={clubBusy}
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label htmlFor={`showcase-local-club-city-${playerApiId}`}>City (optional)</Label>
+                          <Input
+                            id={`showcase-local-club-city-${playerApiId}`}
+                            value={localClubForm.city}
+                            onChange={(event) => setLocalClubForm((form) => ({ ...form, city: event.target.value }))}
+                            maxLength={100}
+                            disabled={clubBusy}
+                          />
+                        </div>
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor={`showcase-local-club-level-${playerApiId}`}>Level (optional)</Label>
+                        <Select
+                          value={localClubForm.level || 'not_specified'}
+                          onValueChange={(value) => setLocalClubForm((form) => ({
+                            ...form,
+                            level: value === 'not_specified' ? '' : value,
+                          }))}
+                          disabled={clubBusy}
+                        >
+                          <SelectTrigger id={`showcase-local-club-level-${playerApiId}`}>
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="not_specified">Not specified</SelectItem>
+                            {CLUB_LEVEL_OPTIONS.map((option) => (
+                              <SelectItem key={option.value} value={option.value}>{option.label}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
+
+              {duplicateClub ? (
+                <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2">
+                  <div className="min-w-0 text-sm text-amber-900">
+                    <p className="font-medium">{duplicateClub.name || duplicateClub.club?.name || 'Existing club found'}</p>
+                    <p className="text-xs text-amber-800">Use the existing community club instead.</p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => chooseClub('local', duplicateClub.club || duplicateClub)}
+                    disabled={clubBusy}
+                  >
+                    Use this club
+                  </Button>
+                </div>
+              ) : null}
+
+              {selectedClub ? (
+                <div className="flex items-center gap-2 rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-sm">
+                  <Check className="h-4 w-4 shrink-0 text-primary" />
+                  <span className="min-w-0 truncate font-medium text-foreground">
+                    Selected: {selectedClub.club.name}
+                  </span>
+                </div>
+              ) : null}
+
+              <div className="space-y-2">
+                <Label htmlFor={`showcase-club-season-${playerApiId}`}>Season (optional)</Label>
+                <Input
+                  id={`showcase-club-season-${playerApiId}`}
+                  placeholder="e.g. 2025/26"
+                  value={clubSeason}
+                  onChange={(event) => setClubSeason(event.target.value)}
+                  maxLength={20}
+                  disabled={clubBusy}
+                />
+              </div>
+
+              {clubError ? <p className="text-xs text-destructive" role="alert">{clubError}</p> : null}
+            </div>
+          )}
+
+          {!clubDone ? (
+            <DialogFooter>
+              <Button variant="ghost" onClick={() => setClubOpen(false)} disabled={clubBusy}>Cancel</Button>
+              <Button
+                onClick={submitClub}
+                disabled={clubBusy || (createClubMode ? !localClubForm.name.trim() : !selectedClub)}
+              >
+                {clubBusy ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : null}
+                {clubBusy ? 'Adding…' : 'Add club'}
+              </Button>
+            </DialogFooter>
+          ) : null}
+        </DialogContent>
+      </Dialog>
+
+      {/* Club affiliation delete dialog */}
+      <Dialog
+        open={clubDeleteOpen}
+        onOpenChange={(open) => {
+          if (clubDeleteBusy) return
+          setClubDeleteOpen(open)
+          if (!open) {
+            clearCloseTimer('clubDelete')
+            setClubDeleteTarget(null)
+            setClubDeleteDone(false)
+            setClubDeleteError(null)
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove club</DialogTitle>
+            <DialogDescription>
+              This removes the affiliation from this player&apos;s showcase.
+            </DialogDescription>
+          </DialogHeader>
+
+          {clubDeleteDone ? (
+            <div className="flex items-center gap-2 py-4 text-sm text-emerald-600" role="status" aria-live="polite">
+              <Check className="h-4 w-4" />
+              Club removed
+            </div>
+          ) : clubDeleteError ? (
+            <p className="py-2 text-sm text-destructive" role="alert">{clubDeleteError}</p>
+          ) : clubDeleteBusy ? (
+            <div className="flex items-center gap-2 py-4 text-sm text-muted-foreground" role="status" aria-live="polite">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Removing club…
+            </div>
+          ) : (
+            <p className="py-2 text-sm text-foreground/90">
+              Remove {clubDeleteTarget?.club_name || 'this club'}? This cannot be undone.
+            </p>
+          )}
+
+          {!clubDeleteDone && !clubDeleteBusy ? (
+            <DialogFooter>
+              <Button variant="ghost" onClick={() => setClubDeleteOpen(false)}>
+                {clubDeleteError ? 'Close' : 'Cancel'}
+              </Button>
+              {!clubDeleteError ? (
+                <Button variant="destructive" onClick={deleteClub}>Remove club</Button>
+              ) : null}
+            </DialogFooter>
+          ) : null}
         </DialogContent>
       </Dialog>
 

--- a/academy-watch-frontend/src/components/ShowcaseSection.jsx
+++ b/academy-watch-frontend/src/components/ShowcaseSection.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react'
+import { Link } from 'react-router-dom'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -36,7 +37,6 @@ import {
   Image as ImageIcon,
   ImagePlus,
   Star,
-  Copy,
   Search,
   Building2,
 } from 'lucide-react'
@@ -44,6 +44,7 @@ import { APIService } from '@/lib/api'
 import { track } from '@/lib/track'
 import { isYouTubeUrl } from '@/lib/youtube'
 import { VideoEmbed } from '@/components/VideoEmbed'
+import { VerificationCode, VerificationInstructions } from '@/components/showcase/VerificationCode'
 import { useAuth, useAuthUI } from '@/context/AuthContext'
 
 const RELATIONSHIP_OPTIONS = [
@@ -139,43 +140,6 @@ function SectionHeader({ icon: Icon, eyebrow, title, action }) {
       </div>
       {action}
     </div>
-  )
-}
-
-function VerificationCode({ code, copyState, onCopy }) {
-  return (
-    <div className="rounded-lg border border-primary/20 bg-primary/5 p-4">
-      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-        Your one-time code
-      </p>
-      <div className="mt-2 flex flex-wrap items-center justify-between gap-3">
-        <code className="text-xl font-bold tracking-[0.16em] text-foreground sm:text-2xl">
-          {code || 'Code unavailable'}
-        </code>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() => onCopy(code)}
-          disabled={!code}
-          className="gap-1.5"
-          aria-label="Copy verification code"
-        >
-          {copyState === 'copied' ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-          <span role="status" aria-live="polite">
-            {copyState === 'copied' ? 'Copied' : copyState === 'failed' ? 'Copy failed' : 'Copy code'}
-          </span>
-        </Button>
-      </div>
-    </div>
-  )
-}
-
-function VerificationInstructions() {
-  return (
-    <p className="text-sm leading-relaxed text-muted-foreground">
-      Add this code to the bio of your public Instagram, TikTok, X, Facebook or YouTube profile, then paste that profile&apos;s URL below.
-    </p>
   )
 }
 
@@ -1565,6 +1529,15 @@ export function ShowcaseSection({ playerApiId, playerName }) {
                     ))}
                   </SelectContent>
                 </Select>
+                {claimRelationship === 'club_official' ? (
+                  <p className="text-xs leading-relaxed text-muted-foreground">
+                    Club officials can claim their club directly on the{' '}
+                    <Link to="/my-club" className="font-medium text-primary hover:underline">
+                      My Club page
+                    </Link>
+                    .
+                  </p>
+                ) : null}
               </div>
               <div className="space-y-2">
                 <Label>Message (optional)</Label>

--- a/academy-watch-frontend/src/components/ShowcaseSection.jsx
+++ b/academy-watch-frontend/src/components/ShowcaseSection.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -33,6 +33,9 @@ import {
   Loader2,
   Check,
   Sparkles,
+  Image as ImageIcon,
+  ImagePlus,
+  Star,
 } from 'lucide-react'
 import { APIService } from '@/lib/api'
 import { track } from '@/lib/track'
@@ -53,6 +56,21 @@ const FOOT_OPTIONS = [
   { value: 'both', label: 'Both' },
 ]
 
+const CONTRACT_STATUS_OPTIONS = [
+  { value: 'under_contract', label: 'Under contract' },
+  { value: 'expiring', label: 'Contract expiring' },
+  { value: 'free_agent', label: 'Free agent' },
+]
+
+const AVAILABILITY_OPTIONS = [
+  { value: 'open_to_moves', label: 'Open to moves' },
+  { value: 'not_looking', label: 'Not looking' },
+  { value: 'trial_available', label: 'Available for trials' },
+]
+
+const PHOTO_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp'])
+const PHOTO_MAX_BYTES = 8 * 1024 * 1024
+
 // Synthetic newsletter-sourced reel items carry string ids like "yt-123" and
 // are not owner-editable (no reorder/delete). Real PlayerLink rows are integers.
 const isSynthetic = (item) =>
@@ -65,10 +83,38 @@ function formatDate(value) {
   return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
 }
 
+function toDateInputValue(value) {
+  if (!value) return ''
+  const text = String(value)
+  const dateOnly = text.match(/^\d{4}-\d{2}-\d{2}/)?.[0]
+  if (dateOnly) return dateOnly
+  const d = new Date(value)
+  return Number.isNaN(d.getTime()) ? '' : d.toISOString().slice(0, 10)
+}
+
+function formatDateOnly(value) {
+  if (!value) return null
+  const match = String(value).match(/^(\d{4})-(\d{2})-(\d{2})/)
+  if (!match) return formatDate(value)
+  const d = new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]))
+  return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
+function optionLabel(options, value) {
+  return options.find((option) => option.value === value)?.label || null
+}
+
+function validatePhoto(file) {
+  if (!file) return 'Choose a photo to upload.'
+  if (!PHOTO_TYPES.has(file.type)) return 'Choose a JPEG, PNG or WebP image.'
+  if (file.size > PHOTO_MAX_BYTES) return 'Photos must be 8MB or smaller.'
+  return null
+}
+
 function SectionHeader({ icon: Icon, eyebrow, title, action }) {
   return (
-    <div className="flex items-start justify-between gap-3">
-      <div>
+    <div className="flex flex-col items-stretch justify-between gap-3 sm:flex-row sm:items-start">
+      <div className="min-w-0">
         <p className="mb-1 inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.2em] text-primary">
           <Icon className="h-3.5 w-3.5" />
           {eyebrow}
@@ -87,6 +133,7 @@ export function ShowcaseSection({ playerApiId, playerName }) {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
   const [showcase, setShowcase] = useState(null)
+  const [loadedPlayerId, setLoadedPlayerId] = useState(null)
   const [myClaims, setMyClaims] = useState([])
 
   // Claim dialog
@@ -105,9 +152,35 @@ export function ShowcaseSection({ playerApiId, playerName }) {
   const [videoDone, setVideoDone] = useState(false)
   const [videoError, setVideoError] = useState(null)
 
+  // Photo upload dialog + inline gallery mutations
+  const [photoOpen, setPhotoOpen] = useState(false)
+  const [photoFile, setPhotoFile] = useState(null)
+  const [photoInputKey, setPhotoInputKey] = useState(0)
+  const [photoBusy, setPhotoBusy] = useState(false)
+  const [photoDone, setPhotoDone] = useState(false)
+  const [photoError, setPhotoError] = useState(null)
+  const [photoActionOpen, setPhotoActionOpen] = useState(false)
+  const [photoActionBusy, setPhotoActionBusy] = useState(false)
+  const [photoActionDone, setPhotoActionDone] = useState(false)
+  const [photoActionError, setPhotoActionError] = useState(null)
+  const [photoActionCopy, setPhotoActionCopy] = useState({ title: 'Update photos', done: 'Photos updated' })
+  const [photoDeleteTarget, setPhotoDeleteTarget] = useState(null)
+
   // Edit-profile dialog
   const [profileOpen, setProfileOpen] = useState(false)
-  const [profileForm, setProfileForm] = useState({ bio: '', positions: '', preferred_foot: '', height_cm: '' })
+  const [profileForm, setProfileForm] = useState({
+    bio: '',
+    positions: '',
+    preferred_foot: '',
+    height_cm: '',
+    contract_status: '',
+    contract_until: '',
+    availability: '',
+    nationality_secondary: '',
+    languages: '',
+    agent_name: '',
+    agent_contact_email: '',
+  })
   const [profileBusy, setProfileBusy] = useState(false)
   const [profileDone, setProfileDone] = useState(false)
   const [profileError, setProfileError] = useState(null)
@@ -127,10 +200,61 @@ export function ShowcaseSection({ playerApiId, playerName }) {
   // PlayerPage is reused across /players/:id navigations — track the active
   // player so an in-flight refresh for the previous player never lands.
   const activePlayerRef = useRef(playerApiId)
+  const previousPlayerRef = useRef(playerApiId)
+  const closeTimersRef = useRef({})
+
+  const clearCloseTimer = useCallback((key) => {
+    const timer = closeTimersRef.current[key]
+    if (timer) {
+      clearTimeout(timer)
+      delete closeTimersRef.current[key]
+    }
+  }, [])
+
+  const clearAllCloseTimers = useCallback(() => {
+    Object.values(closeTimersRef.current).forEach((timer) => clearTimeout(timer))
+    closeTimersRef.current = {}
+  }, [])
+
+  const scheduleClose = useCallback((key, pid, close) => {
+    if (activePlayerRef.current !== pid) return
+    clearCloseTimer(key)
+    closeTimersRef.current[key] = setTimeout(() => {
+      delete closeTimersRef.current[key]
+      if (activePlayerRef.current === pid) close()
+    }, 1600)
+  }, [clearCloseTimer])
+
+  useLayoutEffect(() => {
+    activePlayerRef.current = playerApiId
+  }, [playerApiId])
+
+  useEffect(() => clearAllCloseTimers, [clearAllCloseTimers])
 
   useEffect(() => {
     let cancelled = false
-    activePlayerRef.current = playerApiId
+    if (previousPlayerRef.current !== playerApiId) {
+      previousPlayerRef.current = playerApiId
+      clearAllCloseTimers()
+      setClaimOpen(false)
+      setClaimBusy(false)
+      setVideoOpen(false)
+      setVideoBusy(false)
+      setPhotoOpen(false)
+      setPhotoFile(null)
+      setPhotoBusy(false)
+      setPhotoDone(false)
+      setPhotoError(null)
+      setPhotoActionOpen(false)
+      setPhotoActionBusy(false)
+      setPhotoActionDone(false)
+      setPhotoActionError(null)
+      setPhotoDeleteTarget(null)
+      setPhotoInputKey((key) => key + 1)
+      setProfileOpen(false)
+      setProfileBusy(false)
+      setReelBusy(false)
+    }
     setLoading(true)
     setError(false)
     fetchData()
@@ -143,10 +267,13 @@ export function ShowcaseSection({ playerApiId, playerName }) {
         if (!cancelled) setError(true)
       })
       .finally(() => {
-        if (!cancelled) setLoading(false)
+        if (!cancelled) {
+          setLoadedPlayerId(playerApiId)
+          setLoading(false)
+        }
       })
     return () => { cancelled = true }
-  }, [fetchData, playerApiId])
+  }, [clearAllCloseTimers, fetchData, playerApiId])
 
   const refresh = useCallback(async () => {
     const pid = playerApiId
@@ -160,7 +287,7 @@ export function ShowcaseSection({ playerApiId, playerName }) {
     }
   }, [fetchData, playerApiId])
 
-  if (loading) {
+  if (loading || loadedPlayerId !== playerApiId) {
     return (
       <Card>
         <CardContent className="space-y-4 py-6">
@@ -178,6 +305,7 @@ export function ShowcaseSection({ playerApiId, playerName }) {
   if (error || !showcase) return null
 
   const reel = Array.isArray(showcase.reel) ? showcase.reel : []
+  const photos = Array.isArray(showcase.photos) ? showcase.photos : []
   const profile = showcase.profile || null
   const verified = Array.isArray(showcase.verified_footage) ? showcase.verified_footage : []
   const claimStatus = showcase.claim_status // 'unclaimed' | 'claimed'
@@ -185,11 +313,28 @@ export function ShowcaseSection({ playerApiId, playerName }) {
   const myClaim = myClaims.find((c) => Number(c.player_api_id) === Number(playerApiId))
   const isOwner = myClaim?.status === 'approved'
 
+  const approvedPhotos = photos
+    .filter((photo) => photo.status === 'approved')
+    .sort((a, b) => {
+      const primaryOrder = Number(Boolean(b.is_primary)) - Number(Boolean(a.is_primary))
+      if (primaryOrder) return primaryOrder
+      const aOrder = a.sort_order == null ? Number.MAX_SAFE_INTEGER : a.sort_order
+      const bOrder = b.sort_order == null ? Number.MAX_SAFE_INTEGER : b.sort_order
+      return aOrder - bOrder || a.id - b.id
+    })
+  const pendingPhotos = photos.filter((photo) => photo.status === 'pending' || photo.status === 'pending_upload')
+  const rejectedPhotos = photos.filter((photo) => photo.status === 'rejected')
+  const visiblePhotos = isOwner
+    ? [...approvedPhotos, ...pendingPhotos, ...rejectedPhotos]
+    : approvedPhotos.filter((photo) => photo.public_url)
+  const primaryPhotos = approvedPhotos.filter((photo) => photo.is_primary)
+  const reorderablePhotos = approvedPhotos.filter((photo) => !photo.is_primary)
+
   // Claim strip shows for non-owners who either have a claim (show its status) or
   // can still claim an unclaimed profile.
   const showClaimStrip = !isOwner && (myClaim ? true : claimStatus === 'unclaimed')
 
-  const hasContent = reel.length > 0 || profile || verified.length > 0
+  const hasContent = reel.length > 0 || visiblePhotos.length > 0 || profile || verified.length > 0
   if (!hasContent && !isOwner && !showClaimStrip) return null
 
   const reorderableIds = reel.filter((i) => !isSynthetic(i)).map((i) => i.id)
@@ -199,6 +344,7 @@ export function ShowcaseSection({ playerApiId, playerName }) {
       openLoginModal()
       return
     }
+    clearCloseTimer('claim')
     setClaimError(null)
     setClaimDone(false)
     setClaimOpen(true)
@@ -206,22 +352,32 @@ export function ShowcaseSection({ playerApiId, playerName }) {
 
   const submitClaim = async () => {
     if (claimBusy) return
+    const pid = playerApiId
     setClaimBusy(true)
     setClaimError(null)
     try {
-      await APIService.submitProfileClaim(playerApiId, {
+      await APIService.submitProfileClaim(pid, {
         relationship_type: claimRelationship,
         message: claimMessage.trim() || undefined,
       })
-      track('claim_submitted', { player_api_id: playerApiId, relationship: claimRelationship })
-      setClaimDone(true)
+      track('claim_submitted', { player_api_id: pid, relationship: claimRelationship })
+      if (activePlayerRef.current === pid) setClaimDone(true)
       await refresh()
-      setTimeout(() => setClaimOpen(false), 1600)
+      scheduleClose('claim', pid, () => setClaimOpen(false))
     } catch (err) {
-      setClaimError(err.body?.error || err.message || 'Failed to submit claim')
+      if (activePlayerRef.current === pid) {
+        setClaimError(err.body?.error || err.message || 'Failed to submit claim')
+      }
     } finally {
-      setClaimBusy(false)
+      if (activePlayerRef.current === pid) setClaimBusy(false)
     }
+  }
+
+  const openVideoDialog = () => {
+    clearCloseTimer('video')
+    setVideoError(null)
+    setVideoDone(false)
+    setVideoOpen(true)
   }
 
   const submitVideo = async () => {
@@ -231,28 +387,104 @@ export function ShowcaseSection({ playerApiId, playerName }) {
       setVideoError('Please enter a valid YouTube link.')
       return
     }
+    const pid = playerApiId
     setVideoBusy(true)
     setVideoError(null)
     try {
-      await APIService.addShowcaseReelItem(playerApiId, { url, title: videoTitle.trim() || undefined })
-      setVideoDone(true)
-      setVideoUrl('')
-      setVideoTitle('')
+      await APIService.addShowcaseReelItem(pid, { url, title: videoTitle.trim() || undefined })
+      if (activePlayerRef.current === pid) {
+        setVideoDone(true)
+        setVideoUrl('')
+        setVideoTitle('')
+      }
       await refresh()
-      setTimeout(() => { setVideoOpen(false); setVideoDone(false) }, 1600)
+      scheduleClose('video', pid, () => {
+        setVideoOpen(false)
+        setVideoDone(false)
+      })
     } catch (err) {
-      setVideoError(err.body?.error || err.message || 'Failed to add video')
+      if (activePlayerRef.current === pid) {
+        setVideoError(err.body?.error || err.message || 'Failed to add video')
+      }
     } finally {
-      setVideoBusy(false)
+      if (activePlayerRef.current === pid) setVideoBusy(false)
+    }
+  }
+
+  const openPhotoDialog = () => {
+    clearCloseTimer('photoUpload')
+    setPhotoFile(null)
+    setPhotoError(null)
+    setPhotoDone(false)
+    setPhotoInputKey((key) => key + 1)
+    setPhotoOpen(true)
+  }
+
+  const choosePhoto = (event) => {
+    const file = event.target.files?.[0] || null
+    const validationError = validatePhoto(file)
+    setPhotoFile(validationError ? null : file)
+    setPhotoError(validationError)
+    if (validationError) event.target.value = ''
+  }
+
+  const submitPhoto = async () => {
+    if (photoBusy) return
+    const validationError = validatePhoto(photoFile)
+    if (validationError) {
+      setPhotoError(validationError)
+      return
+    }
+
+    const pid = playerApiId
+    const file = photoFile
+    setPhotoBusy(true)
+    setPhotoError(null)
+    try {
+      const created = await APIService.createShowcasePhoto(pid, {
+        content_type: file.type,
+        size_bytes: file.size,
+      })
+      await APIService.uploadPhotoToUrl(created.upload, file)
+      await APIService.completeShowcasePhoto(pid, created.media.id)
+      if (activePlayerRef.current === pid) {
+        setPhotoDone(true)
+        setPhotoFile(null)
+        setPhotoInputKey((key) => key + 1)
+      }
+      await refresh()
+      scheduleClose('photoUpload', pid, () => {
+        setPhotoOpen(false)
+        setPhotoDone(false)
+      })
+    } catch (err) {
+      if (activePlayerRef.current === pid) {
+        setPhotoError(
+          err.status === 503
+            ? "Photo uploads aren't enabled yet"
+            : err.body?.error || err.message || 'Failed to upload photo',
+        )
+        await refresh()
+      }
+    } finally {
+      if (activePlayerRef.current === pid) setPhotoBusy(false)
     }
   }
 
   const openProfileDialog = () => {
+    clearCloseTimer('profile')
     setProfileForm({
       bio: profile?.bio || '',
       positions: profile?.positions || '',
       preferred_foot: profile?.preferred_foot || '',
       height_cm: profile?.height_cm != null ? String(profile.height_cm) : '',
+      contract_status: profile?.contract_status || '',
+      contract_until: toDateInputValue(profile?.contract_until),
+      availability: profile?.availability || '',
+      nationality_secondary: profile?.nationality_secondary || '',
+      languages: profile?.languages || '',
+      agent_name: profile?.agent_name || '',
+      agent_contact_email: profile?.agent_contact_email || '',
     })
     setProfileError(null)
     setProfileDone(false)
@@ -261,23 +493,33 @@ export function ShowcaseSection({ playerApiId, playerName }) {
 
   const submitProfile = async () => {
     if (profileBusy) return
+    const pid = playerApiId
     setProfileBusy(true)
     setProfileError(null)
     try {
       const heightRaw = profileForm.height_cm.trim()
-      await APIService.updateShowcaseProfile(playerApiId, {
+      await APIService.updateShowcaseProfile(pid, {
         bio: profileForm.bio.trim(),
         positions: profileForm.positions.trim(),
         preferred_foot: profileForm.preferred_foot || null,
         height_cm: heightRaw ? parseInt(heightRaw, 10) : null,
+        contract_status: profileForm.contract_status || null,
+        contract_until: profileForm.contract_until || null,
+        availability: profileForm.availability || null,
+        nationality_secondary: profileForm.nationality_secondary.trim() || null,
+        languages: profileForm.languages.trim() || null,
+        agent_name: profileForm.agent_name.trim() || null,
+        agent_contact_email: profileForm.agent_contact_email.trim() || null,
       })
-      setProfileDone(true)
+      if (activePlayerRef.current === pid) setProfileDone(true)
       await refresh()
-      setTimeout(() => setProfileOpen(false), 1600)
+      scheduleClose('profile', pid, () => setProfileOpen(false))
     } catch (err) {
-      setProfileError(err.body?.error || err.message || 'Failed to update profile')
+      if (activePlayerRef.current === pid) {
+        setProfileError(err.body?.error || err.message || 'Failed to update profile')
+      }
     } finally {
-      setProfileBusy(false)
+      if (activePlayerRef.current === pid) setProfileBusy(false)
     }
   }
 
@@ -288,27 +530,118 @@ export function ShowcaseSection({ playerApiId, playerName }) {
     const next = [...reel]
     ;[next[index], next[target]] = [next[target], next[index]]
     const ordered_ids = next.filter((i) => !isSynthetic(i)).map((i) => i.id)
+    const pid = playerApiId
     setReelBusy(true)
     try {
-      await APIService.reorderShowcaseReel(playerApiId, { ordered_ids })
+      await APIService.reorderShowcaseReel(pid, { ordered_ids })
       await refresh()
     } catch {
       // ignore — order unchanged on failure
     } finally {
-      setReelBusy(false)
+      if (activePlayerRef.current === pid) setReelBusy(false)
     }
   }
 
   const deleteReelItem = async (linkId) => {
     if (reelBusy) return
+    const pid = playerApiId
     setReelBusy(true)
     try {
-      await APIService.deleteShowcaseReelItem(playerApiId, linkId)
+      await APIService.deleteShowcaseReelItem(pid, linkId)
       await refresh()
     } catch {
       // ignore
     } finally {
-      setReelBusy(false)
+      if (activePlayerRef.current === pid) setReelBusy(false)
+    }
+  }
+
+  const beginPhotoAction = (copy) => {
+    clearCloseTimer('photoAction')
+    setPhotoActionCopy(copy)
+    setPhotoActionOpen(true)
+    setPhotoActionBusy(true)
+    setPhotoActionDone(false)
+    setPhotoActionError(null)
+    setPhotoDeleteTarget(null)
+  }
+
+  const finishPhotoAction = (pid) => {
+    if (activePlayerRef.current !== pid) return
+    setPhotoActionDone(true)
+    scheduleClose('photoAction', pid, () => {
+      setPhotoActionOpen(false)
+      setPhotoActionDone(false)
+    })
+  }
+
+  const requestDeletePhoto = (mediaId) => {
+    if (photoActionBusy) return
+    clearCloseTimer('photoAction')
+    setPhotoActionCopy({ title: 'Delete photo', done: 'Photo deleted' })
+    setPhotoDeleteTarget(mediaId)
+    setPhotoActionDone(false)
+    setPhotoActionError(null)
+    setPhotoActionOpen(true)
+  }
+
+  const movePhoto = async (mediaId, dir) => {
+    if (photoActionBusy) return
+    const index = reorderablePhotos.findIndex((photo) => photo.id === mediaId)
+    const target = index + dir
+    if (index < 0 || target < 0 || target >= reorderablePhotos.length) return
+    const next = [...reorderablePhotos]
+    ;[next[index], next[target]] = [next[target], next[index]]
+    const ordered_ids = [...primaryPhotos, ...next].map((photo) => photo.id)
+    const pid = playerApiId
+    beginPhotoAction({ title: 'Reorder photos', done: 'Photo order updated' })
+    try {
+      await APIService.reorderShowcasePhotos(pid, { ordered_ids })
+      if (activePlayerRef.current === pid) setPhotoActionDone(true)
+      await refresh()
+      finishPhotoAction(pid)
+    } catch (err) {
+      if (activePlayerRef.current === pid) {
+        setPhotoActionError(err.body?.error || err.message || 'Failed to reorder photos')
+      }
+    } finally {
+      if (activePlayerRef.current === pid) setPhotoActionBusy(false)
+    }
+  }
+
+  const setPrimaryPhoto = async (mediaId) => {
+    if (photoActionBusy) return
+    const pid = playerApiId
+    beginPhotoAction({ title: 'Set primary photo', done: 'Primary photo updated' })
+    try {
+      await APIService.setShowcasePhotoPrimary(pid, mediaId)
+      if (activePlayerRef.current === pid) setPhotoActionDone(true)
+      await refresh()
+      finishPhotoAction(pid)
+    } catch (err) {
+      if (activePlayerRef.current === pid) {
+        setPhotoActionError(err.body?.error || err.message || 'Failed to set primary photo')
+      }
+    } finally {
+      if (activePlayerRef.current === pid) setPhotoActionBusy(false)
+    }
+  }
+
+  const deletePhoto = async (mediaId) => {
+    if (photoActionBusy) return
+    const pid = playerApiId
+    beginPhotoAction({ title: 'Delete photo', done: 'Photo deleted' })
+    try {
+      await APIService.deleteShowcasePhoto(pid, mediaId)
+      if (activePlayerRef.current === pid) setPhotoActionDone(true)
+      await refresh()
+      finishPhotoAction(pid)
+    } catch (err) {
+      if (activePlayerRef.current === pid) {
+        setPhotoActionError(err.body?.error || err.message || 'Failed to delete photo')
+      }
+    } finally {
+      if (activePlayerRef.current === pid) setPhotoActionBusy(false)
     }
   }
 
@@ -322,8 +655,8 @@ export function ShowcaseSection({ playerApiId, playerName }) {
           title={`${playerName || 'Player'} — Showcase`}
           action={
             isOwner ? (
-              <div className="flex shrink-0 items-center gap-2">
-                <Button variant="outline" size="sm" onClick={() => { setVideoError(null); setVideoDone(false); setVideoOpen(true) }} className="gap-1.5">
+              <div className="flex w-full shrink-0 flex-wrap items-center justify-start gap-2 sm:w-auto sm:justify-end">
+                <Button variant="outline" size="sm" onClick={openVideoDialog} className="gap-1.5">
                   <Plus className="h-3.5 w-3.5" />
                   Add video
                 </Button>
@@ -338,11 +671,166 @@ export function ShowcaseSection({ playerApiId, playerName }) {
 
         {isOwner && (
           <p className="-mt-4 text-xs text-muted-foreground">
-            You manage this profile. Videos and profile edits are reviewed before they appear publicly.
+            You manage this profile. Photos, videos and profile edits are reviewed before they appear publicly.
           </p>
         )}
 
-        {/* 1. Highlight reel */}
+        {/* 1. Photos */}
+        {(visiblePhotos.length > 0 || isOwner) && (
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <p className="inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                <ImageIcon className="h-3.5 w-3.5" />
+                Photos
+              </p>
+              {isOwner && (
+                <Button variant="outline" size="sm" onClick={openPhotoDialog} disabled={photoBusy} className="gap-1.5">
+                  <ImagePlus className="h-3.5 w-3.5" />
+                  Add photo
+                </Button>
+              )}
+            </div>
+
+            {visiblePhotos.length > 0 ? (
+              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+                {visiblePhotos.map((photo, index) => {
+                  const approved = photo.status === 'approved'
+                  const pending = photo.status === 'pending'
+                  const pendingUpload = photo.status === 'pending_upload'
+                  const rejected = photo.status === 'rejected'
+                  const imageUrl = approved ? photo.public_url : photo.pending_preview_url
+                  const reorderIndex = reorderablePhotos.findIndex((item) => item.id === photo.id)
+                  return (
+                    <div key={photo.id} className="min-w-0 space-y-2">
+                      <div className="group relative aspect-[4/3] overflow-hidden rounded-lg border border-border/70 bg-secondary/50">
+                        {imageUrl ? (
+                          <img
+                            src={imageUrl}
+                            alt={`${playerName || 'Player'} showcase photo ${index + 1}`}
+                            width={640}
+                            height={480}
+                            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.02] motion-reduce:transform-none motion-reduce:transition-none"
+                            loading="lazy"
+                          />
+                        ) : (
+                          <div
+                            className="flex h-full flex-col items-center justify-center gap-2 px-3 text-center text-muted-foreground"
+                            role="img"
+                            aria-label="Photo preview unavailable"
+                          >
+                            <ImageIcon className="h-7 w-7 opacity-50" />
+                            <span className="text-[11px]">
+                              {pendingUpload ? 'Upload incomplete' : 'Preview unavailable'}
+                            </span>
+                          </div>
+                        )}
+
+                        <div className="absolute inset-x-2 top-2 flex flex-wrap items-center gap-1.5">
+                          {approved && photo.is_primary && (
+                            <Badge className="border-white/30 bg-foreground/80 text-background shadow-sm">
+                              <Star className="mr-1 h-3 w-3 fill-current" />
+                              Primary
+                            </Badge>
+                          )}
+                          {pending && (
+                            <Badge variant="outline" className="border-amber-200 bg-amber-50/95 text-amber-800 shadow-sm">
+                              Pending review
+                            </Badge>
+                          )}
+                          {pendingUpload && (
+                            <Badge variant="outline" className="border-amber-200 bg-amber-50/95 text-amber-800 shadow-sm">
+                              Upload incomplete
+                            </Badge>
+                          )}
+                          {rejected && (
+                            <Badge variant="outline" className="border-rose-200 bg-rose-50/95 text-rose-800 shadow-sm">
+                              Rejected
+                            </Badge>
+                          )}
+                        </div>
+                      </div>
+
+                      {isOwner && (
+                        <div className="flex min-h-7 items-center justify-between gap-1 px-0.5">
+                          {approved ? (
+                            <div className="flex items-center gap-0.5">
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-7 w-7"
+                                disabled={photoActionBusy || photo.is_primary}
+                                onClick={() => setPrimaryPhoto(photo.id)}
+                                aria-label={photo.is_primary ? 'Primary photo' : 'Set as primary photo'}
+                              >
+                                <Star className={`h-3.5 w-3.5 ${photo.is_primary ? 'fill-current text-amber-600' : ''}`} />
+                              </Button>
+                              {!photo.is_primary && (
+                                <>
+                                  <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="h-7 w-7"
+                                    disabled={photoActionBusy || reorderIndex <= 0}
+                                    onClick={() => movePhoto(photo.id, -1)}
+                                    aria-label="Move photo left"
+                                  >
+                                    <ArrowUp className="h-3.5 w-3.5 -rotate-90" />
+                                  </Button>
+                                  <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="h-7 w-7"
+                                    disabled={photoActionBusy || reorderIndex === reorderablePhotos.length - 1}
+                                    onClick={() => movePhoto(photo.id, 1)}
+                                    aria-label="Move photo right"
+                                  >
+                                    <ArrowDown className="h-3.5 w-3.5 -rotate-90" />
+                                  </Button>
+                                </>
+                              )}
+                            </div>
+                          ) : (
+                            <span className="text-[11px] text-muted-foreground">
+                              {pendingUpload ? 'Remove and try again' : 'Visible only to you'}
+                            </span>
+                          )}
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7 shrink-0 text-muted-foreground hover:text-destructive"
+                            disabled={photoActionBusy}
+                            onClick={() => requestDeletePhoto(photo.id)}
+                            aria-label="Delete photo"
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        </div>
+                      )}
+
+                      {isOwner && rejected && photo.review_note && (
+                        <p className="break-words px-0.5 text-xs leading-relaxed text-rose-700">
+                          Review note: {photo.review_note}
+                        </p>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={openPhotoDialog}
+                className="flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-border py-8 text-sm text-muted-foreground transition-colors hover:border-primary/40 hover:bg-primary/5 hover:text-foreground"
+              >
+                <ImagePlus className="h-4 w-4" />
+                Add the first photo
+              </button>
+            )}
+
+          </div>
+        )}
+
+        {/* 2. Highlight reel */}
         {reel.length > 0 && (
           <div className="space-y-3">
             <p className="inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
@@ -412,9 +900,9 @@ export function ShowcaseSection({ playerApiId, playerName }) {
           </div>
         )}
 
-        {/* 2. Self-reported profile */}
+        {/* 3. Self-reported profile */}
         {profile && (
-          <div className="space-y-3 rounded-lg border border-border/70 bg-secondary/40 p-4">
+          <div className="min-w-0 space-y-3 rounded-lg border border-border/70 bg-secondary/40 p-4">
             <div className="flex items-center gap-2">
               <UserSquare className="h-4 w-4 text-muted-foreground" />
               <span className="text-sm font-semibold text-foreground">Player profile</span>
@@ -425,7 +913,7 @@ export function ShowcaseSection({ playerApiId, playerName }) {
               {profile.positions && (
                 <div>
                   <span className="text-muted-foreground">Positions: </span>
-                  <span className="font-medium text-foreground">{profile.positions}</span>
+                  <span className="break-words font-medium text-foreground">{profile.positions}</span>
                 </div>
               )}
               {profile.preferred_foot && (
@@ -440,11 +928,57 @@ export function ShowcaseSection({ playerApiId, playerName }) {
                   <span className="font-medium text-foreground">{profile.height_cm} cm</span>
                 </div>
               )}
+              {(profile.contract_status || profile.contract_until) && (
+                <div>
+                  <span className="text-muted-foreground">Contract: </span>
+                  <span className="font-medium text-foreground">
+                    {optionLabel(CONTRACT_STATUS_OPTIONS, profile.contract_status) || 'Status not specified'}
+                    {formatDateOnly(profile.contract_until) ? ` · until ${formatDateOnly(profile.contract_until)}` : ''}
+                  </span>
+                </div>
+              )}
+              {profile.availability && optionLabel(AVAILABILITY_OPTIONS, profile.availability) && (
+                <div>
+                  <span className="text-muted-foreground">Availability: </span>
+                  <span className="font-medium text-foreground">
+                    {optionLabel(AVAILABILITY_OPTIONS, profile.availability)}
+                  </span>
+                </div>
+              )}
+              {profile.nationality_secondary && (
+                <div>
+                  <span className="text-muted-foreground">Second nationality: </span>
+                  <span className="break-words font-medium text-foreground">{profile.nationality_secondary}</span>
+                </div>
+              )}
+              {profile.languages && (
+                <div>
+                  <span className="text-muted-foreground">Languages: </span>
+                  <span className="break-words font-medium text-foreground">{profile.languages}</span>
+                </div>
+              )}
+              {profile.agent_name && (
+                <div>
+                  <span className="text-muted-foreground">Agent: </span>
+                  <span className="break-words font-medium text-foreground">{profile.agent_name}</span>
+                </div>
+              )}
+              {profile.agent_contact_email && (
+                <div>
+                  <span className="text-muted-foreground">Agent email: </span>
+                  <a
+                    href={`mailto:${profile.agent_contact_email}`}
+                    className="break-all font-medium text-primary hover:underline"
+                  >
+                    {profile.agent_contact_email}
+                  </a>
+                </div>
+              )}
             </div>
           </div>
         )}
 
-        {/* 3. Club-verified footage */}
+        {/* 4. Club-verified footage */}
         {verified.length > 0 && (
           <div className="space-y-3">
             <div className="flex flex-wrap items-center gap-2">
@@ -487,7 +1021,7 @@ export function ShowcaseSection({ playerApiId, playerName }) {
           </div>
         )}
 
-        {/* 4. Claim strip */}
+        {/* 5. Claim strip */}
         {showClaimStrip && (
           <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border/70 pt-4">
             {myClaim ? (
@@ -616,9 +1150,129 @@ export function ShowcaseSection({ playerApiId, playerName }) {
         </DialogContent>
       </Dialog>
 
+      {/* Add-photo dialog */}
+      <Dialog
+        open={photoOpen}
+        onOpenChange={(open) => {
+          if (photoBusy) return
+          setPhotoOpen(open)
+          if (!open) {
+            setPhotoFile(null)
+            setPhotoDone(false)
+            setPhotoError(null)
+            setPhotoInputKey((key) => key + 1)
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add a showcase photo</DialogTitle>
+            <DialogDescription>
+              Upload a JPEG, PNG or WebP image up to 8MB. Photos are reviewed before appearing publicly.
+            </DialogDescription>
+          </DialogHeader>
+          {photoDone ? (
+            <div className="flex items-center gap-2 py-4 text-sm text-emerald-600" role="status" aria-live="polite">
+              <Check className="h-4 w-4" />
+              Submitted for review
+            </div>
+          ) : (
+            <div className="space-y-4 py-2">
+              <div className="space-y-2">
+                <Label htmlFor={`showcase-photo-${playerApiId}`}>Photo</Label>
+                <Input
+                  key={photoInputKey}
+                  id={`showcase-photo-${playerApiId}`}
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp"
+                  onChange={choosePhoto}
+                  disabled={photoBusy}
+                  aria-invalid={Boolean(photoError)}
+                  aria-describedby={photoError ? `showcase-photo-error-${playerApiId}` : undefined}
+                />
+                {photoFile && (
+                  <p className="text-xs text-muted-foreground">
+                    {photoFile.name} · {(photoFile.size / (1024 * 1024)).toFixed(1)}MB
+                  </p>
+                )}
+              </div>
+              {photoError && (
+                <p id={`showcase-photo-error-${playerApiId}`} className="text-xs text-destructive" role="alert">
+                  {photoError}
+                </p>
+              )}
+            </div>
+          )}
+          {!photoDone && (
+            <DialogFooter>
+              <Button variant="ghost" onClick={() => setPhotoOpen(false)} disabled={photoBusy}>Cancel</Button>
+              <Button onClick={submitPhoto} disabled={photoBusy || !photoFile}>
+                {photoBusy && <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />}
+                {photoBusy ? 'Uploading…' : 'Upload photo'}
+              </Button>
+            </DialogFooter>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Photo-action dialog */}
+      <Dialog
+        open={photoActionOpen}
+        onOpenChange={(open) => {
+          if (photoActionBusy) return
+          setPhotoActionOpen(open)
+          if (!open) {
+            clearCloseTimer('photoAction')
+            setPhotoActionDone(false)
+            setPhotoActionError(null)
+            setPhotoDeleteTarget(null)
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{photoActionCopy.title}</DialogTitle>
+            <DialogDescription>
+              Showcase photo changes are applied to this player&apos;s profile.
+            </DialogDescription>
+          </DialogHeader>
+
+          {photoActionDone ? (
+            <div className="flex items-center gap-2 py-4 text-sm text-emerald-600" role="status" aria-live="polite">
+              <Check className="h-4 w-4" />
+              {photoActionCopy.done}
+            </div>
+          ) : photoActionError ? (
+            <p className="py-2 text-sm text-destructive" role="alert">{photoActionError}</p>
+          ) : photoActionBusy ? (
+            <div className="flex items-center gap-2 py-4 text-sm text-muted-foreground" role="status" aria-live="polite">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Updating photos…
+            </div>
+          ) : photoDeleteTarget != null ? (
+            <p className="py-2 text-sm text-foreground/90">
+              Delete this photo permanently? This cannot be undone.
+            </p>
+          ) : null}
+
+          {!photoActionDone && !photoActionBusy && (
+            <DialogFooter>
+              <Button variant="ghost" onClick={() => setPhotoActionOpen(false)}>
+                {photoDeleteTarget != null ? 'Cancel' : 'Close'}
+              </Button>
+              {photoDeleteTarget != null && !photoActionError && (
+                <Button variant="destructive" onClick={() => deletePhoto(photoDeleteTarget)}>
+                  Delete photo
+                </Button>
+              )}
+            </DialogFooter>
+          )}
+        </DialogContent>
+      </Dialog>
+
       {/* Edit-profile dialog */}
       <Dialog open={profileOpen} onOpenChange={setProfileOpen}>
-        <DialogContent>
+        <DialogContent className="sm:max-w-2xl">
           <DialogHeader>
             <DialogTitle>Edit player profile</DialogTitle>
             <DialogDescription>
@@ -633,8 +1287,9 @@ export function ShowcaseSection({ playerApiId, playerName }) {
           ) : (
             <div className="space-y-4 py-2">
               <div className="space-y-2">
-                <Label>Bio</Label>
+                <Label htmlFor={`showcase-profile-bio-${playerApiId}`}>Bio</Label>
                 <Textarea
+                  id={`showcase-profile-bio-${playerApiId}`}
                   placeholder="A short bio"
                   value={profileForm.bio}
                   onChange={(e) => setProfileForm((f) => ({ ...f, bio: e.target.value }))}
@@ -644,8 +1299,9 @@ export function ShowcaseSection({ playerApiId, playerName }) {
               </div>
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <div className="space-y-2">
-                  <Label>Positions</Label>
+                  <Label htmlFor={`showcase-profile-positions-${playerApiId}`}>Positions</Label>
                   <Input
+                    id={`showcase-profile-positions-${playerApiId}`}
                     placeholder="e.g. LW, ST"
                     value={profileForm.positions}
                     onChange={(e) => setProfileForm((f) => ({ ...f, positions: e.target.value }))}
@@ -653,12 +1309,12 @@ export function ShowcaseSection({ playerApiId, playerName }) {
                   />
                 </div>
                 <div className="space-y-2">
-                  <Label>Preferred foot</Label>
+                  <Label htmlFor={`showcase-profile-foot-${playerApiId}`}>Preferred foot</Label>
                   <Select
                     value={profileForm.preferred_foot}
                     onValueChange={(v) => setProfileForm((f) => ({ ...f, preferred_foot: v }))}
                   >
-                    <SelectTrigger>
+                    <SelectTrigger id={`showcase-profile-foot-${playerApiId}`}>
                       <SelectValue placeholder="Select" />
                     </SelectTrigger>
                     <SelectContent>
@@ -669,15 +1325,109 @@ export function ShowcaseSection({ playerApiId, playerName }) {
                   </Select>
                 </div>
               </div>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor={`showcase-profile-height-${playerApiId}`}>Height (cm)</Label>
+                  <Input
+                    id={`showcase-profile-height-${playerApiId}`}
+                    placeholder="e.g. 178"
+                    value={profileForm.height_cm}
+                    onChange={(e) => setProfileForm((f) => ({ ...f, height_cm: e.target.value.replace(/[^0-9]/g, '') }))}
+                    inputMode="numeric"
+                    maxLength={3}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor={`showcase-profile-nationality-${playerApiId}`}>Second nationality</Label>
+                  <Input
+                    id={`showcase-profile-nationality-${playerApiId}`}
+                    placeholder="e.g. Irish"
+                    value={profileForm.nationality_secondary}
+                    onChange={(e) => setProfileForm((f) => ({ ...f, nationality_secondary: e.target.value }))}
+                  />
+                </div>
+              </div>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                <div className="space-y-2">
+                  <Label htmlFor={`showcase-profile-contract-${playerApiId}`}>Contract status</Label>
+                  <Select
+                    value={profileForm.contract_status || 'not_specified'}
+                    onValueChange={(v) => setProfileForm((f) => ({
+                      ...f,
+                      contract_status: v === 'not_specified' ? '' : v,
+                    }))}
+                  >
+                    <SelectTrigger id={`showcase-profile-contract-${playerApiId}`}>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="not_specified">Not specified</SelectItem>
+                      {CONTRACT_STATUS_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>{option.label}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor={`showcase-profile-contract-until-${playerApiId}`}>Contract until</Label>
+                  <Input
+                    id={`showcase-profile-contract-until-${playerApiId}`}
+                    type="date"
+                    value={profileForm.contract_until}
+                    onChange={(e) => setProfileForm((f) => ({ ...f, contract_until: e.target.value }))}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor={`showcase-profile-availability-${playerApiId}`}>Availability</Label>
+                  <Select
+                    value={profileForm.availability || 'not_specified'}
+                    onValueChange={(v) => setProfileForm((f) => ({
+                      ...f,
+                      availability: v === 'not_specified' ? '' : v,
+                    }))}
+                  >
+                    <SelectTrigger id={`showcase-profile-availability-${playerApiId}`}>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="not_specified">Not specified</SelectItem>
+                      {AVAILABILITY_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>{option.label}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
               <div className="space-y-2">
-                <Label>Height (cm)</Label>
+                <Label htmlFor={`showcase-profile-languages-${playerApiId}`}>Languages</Label>
                 <Input
-                  placeholder="e.g. 178"
-                  value={profileForm.height_cm}
-                  onChange={(e) => setProfileForm((f) => ({ ...f, height_cm: e.target.value.replace(/[^0-9]/g, '') }))}
-                  inputMode="numeric"
-                  maxLength={3}
+                  id={`showcase-profile-languages-${playerApiId}`}
+                  placeholder="e.g. English, French"
+                  value={profileForm.languages}
+                  onChange={(e) => setProfileForm((f) => ({ ...f, languages: e.target.value }))}
                 />
+              </div>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor={`showcase-profile-agent-${playerApiId}`}>Agent name</Label>
+                  <Input
+                    id={`showcase-profile-agent-${playerApiId}`}
+                    placeholder="Agent or agency"
+                    value={profileForm.agent_name}
+                    onChange={(e) => setProfileForm((f) => ({ ...f, agent_name: e.target.value }))}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor={`showcase-profile-agent-email-${playerApiId}`}>Agent contact email</Label>
+                  <Input
+                    id={`showcase-profile-agent-email-${playerApiId}`}
+                    type="email"
+                    placeholder="agent@example.com"
+                    value={profileForm.agent_contact_email}
+                    onChange={(e) => setProfileForm((f) => ({ ...f, agent_contact_email: e.target.value }))}
+                    autoComplete="email"
+                  />
+                </div>
               </div>
               {profileError && <p className="text-xs text-destructive">{profileError}</p>}
             </div>

--- a/academy-watch-frontend/src/components/ShowcaseSection.jsx
+++ b/academy-watch-frontend/src/components/ShowcaseSection.jsx
@@ -168,14 +168,15 @@ function AffiliationStatusBadge({ status }) {
   return <Badge variant="secondary">Self-reported</Badge>
 }
 
-export function ShowcaseSection({ playerApiId, playerName }) {
+export function ShowcaseSection({ playerApiId, playerName, local = false }) {
   const { token } = useAuth()
   const { openLoginModal } = useAuthUI()
+  const subjectKey = `${local ? 'local' : 'api'}:${playerApiId}`
 
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
   const [showcase, setShowcase] = useState(null)
-  const [loadedPlayerId, setLoadedPlayerId] = useState(null)
+  const [loadedSubjectKey, setLoadedSubjectKey] = useState(null)
   const [myClaims, setMyClaims] = useState([])
 
   // Claim dialog
@@ -263,19 +264,20 @@ export function ShowcaseSection({ playerApiId, playerName }) {
 
   const fetchData = useCallback(async () => {
     const [sc, claims] = await Promise.all([
-      APIService.getPlayerShowcase(playerApiId),
+      APIService.getPlayerShowcase(playerApiId, { local }),
       token ? APIService.getMyClaims().catch(() => null) : Promise.resolve(null),
     ])
     const claimsArr = Array.isArray(claims) ? claims : claims?.claims || []
     return { sc, claimsArr }
-  }, [playerApiId, token])
+  }, [local, playerApiId, token])
 
   // PlayerPage is reused across /players/:id navigations — track the active
-  // player so an in-flight refresh for the previous player never lands.
-  const activePlayerRef = useRef(playerApiId)
-  const previousPlayerRef = useRef(playerApiId)
+  // subject so an in-flight refresh for another API/local player never lands.
+  const activeSubjectRef = useRef(subjectKey)
+  const previousSubjectRef = useRef(subjectKey)
   const closeTimersRef = useRef({})
   const clubSearchRequestRef = useRef(0)
+  const isActiveSubject = () => activeSubjectRef.current === subjectKey
 
   const clearCloseTimer = useCallback((key) => {
     const timer = closeTimersRef.current[key]
@@ -290,25 +292,25 @@ export function ShowcaseSection({ playerApiId, playerName }) {
     closeTimersRef.current = {}
   }, [])
 
-  const scheduleClose = useCallback((key, pid, close) => {
-    if (activePlayerRef.current !== pid) return
+  const scheduleClose = useCallback((key, subject, close) => {
+    if (activeSubjectRef.current !== subject) return
     clearCloseTimer(key)
     closeTimersRef.current[key] = setTimeout(() => {
       delete closeTimersRef.current[key]
-      if (activePlayerRef.current === pid) close()
+      if (activeSubjectRef.current === subject) close()
     }, 1600)
   }, [clearCloseTimer])
 
   useLayoutEffect(() => {
-    activePlayerRef.current = playerApiId
-  }, [playerApiId])
+    activeSubjectRef.current = subjectKey
+  }, [subjectKey])
 
   useEffect(() => clearAllCloseTimers, [clearAllCloseTimers])
 
   useEffect(() => {
     let cancelled = false
-    if (previousPlayerRef.current !== playerApiId) {
-      previousPlayerRef.current = playerApiId
+    if (previousSubjectRef.current !== subjectKey) {
+      previousSubjectRef.current = subjectKey
       clearAllCloseTimers()
       setClaimOpen(false)
       setClaimBusy(false)
@@ -372,12 +374,12 @@ export function ShowcaseSection({ playerApiId, playerName }) {
       })
       .finally(() => {
         if (!cancelled) {
-          setLoadedPlayerId(playerApiId)
+          setLoadedSubjectKey(subjectKey)
           setLoading(false)
         }
       })
     return () => { cancelled = true }
-  }, [clearAllCloseTimers, fetchData, playerApiId])
+  }, [clearAllCloseTimers, fetchData, subjectKey])
 
   useEffect(() => {
     const query = clubSearch.trim()
@@ -385,26 +387,26 @@ export function ShowcaseSection({ playerApiId, playerName }) {
 
     const requestId = clubSearchRequestRef.current + 1
     clubSearchRequestRef.current = requestId
-    const pid = playerApiId
+    const subject = subjectKey
     const timer = setTimeout(async () => {
-      if (clubSearchRequestRef.current !== requestId || activePlayerRef.current !== pid) return
+      if (clubSearchRequestRef.current !== requestId || activeSubjectRef.current !== subject) return
       setClubSearchBusy(true)
       setClubSearchError(null)
       try {
         const response = await APIService.searchClubs(query)
-        if (clubSearchRequestRef.current !== requestId || activePlayerRef.current !== pid) return
+        if (clubSearchRequestRef.current !== requestId || activeSubjectRef.current !== subject) return
         setClubResults({
           api_teams: Array.isArray(response?.api_teams) ? response.api_teams : [],
           local_clubs: Array.isArray(response?.local_clubs) ? response.local_clubs : [],
         })
         setClubSearchComplete(true)
       } catch (err) {
-        if (clubSearchRequestRef.current !== requestId || activePlayerRef.current !== pid) return
+        if (clubSearchRequestRef.current !== requestId || activeSubjectRef.current !== subject) return
         setClubResults(EMPTY_CLUB_RESULTS)
         setClubSearchComplete(false)
         setClubSearchError(err.body?.error || err.message || 'Failed to search clubs')
       } finally {
-        if (clubSearchRequestRef.current === requestId && activePlayerRef.current === pid) {
+        if (clubSearchRequestRef.current === requestId && activeSubjectRef.current === subject) {
           setClubSearchBusy(false)
         }
       }
@@ -414,21 +416,21 @@ export function ShowcaseSection({ playerApiId, playerName }) {
       clearTimeout(timer)
       if (clubSearchRequestRef.current === requestId) clubSearchRequestRef.current += 1
     }
-  }, [clubOpen, clubSearch, createClubMode, playerApiId])
+  }, [clubOpen, clubSearch, createClubMode, subjectKey])
 
   const refresh = useCallback(async () => {
-    const pid = playerApiId
+    const subject = subjectKey
     try {
       const { sc, claimsArr } = await fetchData()
-      if (activePlayerRef.current !== pid) return
+      if (activeSubjectRef.current !== subject) return
       setShowcase(sc || null)
       setMyClaims(claimsArr)
     } catch {
       // best-effort refresh
     }
-  }, [fetchData, playerApiId])
+  }, [fetchData, subjectKey])
 
-  if (loading || loadedPlayerId !== playerApiId) {
+  if (loading || loadedSubjectKey !== subjectKey) {
     return (
       <Card>
         <CardContent className="space-y-4 py-6">
@@ -449,10 +451,14 @@ export function ShowcaseSection({ playerApiId, playerName }) {
   const photos = Array.isArray(showcase.photos) ? showcase.photos : []
   const affiliations = Array.isArray(showcase.affiliations) ? showcase.affiliations : []
   const profile = showcase.profile || null
-  const verified = Array.isArray(showcase.verified_footage) ? showcase.verified_footage : []
+  const verified = !local && Array.isArray(showcase.verified_footage) ? showcase.verified_footage : []
   const claimStatus = showcase.claim_status // 'unclaimed' | 'claimed'
 
-  const myClaim = myClaims.find((c) => Number(c.player_api_id) === Number(playerApiId))
+  const myClaim = myClaims.find((claim) => (
+    local
+      ? Number(claim.local_player_id) === Number(playerApiId)
+      : Number(claim.player_api_id) === Number(playerApiId)
+  ))
   const isOwner = myClaim?.status === 'approved'
   const visibleAffiliations = affiliations.filter(
     (affiliation) => isOwner || PUBLIC_AFFILIATION_STATUSES.has(affiliation.status),
@@ -477,7 +483,7 @@ export function ShowcaseSection({ playerApiId, playerName }) {
 
   // Claim strip shows for non-owners who either have a claim (show its status) or
   // can still claim an unclaimed profile.
-  const showClaimStrip = !isOwner && (myClaim ? true : claimStatus === 'unclaimed')
+  const showClaimStrip = !local && !isOwner && (myClaim ? true : claimStatus === 'unclaimed')
 
   const hasContent = reel.length > 0
     || visiblePhotos.length > 0
@@ -489,6 +495,7 @@ export function ShowcaseSection({ playerApiId, playerName }) {
   const reorderableIds = reel.filter((i) => !isSynthetic(i)).map((i) => i.id)
 
   const openClaimDialog = () => {
+    if (local) return
     if (!token) {
       openLoginModal()
       return
@@ -502,7 +509,7 @@ export function ShowcaseSection({ playerApiId, playerName }) {
   }
 
   const submitClaim = async () => {
-    if (claimBusy) return
+    if (local || claimBusy) return
     const pid = playerApiId
     setClaimBusy(true)
     setClaimError(null)
@@ -510,38 +517,38 @@ export function ShowcaseSection({ playerApiId, playerName }) {
       const response = await APIService.submitProfileClaim(pid, {
         relationship_type: claimRelationship,
         message: claimMessage.trim() || undefined,
-      })
+      }, { local })
       track('claim_submitted', { player_api_id: pid, relationship: claimRelationship })
-      if (activePlayerRef.current === pid) {
+      if (isActiveSubject()) {
         setCreatedClaim(response?.claim || null)
         setClaimDone(true)
       }
       await refresh()
     } catch (err) {
-      if (activePlayerRef.current === pid) {
+      if (isActiveSubject()) {
         setClaimError(err.body?.error || err.message || 'Failed to submit claim')
       }
     } finally {
-      if (activePlayerRef.current === pid) setClaimBusy(false)
+      if (isActiveSubject()) setClaimBusy(false)
     }
   }
 
   const copyVerificationCode = async (code) => {
     if (!code) return
-    const pid = playerApiId
     if (typeof navigator === 'undefined' || !navigator.clipboard) {
-      if (activePlayerRef.current === pid) setCodeCopyState('failed')
+      if (isActiveSubject()) setCodeCopyState('failed')
       return
     }
     try {
       await navigator.clipboard.writeText(code)
-      if (activePlayerRef.current === pid) setCodeCopyState('copied')
+      if (isActiveSubject()) setCodeCopyState('copied')
     } catch {
-      if (activePlayerRef.current === pid) setCodeCopyState('failed')
+      if (isActiveSubject()) setCodeCopyState('failed')
     }
   }
 
   const openVerificationDialog = () => {
+    if (local) return
     clearCloseTimer('verify')
     setProofUrl(myClaim?.verification_proof_url || '')
     setVerifyError(null)
@@ -553,8 +560,7 @@ export function ShowcaseSection({ playerApiId, playerName }) {
 
   const submitVerification = async () => {
     const url = proofUrl.trim()
-    if (!url || verifyBusy || !myClaim?.id) return
-    const pid = playerApiId
+    if (local || !url || verifyBusy || !myClaim?.id) return
     const claimId = myClaim.id
     setVerifyBusy(true)
     setVerifyError(null)
@@ -563,23 +569,23 @@ export function ShowcaseSection({ playerApiId, playerName }) {
     try {
       const response = await APIService.verifyClaimProof(claimId, { proof_url: url })
       const checkedClaim = response?.claim || null
-      if (activePlayerRef.current === pid) {
+      if (isActiveSubject()) {
         setVerifyResult(checkedClaim)
         setVerifyDone(true)
       }
       await refresh()
       if (checkedClaim?.verification_status === 'code_found') {
-        scheduleClose('verify', pid, () => {
+        scheduleClose('verify', subjectKey, () => {
           setVerifyOpen(false)
           setVerifyDone(false)
         })
       }
     } catch (err) {
-      if (activePlayerRef.current === pid) {
+      if (isActiveSubject()) {
         setVerifyError(err.body?.error || err.message || 'Failed to check this profile')
       }
     } finally {
-      if (activePlayerRef.current === pid) setVerifyBusy(false)
+      if (isActiveSubject()) setVerifyBusy(false)
     }
   }
 
@@ -601,23 +607,23 @@ export function ShowcaseSection({ playerApiId, playerName }) {
     setVideoBusy(true)
     setVideoError(null)
     try {
-      await APIService.addShowcaseReelItem(pid, { url, title: videoTitle.trim() || undefined })
-      if (activePlayerRef.current === pid) {
+      await APIService.addShowcaseReelItem(pid, { url, title: videoTitle.trim() || undefined }, { local })
+      if (isActiveSubject()) {
         setVideoDone(true)
         setVideoUrl('')
         setVideoTitle('')
       }
       await refresh()
-      scheduleClose('video', pid, () => {
+      scheduleClose('video', subjectKey, () => {
         setVideoOpen(false)
         setVideoDone(false)
       })
     } catch (err) {
-      if (activePlayerRef.current === pid) {
+      if (isActiveSubject()) {
         setVideoError(err.body?.error || err.message || 'Failed to add video')
       }
     } finally {
-      if (activePlayerRef.current === pid) setVideoBusy(false)
+      if (isActiveSubject()) setVideoBusy(false)
     }
   }
 
@@ -654,21 +660,21 @@ export function ShowcaseSection({ playerApiId, playerName }) {
       const created = await APIService.createShowcasePhoto(pid, {
         content_type: file.type,
         size_bytes: file.size,
-      })
+      }, { local })
       await APIService.uploadPhotoToUrl(created.upload, file)
-      await APIService.completeShowcasePhoto(pid, created.media.id)
-      if (activePlayerRef.current === pid) {
+      await APIService.completeShowcasePhoto(pid, created.media.id, { local })
+      if (isActiveSubject()) {
         setPhotoDone(true)
         setPhotoFile(null)
         setPhotoInputKey((key) => key + 1)
       }
       await refresh()
-      scheduleClose('photoUpload', pid, () => {
+      scheduleClose('photoUpload', subjectKey, () => {
         setPhotoOpen(false)
         setPhotoDone(false)
       })
     } catch (err) {
-      if (activePlayerRef.current === pid) {
+      if (isActiveSubject()) {
         setPhotoError(
           err.status === 503
             ? "Photo uploads aren't enabled yet"
@@ -677,7 +683,7 @@ export function ShowcaseSection({ playerApiId, playerName }) {
         await refresh()
       }
     } finally {
-      if (activePlayerRef.current === pid) setPhotoBusy(false)
+      if (isActiveSubject()) setPhotoBusy(false)
     }
   }
 
@@ -720,16 +726,16 @@ export function ShowcaseSection({ playerApiId, playerName }) {
         languages: profileForm.languages.trim() || null,
         agent_name: profileForm.agent_name.trim() || null,
         agent_contact_email: profileForm.agent_contact_email.trim() || null,
-      })
-      if (activePlayerRef.current === pid) setProfileDone(true)
+      }, { local })
+      if (isActiveSubject()) setProfileDone(true)
       await refresh()
-      scheduleClose('profile', pid, () => setProfileOpen(false))
+      scheduleClose('profile', subjectKey, () => setProfileOpen(false))
     } catch (err) {
-      if (activePlayerRef.current === pid) {
+      if (isActiveSubject()) {
         setProfileError(err.body?.error || err.message || 'Failed to update profile')
       }
     } finally {
-      if (activePlayerRef.current === pid) setProfileBusy(false)
+      if (isActiveSubject()) setProfileBusy(false)
     }
   }
 
@@ -743,12 +749,12 @@ export function ShowcaseSection({ playerApiId, playerName }) {
     const pid = playerApiId
     setReelBusy(true)
     try {
-      await APIService.reorderShowcaseReel(pid, { ordered_ids })
+      await APIService.reorderShowcaseReel(pid, { ordered_ids }, { local })
       await refresh()
     } catch {
       // ignore — order unchanged on failure
     } finally {
-      if (activePlayerRef.current === pid) setReelBusy(false)
+      if (isActiveSubject()) setReelBusy(false)
     }
   }
 
@@ -757,12 +763,12 @@ export function ShowcaseSection({ playerApiId, playerName }) {
     const pid = playerApiId
     setReelBusy(true)
     try {
-      await APIService.deleteShowcaseReelItem(pid, linkId)
+      await APIService.deleteShowcaseReelItem(pid, linkId, { local })
       await refresh()
     } catch {
       // ignore
     } finally {
-      if (activePlayerRef.current === pid) setReelBusy(false)
+      if (isActiveSubject()) setReelBusy(false)
     }
   }
 
@@ -776,10 +782,10 @@ export function ShowcaseSection({ playerApiId, playerName }) {
     setPhotoDeleteTarget(null)
   }
 
-  const finishPhotoAction = (pid) => {
-    if (activePlayerRef.current !== pid) return
+  const finishPhotoAction = (subject) => {
+    if (activeSubjectRef.current !== subject) return
     setPhotoActionDone(true)
-    scheduleClose('photoAction', pid, () => {
+    scheduleClose('photoAction', subject, () => {
       setPhotoActionOpen(false)
       setPhotoActionDone(false)
     })
@@ -806,16 +812,16 @@ export function ShowcaseSection({ playerApiId, playerName }) {
     const pid = playerApiId
     beginPhotoAction({ title: 'Reorder photos', done: 'Photo order updated' })
     try {
-      await APIService.reorderShowcasePhotos(pid, { ordered_ids })
-      if (activePlayerRef.current === pid) setPhotoActionDone(true)
+      await APIService.reorderShowcasePhotos(pid, { ordered_ids }, { local })
+      if (isActiveSubject()) setPhotoActionDone(true)
       await refresh()
-      finishPhotoAction(pid)
+      finishPhotoAction(subjectKey)
     } catch (err) {
-      if (activePlayerRef.current === pid) {
+      if (isActiveSubject()) {
         setPhotoActionError(err.body?.error || err.message || 'Failed to reorder photos')
       }
     } finally {
-      if (activePlayerRef.current === pid) setPhotoActionBusy(false)
+      if (isActiveSubject()) setPhotoActionBusy(false)
     }
   }
 
@@ -824,16 +830,16 @@ export function ShowcaseSection({ playerApiId, playerName }) {
     const pid = playerApiId
     beginPhotoAction({ title: 'Set primary photo', done: 'Primary photo updated' })
     try {
-      await APIService.setShowcasePhotoPrimary(pid, mediaId)
-      if (activePlayerRef.current === pid) setPhotoActionDone(true)
+      await APIService.setShowcasePhotoPrimary(pid, mediaId, { local })
+      if (isActiveSubject()) setPhotoActionDone(true)
       await refresh()
-      finishPhotoAction(pid)
+      finishPhotoAction(subjectKey)
     } catch (err) {
-      if (activePlayerRef.current === pid) {
+      if (isActiveSubject()) {
         setPhotoActionError(err.body?.error || err.message || 'Failed to set primary photo')
       }
     } finally {
-      if (activePlayerRef.current === pid) setPhotoActionBusy(false)
+      if (isActiveSubject()) setPhotoActionBusy(false)
     }
   }
 
@@ -842,16 +848,16 @@ export function ShowcaseSection({ playerApiId, playerName }) {
     const pid = playerApiId
     beginPhotoAction({ title: 'Delete photo', done: 'Photo deleted' })
     try {
-      await APIService.deleteShowcasePhoto(pid, mediaId)
-      if (activePlayerRef.current === pid) setPhotoActionDone(true)
+      await APIService.deleteShowcasePhoto(pid, mediaId, { local })
+      if (isActiveSubject()) setPhotoActionDone(true)
       await refresh()
-      finishPhotoAction(pid)
+      finishPhotoAction(subjectKey)
     } catch (err) {
-      if (activePlayerRef.current === pid) {
+      if (isActiveSubject()) {
         setPhotoActionError(err.body?.error || err.message || 'Failed to delete photo')
       }
     } finally {
-      if (activePlayerRef.current === pid) setPhotoActionBusy(false)
+      if (isActiveSubject()) setPhotoActionBusy(false)
     }
   }
 
@@ -949,15 +955,15 @@ export function ShowcaseSection({ playerApiId, playerName }) {
       await APIService.addPlayerAffiliation(pid, {
         ...affiliationPayload,
         season: season || undefined,
-      })
-      if (activePlayerRef.current === pid) setClubDone(true)
+      }, { local })
+      if (isActiveSubject()) setClubDone(true)
       await refresh()
-      scheduleClose('clubAdd', pid, () => {
+      scheduleClose('clubAdd', subjectKey, () => {
         setClubOpen(false)
         setClubDone(false)
       })
     } catch (err) {
-      if (activePlayerRef.current !== pid) return
+      if (!isActiveSubject()) return
       if (stage === 'create' && err.status === 409 && err.body?.existing) {
         setDuplicateClub(err.body.existing)
         setClubError('A matching community club already exists. Use that club instead.')
@@ -965,7 +971,7 @@ export function ShowcaseSection({ playerApiId, playerName }) {
         setClubError(err.body?.error || err.message || 'Failed to add club')
       }
     } finally {
-      if (activePlayerRef.current === pid) setClubBusy(false)
+      if (isActiveSubject()) setClubBusy(false)
     }
   }
 
@@ -986,20 +992,20 @@ export function ShowcaseSection({ playerApiId, playerName }) {
     setClubDeleteDone(false)
     setClubDeleteError(null)
     try {
-      await APIService.deletePlayerAffiliation(pid, affiliationId)
-      if (activePlayerRef.current === pid) setClubDeleteDone(true)
+      await APIService.deletePlayerAffiliation(pid, affiliationId, { local })
+      if (isActiveSubject()) setClubDeleteDone(true)
       await refresh()
-      scheduleClose('clubDelete', pid, () => {
+      scheduleClose('clubDelete', subjectKey, () => {
         setClubDeleteOpen(false)
         setClubDeleteDone(false)
         setClubDeleteTarget(null)
       })
     } catch (err) {
-      if (activePlayerRef.current === pid) {
+      if (isActiveSubject()) {
         setClubDeleteError(err.body?.error || err.message || 'Failed to remove club')
       }
     } finally {
-      if (activePlayerRef.current === pid) setClubDeleteBusy(false)
+      if (isActiveSubject()) setClubDeleteBusy(false)
     }
   }
 
@@ -1409,7 +1415,7 @@ export function ShowcaseSection({ playerApiId, playerName }) {
         )}
 
         {/* 5. Club-verified footage */}
-        {verified.length > 0 && (
+        {!local && verified.length > 0 && (
           <div className="space-y-3">
             <div className="flex flex-wrap items-center gap-2">
               <ShieldCheck className="h-4 w-4 text-emerald-600" />
@@ -1494,7 +1500,7 @@ export function ShowcaseSection({ playerApiId, playerName }) {
       </CardContent>
 
       {/* Claim dialog */}
-      <Dialog open={claimOpen} onOpenChange={setClaimOpen}>
+      <Dialog open={!local && claimOpen} onOpenChange={setClaimOpen}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Claim {playerName || 'this profile'}</DialogTitle>
@@ -1570,7 +1576,7 @@ export function ShowcaseSection({ playerApiId, playerName }) {
 
       {/* Social-proof verification dialog */}
       <Dialog
-        open={verifyOpen}
+        open={!local && verifyOpen}
         onOpenChange={(open) => {
           if (verifyBusy) return
           setVerifyOpen(open)

--- a/academy-watch-frontend/src/components/ShowcaseSection.jsx
+++ b/academy-watch-frontend/src/components/ShowcaseSection.jsx
@@ -36,6 +36,8 @@ import {
   Image as ImageIcon,
   ImagePlus,
   Star,
+  Copy,
+  Search,
 } from 'lucide-react'
 import { APIService } from '@/lib/api'
 import { track } from '@/lib/track'
@@ -126,6 +128,43 @@ function SectionHeader({ icon: Icon, eyebrow, title, action }) {
   )
 }
 
+function VerificationCode({ code, copyState, onCopy }) {
+  return (
+    <div className="rounded-lg border border-primary/20 bg-primary/5 p-4">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+        Your one-time code
+      </p>
+      <div className="mt-2 flex flex-wrap items-center justify-between gap-3">
+        <code className="text-xl font-bold tracking-[0.16em] text-foreground sm:text-2xl">
+          {code || 'Code unavailable'}
+        </code>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => onCopy(code)}
+          disabled={!code}
+          className="gap-1.5"
+          aria-label="Copy verification code"
+        >
+          {copyState === 'copied' ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+          <span role="status" aria-live="polite">
+            {copyState === 'copied' ? 'Copied' : copyState === 'failed' ? 'Copy failed' : 'Copy code'}
+          </span>
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function VerificationInstructions() {
+  return (
+    <p className="text-sm leading-relaxed text-muted-foreground">
+      Add this code to the bio of your public Instagram, TikTok, X, Facebook or YouTube profile, then paste that profile&apos;s URL below.
+    </p>
+  )
+}
+
 export function ShowcaseSection({ playerApiId, playerName }) {
   const { token } = useAuth()
   const { openLoginModal } = useAuthUI()
@@ -143,6 +182,16 @@ export function ShowcaseSection({ playerApiId, playerName }) {
   const [claimBusy, setClaimBusy] = useState(false)
   const [claimDone, setClaimDone] = useState(false)
   const [claimError, setClaimError] = useState(null)
+  const [createdClaim, setCreatedClaim] = useState(null)
+
+  // Social-proof verification dialog
+  const [verifyOpen, setVerifyOpen] = useState(false)
+  const [proofUrl, setProofUrl] = useState('')
+  const [verifyBusy, setVerifyBusy] = useState(false)
+  const [verifyDone, setVerifyDone] = useState(false)
+  const [verifyError, setVerifyError] = useState(null)
+  const [verifyResult, setVerifyResult] = useState(null)
+  const [codeCopyState, setCodeCopyState] = useState('idle')
 
   // Add-video dialog
   const [videoOpen, setVideoOpen] = useState(false)
@@ -238,6 +287,16 @@ export function ShowcaseSection({ playerApiId, playerName }) {
       clearAllCloseTimers()
       setClaimOpen(false)
       setClaimBusy(false)
+      setClaimDone(false)
+      setClaimError(null)
+      setCreatedClaim(null)
+      setVerifyOpen(false)
+      setProofUrl('')
+      setVerifyBusy(false)
+      setVerifyDone(false)
+      setVerifyError(null)
+      setVerifyResult(null)
+      setCodeCopyState('idle')
       setVideoOpen(false)
       setVideoBusy(false)
       setPhotoOpen(false)
@@ -347,6 +406,8 @@ export function ShowcaseSection({ playerApiId, playerName }) {
     clearCloseTimer('claim')
     setClaimError(null)
     setClaimDone(false)
+    setCreatedClaim(null)
+    setCodeCopyState('idle')
     setClaimOpen(true)
   }
 
@@ -356,20 +417,79 @@ export function ShowcaseSection({ playerApiId, playerName }) {
     setClaimBusy(true)
     setClaimError(null)
     try {
-      await APIService.submitProfileClaim(pid, {
+      const response = await APIService.submitProfileClaim(pid, {
         relationship_type: claimRelationship,
         message: claimMessage.trim() || undefined,
       })
       track('claim_submitted', { player_api_id: pid, relationship: claimRelationship })
-      if (activePlayerRef.current === pid) setClaimDone(true)
+      if (activePlayerRef.current === pid) {
+        setCreatedClaim(response?.claim || null)
+        setClaimDone(true)
+      }
       await refresh()
-      scheduleClose('claim', pid, () => setClaimOpen(false))
     } catch (err) {
       if (activePlayerRef.current === pid) {
         setClaimError(err.body?.error || err.message || 'Failed to submit claim')
       }
     } finally {
       if (activePlayerRef.current === pid) setClaimBusy(false)
+    }
+  }
+
+  const copyVerificationCode = async (code) => {
+    if (!code) return
+    const pid = playerApiId
+    if (typeof navigator === 'undefined' || !navigator.clipboard) {
+      if (activePlayerRef.current === pid) setCodeCopyState('failed')
+      return
+    }
+    try {
+      await navigator.clipboard.writeText(code)
+      if (activePlayerRef.current === pid) setCodeCopyState('copied')
+    } catch {
+      if (activePlayerRef.current === pid) setCodeCopyState('failed')
+    }
+  }
+
+  const openVerificationDialog = () => {
+    clearCloseTimer('verify')
+    setProofUrl(myClaim?.verification_proof_url || '')
+    setVerifyError(null)
+    setVerifyDone(false)
+    setVerifyResult(null)
+    setCodeCopyState('idle')
+    setVerifyOpen(true)
+  }
+
+  const submitVerification = async () => {
+    const url = proofUrl.trim()
+    if (!url || verifyBusy || !myClaim?.id) return
+    const pid = playerApiId
+    const claimId = myClaim.id
+    setVerifyBusy(true)
+    setVerifyError(null)
+    setVerifyDone(false)
+    setVerifyResult(null)
+    try {
+      const response = await APIService.verifyClaimProof(claimId, { proof_url: url })
+      const checkedClaim = response?.claim || null
+      if (activePlayerRef.current === pid) {
+        setVerifyResult(checkedClaim)
+        setVerifyDone(true)
+      }
+      await refresh()
+      if (checkedClaim?.verification_status === 'code_found') {
+        scheduleClose('verify', pid, () => {
+          setVerifyOpen(false)
+          setVerifyDone(false)
+        })
+      }
+    } catch (err) {
+      if (activePlayerRef.current === pid) {
+        setVerifyError(err.body?.error || err.message || 'Failed to check this profile')
+      }
+    } finally {
+      if (activePlayerRef.current === pid) setVerifyBusy(false)
     }
   }
 
@@ -1026,9 +1146,26 @@ export function ShowcaseSection({ playerApiId, playerName }) {
           <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border/70 pt-4">
             {myClaim ? (
               myClaim.status === 'pending' ? (
-                <p className="text-sm text-amber-700">
-                  Your claim for this profile is <span className="font-medium">pending review</span>.
-                </p>
+                <>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="text-sm text-amber-700">
+                      Your claim for this profile is <span className="font-medium">pending review</span>.
+                    </p>
+                    {myClaim.verification_status === 'code_found' ? (
+                      <Badge variant="outline" className="border-emerald-300 text-emerald-700">
+                        Code detected
+                      </Badge>
+                    ) : (
+                      <Badge variant="outline" className="border-amber-300 bg-amber-50 text-amber-800">
+                        Unverified
+                      </Badge>
+                    )}
+                  </div>
+                  <Button variant="outline" size="sm" onClick={openVerificationDialog} className="gap-1.5">
+                    <ShieldCheck className="h-3.5 w-3.5" />
+                    Verify it&apos;s you
+                  </Button>
+                </>
               ) : myClaim.status === 'rejected' ? (
                 <p className="text-sm text-muted-foreground">Your previous claim for this profile was not approved.</p>
               ) : (
@@ -1056,9 +1193,17 @@ export function ShowcaseSection({ playerApiId, playerName }) {
             </DialogDescription>
           </DialogHeader>
           {claimDone ? (
-            <div className="flex items-center gap-2 py-4 text-sm text-emerald-600">
-              <Check className="h-4 w-4" />
-              Submitted for review
+            <div className="space-y-4 py-2">
+              <div className="flex items-center gap-2 text-sm text-emerald-600" role="status" aria-live="polite">
+                <Check className="h-4 w-4" />
+                Submitted for review
+              </div>
+              <VerificationCode
+                code={createdClaim?.verification_code || myClaim?.verification_code}
+                copyState={codeCopyState}
+                onCopy={copyVerificationCode}
+              />
+              <VerificationInstructions />
             </div>
           ) : (
             <div className="space-y-4 py-2">
@@ -1088,7 +1233,11 @@ export function ShowcaseSection({ playerApiId, playerName }) {
               {claimError && <p className="text-xs text-destructive">{claimError}</p>}
             </div>
           )}
-          {!claimDone && (
+          {claimDone ? (
+            <DialogFooter>
+              <Button onClick={() => setClaimOpen(false)}>Done</Button>
+            </DialogFooter>
+          ) : (
             <DialogFooter>
               <Button variant="ghost" onClick={() => setClaimOpen(false)}>Cancel</Button>
               <Button onClick={submitClaim} disabled={claimBusy}>
@@ -1097,6 +1246,105 @@ export function ShowcaseSection({ playerApiId, playerName }) {
               </Button>
             </DialogFooter>
           )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Social-proof verification dialog */}
+      <Dialog
+        open={verifyOpen}
+        onOpenChange={(open) => {
+          if (verifyBusy) return
+          setVerifyOpen(open)
+          if (!open) {
+            clearCloseTimer('verify')
+            setVerifyDone(false)
+            setVerifyError(null)
+            setVerifyResult(null)
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Verify it&apos;s you</DialogTitle>
+            <DialogDescription>
+              A best-effort social profile check helps our admin review your claim. It does not approve the claim automatically.
+            </DialogDescription>
+          </DialogHeader>
+
+          {verifyDone ? (
+            <div className="space-y-3 py-2" role="status" aria-live="polite">
+              <div className={verifyResult?.verification_status === 'code_found'
+                ? 'flex items-start gap-2 text-sm font-medium text-emerald-700'
+                : 'flex items-start gap-2 text-sm font-medium text-amber-800'}>
+                {verifyResult?.verification_status === 'code_found' ? (
+                  <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0" />
+                ) : (
+                  <Search className="mt-0.5 h-4 w-4 shrink-0" />
+                )}
+                <span>
+                  {verifyResult?.verification_status === 'code_found'
+                    ? 'Code detected — an admin will review your claim'
+                    : "We couldn't find the code"}
+                </span>
+              </div>
+              {verifyResult?.verification_note && (
+                <p className="rounded-md bg-muted/60 px-3 py-2 text-xs leading-relaxed text-muted-foreground">
+                  {verifyResult.verification_note}
+                </p>
+              )}
+            </div>
+          ) : (
+            <div className="space-y-4 py-2">
+              <VerificationCode
+                code={myClaim?.verification_code}
+                copyState={codeCopyState}
+                onCopy={copyVerificationCode}
+              />
+              <VerificationInstructions />
+              <div className="space-y-2">
+                <Label htmlFor={`claim-proof-url-${playerApiId}`}>Public profile URL</Label>
+                <Input
+                  id={`claim-proof-url-${playerApiId}`}
+                  type="url"
+                  placeholder="https://instagram.com/your-profile"
+                  value={proofUrl}
+                  onChange={(event) => setProofUrl(event.target.value)}
+                  maxLength={500}
+                  disabled={verifyBusy}
+                  aria-invalid={Boolean(verifyError)}
+                  aria-describedby={verifyError ? `claim-proof-error-${playerApiId}` : undefined}
+                />
+              </div>
+              {verifyError && (
+                <p id={`claim-proof-error-${playerApiId}`} className="text-xs text-destructive" role="alert">
+                  {verifyError}
+                </p>
+              )}
+            </div>
+          )}
+
+          {!verifyDone ? (
+            <DialogFooter>
+              <Button variant="ghost" onClick={() => setVerifyOpen(false)} disabled={verifyBusy}>Cancel</Button>
+              <Button onClick={submitVerification} disabled={verifyBusy || !proofUrl.trim()}>
+                {verifyBusy && <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />}
+                {verifyBusy ? 'Checking…' : 'Verify'}
+              </Button>
+            </DialogFooter>
+          ) : verifyResult?.verification_status !== 'code_found' ? (
+            <DialogFooter>
+              <Button variant="ghost" onClick={() => setVerifyOpen(false)}>Close</Button>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setVerifyDone(false)
+                  setVerifyResult(null)
+                }}
+              >
+                Try again
+              </Button>
+            </DialogFooter>
+          ) : null}
         </DialogContent>
       </Dialog>
 

--- a/academy-watch-frontend/src/components/admin/AdminSidebar.jsx
+++ b/academy-watch-frontend/src/components/admin/AdminSidebar.jsx
@@ -21,6 +21,7 @@ import {
     Wrench,
     UserCog,
     Star,
+    Landmark,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible'
@@ -69,6 +70,7 @@ const sidebarGroups = [
         items: [
             { icon: Video, label: 'Film Room', href: '/admin/video' },
             { icon: Star, label: 'Showcase', href: '/admin/showcase' },
+            { icon: Landmark, label: 'Local Clubs', href: '/admin/local-clubs' },
         ],
     },
     {

--- a/academy-watch-frontend/src/components/showcase/VerificationCode.jsx
+++ b/academy-watch-frontend/src/components/showcase/VerificationCode.jsx
@@ -30,10 +30,12 @@ export function VerificationCode({ code, copyState, onCopy }) {
   )
 }
 
-export function VerificationInstructions() {
+export function VerificationInstructions({ includeProofStep = true }) {
   return (
     <p className="text-sm leading-relaxed text-muted-foreground">
-      Add this code to the bio of your public Instagram, TikTok, X, Facebook or YouTube profile, then paste that profile&apos;s URL below.
+      {includeProofStep
+        ? 'Add this code to the bio of your public Instagram, TikTok, X, Facebook or YouTube profile, then paste that profile\'s URL below.'
+        : 'Add this code to the bio of your public Instagram, TikTok, X, Facebook or YouTube profile and keep it there while your profile is reviewed.'}
     </p>
   )
 }

--- a/academy-watch-frontend/src/components/showcase/VerificationCode.jsx
+++ b/academy-watch-frontend/src/components/showcase/VerificationCode.jsx
@@ -1,0 +1,39 @@
+import { Check, Copy } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+export function VerificationCode({ code, copyState, onCopy }) {
+  return (
+    <div className="rounded-lg border border-primary/20 bg-primary/5 p-4">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+        Your one-time code
+      </p>
+      <div className="mt-2 flex flex-wrap items-center justify-between gap-3">
+        <code className="text-xl font-bold tracking-[0.16em] text-foreground sm:text-2xl">
+          {code || 'Code unavailable'}
+        </code>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => onCopy(code)}
+          disabled={!code}
+          className="gap-1.5"
+          aria-label="Copy verification code"
+        >
+          {copyState === 'copied' ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+          <span role="status" aria-live="polite">
+            {copyState === 'copied' ? 'Copied' : copyState === 'failed' ? 'Copy failed' : 'Copy code'}
+          </span>
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export function VerificationInstructions() {
+  return (
+    <p className="text-sm leading-relaxed text-muted-foreground">
+      Add this code to the bio of your public Instagram, TikTok, X, Facebook or YouTube profile, then paste that profile&apos;s URL below.
+    </p>
+  )
+}

--- a/academy-watch-frontend/src/lib/api.js
+++ b/academy-watch-frontend/src/lib/api.js
@@ -1212,6 +1212,13 @@ export class APIService {
         return this.request('/me/claims')
     }
 
+    static async verifyClaimProof(claimId, { proof_url }) {
+        return this.request(`/me/claims/${encodeURIComponent(claimId)}/verify`, {
+            method: 'POST',
+            body: JSON.stringify({ proof_url }),
+        })
+    }
+
     static async updateShowcaseProfile(playerId, payload) {
         if (!playerId) throw new Error('playerId is required')
         return this.request(`/players/${encodeURIComponent(playerId)}/showcase/profile`, {
@@ -1304,6 +1311,12 @@ export class APIService {
         return this.request(`/admin/showcase/claims/${encodeURIComponent(id)}/review`, {
             method: 'POST',
             body: JSON.stringify({ action, note }),
+        }, { admin: true })
+    }
+
+    static async adminRecheckClaim(claimId) {
+        return this.request(`/admin/showcase/claims/${encodeURIComponent(claimId)}/recheck`, {
+            method: 'POST',
         }, { admin: true })
     }
 

--- a/academy-watch-frontend/src/lib/api.js
+++ b/academy-watch-frontend/src/lib/api.js
@@ -1195,9 +1195,13 @@ export class APIService {
     // Public + owner-authed player showcase (highlight reel, self-reported
     // profile, club-verified footage, profile claims). Public reads pass no
     // third arg; owner writes rely on the stored user Bearer.
-    static async getPlayerShowcase(playerId) {
+    static _showcaseSubjectBase(playerId, opts = { local: false }) {
+        return `/${opts.local ? 'local-players' : 'players'}/${encodeURIComponent(playerId)}`
+    }
+
+    static async getPlayerShowcase(playerId, opts = { local: false }) {
         if (!playerId) throw new Error('playerId is required')
-        return this.request(`/players/${encodeURIComponent(playerId)}/showcase`)
+        return this.request(`${this._showcaseSubjectBase(playerId, opts)}/showcase`)
     }
 
     static async searchClubs(q) {
@@ -1212,17 +1216,29 @@ export class APIService {
         })
     }
 
-    static async addPlayerAffiliation(playerId, payload) {
-        if (!playerId) throw new Error('playerId is required')
-        return this.request(`/players/${encodeURIComponent(playerId)}/showcase/affiliations`, {
+    static async createLocalPlayer(payload) {
+        return this.request('/local-players', {
             method: 'POST',
             body: JSON.stringify(payload),
         })
     }
 
-    static async deletePlayerAffiliation(playerId, affId) {
+    static async getLocalPlayer(id) {
+        if (!id) throw new Error('id is required')
+        return this.request(`/local-players/${encodeURIComponent(id)}`)
+    }
+
+    static async addPlayerAffiliation(playerId, payload, opts = { local: false }) {
         if (!playerId) throw new Error('playerId is required')
-        return this.request(`/players/${encodeURIComponent(playerId)}/showcase/affiliations/${encodeURIComponent(affId)}`, {
+        return this.request(`${this._showcaseSubjectBase(playerId, opts)}/showcase/affiliations`, {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        })
+    }
+
+    static async deletePlayerAffiliation(playerId, affId, opts = { local: false }) {
+        if (!playerId) throw new Error('playerId is required')
+        return this.request(`${this._showcaseSubjectBase(playerId, opts)}/showcase/affiliations/${encodeURIComponent(affId)}`, {
             method: 'DELETE',
         })
     }
@@ -1268,8 +1284,9 @@ export class APIService {
         })
     }
 
-    static async submitProfileClaim(playerId, { relationship_type, message }) {
+    static async submitProfileClaim(playerId, { relationship_type, message }, opts = { local: false }) {
         if (!playerId) throw new Error('playerId is required')
+        if (opts.local) throw new Error('Local player claims are created automatically with the profile')
         return this.request(`/players/${encodeURIComponent(playerId)}/claim`, {
             method: 'POST',
             body: JSON.stringify({ relationship_type, message }),
@@ -1287,17 +1304,17 @@ export class APIService {
         })
     }
 
-    static async updateShowcaseProfile(playerId, payload) {
+    static async updateShowcaseProfile(playerId, payload, opts = { local: false }) {
         if (!playerId) throw new Error('playerId is required')
-        return this.request(`/players/${encodeURIComponent(playerId)}/showcase/profile`, {
+        return this.request(`${this._showcaseSubjectBase(playerId, opts)}/showcase/profile`, {
             method: 'PUT',
             body: JSON.stringify(payload),
         })
     }
 
-    static async createShowcasePhoto(playerId, { content_type, size_bytes }) {
+    static async createShowcasePhoto(playerId, { content_type, size_bytes }, opts = { local: false }) {
         if (!playerId) throw new Error('playerId is required')
-        return this.request(`/players/${encodeURIComponent(playerId)}/showcase/photos`, {
+        return this.request(`${this._showcaseSubjectBase(playerId, opts)}/showcase/photos`, {
             method: 'POST',
             body: JSON.stringify({ content_type, size_bytes }),
         })
@@ -1316,55 +1333,55 @@ export class APIService {
         }
     }
 
-    static async completeShowcasePhoto(playerId, mediaId) {
+    static async completeShowcasePhoto(playerId, mediaId, opts = { local: false }) {
         if (!playerId) throw new Error('playerId is required')
-        return this.request(`/players/${encodeURIComponent(playerId)}/showcase/photos/${encodeURIComponent(mediaId)}/complete`, {
+        return this.request(`${this._showcaseSubjectBase(playerId, opts)}/showcase/photos/${encodeURIComponent(mediaId)}/complete`, {
             method: 'POST',
         })
     }
 
-    static async reorderShowcasePhotos(playerId, { ordered_ids }) {
+    static async reorderShowcasePhotos(playerId, { ordered_ids }, opts = { local: false }) {
         if (!playerId) throw new Error('playerId is required')
-        return this.request(`/players/${encodeURIComponent(playerId)}/showcase/photos/order`, {
+        return this.request(`${this._showcaseSubjectBase(playerId, opts)}/showcase/photos/order`, {
             method: 'PATCH',
             body: JSON.stringify({ ordered_ids }),
         })
     }
 
-    static async setShowcasePhotoPrimary(playerId, mediaId) {
+    static async setShowcasePhotoPrimary(playerId, mediaId, opts = { local: false }) {
         if (!playerId) throw new Error('playerId is required')
-        return this.request(`/players/${encodeURIComponent(playerId)}/showcase/photos/${encodeURIComponent(mediaId)}`, {
+        return this.request(`${this._showcaseSubjectBase(playerId, opts)}/showcase/photos/${encodeURIComponent(mediaId)}`, {
             method: 'PATCH',
             body: JSON.stringify({ is_primary: true }),
         })
     }
 
-    static async deleteShowcasePhoto(playerId, mediaId) {
+    static async deleteShowcasePhoto(playerId, mediaId, opts = { local: false }) {
         if (!playerId) throw new Error('playerId is required')
-        return this.request(`/players/${encodeURIComponent(playerId)}/showcase/photos/${encodeURIComponent(mediaId)}`, {
+        return this.request(`${this._showcaseSubjectBase(playerId, opts)}/showcase/photos/${encodeURIComponent(mediaId)}`, {
             method: 'DELETE',
         })
     }
 
-    static async addShowcaseReelItem(playerId, { url, title }) {
+    static async addShowcaseReelItem(playerId, { url, title }, opts = { local: false }) {
         if (!playerId) throw new Error('playerId is required')
-        return this.request(`/players/${encodeURIComponent(playerId)}/showcase/reel`, {
+        return this.request(`${this._showcaseSubjectBase(playerId, opts)}/showcase/reel`, {
             method: 'POST',
             body: JSON.stringify({ url, title }),
         })
     }
 
-    static async reorderShowcaseReel(playerId, { ordered_ids }) {
+    static async reorderShowcaseReel(playerId, { ordered_ids }, opts = { local: false }) {
         if (!playerId) throw new Error('playerId is required')
-        return this.request(`/players/${encodeURIComponent(playerId)}/showcase/reel/order`, {
+        return this.request(`${this._showcaseSubjectBase(playerId, opts)}/showcase/reel/order`, {
             method: 'PATCH',
             body: JSON.stringify({ ordered_ids }),
         })
     }
 
-    static async deleteShowcaseReelItem(playerId, linkId) {
+    static async deleteShowcaseReelItem(playerId, linkId, opts = { local: false }) {
         if (!playerId) throw new Error('playerId is required')
-        return this.request(`/players/${encodeURIComponent(playerId)}/showcase/reel/${encodeURIComponent(linkId)}`, {
+        return this.request(`${this._showcaseSubjectBase(playerId, opts)}/showcase/reel/${encodeURIComponent(linkId)}`, {
             method: 'DELETE',
         })
     }
@@ -1453,6 +1470,32 @@ export class APIService {
         return this.request(`/admin/local-clubs/${encodeURIComponent(id)}/link-api`, {
             method: 'POST',
             body: JSON.stringify({ team_api_id }),
+        }, { admin: true })
+    }
+
+    static async adminListLocalPlayers(params = {}) {
+        const query = new URLSearchParams(params).toString()
+        return this.request(`/admin/local-players${query ? '?' + query : ''}`, {}, { admin: true })
+    }
+
+    static async adminReviewLocalPlayer(id, { action, note }) {
+        return this.request(`/admin/local-players/${encodeURIComponent(id)}/review`, {
+            method: 'POST',
+            body: JSON.stringify({ action, note }),
+        }, { admin: true })
+    }
+
+    static async adminMergeLocalPlayer(id, { into_local_player_id }) {
+        return this.request(`/admin/local-players/${encodeURIComponent(id)}/merge`, {
+            method: 'POST',
+            body: JSON.stringify({ into_local_player_id }),
+        }, { admin: true })
+    }
+
+    static async adminLinkLocalPlayerApi(id, { player_api_id }) {
+        return this.request(`/admin/local-players/${encodeURIComponent(id)}/link-api`, {
+            method: 'POST',
+            body: JSON.stringify({ player_api_id }),
         }, { admin: true })
     }
 

--- a/academy-watch-frontend/src/lib/api.js
+++ b/academy-watch-frontend/src/lib/api.js
@@ -1220,6 +1220,57 @@ export class APIService {
         })
     }
 
+    static async createShowcasePhoto(playerId, { content_type, size_bytes }) {
+        if (!playerId) throw new Error('playerId is required')
+        return this.request(`/players/${encodeURIComponent(playerId)}/showcase/photos`, {
+            method: 'POST',
+            body: JSON.stringify({ content_type, size_bytes }),
+        })
+    }
+
+    static async uploadPhotoToUrl(upload, file) {
+        const response = await fetch(upload.url, {
+            method: 'PUT',
+            headers: upload.headers,
+            body: file,
+        })
+        if (!response.ok) {
+            const err = new Error(`Photo upload failed (HTTP ${response.status})`)
+            err.status = response.status
+            throw err
+        }
+    }
+
+    static async completeShowcasePhoto(playerId, mediaId) {
+        if (!playerId) throw new Error('playerId is required')
+        return this.request(`/players/${encodeURIComponent(playerId)}/showcase/photos/${encodeURIComponent(mediaId)}/complete`, {
+            method: 'POST',
+        })
+    }
+
+    static async reorderShowcasePhotos(playerId, { ordered_ids }) {
+        if (!playerId) throw new Error('playerId is required')
+        return this.request(`/players/${encodeURIComponent(playerId)}/showcase/photos/order`, {
+            method: 'PATCH',
+            body: JSON.stringify({ ordered_ids }),
+        })
+    }
+
+    static async setShowcasePhotoPrimary(playerId, mediaId) {
+        if (!playerId) throw new Error('playerId is required')
+        return this.request(`/players/${encodeURIComponent(playerId)}/showcase/photos/${encodeURIComponent(mediaId)}`, {
+            method: 'PATCH',
+            body: JSON.stringify({ is_primary: true }),
+        })
+    }
+
+    static async deleteShowcasePhoto(playerId, mediaId) {
+        if (!playerId) throw new Error('playerId is required')
+        return this.request(`/players/${encodeURIComponent(playerId)}/showcase/photos/${encodeURIComponent(mediaId)}`, {
+            method: 'DELETE',
+        })
+    }
+
     static async addShowcaseReelItem(playerId, { url, title }) {
         if (!playerId) throw new Error('playerId is required')
         return this.request(`/players/${encodeURIComponent(playerId)}/showcase/reel`, {
@@ -1265,6 +1316,18 @@ export class APIService {
         return this.request(`/admin/showcase/profiles/${encodeURIComponent(playerApiId)}/review`, {
             method: 'POST',
             body: JSON.stringify({ action }),
+        }, { admin: true })
+    }
+
+    static async adminListShowcaseMedia(params = {}) {
+        const query = new URLSearchParams(params).toString()
+        return this.request(`/admin/showcase/media${query ? '?' + query : ''}`, {}, { admin: true })
+    }
+
+    static async adminReviewShowcaseMedia(mediaId, { action, note }) {
+        return this.request(`/admin/showcase/media/${encodeURIComponent(mediaId)}/review`, {
+            method: 'POST',
+            body: JSON.stringify({ action, note }),
         }, { admin: true })
     }
 

--- a/academy-watch-frontend/src/lib/api.js
+++ b/academy-watch-frontend/src/lib/api.js
@@ -1200,6 +1200,33 @@ export class APIService {
         return this.request(`/players/${encodeURIComponent(playerId)}/showcase`)
     }
 
+    static async searchClubs(q) {
+        const query = new URLSearchParams({ q: q || '' }).toString()
+        return this.request(`/clubs/search?${query}`)
+    }
+
+    static async createLocalClub(payload) {
+        return this.request('/local-clubs', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        })
+    }
+
+    static async addPlayerAffiliation(playerId, payload) {
+        if (!playerId) throw new Error('playerId is required')
+        return this.request(`/players/${encodeURIComponent(playerId)}/showcase/affiliations`, {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        })
+    }
+
+    static async deletePlayerAffiliation(playerId, affId) {
+        if (!playerId) throw new Error('playerId is required')
+        return this.request(`/players/${encodeURIComponent(playerId)}/showcase/affiliations/${encodeURIComponent(affId)}`, {
+            method: 'DELETE',
+        })
+    }
+
     static async submitProfileClaim(playerId, { relationship_type, message }) {
         if (!playerId) throw new Error('playerId is required')
         return this.request(`/players/${encodeURIComponent(playerId)}/claim`, {
@@ -1339,6 +1366,44 @@ export class APIService {
 
     static async adminReviewShowcaseMedia(mediaId, { action, note }) {
         return this.request(`/admin/showcase/media/${encodeURIComponent(mediaId)}/review`, {
+            method: 'POST',
+            body: JSON.stringify({ action, note }),
+        }, { admin: true })
+    }
+
+    static async adminListLocalClubs(params = {}) {
+        const query = new URLSearchParams(params).toString()
+        return this.request(`/admin/local-clubs${query ? '?' + query : ''}`, {}, { admin: true })
+    }
+
+    static async adminReviewLocalClub(id, { action, note }) {
+        return this.request(`/admin/local-clubs/${encodeURIComponent(id)}/review`, {
+            method: 'POST',
+            body: JSON.stringify({ action, note }),
+        }, { admin: true })
+    }
+
+    static async adminMergeLocalClub(id, { into_local_club_id }) {
+        return this.request(`/admin/local-clubs/${encodeURIComponent(id)}/merge`, {
+            method: 'POST',
+            body: JSON.stringify({ into_local_club_id }),
+        }, { admin: true })
+    }
+
+    static async adminLinkLocalClubApi(id, { team_api_id }) {
+        return this.request(`/admin/local-clubs/${encodeURIComponent(id)}/link-api`, {
+            method: 'POST',
+            body: JSON.stringify({ team_api_id }),
+        }, { admin: true })
+    }
+
+    static async adminListAffiliations(params = {}) {
+        const query = new URLSearchParams(params).toString()
+        return this.request(`/admin/showcase/affiliations${query ? '?' + query : ''}`, {}, { admin: true })
+    }
+
+    static async adminReviewAffiliation(id, { action, note }) {
+        return this.request(`/admin/showcase/affiliations/${encodeURIComponent(id)}/review`, {
             method: 'POST',
             body: JSON.stringify({ action, note }),
         }, { admin: true })

--- a/academy-watch-frontend/src/lib/api.js
+++ b/academy-watch-frontend/src/lib/api.js
@@ -1227,6 +1227,47 @@ export class APIService {
         })
     }
 
+    static async submitClubClaim(payload) {
+        return this.request('/clubs/claim', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+        })
+    }
+
+    static async getMyClubClaims() {
+        return this.request('/me/club-claims')
+    }
+
+    static async verifyClubClaimProof(claimId, { proof_url }) {
+        return this.request(`/me/club-claims/${encodeURIComponent(claimId)}/verify`, {
+            method: 'POST',
+            body: JSON.stringify({ proof_url }),
+        })
+    }
+
+    static async getMyClub() {
+        return this.request('/me/club')
+    }
+
+    static async confirmClubAffiliation(affId) {
+        return this.request(`/me/club/affiliations/${encodeURIComponent(affId)}/confirm`, {
+            method: 'POST',
+        })
+    }
+
+    static async rejectClubAffiliation(affId, { note }) {
+        return this.request(`/me/club/affiliations/${encodeURIComponent(affId)}/reject`, {
+            method: 'POST',
+            body: JSON.stringify({ note }),
+        })
+    }
+
+    static async vouchPlayerClaim(claimId) {
+        return this.request(`/me/club/player-claims/${encodeURIComponent(claimId)}/vouch`, {
+            method: 'POST',
+        })
+    }
+
     static async submitProfileClaim(playerId, { relationship_type, message }) {
         if (!playerId) throw new Error('playerId is required')
         return this.request(`/players/${encodeURIComponent(playerId)}/claim`, {
@@ -1368,6 +1409,24 @@ export class APIService {
         return this.request(`/admin/showcase/media/${encodeURIComponent(mediaId)}/review`, {
             method: 'POST',
             body: JSON.stringify({ action, note }),
+        }, { admin: true })
+    }
+
+    static async adminListClubClaims(params = {}) {
+        const query = new URLSearchParams(params).toString()
+        return this.request(`/admin/club-claims${query ? '?' + query : ''}`, {}, { admin: true })
+    }
+
+    static async adminReviewClubClaim(id, { action, note }) {
+        return this.request(`/admin/club-claims/${encodeURIComponent(id)}/review`, {
+            method: 'POST',
+            body: JSON.stringify({ action, note }),
+        }, { admin: true })
+    }
+
+    static async adminRecheckClubClaim(id) {
+        return this.request(`/admin/club-claims/${encodeURIComponent(id)}/recheck`, {
+            method: 'POST',
         }, { admin: true })
     }
 

--- a/academy-watch-frontend/src/pages/LocalPlayerCreate.jsx
+++ b/academy-watch-frontend/src/pages/LocalPlayerCreate.jsx
@@ -1,0 +1,352 @@
+import { useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { ArrowRight, CheckCircle2, Loader2, LogIn, ShieldCheck, UserPlus } from 'lucide-react'
+import { APIService } from '@/lib/api'
+import { useAuth, useAuthUI } from '@/context/AuthContext'
+import { VerificationCode, VerificationInstructions } from '@/components/showcase/VerificationCode'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+
+const EMPTY_FORM = {
+  display_name: '',
+  birth_year: '',
+  position: '',
+  country: '',
+  city: '',
+  relationship_type: 'player',
+}
+
+const RELATIONSHIPS = [
+  { value: 'player', label: 'Player' },
+  { value: 'agent', label: 'Agent' },
+  { value: 'guardian', label: 'Parent / Guardian' },
+]
+
+function SignedOutState({ onSignIn }) {
+  return (
+    <div className="mx-auto flex min-h-[70vh] max-w-6xl items-center justify-center px-4 py-12 sm:px-6 lg:px-8">
+      <Card className="w-full max-w-md overflow-hidden border-border/80">
+        <CardContent className="flex flex-col items-center gap-4 px-8 py-12 text-center">
+          <span className="inline-flex h-14 w-14 items-center justify-center rounded-full bg-amber-100 text-amber-900">
+            <UserPlus className="h-6 w-6" />
+          </span>
+          <div className="space-y-2">
+            <h1 className="text-xl font-bold tracking-tight text-foreground">Sign in to create a player profile</h1>
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              Your account will be linked to the profile so you can manage its showcase after review.
+            </p>
+          </div>
+          <Button onClick={onSignIn}>
+            <LogIn className="mr-1.5 h-4 w-4" />
+            Sign in
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function AuthenticatedLocalPlayerCreate({ token }) {
+  const [form, setForm] = useState(EMPTY_FORM)
+  const [errors, setErrors] = useState({})
+  const [submitting, setSubmitting] = useState(false)
+  const [requestError, setRequestError] = useState(null)
+  const [duplicate, setDuplicate] = useState(null)
+  const [created, setCreated] = useState(null)
+  const [copyState, setCopyState] = useState('idle')
+  const activeTokenRef = useRef(token)
+
+  useEffect(() => {
+    activeTokenRef.current = token
+    return () => { activeTokenRef.current = null }
+  }, [token])
+
+  const updateField = (field, value) => {
+    setForm((current) => ({ ...current, [field]: value }))
+    setErrors((current) => {
+      if (!current[field]) return current
+      const next = { ...current }
+      delete next[field]
+      return next
+    })
+    setRequestError(null)
+    setDuplicate(null)
+  }
+
+  const validate = () => {
+    const next = {}
+    const name = form.display_name.trim()
+    const year = form.birth_year.trim()
+    if (name.length < 2) next.display_name = 'Enter at least 2 characters.'
+    if (name.length > 200) next.display_name = 'Use 200 characters or fewer.'
+    if (year && !Number.isInteger(Number(year))) {
+      next.birth_year = 'Enter a whole year, for example 2008.'
+    }
+    return next
+  }
+
+  const submit = async (event) => {
+    event.preventDefault()
+    if (submitting) return
+    const validationErrors = validate()
+    setErrors(validationErrors)
+    if (Object.keys(validationErrors).length > 0) return
+
+    const birthYear = form.birth_year.trim()
+    const payload = {
+      display_name: form.display_name.trim(),
+      relationship_type: form.relationship_type,
+    }
+    if (birthYear) payload.birth_year = Number(birthYear)
+    if (form.position.trim()) payload.position = form.position.trim()
+    if (form.country.trim()) payload.country = form.country.trim()
+    if (form.city.trim()) payload.city = form.city.trim()
+
+    setSubmitting(true)
+    setRequestError(null)
+    setDuplicate(null)
+    const requestToken = token
+    try {
+      const response = await APIService.createLocalPlayer(payload)
+      if (activeTokenRef.current !== requestToken) return
+      setCreated(response)
+      setCopyState('idle')
+    } catch (error) {
+      if (activeTokenRef.current !== requestToken) return
+      if (error.status === 409 && error.body?.existing) {
+        setDuplicate(error.body.existing)
+      } else {
+        setRequestError(error.body?.error || error.message || 'Failed to create this profile')
+      }
+    } finally {
+      if (activeTokenRef.current === requestToken) setSubmitting(false)
+    }
+  }
+
+  const copyVerificationCode = async (code) => {
+    if (!code) return
+    if (typeof navigator === 'undefined' || !navigator.clipboard) {
+      setCopyState('failed')
+      return
+    }
+    try {
+      await navigator.clipboard.writeText(code)
+      setCopyState('copied')
+    } catch {
+      setCopyState('failed')
+    }
+  }
+
+  if (created?.player) {
+    return (
+      <div className="min-h-screen bg-gradient-to-b from-amber-50/60 via-background to-secondary/50">
+        <div className="mx-auto max-w-2xl px-4 py-10 sm:px-6 lg:px-8">
+          <Card className="overflow-hidden border-amber-200 shadow-sm">
+            <CardHeader className="border-b border-amber-200/70 bg-amber-50/70">
+              <div className="flex items-start gap-3">
+                <span className="mt-0.5 inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-emerald-700">
+                  <CheckCircle2 className="h-5 w-5" />
+                </span>
+                <div>
+                  <CardTitle>Profile created and claimed</CardTitle>
+                  <CardDescription className="mt-1">
+                    {created.player.display_name} is now waiting for Academy Watch review.
+                  </CardDescription>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-5 py-6">
+              <div className="flex items-start gap-2 rounded-lg border border-border/70 bg-secondary/40 p-3 text-sm text-foreground/80">
+                <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                Keep this code safe. It belongs to the claim automatically created for your account.
+              </div>
+              <VerificationCode
+                code={created.claim?.verification_code}
+                copyState={copyState}
+                onCopy={copyVerificationCode}
+              />
+              <VerificationInstructions includeProofStep={false} />
+              <Button asChild className="w-full sm:w-auto">
+                <Link to={`/local-players/${created.player.id}`}>
+                  View your profile
+                  <ArrowRight className="ml-1.5 h-4 w-4" />
+                </Link>
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-amber-50/60 via-background to-secondary/50">
+      <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mb-6 space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-800">Community profiles</p>
+          <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">Create a player profile</h1>
+          <p className="max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
+            For players outside official API-Football coverage. Details are self-reported and the profile stays private until review.
+          </p>
+        </div>
+
+        {duplicate ? (
+          <Alert className="mb-5 border-amber-300 bg-amber-50">
+            <UserPlus className="h-4 w-4 text-amber-800" />
+            <AlertDescription className="text-amber-950">
+              <span className="font-semibold">This player may already exist.</span>{' '}
+              <Link to={`/local-players/${duplicate.id}`} className="font-semibold text-primary hover:underline">
+                View {duplicate.display_name || 'the existing profile'}
+              </Link>
+              .
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        {requestError ? (
+          <Alert className="mb-5 border-rose-300 bg-rose-50">
+            <AlertDescription className="text-rose-800">{requestError}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Player details</CardTitle>
+            <CardDescription>Only the display name is required. You can add more showcase details later.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form className="space-y-5" onSubmit={submit} noValidate>
+              <div className="space-y-2">
+                <Label htmlFor="local-player-display-name">Display name</Label>
+                <Input
+                  id="local-player-display-name"
+                  value={form.display_name}
+                  onChange={(event) => updateField('display_name', event.target.value)}
+                  placeholder="Player name"
+                  minLength={2}
+                  maxLength={200}
+                  autoComplete="name"
+                  disabled={submitting}
+                  aria-invalid={Boolean(errors.display_name)}
+                  aria-describedby={errors.display_name ? 'local-player-display-name-error' : undefined}
+                />
+                {errors.display_name ? (
+                  <p id="local-player-display-name-error" className="text-xs text-destructive" role="alert">
+                    {errors.display_name}
+                  </p>
+                ) : null}
+              </div>
+
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="local-player-birth-year">Birth year (optional)</Label>
+                  <Input
+                    id="local-player-birth-year"
+                    type="number"
+                    step="1"
+                    inputMode="numeric"
+                    value={form.birth_year}
+                    onChange={(event) => updateField('birth_year', event.target.value)}
+                    placeholder="e.g. 2008"
+                    disabled={submitting}
+                    aria-invalid={Boolean(errors.birth_year)}
+                    aria-describedby={errors.birth_year ? 'local-player-birth-year-error' : undefined}
+                  />
+                  {errors.birth_year ? (
+                    <p id="local-player-birth-year-error" className="text-xs text-destructive" role="alert">
+                      {errors.birth_year}
+                    </p>
+                  ) : null}
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="local-player-position">Position (optional)</Label>
+                  <Input
+                    id="local-player-position"
+                    value={form.position}
+                    onChange={(event) => updateField('position', event.target.value)}
+                    placeholder="e.g. Centre-forward"
+                    disabled={submitting}
+                  />
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="local-player-country">Country (optional)</Label>
+                  <Input
+                    id="local-player-country"
+                    value={form.country}
+                    onChange={(event) => updateField('country', event.target.value)}
+                    autoComplete="country-name"
+                    disabled={submitting}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="local-player-city">City (optional)</Label>
+                  <Input
+                    id="local-player-city"
+                    value={form.city}
+                    onChange={(event) => updateField('city', event.target.value)}
+                    autoComplete="address-level2"
+                    disabled={submitting}
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="local-player-relationship">Your relationship to the player</Label>
+                <Select
+                  value={form.relationship_type}
+                  onValueChange={(value) => updateField('relationship_type', value)}
+                  disabled={submitting}
+                >
+                  <SelectTrigger id="local-player-relationship">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {RELATIONSHIPS.map((relationship) => (
+                      <SelectItem key={relationship.value} value={relationship.value}>
+                        {relationship.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="flex flex-col-reverse gap-2 border-t border-border/70 pt-5 sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-xs leading-relaxed text-muted-foreground">
+                  Submitting creates a claim for your account automatically.
+                </p>
+                <Button type="submit" disabled={submitting} className="shrink-0">
+                  {submitting ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <UserPlus className="mr-1.5 h-4 w-4" />}
+                  {submitting ? 'Creating…' : 'Create profile'}
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+export function LocalPlayerCreate() {
+  const { token } = useAuth()
+  const { openLoginModal } = useAuthUI()
+
+  if (!token) return <SignedOutState onSignIn={openLoginModal} />
+
+  return <AuthenticatedLocalPlayerCreate key={token} token={token} />
+}
+
+export default LocalPlayerCreate

--- a/academy-watch-frontend/src/pages/LocalPlayerCreate.jsx
+++ b/academy-watch-frontend/src/pages/LocalPlayerCreate.jsx
@@ -123,10 +123,11 @@ function AuthenticatedLocalPlayerCreate({ token }) {
       setCopyState('idle')
     } catch (error) {
       if (activeTokenRef.current !== requestToken) return
-      if (error.status === 409 && error.body?.existing) {
-        setDuplicate(error.body.existing)
+      if (error?.status === 409) {
+        const existing = error.body?.existing
+        setDuplicate(existing && typeof existing === 'object' ? existing : {})
       } else {
-        setRequestError(error.body?.error || error.message || 'Failed to create this profile')
+        setRequestError(error?.body?.error || error?.message || 'Failed to create this profile')
       }
     } finally {
       if (activeTokenRef.current === requestToken) setSubmitting(false)
@@ -189,6 +190,14 @@ function AuthenticatedLocalPlayerCreate({ token }) {
     )
   }
 
+  const duplicateId = duplicate?.id
+  const duplicateName = duplicate?.display_name
+  const duplicateStatus = duplicate?.status
+  const duplicateDetails = [
+    duplicateName || null,
+    duplicateStatus ? `Status: ${duplicateStatus}` : null,
+  ].filter(Boolean).join(' · ')
+
   return (
     <div className="min-h-screen bg-gradient-to-b from-amber-50/60 via-background to-secondary/50">
       <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
@@ -204,11 +213,15 @@ function AuthenticatedLocalPlayerCreate({ token }) {
           <Alert className="mb-5 border-amber-300 bg-amber-50">
             <UserPlus className="h-4 w-4 text-amber-800" />
             <AlertDescription className="text-amber-950">
-              <span className="font-semibold">This player may already exist.</span>{' '}
-              <Link to={`/local-players/${duplicate.id}`} className="font-semibold text-primary hover:underline">
-                View {duplicate.display_name || 'the existing profile'}
-              </Link>
-              .
+              <span className="font-semibold">A player with this name and birth year may already exist.</span>
+              {duplicateId ? (
+                <span className="mt-1 block">
+                  {duplicateDetails ? <span>{duplicateDetails} — </span> : null}
+                  <Link to={`/local-players/${duplicateId}`} className="font-semibold text-primary hover:underline">
+                    View existing profile
+                  </Link>
+                </span>
+              ) : null}
             </AlertDescription>
           </Alert>
         ) : null}

--- a/academy-watch-frontend/src/pages/LocalPlayerPage.jsx
+++ b/academy-watch-frontend/src/pages/LocalPlayerPage.jsx
@@ -1,0 +1,184 @@
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { AlertTriangle, ArrowRight, MapPin, ShieldAlert, UserPlus } from 'lucide-react'
+import { APIService } from '@/lib/api'
+import { ShowcaseSection } from '@/components/ShowcaseSection'
+import { useAuth } from '@/context/AuthContext'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+
+function LoadingState() {
+  return (
+    <div className="mx-auto max-w-6xl space-y-5 px-4 py-8 sm:px-6 lg:px-8" aria-busy="true">
+      <p className="sr-only" role="status" aria-live="polite">Loading player profile…</p>
+      <div className="space-y-3 py-4">
+        <Skeleton className="h-4 w-36" />
+        <Skeleton className="h-10 w-72 max-w-full" />
+        <Skeleton className="h-5 w-96 max-w-full" />
+      </div>
+      <Skeleton className="h-20 w-full rounded-xl" />
+      <Skeleton className="h-80 w-full rounded-xl" />
+    </div>
+  )
+}
+
+function MissingState() {
+  return (
+    <div className="mx-auto flex min-h-[65vh] max-w-6xl items-center justify-center px-4 py-12 sm:px-6 lg:px-8">
+      <Card className="w-full max-w-xl overflow-hidden border-dashed">
+        <CardContent className="flex flex-col items-center gap-4 px-6 py-12 text-center">
+          <span className="inline-flex h-14 w-14 items-center justify-center rounded-full bg-amber-100 text-amber-800">
+            <AlertTriangle className="h-6 w-6" />
+          </span>
+          <div className="space-y-2">
+            <h1 className="text-xl font-bold tracking-tight text-foreground">
+              This profile doesn&apos;t exist or isn&apos;t public yet
+            </h1>
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              It may still be waiting for review, or the profile link may be incorrect.
+            </p>
+          </div>
+          <Link
+            to="/local-players/new"
+            className="inline-flex items-center gap-1.5 text-sm font-semibold text-primary hover:underline"
+          >
+            <UserPlus className="h-4 w-4" />
+            Create a player profile
+            <ArrowRight className="h-3.5 w-3.5" />
+          </Link>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function LocalPlayerProfile({ numericPlayerId, onRetry }) {
+  const [player, setPlayer] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [notFound, setNotFound] = useState(false)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+    APIService.getLocalPlayer(numericPlayerId)
+      .then((response) => {
+        if (cancelled) return
+        if (!response?.player) {
+          setNotFound(true)
+          return
+        }
+        setPlayer(response.player)
+      })
+      .catch((requestError) => {
+        if (cancelled) return
+        if (requestError.status === 404) {
+          setNotFound(true)
+        } else {
+          setError(requestError.body?.error || requestError.message || 'Failed to load this profile')
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+
+    return () => { cancelled = true }
+  }, [numericPlayerId])
+
+  if (loading) return <LoadingState />
+  if (notFound) return <MissingState />
+
+  if (error || !player) {
+    return (
+      <div className="mx-auto flex min-h-[65vh] max-w-6xl items-center justify-center px-4 py-12 sm:px-6 lg:px-8">
+        <Card className="w-full max-w-xl">
+          <CardContent className="flex flex-col items-center gap-4 px-6 py-12 text-center">
+            <AlertTriangle className="h-8 w-8 text-rose-600" />
+            <div>
+              <h1 className="font-semibold text-foreground">We couldn&apos;t load this profile</h1>
+              <p className="mt-1 text-sm text-muted-foreground">{error || 'Try again in a moment.'}</p>
+            </div>
+            <Button variant="outline" onClick={onRetry}>
+              Try again
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  const location = [player.city, player.country].filter(Boolean).join(', ')
+  const details = [
+    player.birth_year != null ? `Born ${player.birth_year}` : null,
+    player.position || null,
+  ].filter(Boolean)
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-amber-50/60 via-background to-secondary/50">
+      <div className="mx-auto max-w-6xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
+        <header className="relative overflow-hidden rounded-2xl border border-border/70 bg-card px-5 py-7 shadow-sm sm:px-8 sm:py-9">
+          <div className="pointer-events-none absolute -right-20 -top-24 h-64 w-64 rounded-full bg-amber-200/25 blur-3xl" />
+          <div className="relative space-y-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-800">Community player</p>
+              {player.status === 'pending' ? (
+                <Badge variant="outline" className="border-amber-300 bg-amber-50 text-amber-800">
+                  Pending review
+                </Badge>
+              ) : null}
+            </div>
+            <h1 className="break-words text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+              {player.display_name}
+            </h1>
+            {details.length > 0 || location ? (
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-muted-foreground sm:text-base">
+                {details.map((detail) => <span key={detail}>{detail}</span>)}
+                {location ? (
+                  <span className="inline-flex items-center gap-1.5">
+                    <MapPin className="h-4 w-4" />
+                    {location}
+                  </span>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        </header>
+
+        <Alert className="border-amber-300 bg-amber-50/95 shadow-sm">
+          <ShieldAlert className="h-4 w-4 text-amber-800" />
+          <AlertDescription className="font-medium leading-relaxed text-amber-950">
+            Community profile — self-reported. Not an official Academy Watch tracked player.
+          </AlertDescription>
+        </Alert>
+
+        <ShowcaseSection
+          local
+          playerApiId={numericPlayerId}
+          playerName={player.display_name}
+        />
+      </div>
+    </div>
+  )
+}
+
+export function LocalPlayerPage() {
+  const { localPlayerId } = useParams()
+  const { token } = useAuth()
+  const [attempt, setAttempt] = useState(0)
+  const numericPlayerId = Number(localPlayerId)
+  const validPlayerId = Number.isInteger(numericPlayerId) && numericPlayerId > 0
+
+  if (!validPlayerId) return <MissingState />
+
+  return (
+    <LocalPlayerProfile
+      key={`${numericPlayerId}-${attempt}-${token || 'public'}`}
+      numericPlayerId={numericPlayerId}
+      onRetry={() => setAttempt((value) => value + 1)}
+    />
+  )
+}
+
+export default LocalPlayerPage

--- a/academy-watch-frontend/src/pages/LocalPlayerPage.jsx
+++ b/academy-watch-frontend/src/pages/LocalPlayerPage.jsx
@@ -109,10 +109,13 @@ function LocalPlayerProfile({ numericPlayerId, onRetry }) {
     )
   }
 
-  const location = [player.city, player.country].filter(Boolean).join(', ')
+  const location = player.city
+    ? [player.city, player.country].filter(Boolean).join(', ')
+    : null
   const details = [
     player.birth_year != null ? `Born ${player.birth_year}` : null,
     player.position || null,
+    !player.city ? player.country || null : null,
   ].filter(Boolean)
 
   return (

--- a/academy-watch-frontend/src/pages/MyClub.jsx
+++ b/academy-watch-frontend/src/pages/MyClub.jsx
@@ -92,6 +92,9 @@ function SignedOutState({ onSignIn }) {
               <LogIn className="mr-1.5 h-4 w-4" />
               Sign in
             </Button>
+            <Link to="/local-players/new" className="text-sm font-medium text-primary hover:underline">
+              Create a player profile
+            </Link>
           </CardContent>
         </Card>
       </div>
@@ -549,6 +552,9 @@ function AuthenticatedMyClub() {
                     </p>
                   </div>
                   <Button onClick={openClaimDialog}>Claim your club</Button>
+                  <Link to="/local-players/new" className="text-sm font-medium text-primary hover:underline">
+                    Create a player profile
+                  </Link>
                 </CardContent>
               </Card>
             ) : (

--- a/academy-watch-frontend/src/pages/MyClub.jsx
+++ b/academy-watch-frontend/src/pages/MyClub.jsx
@@ -1,0 +1,1041 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import {
+  AlertCircle,
+  Building2,
+  Check,
+  CheckCircle2,
+  Loader2,
+  LogIn,
+  Plus,
+  Search,
+  ShieldCheck,
+  UserCheck,
+  X,
+} from 'lucide-react'
+import { APIService } from '@/lib/api'
+import { useAuth, useAuthUI } from '@/context/AuthContext'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { VerificationCode, VerificationInstructions } from '@/components/showcase/VerificationCode'
+
+const EMPTY_CLUB_RESULTS = { api_teams: [], local_clubs: [] }
+
+const CLAIM_STATUS = {
+  pending: { label: 'Pending', className: 'bg-amber-50 text-amber-800 border-amber-200' },
+  approved: { label: 'Approved', className: 'bg-emerald-50 text-emerald-800 border-emerald-200' },
+  rejected: { label: 'Rejected', className: 'bg-rose-50 text-rose-800 border-rose-200' },
+  revoked: { label: 'Revoked', className: 'bg-stone-100 text-stone-700 border-stone-200' },
+}
+
+const VERIFICATION_STATUS = {
+  unverified: { label: 'Unverified', className: 'bg-amber-50 text-amber-800 border-amber-200' },
+  code_found: { label: 'Code detected', className: 'bg-emerald-50 text-emerald-800 border-emerald-300' },
+  code_not_found: { label: 'Code not found', className: 'bg-rose-50 text-rose-800 border-rose-200' },
+}
+
+const AFFILIATION_STATUS = {
+  pending: { label: 'Pending review', className: 'bg-amber-50 text-amber-800 border-amber-200' },
+  self_reported: { label: 'Self-reported', className: 'bg-sky-50 text-sky-800 border-sky-200' },
+}
+
+const RELATIONSHIP_LABELS = {
+  player: 'Player',
+  agent: 'Agent',
+  guardian: 'Parent / Guardian',
+  club_official: 'Club official',
+}
+
+function formatDate(value) {
+  if (!value) return null
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+  return date.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
+function StatusBadge({ status, styles }) {
+  const badge = styles[status] || { label: status || 'Unknown', className: 'bg-stone-100 text-stone-700 border-stone-200' }
+  return <Badge className={badge.className}>{badge.label}</Badge>
+}
+
+function VerificationBadge({ status }) {
+  return <StatusBadge status={status || 'unverified'} styles={VERIFICATION_STATUS} />
+}
+
+function SignedOutState({ onSignIn }) {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-secondary to-background">
+      <div className="mx-auto flex max-w-7xl items-center justify-center px-4 py-24 sm:px-6 lg:px-8">
+        <Card className="w-full max-w-md overflow-hidden border-border/80">
+          <CardContent className="flex flex-col items-center gap-4 px-8 py-12 text-center">
+            <span className="inline-flex h-14 w-14 items-center justify-center rounded-full bg-primary/10">
+              <Building2 className="h-6 w-6 text-primary" />
+            </span>
+            <h1 className="text-xl font-bold tracking-tight text-foreground">Sign in to manage your club</h1>
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              Claim the club you represent, review player affiliations and vouch for people you know.
+            </p>
+            <Button onClick={onSignIn}>
+              <LogIn className="mr-1.5 h-4 w-4" />
+              Sign in
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+export function MyClub() {
+  const auth = useAuth()
+  const { openLoginModal } = useAuthUI()
+
+  if (!auth?.token) return <SignedOutState onSignIn={openLoginModal} />
+
+  return <AuthenticatedMyClub key={auth.token} />
+}
+
+function AuthenticatedMyClub() {
+  const auth = useAuth()
+  const { openLoginModal } = useAuthUI()
+
+  const [claims, setClaims] = useState([])
+  const [clubs, setClubs] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [loadedToken, setLoadedToken] = useState(null)
+  const [hasLoadedData, setHasLoadedData] = useState(false)
+  const [message, setMessage] = useState(null)
+
+  const [claimOpen, setClaimOpen] = useState(false)
+  const [clubSearch, setClubSearch] = useState('')
+  const [clubSearchBusy, setClubSearchBusy] = useState(false)
+  const [clubSearchComplete, setClubSearchComplete] = useState(false)
+  const [clubSearchError, setClubSearchError] = useState(null)
+  const [clubResults, setClubResults] = useState(EMPTY_CLUB_RESULTS)
+  const [selectedClub, setSelectedClub] = useState(null)
+  const [roleTitle, setRoleTitle] = useState('')
+  const [claimMessage, setClaimMessage] = useState('')
+  const [claimBusy, setClaimBusy] = useState(false)
+  const [claimDone, setClaimDone] = useState(false)
+  const [claimError, setClaimError] = useState(null)
+  const [createdClaim, setCreatedClaim] = useState(null)
+
+  const [verifyOpen, setVerifyOpen] = useState(false)
+  const [verifyClaim, setVerifyClaim] = useState(null)
+  const [proofUrl, setProofUrl] = useState('')
+  const [verifyBusy, setVerifyBusy] = useState(false)
+  const [verifyDone, setVerifyDone] = useState(false)
+  const [verifyError, setVerifyError] = useState(null)
+  const [verifyResult, setVerifyResult] = useState(null)
+  const [codeCopyState, setCodeCopyState] = useState('idle')
+
+  const [affiliationNotes, setAffiliationNotes] = useState({})
+  const [actingAffiliationId, setActingAffiliationId] = useState(null)
+  const [vouchTarget, setVouchTarget] = useState(null)
+  const [vouchBusy, setVouchBusy] = useState(false)
+  const [vouchError, setVouchError] = useState(null)
+
+  const activeTokenRef = useRef(auth?.token)
+  const dataRequestRef = useRef(0)
+  const clubSearchRequestRef = useRef(0)
+  const verifyRequestRef = useRef(0)
+  const verifyCloseTimerRef = useRef(null)
+
+  useLayoutEffect(() => {
+    activeTokenRef.current = auth?.token
+    return () => {
+      activeTokenRef.current = null
+    }
+  }, [auth?.token])
+
+  const clearVerifyCloseTimer = useCallback(() => {
+    if (verifyCloseTimerRef.current) {
+      clearTimeout(verifyCloseTimerRef.current)
+      verifyCloseTimerRef.current = null
+    }
+  }, [])
+
+  useEffect(() => clearVerifyCloseTimer, [clearVerifyCloseTimer])
+
+  const refreshData = useCallback(async ({ showLoading = false } = {}) => {
+    const expectedToken = activeTokenRef.current
+    if (!expectedToken) return false
+    const requestId = dataRequestRef.current + 1
+    dataRequestRef.current = requestId
+    if (showLoading) setLoading(true)
+    try {
+      const [claimsResponse, clubsResponse] = await Promise.all([
+        APIService.getMyClubClaims(),
+        APIService.getMyClub(),
+      ])
+      if (dataRequestRef.current !== requestId || activeTokenRef.current !== expectedToken) return false
+      setClaims(Array.isArray(claimsResponse?.claims) ? claimsResponse.claims : [])
+      setClubs(Array.isArray(clubsResponse?.clubs) ? clubsResponse.clubs : [])
+      setHasLoadedData(true)
+      return true
+    } catch (error) {
+      if (dataRequestRef.current === requestId && activeTokenRef.current === expectedToken) {
+        setMessage({ type: 'error', text: error.body?.error || error.message || 'Failed to load club data' })
+      }
+      return false
+    } finally {
+      if (dataRequestRef.current === requestId && activeTokenRef.current === expectedToken) {
+        setLoadedToken(expectedToken)
+        setLoading(false)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!auth?.token) {
+      dataRequestRef.current += 1
+      return undefined
+    }
+    const timer = setTimeout(() => {
+      refreshData({ showLoading: true })
+    }, 0)
+    return () => {
+      clearTimeout(timer)
+      dataRequestRef.current += 1
+    }
+  }, [auth?.token, refreshData])
+
+  useEffect(() => {
+    const query = clubSearch.trim()
+    if (!claimOpen || claimDone || query.length < 2) return undefined
+
+    const requestId = clubSearchRequestRef.current + 1
+    clubSearchRequestRef.current = requestId
+    const expectedToken = auth?.token
+    const timer = setTimeout(async () => {
+      if (clubSearchRequestRef.current !== requestId || activeTokenRef.current !== expectedToken) return
+      setClubSearchBusy(true)
+      setClubSearchError(null)
+      try {
+        const response = await APIService.searchClubs(query)
+        if (clubSearchRequestRef.current !== requestId || activeTokenRef.current !== expectedToken) return
+        setClubResults({
+          api_teams: Array.isArray(response?.api_teams) ? response.api_teams : [],
+          local_clubs: Array.isArray(response?.local_clubs) ? response.local_clubs : [],
+        })
+        setClubSearchComplete(true)
+      } catch (error) {
+        if (clubSearchRequestRef.current !== requestId || activeTokenRef.current !== expectedToken) return
+        setClubResults(EMPTY_CLUB_RESULTS)
+        setClubSearchComplete(false)
+        setClubSearchError(error.body?.error || error.message || 'Failed to search clubs')
+      } finally {
+        if (clubSearchRequestRef.current === requestId && activeTokenRef.current === expectedToken) {
+          setClubSearchBusy(false)
+        }
+      }
+    }, 300)
+
+    return () => {
+      clearTimeout(timer)
+      if (clubSearchRequestRef.current === requestId) clubSearchRequestRef.current += 1
+    }
+  }, [auth?.token, claimDone, claimOpen, clubSearch])
+
+  const resetClaimDialog = () => {
+    clubSearchRequestRef.current += 1
+    setClubSearch('')
+    setClubSearchBusy(false)
+    setClubSearchComplete(false)
+    setClubSearchError(null)
+    setClubResults(EMPTY_CLUB_RESULTS)
+    setSelectedClub(null)
+    setRoleTitle('')
+    setClaimMessage('')
+    setClaimBusy(false)
+    setClaimDone(false)
+    setClaimError(null)
+    setCreatedClaim(null)
+    setCodeCopyState('idle')
+  }
+
+  const openClaimDialog = () => {
+    if (!auth?.token) {
+      openLoginModal()
+      return
+    }
+    resetClaimDialog()
+    setClaimOpen(true)
+  }
+
+  const updateClubSearch = (value) => {
+    clubSearchRequestRef.current += 1
+    setClubSearch(value)
+    setClubSearchBusy(false)
+    setClubSearchComplete(false)
+    setClubSearchError(null)
+    setClubResults(EMPTY_CLUB_RESULTS)
+    setSelectedClub(null)
+    setClaimError(null)
+  }
+
+  const chooseClub = (kind, club) => {
+    setSelectedClub({ kind, club })
+    setClaimError(null)
+  }
+
+  const submitClaim = async () => {
+    const title = roleTitle.trim()
+    if (claimBusy) return
+    if (!selectedClub) {
+      setClaimError('Select a club from the search results.')
+      return
+    }
+    if (title.length < 2) {
+      setClaimError('Enter a role title of at least 2 characters.')
+      return
+    }
+
+    const expectedToken = auth?.token
+    const clubPayload = selectedClub.kind === 'api'
+      ? { team_api_id: selectedClub.club.team_api_id }
+      : { local_club_id: selectedClub.club.id }
+    setClaimBusy(true)
+    setClaimError(null)
+    try {
+      const response = await APIService.submitClubClaim({
+        ...clubPayload,
+        role_title: title,
+        message: claimMessage.trim() || undefined,
+      })
+      if (activeTokenRef.current !== expectedToken) return
+      setCreatedClaim(response?.claim || null)
+      setClaimDone(true)
+      setMessage({ type: 'success', text: 'Club claim submitted for review' })
+      await refreshData()
+    } catch (error) {
+      if (activeTokenRef.current === expectedToken) {
+        setClaimError(error.body?.error || error.message || 'Failed to submit club claim')
+      }
+    } finally {
+      if (activeTokenRef.current === expectedToken) setClaimBusy(false)
+    }
+  }
+
+  const copyVerificationCode = async (code) => {
+    if (!code) return
+    const expectedToken = activeTokenRef.current
+    if (typeof navigator === 'undefined' || !navigator.clipboard) {
+      setCodeCopyState('failed')
+      return
+    }
+    try {
+      await navigator.clipboard.writeText(code)
+      if (activeTokenRef.current === expectedToken) setCodeCopyState('copied')
+    } catch {
+      if (activeTokenRef.current === expectedToken) setCodeCopyState('failed')
+    }
+  }
+
+  const openVerificationDialog = (claim) => {
+    clearVerifyCloseTimer()
+    verifyRequestRef.current += 1
+    setVerifyClaim(claim)
+    setProofUrl(claim.verification_proof_url || '')
+    setVerifyBusy(false)
+    setVerifyDone(false)
+    setVerifyError(null)
+    setVerifyResult(null)
+    setCodeCopyState('idle')
+    setVerifyOpen(true)
+  }
+
+  const closeVerificationDialog = () => {
+    if (verifyBusy) return
+    clearVerifyCloseTimer()
+    verifyRequestRef.current += 1
+    setVerifyOpen(false)
+    setVerifyClaim(null)
+    setVerifyDone(false)
+    setVerifyError(null)
+    setVerifyResult(null)
+  }
+
+  const submitVerification = async () => {
+    const url = proofUrl.trim()
+    if (!url || verifyBusy || !verifyClaim?.id) return
+    const expectedToken = auth?.token
+    const claimId = verifyClaim.id
+    const requestId = verifyRequestRef.current + 1
+    verifyRequestRef.current = requestId
+    setVerifyBusy(true)
+    setVerifyDone(false)
+    setVerifyError(null)
+    setVerifyResult(null)
+    try {
+      const response = await APIService.verifyClubClaimProof(claimId, { proof_url: url })
+      const checkedClaim = response?.claim || null
+      if (verifyRequestRef.current !== requestId || activeTokenRef.current !== expectedToken) return
+      setVerifyResult(checkedClaim)
+      setVerifyClaim(checkedClaim || verifyClaim)
+      setVerifyDone(true)
+      await refreshData()
+      if (checkedClaim?.verification_status === 'code_found') {
+        verifyCloseTimerRef.current = setTimeout(() => {
+          if (verifyRequestRef.current === requestId && activeTokenRef.current === expectedToken) {
+            setVerifyOpen(false)
+            setVerifyClaim(null)
+            setVerifyDone(false)
+            setVerifyResult(null)
+          }
+          verifyCloseTimerRef.current = null
+        }, 1600)
+      }
+    } catch (error) {
+      if (verifyRequestRef.current === requestId && activeTokenRef.current === expectedToken) {
+        setVerifyError(error.body?.error || error.message || 'Failed to check this profile')
+      }
+    } finally {
+      if (verifyRequestRef.current === requestId && activeTokenRef.current === expectedToken) {
+        setVerifyBusy(false)
+      }
+    }
+  }
+
+  const reviewAffiliation = async (affiliation, action) => {
+    if (actingAffiliationId) return
+    const expectedToken = auth?.token
+    setActingAffiliationId(affiliation.id)
+    try {
+      if (action === 'confirm') {
+        await APIService.confirmClubAffiliation(affiliation.id)
+      } else {
+        await APIService.rejectClubAffiliation(affiliation.id, {
+          note: affiliationNotes[affiliation.id]?.trim() || undefined,
+        })
+      }
+      if (activeTokenRef.current !== expectedToken) return
+      setMessage({
+        type: 'success',
+        text: action === 'confirm' ? 'Player affiliation confirmed' : 'Player affiliation rejected',
+      })
+      setAffiliationNotes((current) => {
+        const next = { ...current }
+        delete next[affiliation.id]
+        return next
+      })
+      await refreshData()
+    } catch (error) {
+      if (activeTokenRef.current === expectedToken) {
+        setMessage({ type: 'error', text: error.body?.error || error.message || 'Failed to update affiliation' })
+      }
+    } finally {
+      if (activeTokenRef.current === expectedToken) setActingAffiliationId(null)
+    }
+  }
+
+  const openVouchDialog = (claim, clubName) => {
+    setVouchTarget({ claim, clubName })
+    setVouchError(null)
+  }
+
+  const submitVouch = async () => {
+    if (!vouchTarget?.claim?.id || vouchBusy) return
+    const expectedToken = auth?.token
+    setVouchBusy(true)
+    setVouchError(null)
+    try {
+      await APIService.vouchPlayerClaim(vouchTarget.claim.id)
+      if (activeTokenRef.current !== expectedToken) return
+      setMessage({ type: 'success', text: `Player #${vouchTarget.claim.player_api_id} claim approved by your vouch` })
+      setVouchTarget(null)
+      await refreshData()
+    } catch (error) {
+      if (activeTokenRef.current === expectedToken) {
+        const text = error.body?.error || error.message || 'Failed to vouch for player claim'
+        setVouchError(text)
+        setMessage({ type: 'error', text })
+      }
+    } finally {
+      if (activeTokenRef.current === expectedToken) setVouchBusy(false)
+    }
+  }
+
+  const clubResultCount = clubResults.api_teams.length + clubResults.local_clubs.length
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-secondary to-background">
+      <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <p className="mb-2 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-primary">
+              <ShieldCheck className="h-3.5 w-3.5" />
+              Club officials
+            </p>
+            <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">My Club</h1>
+            <p className="mt-2 max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
+              Prove your role, confirm who represents your club and vouch for player identities you know firsthand.
+            </p>
+          </div>
+          <Button
+            onClick={openClaimDialog}
+            className="shrink-0"
+            disabled={loading || loadedToken !== auth.token || !hasLoadedData}
+          >
+            <Plus className="mr-1.5 h-4 w-4" />
+            Claim your club
+          </Button>
+        </header>
+
+        {message ? (
+          <Alert className={message.type === 'error' ? 'border-rose-500 bg-rose-50' : 'border-emerald-500 bg-emerald-50'}>
+            {message.type === 'error' ? (
+              <AlertCircle className="h-4 w-4 text-rose-600" />
+            ) : (
+              <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+            )}
+            <AlertDescription className={message.type === 'error' ? 'text-rose-800' : 'text-emerald-800'}>
+              {message.text}
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        {loading || loadedToken !== auth.token ? (
+          <Card>
+            <CardContent className="flex items-center justify-center py-16 text-sm text-muted-foreground">
+              <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+              Loading your clubs…
+            </CardContent>
+          </Card>
+        ) : !hasLoadedData ? (
+          <Card className="border-dashed">
+            <CardContent className="flex flex-col items-center gap-3 px-6 py-12 text-center">
+              <AlertCircle className="h-7 w-7 text-rose-600" />
+              <div>
+                <h2 className="font-semibold text-foreground">We couldn&apos;t load your club workspace</h2>
+                <p className="mt-1 text-sm text-muted-foreground">Try again before making club-management decisions.</p>
+              </div>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setMessage(null)
+                  refreshData({ showLoading: true })
+                }}
+              >
+                Try again
+              </Button>
+            </CardContent>
+          </Card>
+        ) : (
+          <>
+            {claims.length === 0 ? (
+              <Card className="overflow-hidden border-dashed">
+                <CardContent className="flex flex-col items-center gap-4 px-6 py-14 text-center">
+                  <span className="inline-flex h-14 w-14 items-center justify-center rounded-full bg-primary/10">
+                    <Building2 className="h-6 w-6 text-primary" />
+                  </span>
+                  <div>
+                    <h2 className="text-xl font-bold tracking-tight text-foreground">Represent a club?</h2>
+                    <p className="mt-2 max-w-lg text-sm leading-relaxed text-muted-foreground">
+                      Claim an official or community club, verify your role through a public social profile and wait for admin approval.
+                    </p>
+                  </div>
+                  <Button onClick={openClaimDialog}>Claim your club</Button>
+                </CardContent>
+              </Card>
+            ) : (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Your club claims</CardTitle>
+                  <CardDescription>Admin approval is required before club-management tools unlock.</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  {claims.map((claim) => (
+                    <div key={claim.id} className="flex flex-col gap-4 rounded-lg border border-border/80 bg-card p-4 sm:flex-row sm:items-center sm:justify-between">
+                      <div className="min-w-0 space-y-2">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <h3 className="font-semibold text-foreground">{claim.club_name || 'Club claim'}</h3>
+                          <StatusBadge status={claim.status} styles={CLAIM_STATUS} />
+                          <VerificationBadge status={claim.verification_status} />
+                        </div>
+                        <p className="text-sm text-muted-foreground">{claim.role_title || 'Club official'}</p>
+                        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                          {formatDate(claim.created_at) ? <span>Submitted {formatDate(claim.created_at)}</span> : null}
+                          {formatDate(claim.verification_checked_at) ? (
+                            <span>Social profile checked {formatDate(claim.verification_checked_at)}</span>
+                          ) : null}
+                        </div>
+                      </div>
+                      {claim.status === 'pending' ? (
+                        <Button variant="outline" size="sm" onClick={() => openVerificationDialog(claim)} className="shrink-0">
+                          <ShieldCheck className="mr-1.5 h-4 w-4" />
+                          Verify claim
+                        </Button>
+                      ) : null}
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+            )}
+
+            {clubs.map((clubEntry) => {
+              const pendingAffiliations = Array.isArray(clubEntry.pending_affiliations) ? clubEntry.pending_affiliations : []
+              const vouchableClaims = Array.isArray(clubEntry.vouchable_player_claims) ? clubEntry.vouchable_player_claims : []
+              return (
+                <section key={clubEntry.claim?.id || clubEntry.club_name} className="space-y-4" aria-labelledby={`club-${clubEntry.claim?.id}-heading`}>
+                  <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-primary/15 bg-primary/5 px-5 py-4">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">Approved club</p>
+                      <h2 id={`club-${clubEntry.claim?.id}-heading`} className="mt-1 text-2xl font-bold tracking-tight text-foreground">
+                        {clubEntry.club_name || clubEntry.claim?.club_name || 'Your club'}
+                      </h2>
+                      {clubEntry.claim?.role_title ? (
+                        <p className="mt-1 text-sm text-muted-foreground">Your role: {clubEntry.claim.role_title}</p>
+                      ) : null}
+                    </div>
+                    <Badge className="border-emerald-200 bg-emerald-50 text-emerald-800">
+                      <ShieldCheck className="mr-1 h-3.5 w-3.5" />
+                      Verified official
+                    </Badge>
+                  </div>
+
+                  <div className="grid gap-4 xl:grid-cols-2">
+                    <Card>
+                      <CardHeader>
+                        <CardTitle className="text-lg">Player affiliations</CardTitle>
+                        <CardDescription>Confirm or reject players who name this club on their showcase.</CardDescription>
+                      </CardHeader>
+                      <CardContent>
+                        {pendingAffiliations.length === 0 ? (
+                          <p className="rounded-lg border border-dashed px-4 py-8 text-center text-sm text-muted-foreground">
+                            No affiliations need your review.
+                          </p>
+                        ) : (
+                          <div className="space-y-3">
+                            {pendingAffiliations.map((affiliation) => {
+                              const isActing = actingAffiliationId === affiliation.id
+                              const affiliationStatus = AFFILIATION_STATUS[affiliation.status] || AFFILIATION_STATUS.pending
+                              return (
+                                <div key={affiliation.id} className="space-y-3 rounded-lg border border-border/80 p-4">
+                                  <div className="flex flex-wrap items-start justify-between gap-3">
+                                    <div>
+                                      <Link to={`/players/${affiliation.player_api_id}`} className="font-semibold text-foreground hover:text-primary hover:underline">
+                                        Player #{affiliation.player_api_id}
+                                      </Link>
+                                      <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                                        <span>Season: {affiliation.season || 'Not provided'}</span>
+                                        {formatDate(affiliation.created_at) ? <span>Submitted {formatDate(affiliation.created_at)}</span> : null}
+                                      </div>
+                                    </div>
+                                    <Badge className={affiliationStatus.className}>{affiliationStatus.label}</Badge>
+                                  </div>
+                                  {affiliation.review_note ? (
+                                    <p className="text-xs text-muted-foreground">Previous note: {affiliation.review_note}</p>
+                                  ) : null}
+                                  <div className="space-y-2">
+                                    <Input
+                                      value={affiliationNotes[affiliation.id] || ''}
+                                      onChange={(event) => setAffiliationNotes((current) => ({ ...current, [affiliation.id]: event.target.value }))}
+                                      placeholder="Rejection note (optional)"
+                                      aria-label={`Rejection note for player ${affiliation.player_api_id}`}
+                                      maxLength={1000}
+                                      disabled={isActing}
+                                    />
+                                    <div className="flex flex-wrap justify-end gap-2">
+                                      <Button
+                                        size="sm"
+                                        variant="outline"
+                                        className="border-rose-600 text-rose-600 hover:bg-rose-50"
+                                        disabled={Boolean(actingAffiliationId)}
+                                        onClick={() => reviewAffiliation(affiliation, 'reject')}
+                                      >
+                                        {isActing ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <X className="mr-1 h-4 w-4" />}
+                                        Reject
+                                      </Button>
+                                      <Button
+                                        size="sm"
+                                        variant="outline"
+                                        className="border-emerald-600 text-emerald-700 hover:bg-emerald-50"
+                                        disabled={Boolean(actingAffiliationId)}
+                                        onClick={() => reviewAffiliation(affiliation, 'confirm')}
+                                      >
+                                        {isActing ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Check className="mr-1 h-4 w-4" />}
+                                        Confirm
+                                      </Button>
+                                    </div>
+                                  </div>
+                                </div>
+                              )
+                            })}
+                          </div>
+                        )}
+                      </CardContent>
+                    </Card>
+
+                    <Card>
+                      <CardHeader>
+                        <CardTitle className="text-lg">Player claim vouching</CardTitle>
+                        <CardDescription>Identity approval only. Profile content remains separately moderated.</CardDescription>
+                      </CardHeader>
+                      <CardContent>
+                        {vouchableClaims.length === 0 ? (
+                          <p className="rounded-lg border border-dashed px-4 py-8 text-center text-sm text-muted-foreground">
+                            No player claims are waiting for a vouch.
+                          </p>
+                        ) : (
+                          <div className="space-y-3">
+                            {vouchableClaims.map((claim) => (
+                              <div key={claim.id} className="flex flex-col gap-3 rounded-lg border border-border/80 p-4 sm:flex-row sm:items-center sm:justify-between">
+                                <div className="min-w-0 space-y-2">
+                                  <div className="flex flex-wrap items-center gap-2">
+                                    <Link to={`/players/${claim.player_api_id}`} className="font-semibold text-foreground hover:text-primary hover:underline">
+                                      Player #{claim.player_api_id}
+                                    </Link>
+                                    <VerificationBadge status={claim.verification_status} />
+                                  </div>
+                                  <p className="text-xs text-muted-foreground">
+                                    {RELATIONSHIP_LABELS[claim.relationship_type] || claim.relationship_type || 'Claimant'}
+                                    {formatDate(claim.created_at) ? ` · Submitted ${formatDate(claim.created_at)}` : ''}
+                                  </p>
+                                  {formatDate(claim.verification_checked_at) ? (
+                                    <p className="text-xs text-muted-foreground">Social profile checked {formatDate(claim.verification_checked_at)}</p>
+                                  ) : null}
+                                </div>
+                                <Button size="sm" onClick={() => openVouchDialog(claim, clubEntry.club_name)} className="shrink-0">
+                                  <UserCheck className="mr-1.5 h-4 w-4" />
+                                  Vouch
+                                </Button>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </CardContent>
+                    </Card>
+                  </div>
+                </section>
+              )
+            })}
+          </>
+        )}
+      </div>
+
+      <Dialog
+        open={claimOpen}
+        onOpenChange={(open) => {
+          if (claimBusy) return
+          setClaimOpen(open)
+          if (!open) resetClaimDialog()
+        }}
+      >
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
+          <DialogHeader>
+            <DialogTitle>Claim your club</DialogTitle>
+            <DialogDescription>
+              Search official and community clubs, then tell us the role you hold. Every claim is reviewed.
+            </DialogDescription>
+          </DialogHeader>
+
+          {claimDone ? (
+            <div className="space-y-4 py-2">
+              <div className="flex items-center gap-2 text-sm text-emerald-600" role="status" aria-live="polite">
+                <Check className="h-4 w-4" />
+                Submitted for review
+              </div>
+              <VerificationCode
+                code={createdClaim?.verification_code}
+                copyState={codeCopyState}
+                onCopy={copyVerificationCode}
+              />
+              <VerificationInstructions />
+            </div>
+          ) : (
+            <div className="space-y-4 py-2">
+              <div className="space-y-2">
+                <Label htmlFor="my-club-search">Search clubs</Label>
+                <div className="relative">
+                  <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    id="my-club-search"
+                    type="search"
+                    placeholder="Search by club name"
+                    value={clubSearch}
+                    onChange={(event) => updateClubSearch(event.target.value)}
+                    maxLength={200}
+                    disabled={claimBusy}
+                    className="pl-9"
+                    autoComplete="off"
+                  />
+                </div>
+                {clubSearch.trim().length > 0 && clubSearch.trim().length < 2 ? (
+                  <p className="text-xs text-muted-foreground">Enter at least 2 characters.</p>
+                ) : null}
+              </div>
+
+              {clubSearchBusy ? (
+                <div className="flex items-center gap-2 rounded-md bg-muted/50 px-3 py-2 text-sm text-muted-foreground" role="status">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Searching clubs…
+                </div>
+              ) : null}
+
+              {clubSearchError ? <p className="text-xs text-destructive" role="alert">{clubSearchError}</p> : null}
+
+              {!clubSearchBusy && clubSearchComplete && clubResultCount > 0 ? (
+                <div className="max-h-64 space-y-4 overflow-y-auto pr-1">
+                  {clubResults.api_teams.length > 0 ? (
+                    <div className="space-y-2">
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">Official clubs</p>
+                      <div className="space-y-1" role="listbox" aria-label="Official clubs">
+                        {clubResults.api_teams.map((club) => {
+                          const selected = selectedClub?.kind === 'api'
+                            && Number(selectedClub.club.team_api_id) === Number(club.team_api_id)
+                          return (
+                            <button
+                              key={`api-${club.team_api_id}`}
+                              type="button"
+                              role="option"
+                              aria-selected={selected}
+                              onClick={() => chooseClub('api', club)}
+                              disabled={claimBusy}
+                              className={`flex w-full items-center justify-between gap-3 rounded-md border px-3 py-2 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${selected
+                                ? 'border-primary/50 bg-primary/5'
+                                : 'border-border/70 hover:border-primary/30 hover:bg-muted/50'}`}
+                            >
+                              <span className="min-w-0">
+                                <span className="block truncate text-sm font-medium text-foreground">{club.name}</span>
+                                {club.country ? <span className="block truncate text-xs text-muted-foreground">{club.country}</span> : null}
+                              </span>
+                              {selected ? <Check className="h-4 w-4 shrink-0 text-primary" /> : null}
+                            </button>
+                          )
+                        })}
+                      </div>
+                    </div>
+                  ) : null}
+
+                  {clubResults.local_clubs.length > 0 ? (
+                    <div className="space-y-2">
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">Community clubs</p>
+                      <div className="space-y-1" role="listbox" aria-label="Community clubs">
+                        {clubResults.local_clubs.map((club) => {
+                          const selected = selectedClub?.kind === 'local'
+                            && Number(selectedClub.club.id) === Number(club.id)
+                          const location = [club.city, club.country].filter(Boolean).join(', ')
+                          return (
+                            <button
+                              key={`local-${club.id}`}
+                              type="button"
+                              role="option"
+                              aria-selected={selected}
+                              onClick={() => chooseClub('local', club)}
+                              disabled={claimBusy}
+                              className={`flex w-full items-center justify-between gap-3 rounded-md border px-3 py-2 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${selected
+                                ? 'border-primary/50 bg-primary/5'
+                                : 'border-border/70 hover:border-primary/30 hover:bg-muted/50'}`}
+                            >
+                              <span className="min-w-0">
+                                <span className="block truncate text-sm font-medium text-foreground">{club.name}</span>
+                                {location || club.level ? (
+                                  <span className="block truncate text-xs text-muted-foreground">
+                                    {[location, club.level].filter(Boolean).join(' · ')}
+                                  </span>
+                                ) : null}
+                              </span>
+                              {selected ? <Check className="h-4 w-4 shrink-0 text-primary" /> : null}
+                            </button>
+                          )
+                        })}
+                      </div>
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
+
+              {!clubSearchBusy && clubSearchComplete && clubResultCount === 0 ? (
+                <p className="rounded-md border border-dashed px-3 py-5 text-center text-sm text-muted-foreground">
+                  No matching clubs found.
+                </p>
+              ) : null}
+
+              {selectedClub ? (
+                <div className="flex items-center gap-2 rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-sm">
+                  <Check className="h-4 w-4 shrink-0 text-primary" />
+                  <span className="min-w-0 truncate font-medium text-foreground">Selected: {selectedClub.club.name}</span>
+                </div>
+              ) : null}
+
+              <div className="space-y-2">
+                <Label htmlFor="my-club-role-title">Your role title</Label>
+                <Input
+                  id="my-club-role-title"
+                  value={roleTitle}
+                  onChange={(event) => setRoleTitle(event.target.value)}
+                  placeholder="e.g. Academy director"
+                  minLength={2}
+                  maxLength={100}
+                  disabled={claimBusy}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="my-club-claim-message">Message (optional)</Label>
+                <Textarea
+                  id="my-club-claim-message"
+                  value={claimMessage}
+                  onChange={(event) => setClaimMessage(event.target.value)}
+                  placeholder="Anything that helps us verify your role"
+                  maxLength={1000}
+                  rows={3}
+                  disabled={claimBusy}
+                />
+              </div>
+
+              {claimError ? <p className="text-xs text-destructive" role="alert">{claimError}</p> : null}
+            </div>
+          )}
+
+          {claimDone ? (
+            <DialogFooter>
+              <Button onClick={() => { setClaimOpen(false); resetClaimDialog() }}>Done</Button>
+            </DialogFooter>
+          ) : (
+            <DialogFooter>
+              <Button variant="ghost" onClick={() => setClaimOpen(false)} disabled={claimBusy}>Cancel</Button>
+              <Button onClick={submitClaim} disabled={claimBusy || !selectedClub || roleTitle.trim().length < 2}>
+                {claimBusy ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : null}
+                {claimBusy ? 'Submitting…' : 'Submit claim'}
+              </Button>
+            </DialogFooter>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={verifyOpen} onOpenChange={(open) => { if (!open) closeVerificationDialog() }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Verify your club role</DialogTitle>
+            <DialogDescription>
+              A best-effort social profile check helps our admin review your claim. It does not approve the claim automatically.
+            </DialogDescription>
+          </DialogHeader>
+
+          {verifyDone ? (
+            <div className="space-y-3 py-2" role="status" aria-live="polite">
+              <div className={verifyResult?.verification_status === 'code_found'
+                ? 'flex items-start gap-2 text-sm font-medium text-emerald-700'
+                : 'flex items-start gap-2 text-sm font-medium text-amber-800'}>
+                {verifyResult?.verification_status === 'code_found' ? (
+                  <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0" />
+                ) : (
+                  <Search className="mt-0.5 h-4 w-4 shrink-0" />
+                )}
+                <span>
+                  {verifyResult?.verification_status === 'code_found'
+                    ? 'Code detected — an admin will review your claim'
+                    : "We couldn't find the code"}
+                </span>
+              </div>
+              {verifyResult?.verification_note ? (
+                <p className="rounded-md bg-muted/60 px-3 py-2 text-xs leading-relaxed text-muted-foreground">
+                  {verifyResult.verification_note}
+                </p>
+              ) : null}
+            </div>
+          ) : (
+            <div className="space-y-4 py-2">
+              <VerificationCode
+                code={verifyClaim?.verification_code}
+                copyState={codeCopyState}
+                onCopy={copyVerificationCode}
+              />
+              <VerificationInstructions />
+              <div className="space-y-2">
+                <Label htmlFor="club-claim-proof-url">Public profile URL</Label>
+                <Input
+                  id="club-claim-proof-url"
+                  type="url"
+                  placeholder="https://instagram.com/your-club-profile"
+                  value={proofUrl}
+                  onChange={(event) => setProofUrl(event.target.value)}
+                  maxLength={500}
+                  disabled={verifyBusy}
+                  aria-invalid={Boolean(verifyError)}
+                  aria-describedby={verifyError ? 'club-claim-proof-error' : undefined}
+                />
+              </div>
+              {verifyError ? (
+                <p id="club-claim-proof-error" className="text-xs text-destructive" role="alert">{verifyError}</p>
+              ) : null}
+            </div>
+          )}
+
+          {!verifyDone ? (
+            <DialogFooter>
+              <Button variant="ghost" onClick={closeVerificationDialog} disabled={verifyBusy}>Cancel</Button>
+              <Button onClick={submitVerification} disabled={verifyBusy || !proofUrl.trim()}>
+                {verifyBusy ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : null}
+                {verifyBusy ? 'Checking…' : 'Verify'}
+              </Button>
+            </DialogFooter>
+          ) : verifyResult?.verification_status !== 'code_found' ? (
+            <DialogFooter>
+              <Button variant="ghost" onClick={closeVerificationDialog}>Close</Button>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setVerifyDone(false)
+                  setVerifyResult(null)
+                }}
+              >
+                Try again
+              </Button>
+            </DialogFooter>
+          ) : null}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={Boolean(vouchTarget)}
+        onOpenChange={(open) => {
+          if (!open && !vouchBusy) {
+            setVouchTarget(null)
+            setVouchError(null)
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Vouch for Player #{vouchTarget?.claim?.player_api_id}</DialogTitle>
+            <DialogDescription>
+              Confirm this person&apos;s identity for {vouchTarget?.clubName || 'your club'}.
+            </DialogDescription>
+          </DialogHeader>
+          <Alert className="border-amber-300 bg-amber-50">
+            <AlertCircle className="h-4 w-4 text-amber-700" />
+            <AlertDescription className="text-amber-900">
+              Vouching approves this claim immediately. Only vouch for players you know are who they say they are.
+            </AlertDescription>
+          </Alert>
+          {vouchError ? <p className="text-sm text-destructive" role="alert">{vouchError}</p> : null}
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setVouchTarget(null)} disabled={vouchBusy}>Cancel</Button>
+            <Button onClick={submitVouch} disabled={vouchBusy}>
+              {vouchBusy ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <UserCheck className="mr-1.5 h-4 w-4" />}
+              {vouchBusy ? 'Approving…' : 'Confirm vouch'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+export default MyClub

--- a/academy-watch-frontend/src/pages/admin/AdminLocalClubs.jsx
+++ b/academy-watch-frontend/src/pages/admin/AdminLocalClubs.jsx
@@ -1,0 +1,687 @@
+import { useEffect, useMemo, useState } from 'react'
+import { APIService } from '@/lib/api'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import {
+    AlertCircle,
+    Check,
+    CheckCircle2,
+    GitMerge,
+    Landmark,
+    Link2,
+    Loader2,
+    Search,
+    X,
+} from 'lucide-react'
+
+const CLUB_STATUS_STYLES = {
+    pending: 'bg-amber-50 text-amber-800 border-amber-200',
+    verified: 'bg-emerald-50 text-emerald-800 border-emerald-200',
+    rejected: 'bg-rose-50 text-rose-800 border-rose-200',
+    merged: 'bg-stone-100 text-stone-700 border-stone-200',
+}
+
+const AFFILIATION_STATUS_STYLES = {
+    pending: 'bg-amber-50 text-amber-800 border-amber-200',
+    self_reported: 'bg-sky-50 text-sky-800 border-sky-200',
+    club_confirmed: 'bg-emerald-50 text-emerald-800 border-emerald-200',
+    rejected: 'bg-rose-50 text-rose-800 border-rose-200',
+}
+
+const AFFILIATION_STATUS_LABELS = {
+    pending: 'Pending',
+    self_reported: 'Self-reported',
+    club_confirmed: 'Club-confirmed',
+    rejected: 'Rejected',
+}
+
+const LEVEL_LABELS = {
+    grassroots: 'Grassroots',
+    academy: 'Academy',
+    youth: 'Youth',
+    semi_pro: 'Semi-pro',
+    professional: 'Professional',
+    other: 'Other',
+}
+
+function formatLabel(value) {
+    if (!value) return 'Unknown'
+    return String(value)
+        .split('_')
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' ')
+}
+
+function formatDate(value) {
+    if (!value) return null
+    const date = new Date(value)
+    if (Number.isNaN(date.getTime())) return null
+    return date.toLocaleDateString(undefined, {
+        day: 'numeric',
+        month: 'short',
+        year: 'numeric',
+    })
+}
+
+function locationLabel(club) {
+    return [club.city, club.country].filter(Boolean).join(', ') || 'Location not provided'
+}
+
+function Loading() {
+    return (
+        <div className="flex items-center justify-center py-12">
+            <Loader2 className="mr-2 h-5 w-5 animate-spin text-muted-foreground/70" />
+            <span className="text-sm text-muted-foreground">Loading…</span>
+        </div>
+    )
+}
+
+function StatusBadge({ status, styles, labels }) {
+    return (
+        <Badge className={styles[status] || 'bg-stone-100 text-stone-700 border-stone-200'}>
+            {labels?.[status] || formatLabel(status)}
+        </Badge>
+    )
+}
+
+function ClubsTab({ setMessage }) {
+    const [clubs, setClubs] = useState([])
+    const [loading, setLoading] = useState(true)
+    const [status, setStatus] = useState('pending')
+    const [reloadKey, setReloadKey] = useState(0)
+    const [actingId, setActingId] = useState(null)
+    const [notes, setNotes] = useState({})
+
+    const [mergeSource, setMergeSource] = useState(null)
+    const [mergeQuery, setMergeQuery] = useState('')
+    const [mergeTargets, setMergeTargets] = useState([])
+    const [mergeTargetsLoading, setMergeTargetsLoading] = useState(false)
+    const [mergeTargetId, setMergeTargetId] = useState('')
+    const [mergeError, setMergeError] = useState('')
+
+    const [linkClub, setLinkClub] = useState(null)
+    const [teamApiId, setTeamApiId] = useState('')
+    const [linkError, setLinkError] = useState('')
+
+    useEffect(() => {
+        let cancelled = false
+        const params = status === 'all' ? {} : { status }
+        APIService.adminListLocalClubs(params)
+            .then((data) => {
+                if (!cancelled) setClubs(Array.isArray(data?.clubs) ? data.clubs : [])
+            })
+            .catch((err) => {
+                if (!cancelled) setMessage({ type: 'error', text: err.message || 'Failed to load local clubs' })
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false)
+            })
+        return () => { cancelled = true }
+    }, [reloadKey, setMessage, status])
+
+    useEffect(() => {
+        if (!mergeSource) return undefined
+
+        let cancelled = false
+        APIService.adminListLocalClubs()
+            .then((data) => {
+                if (!cancelled) setMergeTargets(Array.isArray(data?.clubs) ? data.clubs : [])
+            })
+            .catch((err) => {
+                if (!cancelled) setMergeError(err.message || 'Failed to load merge targets')
+            })
+            .finally(() => {
+                if (!cancelled) setMergeTargetsLoading(false)
+            })
+
+        return () => { cancelled = true }
+    }, [mergeSource])
+
+    const filteredMergeTargets = useMemo(() => {
+        const query = mergeQuery.trim().toLowerCase()
+        return mergeTargets.filter((club) => {
+            if (Number(club.id) === Number(mergeSource?.id) || ['merged', 'rejected'].includes(club.status)) return false
+            if (!query) return true
+            return [club.name, club.city, club.country]
+                .filter(Boolean)
+                .some((value) => String(value).toLowerCase().includes(query))
+        })
+    }, [mergeQuery, mergeSource?.id, mergeTargets])
+
+    const reviewClub = async (club, action) => {
+        setActingId(club.id)
+        try {
+            await APIService.adminReviewLocalClub(club.id, {
+                action,
+                note: notes[club.id]?.trim() || '',
+            })
+            setMessage({
+                type: 'success',
+                text: action === 'verify' ? `${club.name} verified` : `${club.name} rejected`,
+            })
+            setNotes((current) => {
+                const next = { ...current }
+                delete next[club.id]
+                return next
+            })
+            setLoading(true)
+            setReloadKey((key) => key + 1)
+        } catch (err) {
+            setMessage({ type: 'error', text: err.message || 'Failed to review local club' })
+        } finally {
+            setActingId(null)
+        }
+    }
+
+    const openMerge = (club) => {
+        setMergeSource(club)
+        setMergeQuery('')
+        setMergeTargets([])
+        setMergeTargetsLoading(true)
+        setMergeTargetId('')
+        setMergeError('')
+    }
+
+    const closeMerge = () => {
+        setMergeSource(null)
+        setMergeQuery('')
+        setMergeTargets([])
+        setMergeTargetId('')
+        setMergeError('')
+    }
+
+    const mergeClub = async () => {
+        const targetId = Number(mergeTargetId)
+        if (!Number.isInteger(targetId) || targetId <= 0 || targetId === mergeSource?.id) {
+            setMergeError('Select a different club as the merge target')
+            return
+        }
+
+        setActingId(mergeSource.id)
+        setMergeError('')
+        try {
+            await APIService.adminMergeLocalClub(mergeSource.id, { into_local_club_id: targetId })
+            setMessage({ type: 'success', text: `${mergeSource.name} merged successfully` })
+            closeMerge()
+            setLoading(true)
+            setReloadKey((key) => key + 1)
+        } catch (err) {
+            setMergeError(err.message || 'Failed to merge local club')
+        } finally {
+            setActingId(null)
+        }
+    }
+
+    const openLink = (club) => {
+        setLinkClub(club)
+        setTeamApiId(club.api_team_id != null ? String(club.api_team_id) : '')
+        setLinkError('')
+    }
+
+    const closeLink = () => {
+        setLinkClub(null)
+        setTeamApiId('')
+        setLinkError('')
+    }
+
+    const linkApiClub = async () => {
+        const parsedTeamApiId = Number(teamApiId)
+        if (!Number.isInteger(parsedTeamApiId) || parsedTeamApiId <= 0) {
+            setLinkError('Enter a valid positive API-Football team ID')
+            return
+        }
+
+        setActingId(linkClub.id)
+        setLinkError('')
+        try {
+            await APIService.adminLinkLocalClubApi(linkClub.id, { team_api_id: parsedTeamApiId })
+            setMessage({ type: 'success', text: `${linkClub.name} linked to API team #${parsedTeamApiId}` })
+            closeLink()
+            setLoading(true)
+            setReloadKey((key) => key + 1)
+        } catch (err) {
+            setLinkError(err.message || 'Failed to link API-Football team')
+        } finally {
+            setActingId(null)
+        }
+    }
+
+    return (
+        <>
+            <Card>
+                <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <CardTitle>Community clubs</CardTitle>
+                        <CardDescription>Review, deduplicate and connect community-created clubs</CardDescription>
+                    </div>
+                    <Select value={status} onValueChange={(value) => { setLoading(true); setStatus(value) }}>
+                        <SelectTrigger className="w-40" aria-label="Filter local clubs by status">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="pending">Pending</SelectItem>
+                            <SelectItem value="verified">Verified</SelectItem>
+                            <SelectItem value="rejected">Rejected</SelectItem>
+                            <SelectItem value="merged">Merged</SelectItem>
+                            <SelectItem value="all">All</SelectItem>
+                        </SelectContent>
+                    </Select>
+                </CardHeader>
+                <CardContent>
+                    {loading ? (
+                        <Loading />
+                    ) : clubs.length === 0 ? (
+                        <p className="py-8 text-center text-sm text-muted-foreground">
+                            No {status === 'all' ? '' : status} local clubs.
+                        </p>
+                    ) : (
+                        <div className="space-y-3">
+                            {clubs.map((club) => {
+                                const isActing = actingId === club.id
+                                const canReview = club.status === 'pending'
+                                const canMerge = club.status === 'pending' || club.status === 'verified'
+                                const canLink = club.status !== 'merged'
+                                const hasActions = canReview || canMerge || canLink
+                                return (
+                                    <div key={club.id} className="flex flex-col gap-4 rounded-lg border bg-card p-4 xl:flex-row xl:items-start">
+                                        <div className="min-w-0 flex-1 space-y-2">
+                                            <div className="flex flex-wrap items-center gap-2">
+                                                <StatusBadge status={club.status} styles={CLUB_STATUS_STYLES} />
+                                                <span className="text-sm font-semibold text-foreground">{club.name}</span>
+                                                <Badge variant="outline">Club #{club.id}</Badge>
+                                            </div>
+                                            <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-muted-foreground">
+                                                <span>{locationLabel(club)}</span>
+                                                <span>Level: <span className="text-foreground">{LEVEL_LABELS[club.level] || formatLabel(club.level)}</span></span>
+                                                <span>Provenance: <span className="text-foreground">{formatLabel(club.provenance)}</span></span>
+                                                {club.api_team_id != null && (
+                                                    <span className="font-medium text-emerald-700">API team #{club.api_team_id}</span>
+                                                )}
+                                            </div>
+                                            {club.review_note && (
+                                                <p className="text-xs text-muted-foreground">Review note: {club.review_note}</p>
+                                            )}
+                                        </div>
+
+                                        {hasActions && (
+                                            <div className="flex w-full shrink-0 flex-col gap-2 xl:w-[31rem]">
+                                                {canReview && (
+                                                    <Input
+                                                        value={notes[club.id] || ''}
+                                                        onChange={(event) => setNotes((current) => ({ ...current, [club.id]: event.target.value }))}
+                                                        placeholder="Review note (optional)"
+                                                        aria-label={`Review note for ${club.name}`}
+                                                        maxLength={1000}
+                                                        disabled={isActing}
+                                                    />
+                                                )}
+                                                <div className="flex flex-wrap justify-end gap-2">
+                                                    {canReview && (
+                                                        <Button
+                                                            size="sm"
+                                                            variant="outline"
+                                                            className="border-emerald-600 text-emerald-600 hover:bg-emerald-50"
+                                                            disabled={isActing}
+                                                            onClick={() => reviewClub(club, 'verify')}
+                                                        >
+                                                            {isActing ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Check className="mr-1 h-4 w-4" />}
+                                                            Verify
+                                                        </Button>
+                                                    )}
+                                                    {canReview && (
+                                                        <Button
+                                                            size="sm"
+                                                            variant="outline"
+                                                            className="border-rose-600 text-rose-600 hover:bg-rose-50"
+                                                            disabled={isActing}
+                                                            onClick={() => reviewClub(club, 'reject')}
+                                                        >
+                                                            {isActing ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <X className="mr-1 h-4 w-4" />}
+                                                            Reject
+                                                        </Button>
+                                                    )}
+                                                    {canMerge && (
+                                                        <Button size="sm" variant="outline" disabled={isActing} onClick={() => openMerge(club)}>
+                                                            <GitMerge className="mr-1 h-4 w-4" />
+                                                            Merge
+                                                        </Button>
+                                                    )}
+                                                    {canLink && (
+                                                        <Button size="sm" variant="outline" disabled={isActing} onClick={() => openLink(club)}>
+                                                            <Link2 className="mr-1 h-4 w-4" />
+                                                            {club.api_team_id != null ? 'Edit API link' : 'Link API'}
+                                                        </Button>
+                                                    )}
+                                                </div>
+                                            </div>
+                                        )}
+                                    </div>
+                                )
+                            })}
+                        </div>
+                    )}
+                </CardContent>
+            </Card>
+
+            <Dialog open={Boolean(mergeSource)} onOpenChange={(open) => { if (!open) closeMerge() }}>
+                <DialogContent className="sm:max-w-xl">
+                    <DialogHeader>
+                        <DialogTitle>Merge {mergeSource?.name}</DialogTitle>
+                        <DialogDescription>
+                            Choose the canonical community club. Affiliations will move to the selected club.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <div className="space-y-3">
+                        <div className="space-y-2">
+                            <Label htmlFor="merge-club-search">Find target club</Label>
+                            <div className="relative">
+                                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                                <Input
+                                    id="merge-club-search"
+                                    value={mergeQuery}
+                                    onChange={(event) => setMergeQuery(event.target.value)}
+                                    placeholder="Search by club or location"
+                                    className="pl-9"
+                                    autoComplete="off"
+                                />
+                            </div>
+                        </div>
+
+                        {mergeTargetsLoading ? (
+                            <Loading />
+                        ) : filteredMergeTargets.length === 0 ? (
+                            <p className="rounded-md border border-dashed p-5 text-center text-sm text-muted-foreground">
+                                No matching merge targets.
+                            </p>
+                        ) : (
+                            <div className="max-h-64 space-y-1 overflow-y-auto rounded-md border p-1" role="listbox" aria-label="Merge target clubs">
+                                {filteredMergeTargets.map((club) => {
+                                    const selected = mergeTargetId === String(club.id)
+                                    return (
+                                        <button
+                                            key={club.id}
+                                            type="button"
+                                            role="option"
+                                            aria-selected={selected}
+                                            className={`flex w-full items-center justify-between gap-3 rounded px-3 py-2 text-left transition-colors ${selected ? 'bg-primary/10 text-primary' : 'hover:bg-accent'}`}
+                                            onClick={() => setMergeTargetId(String(club.id))}
+                                        >
+                                            <span className="min-w-0">
+                                                <span className="block truncate text-sm font-medium">{club.name}</span>
+                                                <span className="block truncate text-xs text-muted-foreground">{locationLabel(club)}</span>
+                                            </span>
+                                            <StatusBadge status={club.status} styles={CLUB_STATUS_STYLES} />
+                                        </button>
+                                    )
+                                })}
+                            </div>
+                        )}
+
+                        {mergeError && <p className="text-sm text-rose-700" role="alert">{mergeError}</p>}
+                    </div>
+                    <DialogFooter>
+                        <Button variant="outline" onClick={closeMerge} disabled={actingId === mergeSource?.id}>Cancel</Button>
+                        <Button onClick={mergeClub} disabled={!mergeTargetId || actingId === mergeSource?.id}>
+                            {actingId === mergeSource?.id && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                            Merge club
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            <Dialog open={Boolean(linkClub)} onOpenChange={(open) => { if (!open) closeLink() }}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Link {linkClub?.name} to API-Football</DialogTitle>
+                        <DialogDescription>
+                            Enter the official API-Football team ID that represents this community club.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <div className="space-y-2">
+                        <Label htmlFor="local-club-team-api-id">Team API ID</Label>
+                        <Input
+                            id="local-club-team-api-id"
+                            type="number"
+                            min="1"
+                            step="1"
+                            inputMode="numeric"
+                            value={teamApiId}
+                            onChange={(event) => setTeamApiId(event.target.value)}
+                            placeholder="e.g. 42"
+                        />
+                        {linkError && <p className="text-sm text-rose-700" role="alert">{linkError}</p>}
+                    </div>
+                    <DialogFooter>
+                        <Button variant="outline" onClick={closeLink} disabled={actingId === linkClub?.id}>Cancel</Button>
+                        <Button onClick={linkApiClub} disabled={!teamApiId || actingId === linkClub?.id}>
+                            {actingId === linkClub?.id && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                            Save API link
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </>
+    )
+}
+
+function AffiliationsTab({ setMessage }) {
+    const [affiliations, setAffiliations] = useState([])
+    const [loading, setLoading] = useState(true)
+    const [status, setStatus] = useState('pending')
+    const [reloadKey, setReloadKey] = useState(0)
+    const [actingId, setActingId] = useState(null)
+    const [notes, setNotes] = useState({})
+
+    useEffect(() => {
+        let cancelled = false
+        const params = status === 'all' ? {} : { status }
+        APIService.adminListAffiliations(params)
+            .then((data) => {
+                if (!cancelled) setAffiliations(Array.isArray(data?.affiliations) ? data.affiliations : [])
+            })
+            .catch((err) => {
+                if (!cancelled) setMessage({ type: 'error', text: err.message || 'Failed to load affiliations' })
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false)
+            })
+        return () => { cancelled = true }
+    }, [reloadKey, setMessage, status])
+
+    const reviewAffiliation = async (affiliation, action) => {
+        setActingId(affiliation.id)
+        try {
+            await APIService.adminReviewAffiliation(affiliation.id, {
+                action,
+                note: notes[affiliation.id]?.trim() || '',
+            })
+            setMessage({
+                type: 'success',
+                text: action === 'approve' ? 'Affiliation approved' : 'Affiliation rejected',
+            })
+            setNotes((current) => {
+                const next = { ...current }
+                delete next[affiliation.id]
+                return next
+            })
+            setLoading(true)
+            setReloadKey((key) => key + 1)
+        } catch (err) {
+            setMessage({ type: 'error', text: err.message || 'Failed to review affiliation' })
+        } finally {
+            setActingId(null)
+        }
+    }
+
+    return (
+        <Card>
+            <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                    <CardTitle>Player affiliations</CardTitle>
+                    <CardDescription>Moderate player-submitted club relationships before they appear publicly</CardDescription>
+                </div>
+                <Select value={status} onValueChange={(value) => { setLoading(true); setStatus(value) }}>
+                    <SelectTrigger className="w-44" aria-label="Filter affiliations by status">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="pending">Pending</SelectItem>
+                        <SelectItem value="self_reported">Self-reported</SelectItem>
+                        <SelectItem value="club_confirmed">Club-confirmed</SelectItem>
+                        <SelectItem value="rejected">Rejected</SelectItem>
+                        <SelectItem value="all">All</SelectItem>
+                    </SelectContent>
+                </Select>
+            </CardHeader>
+            <CardContent>
+                {loading ? (
+                    <Loading />
+                ) : affiliations.length === 0 ? (
+                    <p className="py-8 text-center text-sm text-muted-foreground">
+                        No {status === 'all' ? '' : formatLabel(status).toLowerCase()} affiliations.
+                    </p>
+                ) : (
+                    <div className="space-y-3">
+                        {affiliations.map((affiliation) => {
+                            const isActing = actingId === affiliation.id
+                            const isReviewable = affiliation.status === 'pending'
+                            return (
+                                <div key={affiliation.id} className="flex flex-col gap-4 rounded-lg border bg-card p-4 lg:flex-row lg:items-start">
+                                    <div className="min-w-0 flex-1 space-y-2">
+                                        <div className="flex flex-wrap items-center gap-2">
+                                            <StatusBadge
+                                                status={affiliation.status}
+                                                styles={AFFILIATION_STATUS_STYLES}
+                                                labels={AFFILIATION_STATUS_LABELS}
+                                            />
+                                            <span className="text-sm font-semibold text-foreground">{affiliation.club_name || 'Unknown club'}</span>
+                                            <Badge variant="outline">Player #{affiliation.player_api_id}</Badge>
+                                        </div>
+                                        <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-muted-foreground">
+                                            <span>Season: <span className="text-foreground">{affiliation.season || 'Not provided'}</span></span>
+                                            {formatDate(affiliation.created_at) && (
+                                                <span>Submitted {formatDate(affiliation.created_at)}</span>
+                                            )}
+                                        </div>
+                                        {affiliation.review_note && (
+                                            <p className="text-xs text-muted-foreground">Review note: {affiliation.review_note}</p>
+                                        )}
+                                    </div>
+
+                                    {isReviewable && (
+                                        <div className="flex w-full shrink-0 flex-col gap-2 lg:w-80">
+                                            <Input
+                                                value={notes[affiliation.id] || ''}
+                                                onChange={(event) => setNotes((current) => ({ ...current, [affiliation.id]: event.target.value }))}
+                                                placeholder="Review note (optional)"
+                                                aria-label={`Review note for affiliation ${affiliation.id}`}
+                                                maxLength={1000}
+                                                disabled={isActing}
+                                            />
+                                            <div className="flex justify-end gap-2">
+                                                <Button
+                                                    size="sm"
+                                                    variant="outline"
+                                                    className="border-emerald-600 text-emerald-600 hover:bg-emerald-50"
+                                                    disabled={isActing}
+                                                    onClick={() => reviewAffiliation(affiliation, 'approve')}
+                                                >
+                                                    {isActing ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Check className="mr-1 h-4 w-4" />}
+                                                    Approve
+                                                </Button>
+                                                <Button
+                                                    size="sm"
+                                                    variant="outline"
+                                                    className="border-rose-600 text-rose-600 hover:bg-rose-50"
+                                                    disabled={isActing}
+                                                    onClick={() => reviewAffiliation(affiliation, 'reject')}
+                                                >
+                                                    {isActing ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <X className="mr-1 h-4 w-4" />}
+                                                    Reject
+                                                </Button>
+                                            </div>
+                                        </div>
+                                    )}
+                                </div>
+                            )
+                        })}
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    )
+}
+
+export function AdminLocalClubs() {
+    const [message, setMessage] = useState(null)
+    const [tab, setTab] = useState('clubs')
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-center gap-3">
+                <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10">
+                    <Landmark className="h-5 w-5 text-primary" />
+                </div>
+                <div>
+                    <h2 className="text-3xl font-bold tracking-tight">Local Clubs</h2>
+                    <p className="text-muted-foreground">Moderate community clubs and player affiliations</p>
+                </div>
+            </div>
+
+            {message && (
+                <Alert className={message.type === 'error' ? 'border-rose-500 bg-rose-50' : 'border-emerald-500 bg-emerald-50'}>
+                    {message.type === 'error' ? (
+                        <AlertCircle className="h-4 w-4 text-rose-600" />
+                    ) : (
+                        <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+                    )}
+                    <AlertDescription className={message.type === 'error' ? 'text-rose-800' : 'text-emerald-800'}>
+                        {message.text}
+                    </AlertDescription>
+                </Alert>
+            )}
+
+            <Tabs value={tab} onValueChange={setTab}>
+                <TabsList className="h-auto flex-wrap justify-start">
+                    <TabsTrigger value="clubs">
+                        <Landmark className="mr-1.5 h-4 w-4" />
+                        Clubs
+                    </TabsTrigger>
+                    <TabsTrigger value="affiliations">
+                        <Link2 className="mr-1.5 h-4 w-4" />
+                        Affiliations
+                    </TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="clubs" className="mt-4">
+                    {tab === 'clubs' && <ClubsTab setMessage={setMessage} />}
+                </TabsContent>
+                <TabsContent value="affiliations" className="mt-4">
+                    {tab === 'affiliations' && <AffiliationsTab setMessage={setMessage} />}
+                </TabsContent>
+            </Tabs>
+        </div>
+    )
+}
+
+export default AdminLocalClubs

--- a/academy-watch-frontend/src/pages/admin/AdminLocalClubs.jsx
+++ b/academy-watch-frontend/src/pages/admin/AdminLocalClubs.jsx
@@ -30,7 +30,10 @@ import {
     Landmark,
     Link2,
     Loader2,
+    RefreshCw,
     Search,
+    ShieldCheck,
+    Undo2,
     X,
 } from 'lucide-react'
 
@@ -53,6 +56,28 @@ const AFFILIATION_STATUS_LABELS = {
     self_reported: 'Self-reported',
     club_confirmed: 'Club-confirmed',
     rejected: 'Rejected',
+}
+
+const CLUB_CLAIM_STATUS_STYLES = {
+    pending: 'bg-amber-50 text-amber-800 border-amber-200',
+    approved: 'bg-emerald-50 text-emerald-800 border-emerald-200',
+    rejected: 'bg-rose-50 text-rose-800 border-rose-200',
+    revoked: 'bg-stone-100 text-stone-700 border-stone-200',
+}
+
+const VERIFICATION_STATUS = {
+    unverified: {
+        label: 'Unverified',
+        className: 'bg-amber-50 text-amber-800 border-amber-200',
+    },
+    code_found: {
+        label: 'Code detected',
+        className: 'bg-emerald-50 text-emerald-800 border-emerald-300',
+    },
+    code_not_found: {
+        label: 'Code not found',
+        className: 'bg-rose-50 text-rose-800 border-rose-200',
+    },
 }
 
 const LEVEL_LABELS = {
@@ -632,6 +657,268 @@ function AffiliationsTab({ setMessage }) {
     )
 }
 
+function OfficialsTab({ setMessage }) {
+    const [claims, setClaims] = useState([])
+    const [loading, setLoading] = useState(true)
+    const [loadFailed, setLoadFailed] = useState(false)
+    const [status, setStatus] = useState('pending')
+    const [reloadKey, setReloadKey] = useState(0)
+    const [actingId, setActingId] = useState(null)
+    const [notes, setNotes] = useState({})
+
+    useEffect(() => {
+        let cancelled = false
+        const params = status === 'all' ? {} : { status }
+        APIService.adminListClubClaims(params)
+            .then((data) => {
+                if (!cancelled) {
+                    setClaims(Array.isArray(data?.claims) ? data.claims : [])
+                    setLoadFailed(false)
+                }
+            })
+            .catch((err) => {
+                if (!cancelled) {
+                    setLoadFailed(true)
+                    setMessage({ type: 'error', text: err.message || 'Failed to load club-official claims' })
+                }
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false)
+            })
+        return () => { cancelled = true }
+    }, [reloadKey, setMessage, status])
+
+    const reviewClaim = async (claim, action) => {
+        if (actingId !== null) return
+        setActingId(claim.id)
+        try {
+            await APIService.adminReviewClubClaim(claim.id, {
+                action,
+                note: notes[claim.id]?.trim() || '',
+            })
+            const actionLabel = action === 'approve' ? 'approved' : action === 'reject' ? 'rejected' : 'revoked'
+            setMessage({ type: 'success', text: `${claim.club_name || 'Club-official claim'} ${actionLabel}` })
+            setNotes((current) => {
+                const next = { ...current }
+                delete next[claim.id]
+                return next
+            })
+            setClaims([])
+            setLoadFailed(false)
+            setLoading(true)
+            setReloadKey((key) => key + 1)
+        } catch (err) {
+            setMessage({ type: 'error', text: err.message || 'Failed to review club-official claim' })
+        } finally {
+            setActingId(null)
+        }
+    }
+
+    const recheckProof = async (claim) => {
+        if (actingId !== null) return
+        setActingId(claim.id)
+        try {
+            await APIService.adminRecheckClubClaim(claim.id)
+            setMessage({ type: 'success', text: 'Social profile check refreshed' })
+            setClaims([])
+            setLoadFailed(false)
+            setLoading(true)
+            setReloadKey((key) => key + 1)
+        } catch (err) {
+            setMessage({ type: 'error', text: err.message || 'Failed to re-check social profile' })
+        } finally {
+            setActingId(null)
+        }
+    }
+
+    return (
+        <Card>
+            <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                    <CardTitle>Club officials</CardTitle>
+                    <CardDescription>Review people requesting authority to act for a club</CardDescription>
+                </div>
+                <Select
+                    value={status}
+                    onValueChange={(value) => { setClaims([]); setLoadFailed(false); setLoading(true); setStatus(value) }}
+                    disabled={actingId !== null}
+                >
+                    <SelectTrigger className="w-40" aria-label="Filter club-official claims by status">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="pending">Pending</SelectItem>
+                        <SelectItem value="approved">Approved</SelectItem>
+                        <SelectItem value="rejected">Rejected</SelectItem>
+                        <SelectItem value="revoked">Revoked</SelectItem>
+                        <SelectItem value="all">All</SelectItem>
+                    </SelectContent>
+                </Select>
+            </CardHeader>
+            <CardContent>
+                {loading ? (
+                    <Loading />
+                ) : loadFailed ? (
+                    <p className="rounded-md border border-dashed py-8 text-center text-sm text-muted-foreground">
+                        Club-official claims could not be loaded. Change the filter to try again.
+                    </p>
+                ) : claims.length === 0 ? (
+                    <p className="py-8 text-center text-sm text-muted-foreground">
+                        No {status === 'all' ? '' : status} club-official claims.
+                    </p>
+                ) : (
+                    <div className="space-y-3">
+                        {claims.map((claim) => {
+                            const isActing = actingId === claim.id
+                            const isPending = claim.status === 'pending'
+                            const isApproved = claim.status === 'approved'
+                            const claimant = claim.claimant_display_name
+                                || claim.claimant_email
+                                || claim.user_email
+                                || `User #${claim.user_account_id ?? '—'}`
+                            const verification = VERIFICATION_STATUS[claim.verification_status] || VERIFICATION_STATUS.unverified
+                            return (
+                                <div key={claim.id} className="space-y-4 rounded-lg border bg-card p-4">
+                                    <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                                        <div className="min-w-0 flex-1 space-y-2">
+                                            <div className="flex flex-wrap items-center gap-2">
+                                                <StatusBadge status={claim.status} styles={CLUB_CLAIM_STATUS_STYLES} />
+                                                <span className="text-sm font-semibold text-foreground">{claim.club_name || 'Unknown club'}</span>
+                                                <Badge variant="secondary">{claim.role_title || 'Club official'}</Badge>
+                                            </div>
+                                            <p className="text-sm font-medium text-foreground">{claimant}</p>
+                                            {claim.message && (
+                                                <p className="text-sm text-muted-foreground">“{claim.message}”</p>
+                                            )}
+                                            {formatDate(claim.created_at) && (
+                                                <p className="text-xs text-muted-foreground">Submitted {formatDate(claim.created_at)}</p>
+                                            )}
+
+                                            <div className="mt-3 rounded-md border border-border/70 bg-secondary/30 p-3">
+                                                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                                    <div className="flex flex-wrap items-center gap-2">
+                                                        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                                            Social profile check
+                                                        </span>
+                                                        <Badge className={verification.className}>{verification.label}</Badge>
+                                                    </div>
+                                                    <Button
+                                                        size="sm"
+                                                        variant="outline"
+                                                        className="self-start sm:self-auto"
+                                                        disabled={!claim.verification_proof_url || actingId !== null}
+                                                        onClick={() => recheckProof(claim)}
+                                                        title={claim.verification_proof_url ? 'Run the automated check again' : 'No proof URL has been submitted'}
+                                                    >
+                                                        {isActing ? (
+                                                            <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                                                        ) : (
+                                                            <RefreshCw className="mr-1 h-4 w-4" />
+                                                        )}
+                                                        Re-check
+                                                    </Button>
+                                                </div>
+                                                <dl className="mt-3 grid gap-x-6 gap-y-2 text-xs sm:grid-cols-2">
+                                                    <div>
+                                                        <dt className="text-muted-foreground">Verification code</dt>
+                                                        <dd className="mt-0.5 font-mono font-semibold tracking-wide text-foreground">
+                                                            {claim.verification_code || '—'}
+                                                        </dd>
+                                                    </div>
+                                                    <div>
+                                                        <dt className="text-muted-foreground">Last checked</dt>
+                                                        <dd className="mt-0.5 text-foreground">
+                                                            {formatDate(claim.verification_checked_at) || 'Not checked yet'}
+                                                        </dd>
+                                                    </div>
+                                                    <div className="sm:col-span-2">
+                                                        <dt className="text-muted-foreground">Public profile</dt>
+                                                        <dd className="mt-0.5 min-w-0">
+                                                            {claim.verification_proof_url ? (
+                                                                <a
+                                                                    href={claim.verification_proof_url}
+                                                                    target="_blank"
+                                                                    rel="noreferrer"
+                                                                    className="break-all font-medium text-primary hover:underline"
+                                                                >
+                                                                    {claim.verification_proof_url}
+                                                                </a>
+                                                            ) : (
+                                                                <span className="text-foreground">No profile URL submitted</span>
+                                                            )}
+                                                        </dd>
+                                                    </div>
+                                                    {claim.verification_note && (
+                                                        <div className="sm:col-span-2">
+                                                            <dt className="text-muted-foreground">Check note</dt>
+                                                            <dd className="mt-0.5 text-foreground">{claim.verification_note}</dd>
+                                                        </div>
+                                                    )}
+                                                </dl>
+                                            </div>
+                                        </div>
+
+                                        {(isPending || isApproved) && (
+                                            <div className="flex w-full shrink-0 flex-col gap-2 lg:w-80">
+                                                <Input
+                                                    value={notes[claim.id] || ''}
+                                                    onChange={(event) => setNotes((current) => ({ ...current, [claim.id]: event.target.value }))}
+                                                    placeholder="Review note (optional)"
+                                                    aria-label={`Review note for club-official claim ${claim.id}`}
+                                                    maxLength={1000}
+                                                    disabled={isActing}
+                                                />
+                                                <div className="flex flex-wrap justify-end gap-2">
+                                                    {isPending && (
+                                                        <>
+                                                            <Button
+                                                                size="sm"
+                                                                variant="outline"
+                                                                className="border-emerald-600 text-emerald-600 hover:bg-emerald-50"
+                                                                disabled={actingId !== null}
+                                                                onClick={() => reviewClaim(claim, 'approve')}
+                                                            >
+                                                                {isActing ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Check className="mr-1 h-4 w-4" />}
+                                                                Approve
+                                                            </Button>
+                                                            <Button
+                                                                size="sm"
+                                                                variant="outline"
+                                                                className="border-rose-600 text-rose-600 hover:bg-rose-50"
+                                                                disabled={actingId !== null}
+                                                                onClick={() => reviewClaim(claim, 'reject')}
+                                                            >
+                                                                {isActing ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <X className="mr-1 h-4 w-4" />}
+                                                                Reject
+                                                            </Button>
+                                                        </>
+                                                    )}
+                                                    {isApproved && (
+                                                        <Button
+                                                            size="sm"
+                                                            variant="outline"
+                                                            className="border-stone-400 text-stone-600 hover:bg-stone-50"
+                                                            disabled={actingId !== null}
+                                                            onClick={() => reviewClaim(claim, 'revoke')}
+                                                        >
+                                                            {isActing ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Undo2 className="mr-1 h-4 w-4" />}
+                                                            Revoke
+                                                        </Button>
+                                                    )}
+                                                </div>
+                                            </div>
+                                        )}
+                                    </div>
+                                </div>
+                            )
+                        })}
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    )
+}
+
 export function AdminLocalClubs() {
     const [message, setMessage] = useState(null)
     const [tab, setTab] = useState('clubs')
@@ -644,7 +931,7 @@ export function AdminLocalClubs() {
                 </div>
                 <div>
                     <h2 className="text-3xl font-bold tracking-tight">Local Clubs</h2>
-                    <p className="text-muted-foreground">Moderate community clubs and player affiliations</p>
+                    <p className="text-muted-foreground">Moderate community clubs, player affiliations and club officials</p>
                 </div>
             </div>
 
@@ -671,6 +958,10 @@ export function AdminLocalClubs() {
                         <Link2 className="mr-1.5 h-4 w-4" />
                         Affiliations
                     </TabsTrigger>
+                    <TabsTrigger value="officials">
+                        <ShieldCheck className="mr-1.5 h-4 w-4" />
+                        Officials
+                    </TabsTrigger>
                 </TabsList>
 
                 <TabsContent value="clubs" className="mt-4">
@@ -678,6 +969,9 @@ export function AdminLocalClubs() {
                 </TabsContent>
                 <TabsContent value="affiliations" className="mt-4">
                     {tab === 'affiliations' && <AffiliationsTab setMessage={setMessage} />}
+                </TabsContent>
+                <TabsContent value="officials" className="mt-4">
+                    {tab === 'officials' && <OfficialsTab setMessage={setMessage} />}
                 </TabsContent>
             </Tabs>
         </div>

--- a/academy-watch-frontend/src/pages/admin/AdminShowcase.jsx
+++ b/academy-watch-frontend/src/pages/admin/AdminShowcase.jsx
@@ -28,6 +28,7 @@ import {
     UserSquare,
     Link2,
     Image as ImageIcon,
+    RefreshCw,
 } from 'lucide-react'
 
 const CLAIM_STATUS_COLORS = {
@@ -35,6 +36,21 @@ const CLAIM_STATUS_COLORS = {
     approved: 'bg-emerald-50 text-emerald-800 border-emerald-200',
     rejected: 'bg-rose-50 text-rose-800 border-rose-200',
     revoked: 'bg-stone-100 text-stone-700 border-stone-200',
+}
+
+const VERIFICATION_STATUS = {
+    unverified: {
+        label: 'Unverified',
+        className: 'bg-amber-50 text-amber-800 border-amber-200',
+    },
+    code_found: {
+        label: 'Code detected',
+        className: 'bg-emerald-50 text-emerald-800 border-emerald-300',
+    },
+    code_not_found: {
+        label: 'Code not found',
+        className: 'bg-rose-50 text-rose-800 border-rose-200',
+    },
 }
 
 const IDENTITY_COLORS = {
@@ -140,6 +156,19 @@ function ClaimsTab({ setMessage }) {
         }
     }
 
+    const recheckProof = async (claim) => {
+        setActingId(claim.id)
+        try {
+            await APIService.adminRecheckClaim(claim.id)
+            setMessage({ type: 'success', text: 'Social profile check refreshed' })
+            setReloadKey((k) => k + 1)
+        } catch (err) {
+            setMessage({ type: 'error', text: err.message || 'Failed to re-check social profile' })
+        } finally {
+            setActingId(null)
+        }
+    }
+
     return (
         <Card>
             <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -169,6 +198,7 @@ function ClaimsTab({ setMessage }) {
                     <div className="space-y-3">
                         {claims.map((claim) => {
                             const claimant = claim.claimant_display_name || claim.claimant_email || claim.user_email || `User #${claim.user_account_id ?? '—'}`
+                            const verification = VERIFICATION_STATUS[claim.verification_status] || VERIFICATION_STATUS.unverified
                             return (
                                 <div key={claim.id} className="flex flex-col justify-between gap-4 rounded-lg border bg-card p-4 sm:flex-row sm:items-start">
                                     <div className="min-w-0 flex-1 space-y-1">
@@ -189,6 +219,68 @@ function ClaimsTab({ setMessage }) {
                                         {formatDate(claim.created_at) && (
                                             <p className="text-xs text-muted-foreground">Submitted {formatDate(claim.created_at)}</p>
                                         )}
+                                        <div className="mt-3 rounded-md border border-border/70 bg-secondary/30 p-3">
+                                            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                                <div className="flex flex-wrap items-center gap-2">
+                                                    <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                                        Social profile check
+                                                    </span>
+                                                    <Badge className={verification.className}>{verification.label}</Badge>
+                                                </div>
+                                                <Button
+                                                    size="sm"
+                                                    variant="outline"
+                                                    className="self-start sm:self-auto"
+                                                    disabled={!claim.verification_proof_url || actingId === claim.id}
+                                                    onClick={() => recheckProof(claim)}
+                                                    title={claim.verification_proof_url ? 'Run the automated check again' : 'No proof URL has been submitted'}
+                                                >
+                                                    {actingId === claim.id ? (
+                                                        <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                                                    ) : (
+                                                        <RefreshCw className="mr-1 h-4 w-4" />
+                                                    )}
+                                                    Re-check
+                                                </Button>
+                                            </div>
+                                            <dl className="mt-3 grid gap-x-6 gap-y-2 text-xs sm:grid-cols-2">
+                                                <div>
+                                                    <dt className="text-muted-foreground">Verification code</dt>
+                                                    <dd className="mt-0.5 font-mono font-semibold tracking-wide text-foreground">
+                                                        {claim.verification_code || '—'}
+                                                    </dd>
+                                                </div>
+                                                <div>
+                                                    <dt className="text-muted-foreground">Last checked</dt>
+                                                    <dd className="mt-0.5 text-foreground">
+                                                        {formatDate(claim.verification_checked_at) || 'Not checked yet'}
+                                                    </dd>
+                                                </div>
+                                                <div className="sm:col-span-2">
+                                                    <dt className="text-muted-foreground">Public profile</dt>
+                                                    <dd className="mt-0.5 min-w-0">
+                                                        {claim.verification_proof_url ? (
+                                                            <a
+                                                                href={claim.verification_proof_url}
+                                                                target="_blank"
+                                                                rel="noreferrer"
+                                                                className="break-all font-medium text-primary hover:underline"
+                                                            >
+                                                                {claim.verification_proof_url}
+                                                            </a>
+                                                        ) : (
+                                                            <span className="text-foreground">No profile URL submitted</span>
+                                                        )}
+                                                    </dd>
+                                                </div>
+                                                {claim.verification_note && (
+                                                    <div className="sm:col-span-2">
+                                                        <dt className="text-muted-foreground">Check note</dt>
+                                                        <dd className="mt-0.5 text-foreground">{claim.verification_note}</dd>
+                                                    </div>
+                                                )}
+                                            </dl>
+                                        </div>
                                     </div>
                                     <div className="flex shrink-0 items-center gap-2">
                                         {claim.status === 'pending' && (

--- a/academy-watch-frontend/src/pages/admin/AdminShowcase.jsx
+++ b/academy-watch-frontend/src/pages/admin/AdminShowcase.jsx
@@ -1,12 +1,21 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { APIService } from '@/lib/api'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog'
 import {
     Select,
     SelectContent,
@@ -29,6 +38,7 @@ import {
     Link2,
     Image as ImageIcon,
     RefreshCw,
+    GitMerge,
 } from 'lucide-react'
 
 const CLAIM_STATUS_COLORS = {
@@ -58,6 +68,13 @@ const IDENTITY_COLORS = {
     high: 'bg-sky-50 text-sky-800 border-sky-200',
     low: 'bg-amber-50 text-amber-800 border-amber-200',
     unverified: 'bg-stone-100 text-stone-700 border-stone-200',
+}
+
+const LOCAL_PLAYER_STATUS_COLORS = {
+    pending: 'bg-amber-50 text-amber-800 border-amber-200',
+    approved: 'bg-emerald-50 text-emerald-800 border-emerald-200',
+    rejected: 'bg-rose-50 text-rose-800 border-rose-200',
+    merged: 'bg-stone-100 text-stone-700 border-stone-200',
 }
 
 const RELATIONSHIP_LABELS = {
@@ -117,6 +134,10 @@ function Loading() {
             <span className="text-sm text-muted-foreground">Loading…</span>
         </div>
     )
+}
+
+function localPlayerLocation(player) {
+    return [player.city, player.country].filter(Boolean).join(', ') || 'Location not provided'
 }
 
 // ---------------------------------------------------------------------------
@@ -579,6 +600,419 @@ function MediaTab({ setMessage }) {
 }
 
 // ---------------------------------------------------------------------------
+// Local players
+// ---------------------------------------------------------------------------
+
+function LocalPlayersTab({ setMessage }) {
+    const [players, setPlayers] = useState([])
+    const [loading, setLoading] = useState(true)
+    const [status, setStatus] = useState('pending')
+    const [reloadKey, setReloadKey] = useState(0)
+    const [actingId, setActingId] = useState(null)
+    const [notes, setNotes] = useState({})
+
+    const [mergeSource, setMergeSource] = useState(null)
+    const [mergeQuery, setMergeQuery] = useState('')
+    const [mergeTargets, setMergeTargets] = useState([])
+    const [mergeTargetsLoading, setMergeTargetsLoading] = useState(false)
+    const [mergeTargetId, setMergeTargetId] = useState('')
+    const [mergeError, setMergeError] = useState('')
+
+    const [linkPlayer, setLinkPlayer] = useState(null)
+    const [playerApiId, setPlayerApiId] = useState('')
+    const [linkError, setLinkError] = useState('')
+
+    useEffect(() => {
+        let cancelled = false
+        const params = status === 'all' ? {} : { status }
+        APIService.adminListLocalPlayers(params)
+            .then((data) => {
+                if (!cancelled) setPlayers(asArray(data, 'players'))
+            })
+            .catch((err) => {
+                if (!cancelled) setMessage({ type: 'error', text: err.message || 'Failed to load local players' })
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false)
+            })
+        return () => { cancelled = true }
+    }, [reloadKey, setMessage, status])
+
+    useEffect(() => {
+        if (!mergeSource) return undefined
+
+        let cancelled = false
+        APIService.adminListLocalPlayers({})
+            .then((data) => {
+                if (!cancelled) setMergeTargets(asArray(data, 'players'))
+            })
+            .catch((err) => {
+                if (!cancelled) setMergeError(err.message || 'Failed to load merge targets')
+            })
+            .finally(() => {
+                if (!cancelled) setMergeTargetsLoading(false)
+            })
+
+        return () => { cancelled = true }
+    }, [mergeSource])
+
+    const filteredMergeTargets = useMemo(() => {
+        const query = mergeQuery.trim().toLowerCase()
+        return mergeTargets.filter((player) => {
+            if (Number(player.id) === Number(mergeSource?.id)) return false
+            if (!query) return true
+            return [player.display_name, player.position, player.city, player.country, player.birth_year]
+                .filter((value) => value != null && value !== '')
+                .some((value) => String(value).toLowerCase().includes(query))
+        })
+    }, [mergeQuery, mergeSource?.id, mergeTargets])
+
+    const reviewPlayer = async (player, action) => {
+        setActingId(player.id)
+        try {
+            await APIService.adminReviewLocalPlayer(player.id, {
+                action,
+                note: notes[player.id]?.trim() || undefined,
+            })
+            setMessage({
+                type: 'success',
+                text: `${player.display_name || 'Local player'} ${action === 'approve' ? 'approved' : 'rejected'}`,
+            })
+            setNotes((current) => {
+                const next = { ...current }
+                delete next[player.id]
+                return next
+            })
+            setLoading(true)
+            setReloadKey((key) => key + 1)
+        } catch (err) {
+            setMessage({ type: 'error', text: err.message || 'Failed to review local player' })
+        } finally {
+            setActingId(null)
+        }
+    }
+
+    const openMerge = (player) => {
+        setMergeSource(player)
+        setMergeQuery('')
+        setMergeTargets([])
+        setMergeTargetsLoading(true)
+        setMergeTargetId('')
+        setMergeError('')
+    }
+
+    const closeMerge = () => {
+        setMergeSource(null)
+        setMergeQuery('')
+        setMergeTargets([])
+        setMergeTargetsLoading(false)
+        setMergeTargetId('')
+        setMergeError('')
+    }
+
+    const mergePlayer = async () => {
+        const targetId = Number(mergeTargetId)
+        if (!mergeSource || !Number.isInteger(targetId) || targetId <= 0 || targetId === Number(mergeSource.id)) {
+            setMergeError('Select a different player as the merge target')
+            return
+        }
+
+        setActingId(mergeSource.id)
+        setMergeError('')
+        try {
+            await APIService.adminMergeLocalPlayer(mergeSource.id, { into_local_player_id: targetId })
+            setMessage({ type: 'success', text: `${mergeSource.display_name || 'Local player'} merged successfully` })
+            closeMerge()
+            setLoading(true)
+            setReloadKey((key) => key + 1)
+        } catch (err) {
+            setMergeError(err.message || 'Failed to merge local player')
+        } finally {
+            setActingId(null)
+        }
+    }
+
+    const openLink = (player) => {
+        setLinkPlayer(player)
+        setPlayerApiId(player.api_player_id != null ? String(player.api_player_id) : '')
+        setLinkError('')
+    }
+
+    const closeLink = () => {
+        setLinkPlayer(null)
+        setPlayerApiId('')
+        setLinkError('')
+    }
+
+    const linkApiPlayer = async () => {
+        const parsedPlayerApiId = Number(playerApiId)
+        if (!linkPlayer || !Number.isInteger(parsedPlayerApiId) || parsedPlayerApiId <= 0) {
+            setLinkError('Enter a valid positive API-Football player ID')
+            return
+        }
+
+        setActingId(linkPlayer.id)
+        setLinkError('')
+        try {
+            await APIService.adminLinkLocalPlayerApi(linkPlayer.id, { player_api_id: parsedPlayerApiId })
+            setMessage({
+                type: 'success',
+                text: `${linkPlayer.display_name || 'Local player'} linked to API player #${parsedPlayerApiId}`,
+            })
+            closeLink()
+            setLoading(true)
+            setReloadKey((key) => key + 1)
+        } catch (err) {
+            setLinkError(err.message || 'Failed to link API-Football player')
+        } finally {
+            setActingId(null)
+        }
+    }
+
+    return (
+        <>
+            <Card>
+                <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <CardTitle>Local players</CardTitle>
+                        <CardDescription>Review, deduplicate and connect community-created player profiles</CardDescription>
+                    </div>
+                    <Select
+                        value={status}
+                        onValueChange={(value) => { setLoading(true); setStatus(value) }}
+                        disabled={loading || actingId !== null}
+                    >
+                        <SelectTrigger className="w-40" aria-label="Filter local players by status">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="pending">Pending</SelectItem>
+                            <SelectItem value="approved">Approved</SelectItem>
+                            <SelectItem value="rejected">Rejected</SelectItem>
+                            <SelectItem value="merged">Merged</SelectItem>
+                            <SelectItem value="all">All</SelectItem>
+                        </SelectContent>
+                    </Select>
+                </CardHeader>
+                <CardContent>
+                    {loading ? (
+                        <Loading />
+                    ) : players.length === 0 ? (
+                        <p className="py-8 text-center text-sm text-muted-foreground">
+                            No {status === 'all' ? '' : status} local players.
+                        </p>
+                    ) : (
+                        <div className="space-y-3">
+                            {players.map((player) => {
+                                const playerName = player.display_name || `Local player #${player.id}`
+                                const creatorEmail = player.creator_email
+                                    || player.created_by_email
+                                    || player.user_email
+                                    || player.creator?.email
+                                const isActing = actingId === player.id
+                                const isBusy = actingId !== null
+                                const canReview = player.status === 'pending'
+                                const canManage = player.status !== 'merged'
+                                return (
+                                    <div key={player.id} className="flex flex-col gap-4 rounded-lg border bg-card p-4 xl:flex-row xl:items-start">
+                                        <div className="min-w-0 flex-1 space-y-2">
+                                            <div className="flex flex-wrap items-center gap-2">
+                                                <Badge className={LOCAL_PLAYER_STATUS_COLORS[player.status] || 'bg-stone-100 text-stone-700 border-stone-200'}>
+                                                    {String(player.status || 'unknown').replace(/_/g, ' ')}
+                                                </Badge>
+                                                <span className="text-sm font-semibold text-foreground">{playerName}</span>
+                                                <Badge variant="outline">Local player #{player.id}</Badge>
+                                            </div>
+                                            <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-muted-foreground">
+                                                {player.birth_year != null && (
+                                                    <span>Birth year: <span className="text-foreground">{player.birth_year}</span></span>
+                                                )}
+                                                {player.position && (
+                                                    <span>Position: <span className="text-foreground">{player.position}</span></span>
+                                                )}
+                                                <span>{localPlayerLocation(player)}</span>
+                                                {creatorEmail && (
+                                                    <span>Created by: <span className="text-foreground">{creatorEmail}</span></span>
+                                                )}
+                                                {player.api_player_id != null && (
+                                                    <span className="font-medium text-emerald-700">API player #{player.api_player_id}</span>
+                                                )}
+                                            </div>
+                                            {player.review_note && (
+                                                <p className="text-xs text-muted-foreground">Review note: {player.review_note}</p>
+                                            )}
+                                        </div>
+
+                                        {canReview || canManage ? (
+                                            <div className="flex w-full shrink-0 flex-col gap-2 xl:w-[31rem]">
+                                                {canReview && (
+                                                    <Input
+                                                        value={notes[player.id] || ''}
+                                                        onChange={(event) => setNotes((current) => ({ ...current, [player.id]: event.target.value }))}
+                                                        placeholder="Review note (optional)"
+                                                        aria-label={`Review note for ${playerName}`}
+                                                        maxLength={1000}
+                                                        disabled={isBusy}
+                                                    />
+                                                )}
+                                                <div className="flex flex-wrap justify-end gap-2">
+                                                    {canReview && (
+                                                        <Button
+                                                            size="sm"
+                                                            variant="outline"
+                                                            className="border-emerald-600 text-emerald-600 hover:bg-emerald-50"
+                                                            disabled={isBusy}
+                                                            onClick={() => reviewPlayer(player, 'approve')}
+                                                        >
+                                                            {isActing ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Check className="mr-1 h-4 w-4" />}
+                                                            Approve
+                                                        </Button>
+                                                    )}
+                                                    {canReview && (
+                                                        <Button
+                                                            size="sm"
+                                                            variant="outline"
+                                                            className="border-rose-600 text-rose-600 hover:bg-rose-50"
+                                                            disabled={isBusy}
+                                                            onClick={() => reviewPlayer(player, 'reject')}
+                                                        >
+                                                            {isActing ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <X className="mr-1 h-4 w-4" />}
+                                                            Reject
+                                                        </Button>
+                                                    )}
+                                                    {canManage && (
+                                                        <Button size="sm" variant="outline" disabled={isBusy} onClick={() => openMerge(player)}>
+                                                            <GitMerge className="mr-1 h-4 w-4" />
+                                                            Merge
+                                                        </Button>
+                                                    )}
+                                                    {canManage && (
+                                                        <Button size="sm" variant="outline" disabled={isBusy} onClick={() => openLink(player)}>
+                                                            <Link2 className="mr-1 h-4 w-4" />
+                                                            {player.api_player_id != null ? 'Edit API link' : 'Link API'}
+                                                        </Button>
+                                                    )}
+                                                </div>
+                                            </div>
+                                        ) : null}
+                                    </div>
+                                )
+                            })}
+                        </div>
+                    )}
+                </CardContent>
+            </Card>
+
+            <Dialog open={Boolean(mergeSource)} onOpenChange={(open) => { if (!open && actingId !== mergeSource?.id) closeMerge() }}>
+                <DialogContent className="sm:max-w-xl">
+                    <DialogHeader>
+                        <DialogTitle>Merge {mergeSource?.display_name || 'local player'}</DialogTitle>
+                        <DialogDescription>
+                            Choose the canonical community player profile. The source profile will be merged into it.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <div className="space-y-3">
+                        <div className="space-y-2">
+                            <Label htmlFor="merge-local-player-search">Find target player</Label>
+                            <div className="relative">
+                                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                                <Input
+                                    id="merge-local-player-search"
+                                    value={mergeQuery}
+                                    onChange={(event) => setMergeQuery(event.target.value)}
+                                    placeholder="Search by name, position or location"
+                                    className="pl-9"
+                                    autoComplete="off"
+                                    disabled={actingId === mergeSource?.id}
+                                />
+                            </div>
+                        </div>
+
+                        {mergeTargetsLoading ? (
+                            <Loading />
+                        ) : filteredMergeTargets.length === 0 ? (
+                            <p className="rounded-md border border-dashed p-5 text-center text-sm text-muted-foreground">
+                                No matching merge targets.
+                            </p>
+                        ) : (
+                            <div className="max-h-64 space-y-1 overflow-y-auto rounded-md border p-1" aria-label="Merge target players">
+                                {filteredMergeTargets.map((player) => {
+                                    const selected = mergeTargetId === String(player.id)
+                                    return (
+                                        <button
+                                            key={player.id}
+                                            type="button"
+                                            aria-pressed={selected}
+                                            disabled={actingId === mergeSource?.id}
+                                            className={`flex w-full items-center justify-between gap-3 rounded px-3 py-2 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${selected ? 'bg-primary/10 text-primary' : 'hover:bg-accent'}`}
+                                            onClick={() => setMergeTargetId(String(player.id))}
+                                        >
+                                            <span className="min-w-0">
+                                                <span className="block truncate text-sm font-medium">
+                                                    {player.display_name || `Local player #${player.id}`}
+                                                </span>
+                                                <span className="block truncate text-xs text-muted-foreground">
+                                                    {[player.position, player.birth_year, localPlayerLocation(player)].filter(Boolean).join(' · ')}
+                                                </span>
+                                            </span>
+                                            <Badge className={LOCAL_PLAYER_STATUS_COLORS[player.status] || 'bg-stone-100 text-stone-700 border-stone-200'}>
+                                                {String(player.status || 'unknown').replace(/_/g, ' ')}
+                                            </Badge>
+                                        </button>
+                                    )
+                                })}
+                            </div>
+                        )}
+
+                        {mergeError && <p className="text-sm text-rose-700" role="alert">{mergeError}</p>}
+                    </div>
+                    <DialogFooter>
+                        <Button variant="outline" onClick={closeMerge} disabled={actingId === mergeSource?.id}>Cancel</Button>
+                        <Button onClick={mergePlayer} disabled={!mergeTargetId || mergeTargetsLoading || actingId === mergeSource?.id}>
+                            {actingId === mergeSource?.id && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                            Merge player
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            <Dialog open={Boolean(linkPlayer)} onOpenChange={(open) => { if (!open && actingId !== linkPlayer?.id) closeLink() }}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Link {linkPlayer?.display_name || 'local player'} to API-Football</DialogTitle>
+                        <DialogDescription>
+                            Enter the official API-Football player ID that represents this community profile.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <div className="space-y-2">
+                        <Label htmlFor="local-player-api-id">Player API ID</Label>
+                        <Input
+                            id="local-player-api-id"
+                            type="number"
+                            min="1"
+                            step="1"
+                            inputMode="numeric"
+                            value={playerApiId}
+                            onChange={(event) => setPlayerApiId(event.target.value)}
+                            placeholder="e.g. 284324"
+                            disabled={actingId === linkPlayer?.id}
+                        />
+                        {linkError && <p className="text-sm text-rose-700" role="alert">{linkError}</p>}
+                    </div>
+                    <DialogFooter>
+                        <Button variant="outline" onClick={closeLink} disabled={actingId === linkPlayer?.id}>Cancel</Button>
+                        <Button onClick={linkApiPlayer} disabled={!playerApiId.trim() || actingId === linkPlayer?.id}>
+                            {actingId === linkPlayer?.id && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                            Save API link
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </>
+    )
+}
+
+// ---------------------------------------------------------------------------
 // Film Room links — link finalized-match roster entries to a tracked player
 // ---------------------------------------------------------------------------
 
@@ -829,6 +1263,10 @@ export function AdminShowcase() {
                         <ImageIcon className="mr-1.5 h-4 w-4" />
                         Media
                     </TabsTrigger>
+                    <TabsTrigger value="local-players">
+                        <UserSquare className="mr-1.5 h-4 w-4" />
+                        Local players
+                    </TabsTrigger>
                 </TabsList>
 
                 <TabsContent value="claims" className="mt-4">
@@ -842,6 +1280,9 @@ export function AdminShowcase() {
                 </TabsContent>
                 <TabsContent value="media" className="mt-4">
                     {tab === 'media' && <MediaTab setMessage={setMessage} />}
+                </TabsContent>
+                <TabsContent value="local-players" className="mt-4">
+                    {tab === 'local-players' && <LocalPlayersTab setMessage={setMessage} />}
                 </TabsContent>
             </Tabs>
         </div>

--- a/academy-watch-frontend/src/pages/admin/AdminShowcase.jsx
+++ b/academy-watch-frontend/src/pages/admin/AdminShowcase.jsx
@@ -27,6 +27,7 @@ import {
     Inbox,
     UserSquare,
     Link2,
+    Image as ImageIcon,
 } from 'lucide-react'
 
 const CLAIM_STATUS_COLORS = {
@@ -50,11 +51,39 @@ const RELATIONSHIP_LABELS = {
     club_official: 'Club official',
 }
 
+const CONTRACT_STATUS_LABELS = {
+    under_contract: 'Under contract',
+    expiring: 'Contract expiring',
+    free_agent: 'Free agent',
+}
+
+const AVAILABILITY_LABELS = {
+    open_to_moves: 'Open to moves',
+    not_looking: 'Not looking',
+    trial_available: 'Available for trials',
+}
+
 function formatDate(value) {
     if (!value) return null
     const d = new Date(value)
     if (Number.isNaN(d.getTime())) return null
     return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
+function formatDateOnly(value) {
+    if (!value) return null
+    const match = String(value).match(/^(\d{4})-(\d{2})-(\d{2})/)
+    if (!match) return formatDate(value)
+    const d = new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]))
+    return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
+function formatBytes(value) {
+    const bytes = Number(value)
+    if (!Number.isFinite(bytes) || bytes < 0) return 'Size unavailable'
+    if (bytes < 1024) return `${bytes} B`
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(bytes < 10 * 1024 ? 1 : 0)} KB`
+    return `${(bytes / (1024 * 1024)).toFixed(bytes < 10 * 1024 * 1024 ? 1 : 0)} MB`
 }
 
 function asArray(data, ...keys) {
@@ -238,7 +267,7 @@ function ProfilesTab({ setMessage }) {
             <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <div>
                     <CardTitle>Profile edits</CardTitle>
-                    <CardDescription>Self-reported bio, positions, foot and height awaiting review</CardDescription>
+                    <CardDescription>Self-reported profile and availability details awaiting review</CardDescription>
                 </div>
                 <Select value={status} onValueChange={setStatus}>
                     <SelectTrigger className="w-40">
@@ -271,6 +300,13 @@ function ProfilesTab({ setMessage }) {
                                         {profile.positions && <span>Positions: <span className="text-foreground">{profile.positions}</span></span>}
                                         {profile.preferred_foot && <span>Foot: <span className="capitalize text-foreground">{profile.preferred_foot}</span></span>}
                                         {profile.height_cm != null && <span>Height: <span className="text-foreground">{profile.height_cm} cm</span></span>}
+                                        {profile.contract_status && <span>Contract: <span className="text-foreground">{CONTRACT_STATUS_LABELS[profile.contract_status] || profile.contract_status}</span></span>}
+                                        {profile.contract_until && <span>Contract until: <span className="text-foreground">{formatDateOnly(profile.contract_until)}</span></span>}
+                                        {profile.availability && <span>Availability: <span className="text-foreground">{AVAILABILITY_LABELS[profile.availability] || profile.availability}</span></span>}
+                                        {profile.nationality_secondary && <span>Second nationality: <span className="text-foreground">{profile.nationality_secondary}</span></span>}
+                                        {profile.languages && <span>Languages: <span className="text-foreground">{profile.languages}</span></span>}
+                                        {profile.agent_name && <span>Agent: <span className="text-foreground">{profile.agent_name}</span></span>}
+                                        {profile.agent_contact_email && <span>Agent email: <span className="text-foreground">{profile.agent_contact_email}</span></span>}
                                     </div>
                                     {formatDate(profile.updated_at) && (
                                         <p className="text-xs text-muted-foreground">Updated {formatDate(profile.updated_at)}</p>
@@ -290,6 +326,159 @@ function ProfilesTab({ setMessage }) {
                                 )}
                             </div>
                         ))}
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Photo moderation
+// ---------------------------------------------------------------------------
+
+function MediaTab({ setMessage }) {
+    const [media, setMedia] = useState([])
+    const [loading, setLoading] = useState(true)
+    const [status, setStatus] = useState('pending')
+    const [reloadKey, setReloadKey] = useState(0)
+    const [actingId, setActingId] = useState(null)
+    const [notes, setNotes] = useState({})
+
+    useEffect(() => {
+        let cancelled = false
+        setLoading(true)
+        const params = status === 'all' ? {} : { status }
+        APIService.adminListShowcaseMedia(params)
+            .then((data) => { if (!cancelled) setMedia(asArray(data, 'media')) })
+            .catch((err) => {
+                if (!cancelled) setMessage({ type: 'error', text: err.message || 'Failed to load showcase media' })
+            })
+            .finally(() => { if (!cancelled) setLoading(false) })
+        return () => { cancelled = true }
+    }, [status, reloadKey, setMessage])
+
+    const act = async (item, action) => {
+        setActingId(item.id)
+        try {
+            await APIService.adminReviewShowcaseMedia(item.id, {
+                action,
+                note: notes[item.id]?.trim() || undefined,
+            })
+            setMessage({ type: 'success', text: `Photo ${action === 'approve' ? 'approved' : 'rejected'}` })
+            setNotes((current) => {
+                const next = { ...current }
+                delete next[item.id]
+                return next
+            })
+            setReloadKey((k) => k + 1)
+        } catch (err) {
+            setMessage({ type: 'error', text: err.message || 'Failed to review photo' })
+        } finally {
+            setActingId(null)
+        }
+    }
+
+    return (
+        <Card>
+            <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                    <CardTitle>Showcase photos</CardTitle>
+                    <CardDescription>Review player-uploaded photos before they appear publicly</CardDescription>
+                </div>
+                <Select value={status} onValueChange={setStatus}>
+                    <SelectTrigger className="w-40">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="pending">Pending</SelectItem>
+                        <SelectItem value="approved">Approved</SelectItem>
+                        <SelectItem value="rejected">Rejected</SelectItem>
+                        <SelectItem value="all">All</SelectItem>
+                    </SelectContent>
+                </Select>
+            </CardHeader>
+            <CardContent>
+                {loading ? (
+                    <Loading />
+                ) : media.length === 0 ? (
+                    <p className="py-8 text-center text-sm text-muted-foreground">No {status === 'all' ? '' : status} photos.</p>
+                ) : (
+                    <div className="space-y-3">
+                        {media.map((item) => {
+                            const thumbnail = item.pending_preview_url || item.public_url
+                            const isActing = actingId === item.id
+                            return (
+                                <div key={item.id} className="flex flex-col gap-4 rounded-lg border bg-card p-4 lg:flex-row lg:items-start">
+                                    <div className="flex min-w-0 flex-1 flex-col gap-4 sm:flex-row">
+                                        <div className="flex aspect-[4/3] w-full shrink-0 items-center justify-center overflow-hidden rounded-md border bg-muted sm:w-36">
+                                            {thumbnail ? (
+                                                <img
+                                                    src={thumbnail}
+                                                    alt={`Showcase photo for player ${item.player_api_id}`}
+                                                    className="h-full w-full object-cover"
+                                                    loading="lazy"
+                                                />
+                                            ) : (
+                                                <ImageIcon className="h-8 w-8 text-muted-foreground/50" aria-hidden="true" />
+                                            )}
+                                        </div>
+                                        <div className="min-w-0 flex-1 space-y-2">
+                                            <div className="flex flex-wrap items-center gap-2">
+                                                <Badge className={CLAIM_STATUS_COLORS[item.status] || CLAIM_STATUS_COLORS.revoked}>
+                                                    {String(item.status || 'unknown').replace('_', ' ')}
+                                                </Badge>
+                                                <Badge variant="outline">Player #{item.player_api_id}</Badge>
+                                            </div>
+                                            <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                                                <span>{formatBytes(item.size_bytes)}</span>
+                                                {item.content_type && <span>{item.content_type}</span>}
+                                                {formatDate(item.created_at) && <span>Uploaded {formatDate(item.created_at)}</span>}
+                                            </div>
+                                            {item.review_note && (
+                                                <p className="text-xs text-muted-foreground">Review note: {item.review_note}</p>
+                                            )}
+                                        </div>
+                                    </div>
+                                    <div className="flex w-full shrink-0 flex-col gap-2 lg:w-72">
+                                        <Input
+                                            value={notes[item.id] || ''}
+                                            onChange={(event) => setNotes((current) => ({ ...current, [item.id]: event.target.value }))}
+                                            placeholder="Review note (optional)"
+                                            aria-label={`Review note for photo ${item.id}`}
+                                            maxLength={1000}
+                                            disabled={isActing}
+                                        />
+                                        <div className="flex items-center justify-end gap-2">
+                                            {item.status !== 'approved' && (
+                                                <Button
+                                                    size="sm"
+                                                    variant="outline"
+                                                    className="border-emerald-600 text-emerald-600 hover:bg-emerald-50"
+                                                    disabled={isActing}
+                                                    onClick={() => act(item, 'approve')}
+                                                >
+                                                    {isActing ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Check className="mr-1 h-4 w-4" />}
+                                                    Approve
+                                                </Button>
+                                            )}
+                                            {item.status !== 'rejected' && (
+                                                <Button
+                                                    size="sm"
+                                                    variant="outline"
+                                                    className="border-rose-600 text-rose-600 hover:bg-rose-50"
+                                                    disabled={isActing}
+                                                    onClick={() => act(item, 'reject')}
+                                                >
+                                                    {isActing ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <X className="mr-1 h-4 w-4" />}
+                                                    Reject
+                                                </Button>
+                                            )}
+                                        </div>
+                                    </div>
+                                </div>
+                            )
+                        })}
                     </div>
                 )}
             </CardContent>
@@ -508,7 +697,7 @@ export function AdminShowcase() {
                 </div>
                 <div>
                     <h2 className="text-3xl font-bold tracking-tight">Talent Showcase</h2>
-                    <p className="text-muted-foreground">Moderate profile claims, self-reported edits and Film Room evidence</p>
+                    <p className="text-muted-foreground">Moderate profile claims, self-reported edits, photos and Film Room evidence</p>
                 </div>
             </div>
 
@@ -531,7 +720,7 @@ export function AdminShowcase() {
             </div>
 
             <Tabs value={tab} onValueChange={setTab}>
-                <TabsList>
+                <TabsList className="h-auto flex-wrap justify-start">
                     <TabsTrigger value="claims">
                         <UserSquare className="mr-1.5 h-4 w-4" />
                         Claims
@@ -544,6 +733,10 @@ export function AdminShowcase() {
                         <Film className="mr-1.5 h-4 w-4" />
                         Film Room links
                     </TabsTrigger>
+                    <TabsTrigger value="media">
+                        <ImageIcon className="mr-1.5 h-4 w-4" />
+                        Media
+                    </TabsTrigger>
                 </TabsList>
 
                 <TabsContent value="claims" className="mt-4">
@@ -554,6 +747,9 @@ export function AdminShowcase() {
                 </TabsContent>
                 <TabsContent value="rosters" className="mt-4">
                     {tab === 'rosters' && <RostersTab setMessage={setMessage} />}
+                </TabsContent>
+                <TabsContent value="media" className="mt-4">
+                    {tab === 'media' && <MediaTab setMessage={setMessage} />}
                 </TabsContent>
             </Tabs>
         </div>

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -71,7 +71,49 @@ action; opposition players have no roster rows and can never appear.
   reorder approved photos, select one primary photo, and delete their media; anonymous
   visitors see approved photos only.
 
-## 4. API surface (all under /api)
+## 4. Local clubs & affiliations
+
+A **local club** is a community-created club record for a team that is not covered by
+API-Football. It lives separately from the API-synced `teams` table and lets a player name
+their real club on Showcase without inventing an API team. Authenticated users search both
+API teams and pending/verified local clubs before creating a local club.
+
+The local-club lifecycle is:
+
+1. Creation starts at `pending` and records user provenance; an admin either moves it to
+   `verified` or `rejected`.
+2. An admin can merge a duplicate into an active target. The source becomes `merged`, all
+   affiliations pointing at it move to the target, and merged/rejected clubs disappear from
+   user search and cannot receive new affiliations.
+3. If API-Football later covers the club, an admin may store its API team id as a bridge on
+   the local-club row. Linking does not create or modify a `teams` row and does not turn the
+   local club into synced data.
+
+An approved profile owner can submit an affiliation to exactly one API team or local club.
+Affiliations are pre-moderated: `pending` → `self_reported` after admin approval, or
+`rejected`. `club_confirmed` is reserved for the club-official confirmation flow in Chunk 4.
+Anonymous/public responses include only `self_reported` and `club_confirmed` affiliations;
+owners can also see their pending/rejected rows and moderation notes.
+
+**Hard isolation rule:** local clubs and affiliations are a parallel, self-reported Showcase
+layer only. They must never enter player journeys, team sync, crawl scope, classifiers, Scout
+queries, leaderboards, or any other API-Football-derived data pipeline.
+
+New API surface (all under `/api`):
+
+- Authenticated: `GET /clubs/search?q=<name>` and `POST /local-clubs`.
+- Approved profile owner: `POST /players/<id>/showcase/affiliations` and
+  `DELETE /players/<id>/showcase/affiliations/<affiliation_id>`.
+- Public: `GET /players/<id>/showcase` includes the visibility-filtered `affiliations` list;
+  an approved owner may authenticate to see their moderation state.
+- Admin (`require_api_key`): `GET /admin/local-clubs?status=<status>`,
+  `POST /admin/local-clubs/<club_id>/review`,
+  `POST /admin/local-clubs/<club_id>/merge`,
+  `POST /admin/local-clubs/<club_id>/link-api`,
+  `GET /admin/showcase/affiliations?status=<status>`, and
+  `POST /admin/showcase/affiliations/<affiliation_id>/review`.
+
+## 5. API surface (all under /api)
 
 Public: `GET /players/<id>/showcase` includes approved `photos` (optional Bearer: approved
 owners also get their pending/rejected items and preview URLs). It exposes claim status but
@@ -118,7 +160,7 @@ URL safety: Showcase reel links must be https + YouTube (server-side `_is_youtub
 Instagram, TikTok, X/Twitter, Facebook, or YouTube; the checker rejects IP literals,
 userinfo, explicit ports, and unsafe redirects, and applies strict time and body-size caps.
 
-## 5. Operator notes
+## 6. Operator notes
 
 - **Migration `aw19`** merges the `cs01` + `vid02` heads back to one and adds
   `player_profile_claims`, `player_showcase_profiles`, `player_links.sort_order`.
@@ -131,6 +173,9 @@ userinfo, explicit ports, and unsafe redirects, and applies strict time and body
 - **Migration `shp02`** adds social-proof code, URL, method, result, checked-at, and note
   fields to `player_profile_claims`. No external credentials or social-platform API keys
   are required; checks fetch only public profile pages and fail closed as advisory results.
+- **Migration `shp03`** adds the guarded, RLS-enabled `local_clubs` and
+  `player_club_affiliations` tables. Both remain Showcase-only and never feed API-Football
+  sync, crawl, classifier, journey, or Scout paths.
 - **Local dev DB caveat (2026-07-02):** the local DB is stamped `vid03` (uncommitted
   migration); aw19's DDL was applied there manually (guarded SQL) without touching
   `alembic_version`. After the vid-chain work lands, rebase vid03 onto aw19
@@ -138,12 +183,17 @@ userinfo, explicit ports, and unsafe redirects, and applies strict time and body
 - **Known pre-existing issue:** the historical migration chain cannot replay on an EMPTY
   database (an old unguarded migration alters the deleted `supplemental_loans` table).
   Existing stamped DBs are unaffected.
-- Tests: `pytest tests/test_showcase.py tests/test_showcase_media.py tests/test_claim_verification.py`.
+- Tests: `pytest tests/test_showcase.py tests/test_showcase_media.py tests/test_claim_verification.py
+  tests/test_local_clubs.py`.
   Demo data on local dev DB: player 403064
   (H. Amass) has a claimed profile, curated reel, and a club-verified appearance from
   Film Room match 4.
 
-## 6. Changelog
+## 7. Changelog
+
+- **2026-07-14** — Added community-created local clubs, admin verification/merge/API-bridge
+  tooling, and pre-moderated player affiliations. Local clubs remain permanently isolated
+  from journey/team sync, crawl scope, classifiers, and Scout data.
 
 - **2026-07-14** — Added the claim-verification ladder: one-time code in a known public
   social profile, SSRF-hardened best-effort checking, claimant retry and admin re-check.

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -27,8 +27,7 @@ Every player page carries a **Showcase** section (top of page, above stats):
 user (logged in) claims player  →  receives a one-time code
   →  places the code in the bio of a public Instagram / TikTok / X / Facebook / YouTube profile
   →  submits that profile URL for a best-effort automated check
-  →  admin reviews the claim and the advisory check (Admin → Showcase → Claims)
-  →  admin approves
+  →  admin reviews and approves, OR an eligible verified club official vouches for identity
   →  owner curates: upload/reorder photos, add/reorder/delete reel videos, edit profile card
   →  every content edit is PRE-MODERATED (pending → admin approves → public)
 ```
@@ -37,7 +36,8 @@ user (logged in) claims player  →  receives a one-time code
   per player are allowed (player + agent may co-own).
 - Social proof demonstrates control of a known public profile; it does not prove legal
   identity. The automated result is advisory (`unverified`, `code_found`, or
-  `code_not_found`) and **admin approval remains the only gate that approves a claim**.
+  `code_not_found`) and never approves a claim by itself. Identity approval comes from
+  admin review or an eligible verified-club-official vouch.
 - Claimants may retry with the same one-time code. Admins can re-run the check against the
   stored profile URL before deciding a claim.
 - **There is no document or ID upload, ever.** The platform does not collect or store KYC
@@ -113,7 +113,44 @@ New API surface (all under `/api`):
   `GET /admin/showcase/affiliations?status=<status>`, and
   `POST /admin/showcase/affiliations/<affiliation_id>/review`.
 
-## 5. API surface (all under /api)
+## 5. Club officials & vouching
+
+A club official claims exactly one API-Football team or active local club. Official claims
+reuse the player-claim social-proof ladder: the claimant receives a one-time code, places it
+on an allowlisted public social profile, submits that profile URL for a best-effort check,
+and remains `pending` until an admin approves or rejects the claim. An approved claim may
+later be revoked. Automated social proof remains advisory; only an approved official claim
+opens the club trust actions below.
+
+An approved official's **My Club** queue contains pending or self-reported affiliations that
+name their club and pending player-profile claims linked to it by a non-rejected affiliation.
+Local-club matching follows one merge hop, so work attached to a merged duplicate reaches the
+official for the surviving club.
+
+- Confirming an affiliation changes it to `club_confirmed`; rejecting it changes it to
+  `rejected` and may record a review note.
+- Vouching auto-approves a pending player-profile claim and records verification method
+  `vouch`. **A vouch approves identity only.** Every owner-submitted photo, reel link, and
+  profile edit remains pre-moderated before it can appear publicly.
+- A club-claim verification code is returned only in the authenticated creation response,
+  the claimant's own `/me/club-claims` list, and the admin list. It is never included in
+  public or cross-user payloads.
+- Player-claim verification codes are likewise stripped from the cross-user My Club vouch
+  queue and vouch response; advisory status and check timestamps remain visible.
+
+Club-official API surface (all under `/api`):
+
+- Authenticated: `POST /clubs/claim`, `GET /me/club-claims`,
+  `POST /me/club-claims/<claim_id>/verify`, and `GET /me/club`.
+- Approved official for the referenced club:
+  `POST /me/club/affiliations/<affiliation_id>/confirm`,
+  `POST /me/club/affiliations/<affiliation_id>/reject`, and
+  `POST /me/club/player-claims/<claim_id>/vouch`.
+- Admin (`require_api_key`): `GET /admin/club-claims?status=<status>`,
+  `POST /admin/club-claims/<claim_id>/review` (`approve`, `reject`, or `revoke`), and
+  `POST /admin/club-claims/<claim_id>/recheck`.
+
+## 6. API surface (all under /api)
 
 Public: `GET /players/<id>/showcase` includes approved `photos` (optional Bearer: approved
 owners also get their pending/rejected items and preview URLs). It exposes claim status but
@@ -160,7 +197,7 @@ URL safety: Showcase reel links must be https + YouTube (server-side `_is_youtub
 Instagram, TikTok, X/Twitter, Facebook, or YouTube; the checker rejects IP literals,
 userinfo, explicit ports, and unsafe redirects, and applies strict time and body-size caps.
 
-## 6. Operator notes
+## 7. Operator notes
 
 - **Migration `aw19`** merges the `cs01` + `vid02` heads back to one and adds
   `player_profile_claims`, `player_showcase_profiles`, `player_links.sort_order`.
@@ -176,6 +213,9 @@ userinfo, explicit ports, and unsafe redirects, and applies strict time and body
 - **Migration `shp03`** adds the guarded, RLS-enabled `local_clubs` and
   `player_club_affiliations` tables. Both remain Showcase-only and never feed API-Football
   sync, crawl, classifier, journey, or Scout paths.
+- **Migration `shp04`** adds the guarded, RLS-enabled `club_official_claims` table. Official
+  claims reuse the social-proof evidence fields but remain a separate lifecycle from player
+  claims; vouching records identity approval without bypassing content moderation.
 - **Local dev DB caveat (2026-07-02):** the local DB is stamped `vid03` (uncommitted
   migration); aw19's DDL was applied there manually (guarded SQL) without touching
   `alembic_version`. After the vid-chain work lands, rebase vid03 onto aw19
@@ -184,12 +224,16 @@ userinfo, explicit ports, and unsafe redirects, and applies strict time and body
   database (an old unguarded migration alters the deleted `supplemental_loans` table).
   Existing stamped DBs are unaffected.
 - Tests: `pytest tests/test_showcase.py tests/test_showcase_media.py tests/test_claim_verification.py
-  tests/test_local_clubs.py`.
+  tests/test_local_clubs.py tests/test_club_officials.py`.
   Demo data on local dev DB: player 403064
   (H. Amass) has a claimed profile, curated reel, and a club-verified appearance from
   Film Room match 4.
 
-## 7. Changelog
+## 8. Changelog
+
+- **2026-07-14** — Added club-official claims using the social-proof ladder, a My Club queue
+  for confirming or rejecting player affiliations, and verified-official vouching for player
+  identity claims. Vouching approves identity only; all owner content remains pre-moderated.
 
 - **2026-07-14** — Added community-created local clubs, admin verification/merge/API-bridge
   tooling, and pre-moderated player affiliations. Local clubs remain permanently isolated
@@ -197,8 +241,9 @@ userinfo, explicit ports, and unsafe redirects, and applies strict time and body
 
 - **2026-07-14** — Added the claim-verification ladder: one-time code in a known public
   social profile, SSRF-hardened best-effort checking, claimant retry and admin re-check.
-  Automated evidence remains advisory and admin approval remains the sole approval gate;
-  document/ID upload is explicitly never part of Showcase verification.
+  Automated evidence remains advisory and never self-approves; identity approval is an admin
+  decision or, since Chunk 4, an eligible verified-official vouch. Document/ID upload is
+  explicitly never part of Showcase verification.
 - **2026-07-08** — Added pre-moderated, self-hosted player photos with direct blob upload,
   EXIF/GPS stripping, gallery ordering/primary selection, admin media review, and enriched
   contract/availability/agent/nationality/language profile fields. Codified the permanent

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -1,6 +1,6 @@
 # Talent Showcase — Player Profiles, Photos, Claims & Club-Verified Evidence
 
-> **Living document.** Last updated **2026-07-08**. When the feature changes, update the
+> **Living document.** Last updated **2026-07-14**. When the feature changes, update the
 > relevant section and add a line to the Changelog. Roadmap/state:
 > `ledgers/ROADMAP_talent-showcase-vision.md`.
 
@@ -24,13 +24,24 @@ Every player page carries a **Showcase** section (top of page, above stats):
 ## 2. The claim → curate lifecycle
 
 ```
-user (logged in) claims player  →  admin approves (Admin → Showcase → Claims)
+user (logged in) claims player  →  receives a one-time code
+  →  places the code in the bio of a public Instagram / TikTok / X / Facebook / YouTube profile
+  →  submits that profile URL for a best-effort automated check
+  →  admin reviews the claim and the advisory check (Admin → Showcase → Claims)
+  →  admin approves
   →  owner curates: upload/reorder photos, add/reorder/delete reel videos, edit profile card
   →  every content edit is PRE-MODERATED (pending → admin approves → public)
 ```
 
 - Relationships: `player | agent | guardian | club_official`. Multiple approved claims
   per player are allowed (player + agent may co-own).
+- Social proof demonstrates control of a known public profile; it does not prove legal
+  identity. The automated result is advisory (`unverified`, `code_found`, or
+  `code_not_found`) and **admin approval remains the only gate that approves a claim**.
+- Claimants may retry with the same one-time code. Admins can re-run the check against the
+  stored profile URL before deciding a claim.
+- **There is no document or ID upload, ever.** The platform does not collect or store KYC
+  documents for Showcase claims; unresolved claims remain a manual-review decision.
 - **Safeguarding posture:** many players are minors — all owner content is pre-moderated;
   a rejected/revoked claim can be resubmitted (resets to pending); no commentary surfaces.
 - Owners see their own pending items (amber badge); the public never does.
@@ -63,9 +74,17 @@ action; opposition players have no roster rows and can never appear.
 ## 4. API surface (all under /api)
 
 Public: `GET /players/<id>/showcase` includes approved `photos` (optional Bearer: approved
-owners also get their pending/rejected items and preview URLs). User:
-`POST /players/<id>/claim`, `GET /me/claims`, owner-gated
-`PUT .../showcase/profile`, `POST/PATCH/DELETE .../showcase/reel*`.
+owners also get their pending/rejected items and preview URLs). It exposes claim status but
+never a claim verification code. User:
+
+- `POST /players/<id>/claim` — create a pending claim and receive its one-time verification
+  code in the authenticated response.
+- `GET /me/claims` — list the caller's claims and their verification state; legacy claims
+  receive a code lazily.
+- `POST /me/claims/<claim_id>/verify` — submit `{ "proof_url": "https://..." }` and run a
+  best-effort social-profile check. Both code-found and code-not-found checks return a
+  normal claim response; neither approves the claim.
+- Owner-gated `PUT .../showcase/profile` and `POST/PATCH/DELETE .../showcase/reel*`.
 
 Photo media:
 
@@ -84,6 +103,8 @@ public; agent contact email is returned only to authenticated callers.
 Admin (`require_api_key`) retains the existing claims, profiles, Film Room links, and player
 search routes, and adds:
 
+- `POST /admin/showcase/claims/<claim_id>/recheck` — re-run the advisory check against the
+  stored proof URL and return the updated claim.
 - `GET /admin/showcase/media?status=<status>` — list media, optionally by lifecycle status.
 - `POST /admin/showcase/media/<media_id>/review` — approve or reject; approval performs the
   EXIF-stripping conversion before publication.
@@ -91,9 +112,11 @@ search routes, and adds:
 Local development additionally exposes direct `PUT` and `GET` operations at
 `/dev/showcase-media/<blob_path>`. Both are disabled in production.
 
-URL safety: all submitted links must be https + YouTube (server-side `_is_youtube_url`);
+URL safety: Showcase reel links must be https + YouTube (server-side `_is_youtube_url`);
 `javascript:`/`data:`/http are rejected everywhere, including the pre-existing
-`POST /players/<id>/links` (hardened in this slice).
+`POST /players/<id>/links`. Social-proof URLs are separately limited to https profiles on
+Instagram, TikTok, X/Twitter, Facebook, or YouTube; the checker rejects IP literals,
+userinfo, explicit ports, and unsafe redirects, and applies strict time and body-size caps.
 
 ## 5. Operator notes
 
@@ -105,6 +128,9 @@ URL safety: all submitted links must be https + YouTube (server-side `_is_youtub
   uploads require the private `showcase-media-pending` and public-read `showcase-media`
   containers; until Azure is configured, photo upload creation returns 503 while the rest
   of Showcase remains available.
+- **Migration `shp02`** adds social-proof code, URL, method, result, checked-at, and note
+  fields to `player_profile_claims`. No external credentials or social-platform API keys
+  are required; checks fetch only public profile pages and fail closed as advisory results.
 - **Local dev DB caveat (2026-07-02):** the local DB is stamped `vid03` (uncommitted
   migration); aw19's DDL was applied there manually (guarded SQL) without touching
   `alembic_version`. After the vid-chain work lands, rebase vid03 onto aw19
@@ -112,12 +138,17 @@ URL safety: all submitted links must be https + YouTube (server-side `_is_youtub
 - **Known pre-existing issue:** the historical migration chain cannot replay on an EMPTY
   database (an old unguarded migration alters the deleted `supplemental_loans` table).
   Existing stamped DBs are unaffected.
-- Tests: `pytest tests/test_showcase.py tests/test_showcase_media.py`. Demo data on local dev DB: player 403064
+- Tests: `pytest tests/test_showcase.py tests/test_showcase_media.py tests/test_claim_verification.py`.
+  Demo data on local dev DB: player 403064
   (H. Amass) has a claimed profile, curated reel, and a club-verified appearance from
   Film Room match 4.
 
 ## 6. Changelog
 
+- **2026-07-14** — Added the claim-verification ladder: one-time code in a known public
+  social profile, SSRF-hardened best-effort checking, claimant retry and admin re-check.
+  Automated evidence remains advisory and admin approval remains the sole approval gate;
+  document/ID upload is explicitly never part of Showcase verification.
 - **2026-07-08** — Added pre-moderated, self-hosted player photos with direct blob upload,
   EXIF/GPS stripping, gallery ordering/primary selection, admin media review, and enriched
   contract/availability/agent/nationality/language profile fields. Codified the permanent

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -113,7 +113,51 @@ New API surface (all under `/api`):
   `GET /admin/showcase/affiliations?status=<status>`, and
   `POST /admin/showcase/affiliations/<affiliation_id>/review`.
 
-## 5. Club officials & vouching
+## 5. Local players
+
+A **local player** is a community-created identity for a young player who is not covered by
+API-Football. It is a first-class Showcase profile, but it is deliberately not a tracked-player
+record: every local profile carries the **Self-reported** presentation, has no synced statistics
+or journey, never appears in Scout/search/leaderboards, and always has an empty Film Room
+`verified_footage` list. Local players can curate the same moderated profile card, YouTube reel,
+photos, and club affiliations as API-backed players.
+
+**Safeguarding decision:** creation may collect an integer `birth_year` only. The platform never
+collects or stores a full date of birth for these community-created identities, many of whom are
+minors. The accepted range is 1950–2020.
+
+Lifecycle:
+
+1. An authenticated user creates a local player after duplicate checking by normalized name and
+   birth year. The identity starts `pending`, and the creator automatically receives a pending
+   player-profile claim with the same one-time social verification code used elsewhere.
+2. Pending and rejected identities return 404 publicly. A pending or approved claimant may see
+   their own identity; curation still requires an approved claim. An admin approves or rejects
+   the identity independently from the claim/content moderation gates.
+3. An admin may merge a duplicate into an active local player. Claims, profiles, photos,
+   affiliations, and reel links are repointed by their explicit `local_player_id`; the source
+   records one merge hop to the target. If both identities already have a claim from the same
+   user or a profile card, merge consolidates the collision into one canonical row; source-only
+   profile fields return the combined card to pending moderation. Local ids are never encoded as
+   negative API ids.
+4. If API-Football later gains coverage, an admin may store a positive `api_player_id` bridge on
+   the local row. This is metadata only: it does not move content, create a `TrackedPlayer`, opt
+   the player into sync/Scout/journey pipelines, or expose Film Room evidence.
+
+Local-player API surface (all under `/api`):
+
+- Authenticated: `POST /local-players`; `GET /me/claims` includes `local_player_id` and a local
+  player summary; the existing `POST /me/claims/<claim_id>/verify` works for local claims.
+- Public/claimant: `GET /local-players/<id>` and `GET /local-players/<id>/showcase`.
+- Approved claimant: the profile, reel, photo, and affiliation routes mirror the existing
+  `/players/<id>/showcase/...` routes under `/local-players/<id>/showcase/...`.
+- Admin (`require_api_key`): `GET /admin/local-players?status=<status>`,
+  `POST /admin/local-players/<id>/review`, `POST /admin/local-players/<id>/merge`, and
+  `POST /admin/local-players/<id>/link-api`. Local profile-card moderation uses
+  `POST /admin/showcase/local-profiles/<id>/review`; row-id media, link, claim, and affiliation
+  moderation queues work for both subject kinds.
+
+## 6. Club officials & vouching
 
 A club official claims exactly one API-Football team or active local club. Official claims
 reuse the player-claim social-proof ladder: the claimant receives a one-time code, places it
@@ -150,7 +194,7 @@ Club-official API surface (all under `/api`):
   `POST /admin/club-claims/<claim_id>/review` (`approve`, `reject`, or `revoke`), and
   `POST /admin/club-claims/<claim_id>/recheck`.
 
-## 6. API surface (all under /api)
+## 7. API surface (all under /api)
 
 Public: `GET /players/<id>/showcase` includes approved `photos` (optional Bearer: approved
 owners also get their pending/rejected items and preview URLs). It exposes claim status but
@@ -197,7 +241,7 @@ URL safety: Showcase reel links must be https + YouTube (server-side `_is_youtub
 Instagram, TikTok, X/Twitter, Facebook, or YouTube; the checker rejects IP literals,
 userinfo, explicit ports, and unsafe redirects, and applies strict time and body-size caps.
 
-## 7. Operator notes
+## 8. Operator notes
 
 - **Migration `aw19`** merges the `cs01` + `vid02` heads back to one and adds
   `player_profile_claims`, `player_showcase_profiles`, `player_links.sort_order`.
@@ -216,6 +260,10 @@ userinfo, explicit ports, and unsafe redirects, and applies strict time and body
 - **Migration `shp04`** adds the guarded, RLS-enabled `club_official_claims` table. Official
   claims reuse the social-proof evidence fields but remain a separate lifecycle from player
   claims; vouching records identity approval without bypassing content moderation.
+- **Migration `shp05`** adds the guarded, RLS-enabled `local_players` table and explicit nullable
+  `local_player_id` keys on claims, profiles, media, affiliations, and reel links. The legacy API
+  key columns become nullable so the application can enforce an exact API-player XOR local-player
+  subject without negative-id overloading.
 - **Local dev DB caveat (2026-07-02):** the local DB is stamped `vid03` (uncommitted
   migration); aw19's DDL was applied there manually (guarded SQL) without touching
   `alembic_version`. After the vid-chain work lands, rebase vid03 onto aw19
@@ -224,12 +272,17 @@ userinfo, explicit ports, and unsafe redirects, and applies strict time and body
   database (an old unguarded migration alters the deleted `supplemental_loans` table).
   Existing stamped DBs are unaffected.
 - Tests: `pytest tests/test_showcase.py tests/test_showcase_media.py tests/test_claim_verification.py
-  tests/test_local_clubs.py tests/test_club_officials.py`.
+  tests/test_local_clubs.py tests/test_club_officials.py tests/test_local_players.py`.
   Demo data on local dev DB: player 403064
   (H. Amass) has a claimed profile, curated reel, and a club-verified appearance from
   Film Room match 4.
 
-## 8. Changelog
+## 9. Changelog
+
+- **2026-07-14** — Added community-created local player identities with birth-year-only
+  safeguarding, automatic pending claims, the full pre-moderated Showcase curation surface,
+  duplicate merge/repoint tooling, and a metadata-only API-Football bridge. Local players remain
+  excluded from stats, journeys, Film Room, tracked-player search, Scout, and leaderboards.
 
 - **2026-07-14** — Added club-official claims using the social-proof ladder, a My Club queue
   for confirming or rejecting player affiliations, and verified-official vouching for player

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -1,6 +1,6 @@
-# Talent Showcase — Player Profiles, Claims & Club-Verified Evidence
+# Talent Showcase — Player Profiles, Photos, Claims & Club-Verified Evidence
 
-> **Living document.** Last updated **2026-07-02**. When the feature changes, update the
+> **Living document.** Last updated **2026-07-08**. When the feature changes, update the
 > relevant section and add a line to the Changelog. Roadmap/state:
 > `ledgers/ROADMAP_talent-showcase-vision.md`.
 
@@ -11,19 +11,21 @@ Every player page carries a **Showcase** section (top of page, above stats):
 1. **Highlight reel** — embedded YouTube videos. Sources: owner-curated links,
    fan-submitted links (moderated), and admin-entered newsletter YouTube links
    (merged read-only, deduped by video id).
-2. **Player profile card** — bio / positions / preferred foot / height, always badged
+2. **Photo gallery** — owner-uploaded, admin-approved images with a primary-photo slot;
+   anonymous visitors never see pending or rejected media.
+3. **Player profile card** — bio / positions / preferred foot / height, always badged
    **"Self-reported"** (never styled like verified stats).
-3. **Verified appearances** — badged **"Club-verified"** (emerald): appearance evidence
+4. **Verified appearances** — badged **"Club-verified"** (emerald): appearance evidence
    from Film Room reports where a **human confirmed the identity** and an admin linked
    the roster entry to the platform player. Shows opponent, date, minutes on camera,
    % of match.
-4. **Claim strip** — "Is this you? Claim this profile."
+5. **Claim strip** — "Is this you? Claim this profile."
 
 ## 2. The claim → curate lifecycle
 
 ```
 user (logged in) claims player  →  admin approves (Admin → Showcase → Claims)
-  →  owner curates: add/reorder/delete reel videos, edit profile card
+  →  owner curates: upload/reorder photos, add/reorder/delete reel videos, edit profile card
   →  every content edit is PRE-MODERATED (pending → admin approves → public)
 ```
 
@@ -42,13 +44,52 @@ Admin → Showcase → **Film Room links**: for finalized matches, link a roster
 Only **human-confirmed** identities ever surface publicly; linking is an explicit admin
 action; opposition players have no roster rows and can never appear.
 
+## Media policy
+
+- **Photos are self-hosted and pre-moderated.** An approved profile owner uploads JPEG,
+  PNG, or WebP directly to private blob storage. The Flask app mints the short-lived PUT
+  URL; it never relays browser upload bytes. An admin must approve every image before it
+  appears publicly.
+- **Location data is never published.** Approval decodes the source image, limits its long
+  edge to 1600 px, strips all EXIF (especially GPS), and re-encodes it as JPEG before
+  writing to the public media container. Pending and rejected originals are never public.
+- **Native video is never accepted.** Public video remains YouTube embeds only. Film Room's
+  private, club-consented match-analysis pipeline is the sole exception; it does not turn
+  native match footage into a public player upload surface.
+- A player may have at most eight non-rejected photos. Owners can see moderation state,
+  reorder approved photos, select one primary photo, and delete their media; anonymous
+  visitors see approved photos only.
+
 ## 4. API surface (all under /api)
 
-Public: `GET /players/<id>/showcase` (optional Bearer: approved owners also get their
-pending items). User: `POST /players/<id>/claim`, `GET /me/claims`, owner-gated
-`PUT .../showcase/profile`, `POST/PATCH/DELETE .../showcase/reel*`. Admin
-(`require_api_key`): `/admin/showcase/{claims,claims/<id>/review,profiles,
-profiles/<pid>/review,video-rosters,video-rosters/<rid>/link,player-search}`.
+Public: `GET /players/<id>/showcase` includes approved `photos` (optional Bearer: approved
+owners also get their pending/rejected items and preview URLs). User:
+`POST /players/<id>/claim`, `GET /me/claims`, owner-gated
+`PUT .../showcase/profile`, `POST/PATCH/DELETE .../showcase/reel*`.
+
+Photo media:
+
+- `POST /players/<id>/showcase/photos` — create a pending upload and receive a direct
+  `PUT` URL plus its required headers.
+- `POST /players/<id>/showcase/photos/<media_id>/complete` — verify the private blob and
+  move it to the moderation queue.
+- `PATCH /players/<id>/showcase/photos/order` — reorder approved photos.
+- `PATCH /players/<id>/showcase/photos/<media_id>` — select an approved primary photo.
+- `DELETE /players/<id>/showcase/photos/<media_id>` — delete the row and stored blobs.
+
+The showcase profile API also accepts `contract_status`, `contract_until`, `availability`,
+`agent_name`, `agent_contact_email`, `nationality_secondary`, and `languages`. Agent name is
+public; agent contact email is returned only to authenticated callers.
+
+Admin (`require_api_key`) retains the existing claims, profiles, Film Room links, and player
+search routes, and adds:
+
+- `GET /admin/showcase/media?status=<status>` — list media, optionally by lifecycle status.
+- `POST /admin/showcase/media/<media_id>/review` — approve or reject; approval performs the
+  EXIF-stripping conversion before publication.
+
+Local development additionally exposes direct `PUT` and `GET` operations at
+`/dev/showcase-media/<blob_path>`. Both are disabled in production.
 
 URL safety: all submitted links must be https + YouTube (server-side `_is_youtube_url`);
 `javascript:`/`data:`/http are rejected everywhere, including the pre-existing
@@ -60,6 +101,10 @@ URL safety: all submitted links must be https + YouTube (server-side `_is_youtub
   `player_profile_claims`, `player_showcase_profiles`, `player_links.sort_order`.
   Idempotent/guarded. Note: `flask db downgrade` across any merge revision needs an
   explicit target revision (alembic "Ambiguous walk" — same as aw17).
+- **Migration `shp01`** adds Showcase media plus enriched profile fields. Production photo
+  uploads require the private `showcase-media-pending` and public-read `showcase-media`
+  containers; until Azure is configured, photo upload creation returns 503 while the rest
+  of Showcase remains available.
 - **Local dev DB caveat (2026-07-02):** the local DB is stamped `vid03` (uncommitted
   migration); aw19's DDL was applied there manually (guarded SQL) without touching
   `alembic_version`. After the vid-chain work lands, rebase vid03 onto aw19
@@ -67,12 +112,16 @@ URL safety: all submitted links must be https + YouTube (server-side `_is_youtub
 - **Known pre-existing issue:** the historical migration chain cannot replay on an EMPTY
   database (an old unguarded migration alters the deleted `supplemental_loans` table).
   Existing stamped DBs are unaffected.
-- Tests: `pytest tests/test_showcase.py` (40). Demo data on local dev DB: player 403064
+- Tests: `pytest tests/test_showcase.py tests/test_showcase_media.py`. Demo data on local dev DB: player 403064
   (H. Amass) has a claimed profile, curated reel, and a club-verified appearance from
   Film Room match 4.
 
 ## 6. Changelog
 
+- **2026-07-08** — Added pre-moderated, self-hosted player photos with direct blob upload,
+  EXIF/GPS stripping, gallery ordering/primary selection, admin media review, and enriched
+  contract/availability/agent/nationality/language profile fields. Codified the permanent
+  no-native-video policy (YouTube embeds only; club-consented Film Room is the sole exception).
 - **2026-07-02** — Initial slice shipped (P0 showcase surfacing + P1 claim & curate +
   X Film Room verified evidence). Built multi-agent (Fable 5 orchestrating Opus 4.8
   builders), adversarially reviewed (23 agents, 8 findings fixed), live-verified.


### PR DESCRIPTION
## Showcase P2 — profile claiming, local entities, moderated media

Builds the three MJ-approved profile-claiming design decisions as a 6-chunk slice on top of the P1 showcase foundation. The platform profiles **minors**, so every surface here is safeguarding-first.

### The three design decisions this implements

1. **Claim verification ladder — no document/ID upload, ever.** Identity is proven by a social-proof code (a minted `AW-XXXXXXXX` the claimant posts on an allowlisted social profile, checked by an SSRF-hardened advisory fetcher), escalating to club-official vouching, then manual admin review. We never ask a young player to upload a passport or ID.
2. **Local entities (clubs + players not in API-Football).** Search-before-create, admin merge with an API-bridge, two-sided club↔player affiliation. Community-supplied identities coexist with the API-Football layer without polluting it.
3. **Media boundary.** Self-hosted photos are pre-moderated and fully EXIF/metadata-stripped via a server-side Pillow re-encode; **no native video ever** (YouTube embeds only; Film Room is the sole analysis exception).

### Chunks (each its own commit)

- **shp01** — moderated player photos + profile enrichment
- **shp02** — claim verification ladder (social-proof codes)
- **shp03** — local clubs + player affiliations
- **shp04** — club officials + vouching (My Club trust surface)
- **shp05** — local player profiles (community identities)
- **fix round** — safeguarding + security hardening across the slice (this is the remediation of a Codex adversarial safeguarding review)

### Safeguarding / security posture (fix round)

- **No data-leak in duplicate responses.** A 409 on create only echoes an `existing` record when it is publicly visible (verified/approved) **or** caller-owned, and even then only `{id, display_name, status}` for players / `{id, name, country, status}` for clubs — never a minor's `city`, `birth_year`, or `position`.
- **Precise locality is owner/admin-only.** `city` is dropped from the public local-player payload; the claimant and admins see it, nobody else.
- **Verified-only club visibility.** Club search returns verified clubs plus the caller's own pending; unverified local club **names** never resolve into public affiliation payloads.
- **Photo validation at completion.** `/complete` decodes and validates the uploaded bytes (format allowlist, decompression-bomb + pixel-cap guard) and deletes the pending blob + returns 422 on invalid input — invalid images can't sit waiting for a moderator.
- **Existence-uniform errors.** Official affiliation actions and player-claim vouching return a uniform 404 (not 403) so a non-official can't probe which claims/affiliations exist.
- **Abuse controls.** LIKE-metacharacter escaping on club search; per-user pending quotas (players 10 / clubs 10 / club-claims 5) with pg advisory-xact locks to serialize the count; rejection of proof URLs that merely reflect the claimant's own verification code.
- **Migration downgrade guards.** shp01/shp05 downgrades refuse to run while showcase-media / local-player rows exist, so a downgrade can't orphan blobs.

### Verification

- Backend: **245 tests pass** across all 7 showcase modules (including tests asserting the exact new privacy contracts — field-limited/absent duplicate echoes, verified-only visibility, photo 422+cleanup, uniform 404s); `ruff check` + `ruff format --check` clean.
- Frontend: `pnpm lint` 0 errors (pre-existing warnings only); `pnpm build` succeeds; `pnpm install --frozen-lockfile` clean against the rebased lockfile.
- Rebased clean onto `origin/main` (zero file overlap; single migration head `shp05`).
- **Not yet run — live browser drive.** The two frontend deltas are defensive field-guards (hide `city` when absent, degrade the duplicate banner to the now-limited fields) whose backend behavior is exhaustively covered above. A live Playwright drive was not performed: the repo's E2E `webServer` still points at the pre-rename `loan-army-backend` dir and needs a local Postgres + seed that isn't present in the worktree, and the write-flows can't be driven against the tiny prod DB. Worth a visual pass on the SWA preview before/after merge, or fixing the E2E harness dir + adding a seeded showcase spec as a follow-up.

### Deferred follow-ups (tracked, not blocking)

- Scheduled sweeper for orphaned pending blobs whose `/complete` never ran.
- Recursive/path-compressed merge-alias resolution + official-claim repoint on club merge.
- Bulk-merge cap / primary reconciliation.
- Club-rejection cascade to dependent affiliations.
- `submit_club_official_claim` pending quota is not yet under the advisory lock (low-severity race on the claim cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
