### PR TITLE
feat(season-data): D3 — sea02/sea03 rollup tables + season_rollup_service + admin rebuild/gauge

### DIFF
--- a/academy-watch-backend/migrations/versions/sea02_season_rollup_tables.py
+++ b/academy-watch-backend/migrations/versions/sea02_season_rollup_tables.py
@@ -1,0 +1,164 @@
+"""Season-rollup tables — player_season_cells / _totals + league_season_config
+
+Revision ID: sea02
+Revises: sea01
+Create Date: 2026-07-08
+
+Creates the sea02 half of proposal §2 (ledgers/research/seasons-design-proposal.md):
+the precomputed, provenance-tagged per-player-per-season read surface that lets every
+hot stats surface read ONE indexed row instead of a live cross-source aggregation on
+the 0.5 CPU prod box.
+
+- player_season_cells  — fine grain: one row per SOURCE-contributed cell
+                         (player, season, source, club, competition_tier). source is
+                         IN the unique key so feeders never collide.
+- player_season_totals — coarse grain: the single hot-read row per
+                         (player, season, level_group). Both raw fixtures/journey
+                         minutes + a reconcile_flag ride along (never-cross-source-sum).
+- league_season_config — per-league "what season is NOW" (calendar vs Aug-rollover);
+                         seeded for the five calendar-year leagues (Brazil 71,
+                         Argentina 128, MLS 253, Liga MX 262, J1 98).
+
+D3a is SCHEMA ONLY — the D3b rollup service is the sole writer. No route/service
+SELECTs these tables in the shipped image yet, so unlike sea01 there is NO
+UndefinedTable 500 window (the ORM classes in src/models/season_rollup.py only
+register metadata; they issue no query).
+
+All DDL is guarded (invariants §8 — prod schema has drifted out-of-band): table
+creation via table_exists, indexes via create_index_safe, the seed via
+ON CONFLICT DO NOTHING, and ENABLE ROW LEVEL SECURITY is itself idempotent. Re-applied
+or partially-applied, upgrade() is a clean no-op.
+
+RLS: all THREE new public tables ENABLE ROW LEVEL SECURITY in this migration — the
+Deploy security-check fails the deploy for any public table with relrowsecurity=false
+(invariants §2). The ALTER runs unconditionally after the table is guaranteed to exist.
+
+DEPLOY ORDERING (migrations do NOT auto-run — deploy.yml runs only the RLS
+security-check; the container CMD is gunicorn, nothing runs `flask db upgrade`).
+Preferred sequence: PRE-APPLY this migration out-of-band against prod BEFORE merging —
+from a local checkout with the prod DB env (IPv4 pooler + `postgresql+psycopg://`,
+invariants §1) run `FLASK_APP=src/main.py flask db upgrade`. The three CREATE TABLEs are
+instant metadata ops; the seed and RLS are trivial. Then merge: the in-container
+`flask db upgrade` is a pure no-op stamp (every op guarded), and the security-check
+sees the tables already RLS-enabled.
+Fallback (safe here, unlike sea01): apply post-deploy in the container. Because no read
+path SELECTs these tables in the D3a image, a not-yet-applied migration causes no 500s —
+and while the tables are absent from prod they simply don't appear in the RLS scan;
+once created (by this migration) they are RLS-enabled in the same transaction.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from migrations._migration_helpers import (
+    create_index_safe,
+    index_exists,
+    table_exists,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "sea02"
+down_revision = "sea01"
+branch_labels = None
+depends_on = None
+
+
+# The eight aggregatable stat columns shared by cells and totals (all nullable —
+# a source that doesn't observe a metric leaves it NULL; observed-zero stays 0).
+def _stat_columns():
+    return [
+        sa.Column("appearances", sa.Integer(), nullable=True),
+        sa.Column("goals", sa.Integer(), nullable=True),
+        sa.Column("assists", sa.Integer(), nullable=True),
+        sa.Column("minutes", sa.Integer(), nullable=True),
+        sa.Column("yellows", sa.Integer(), nullable=True),
+        sa.Column("reds", sa.Integer(), nullable=True),
+        sa.Column("saves", sa.Integer(), nullable=True),
+        sa.Column("goals_conceded", sa.Integer(), nullable=True),
+    ]
+
+
+def upgrade():
+    # ---- player_season_cells (fine grain) --------------------------------
+    if not table_exists("player_season_cells"):
+        op.create_table(
+            "player_season_cells",
+            sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+            sa.Column("player_api_id", sa.Integer(), nullable=False),
+            sa.Column("season", sa.Integer(), nullable=False),
+            sa.Column("source", sa.String(length=12), nullable=False),
+            sa.Column("club_api_id", sa.Integer(), nullable=False),
+            sa.Column("club_name", sa.String(length=200), nullable=True),
+            sa.Column("competition_tier", sa.String(length=20), nullable=False),
+            sa.Column("level_group", sa.String(length=13), nullable=False),
+            *_stat_columns(),
+            sa.Column("avg_rating", sa.Numeric(precision=4, scale=2), nullable=True),
+            sa.Column("detail", JSONB(), nullable=True),
+            sa.Column("synced_at", sa.TIMESTAMP(timezone=True), nullable=False),
+            sa.UniqueConstraint(
+                "player_api_id",
+                "season",
+                "source",
+                "club_api_id",
+                "competition_tier",
+                name="uq_psc_player_season_source_club_tier",
+            ),
+        )
+    create_index_safe("ix_psc_player_season", "player_season_cells", ["player_api_id", "season"])
+
+    # ---- player_season_totals (coarse grain) -----------------------------
+    if not table_exists("player_season_totals"):
+        op.create_table(
+            "player_season_totals",
+            sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+            sa.Column("player_api_id", sa.Integer(), nullable=False),
+            sa.Column("season", sa.Integer(), nullable=False),
+            sa.Column("level_group", sa.String(length=13), nullable=False),
+            *_stat_columns(),
+            sa.Column("avg_rating", sa.Numeric(precision=4, scale=2), nullable=True),
+            sa.Column("primary_source", sa.String(length=12), nullable=False),
+            sa.Column("fixtures_minutes", sa.Integer(), nullable=True),
+            sa.Column("journey_minutes", sa.Integer(), nullable=True),
+            sa.Column("reconcile_flag", sa.String(length=20), nullable=True),
+            sa.Column("source_breakdown", JSONB(), nullable=True),
+            sa.Column("clubs", JSONB(), nullable=True),
+            sa.Column("computed_at", sa.TIMESTAMP(timezone=True), nullable=False),
+            sa.UniqueConstraint("player_api_id", "season", "level_group", name="uq_pst_player_season_group"),
+        )
+    create_index_safe("ix_pst_season_group", "player_season_totals", ["season", "level_group"])
+    create_index_safe("ix_pst_player", "player_season_totals", ["player_api_id", "season"])
+
+    # ---- league_season_config (natural key, no sequence) -----------------
+    if not table_exists("league_season_config"):
+        op.create_table(
+            "league_season_config",
+            sa.Column("league_api_id", sa.Integer(), primary_key=True, autoincrement=False),
+            sa.Column("season_type", sa.String(length=12), nullable=True),
+            sa.Column("rollover_month", sa.Integer(), nullable=True),
+        )
+    # Idempotent seed of the five calendar-year leagues (Brazil/Argentina/MLS/Liga MX/J1).
+    op.execute(
+        "INSERT INTO league_season_config (league_api_id, season_type, rollover_month) VALUES "
+        "(71, 'calendar', 1), (128, 'calendar', 1), (253, 'calendar', 1), "
+        "(262, 'calendar', 1), (98, 'calendar', 1) "
+        "ON CONFLICT (league_api_id) DO NOTHING"
+    )
+
+    # ---- RLS on all three new public tables (invariants §2; idempotent) ---
+    for table in ("player_season_cells", "player_season_totals", "league_season_config"):
+        op.execute(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY")
+
+
+def downgrade():
+    if index_exists("ix_pst_player"):
+        op.drop_index("ix_pst_player", table_name="player_season_totals")
+    if index_exists("ix_pst_season_group"):
+        op.drop_index("ix_pst_season_group", table_name="player_season_totals")
+    if index_exists("ix_psc_player_season"):
+        op.drop_index("ix_psc_player_season", table_name="player_season_cells")
+
+    if table_exists("league_season_config"):
+        op.drop_table("league_season_config")
+    if table_exists("player_season_totals"):
+        op.drop_table("player_season_totals")
+    if table_exists("player_season_cells"):
+        op.drop_table("player_season_cells")

--- a/academy-watch-backend/migrations/versions/sea02_season_rollup_tables.py
+++ b/academy-watch-backend/migrations/versions/sea02_season_rollup_tables.py
@@ -11,7 +11,9 @@ the 0.5 CPU prod box.
 
 - player_season_cells  — fine grain: one row per SOURCE-contributed cell
                          (player, season, source, club, competition_tier). source is
-                         IN the unique key so feeders never collide.
+                         IN the unique key so feeders never collide. Carries a
+                         single-column ix_psc_synced_at so the /status gauge's
+                         MAX(synced_at) is an index lookup, not a full-table seq scan.
 - player_season_totals — coarse grain: the single hot-read row per
                          (player, season, level_group). Both raw fixtures/journey
                          minutes + a reconcile_flag ride along (never-cross-source-sum).
@@ -104,6 +106,10 @@ def upgrade():
             ),
         )
     create_index_safe("ix_psc_player_season", "player_season_cells", ["player_api_id", "season"])
+    # Single-column clock index so the cheap /status gauge's MAX(synced_at) is an
+    # index lookup instead of a full seq scan of the largest rollup table
+    # (season_rollup route _max_source_change). Matches PlayerSeasonCell.__table_args__.
+    create_index_safe("ix_psc_synced_at", "player_season_cells", ["synced_at"])
 
     # ---- player_season_totals (coarse grain) -----------------------------
     if not table_exists("player_season_totals"):
@@ -153,6 +159,8 @@ def downgrade():
         op.drop_index("ix_pst_player", table_name="player_season_totals")
     if index_exists("ix_pst_season_group"):
         op.drop_index("ix_pst_season_group", table_name="player_season_totals")
+    if index_exists("ix_psc_synced_at"):
+        op.drop_index("ix_psc_synced_at", table_name="player_season_cells")
     if index_exists("ix_psc_player_season"):
         op.drop_index("ix_psc_player_season", table_name="player_season_cells")
 

--- a/academy-watch-backend/migrations/versions/sea03_status_clock_indexes.py
+++ b/academy-watch-backend/migrations/versions/sea03_status_clock_indexes.py
@@ -1,0 +1,71 @@
+"""Single-column clock indexes for the season-rollup /status gauge
+
+Revision ID: sea03
+Revises: sea02
+Create Date: 2026-07-08
+
+The cheap default ``GET /api/admin/season-rollup/status`` gauge reads the newest
+mutation clock of each timed source via ``MAX(<clock>)`` (season_rollup route
+``_max_source_change``). PostgreSQL only turns ``MAX(col)`` into an index lookup
+(ORDER BY col DESC LIMIT 1) when a b-tree exists on that column — otherwise every
+call is a full sequential scan of the source table. The rollup tables' own clock
+(``player_season_cells.synced_at``) is indexed in sea02; this migration adds the
+matching single-column indexes on the three EXISTING source tables so all four
+gauge MAX scans are genuine index lookups and the admin gauge stays pollable on
+the 0.5 CPU prod box (invariants §7):
+
+  ix_pje_stats_synced_at   — player_journey_entries(stats_synced_at)   [sea01 column]
+  ix_apss_updated_at       — academy_player_season_stats(updated_at)
+  ix_pss_updated_at        — player_shadow_stats(updated_at)
+
+These tables' CREATE migrations (sea01 / aw14 / older) are already merged to main,
+so the indexes cannot be folded into them — a follow-up migration is the correct
+vehicle. All three shipped ORM models declare the matching ``db.Index`` in
+``__table_args__`` (autogenerate parity), so ``flask db migrate`` proposes no diff.
+
+No new table and no ADD COLUMN — only CREATE INDEX on existing, already-populated
+columns — so there is NO RLS statement (invariants §2 applies to new public tables
+only) and NO UndefinedColumn/UndefinedTable read-path 500 window: adding a
+``db.Index`` to a model changes metadata only and issues no new SELECT. Every op is
+guarded via create_index_safe / index_exists (invariants §8 — prod schema drifted
+out-of-band); re-applied or partially-applied, upgrade() is a clean no-op.
+
+DEPLOY ORDERING (migrations do NOT auto-run — deploy.yml runs only the RLS
+security-check; the container CMD is gunicorn, nothing runs `flask db upgrade`).
+Because no read path depends on these indexes existing, ordering is relaxed
+relative to sea01/sea02: a not-yet-applied migration causes no 500s — the gauge
+merely falls back to seq scans until the index lands. Preferred sequence still
+mirrors the others: PRE-APPLY out-of-band against prod BEFORE merging — from a
+local checkout with the prod DB env (IPv4 pooler + `postgresql+psycopg://`,
+invariants §1) run `FLASK_APP=src/main.py flask db upgrade`. Each CREATE INDEX is a
+single-column b-tree build; PJE is the only sizeable table (~77k rows) and still
+builds in well under a second. Then merge: the in-container `flask db upgrade` is a
+pure no-op stamp (every op guarded via index_exists). Fallback (safe here): apply
+post-deploy in the container.
+"""
+
+from alembic import op
+from migrations._migration_helpers import (
+    create_index_safe,
+    index_exists,
+)
+
+revision = "sea03"
+down_revision = "sea02"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    create_index_safe("ix_pje_stats_synced_at", "player_journey_entries", ["stats_synced_at"])
+    create_index_safe("ix_apss_updated_at", "academy_player_season_stats", ["updated_at"])
+    create_index_safe("ix_pss_updated_at", "player_shadow_stats", ["updated_at"])
+
+
+def downgrade():
+    if index_exists("ix_pss_updated_at"):
+        op.drop_index("ix_pss_updated_at", table_name="player_shadow_stats")
+    if index_exists("ix_apss_updated_at"):
+        op.drop_index("ix_apss_updated_at", table_name="academy_player_season_stats")
+    if index_exists("ix_pje_stats_synced_at"):
+        op.drop_index("ix_pje_stats_synced_at", table_name="player_journey_entries")

--- a/academy-watch-backend/src/agents/weekly_agent.py
+++ b/academy-watch-backend/src/agents/weekly_agent.py
@@ -871,6 +871,11 @@ async def fetch_weekly_report(ctx, args) -> dict[str, Any]:
     # normalize parent team payload shape
     report["parent_team"] = {"db_id": team.id, "id": team.team_id, "name": team.name}
     db.session.commit()
+    # Post-commit: refresh the season rollup for every loanee whose FPS the
+    # week-summary wrote (one refresh per player, after the batch commit).
+    from src.services.season_rollup_service import flush_player_refresh_queue
+
+    flush_player_refresh_queue()
     return report
 
 

--- a/academy-watch-backend/src/agents/weekly_newsletter_agent.py
+++ b/academy-watch-backend/src/agents/weekly_newsletter_agent.py
@@ -1980,6 +1980,10 @@ def _sync_team_fixtures_for_week(
                         )
                         db.session.add(fps)
                         total_synced += 1
+                        # FPS choke point: mark (player, season) rollup dirty.
+                        from src.services.season_rollup_service import queue_player_refresh
+
+                        queue_player_refresh(pid, season)
 
                     missing.discard(pid)
 
@@ -1987,6 +1991,10 @@ def _sync_team_fixtures_for_week(
                 _time.sleep(delay)
 
         db.session.commit()
+        # One refresh per affected player, after the batch commit.
+        from src.services.season_rollup_service import flush_player_refresh_queue
+
+        flush_player_refresh_queue()
 
     result = {
         "synced": total_synced,

--- a/academy-watch-backend/src/api_football_client.py
+++ b/academy-watch-backend/src/api_football_client.py
@@ -3233,6 +3233,21 @@ class APIFootballClient:
                                             .delete()
                                         )
                                         if ghost_deleted:
+                                            # Sole-writer contract: rebuild the OLD
+                                            # id's rollup from what remains after the
+                                            # ghost FPS delete.
+                                            try:
+                                                from src.services.season_rollup_service import (
+                                                    refresh_player as _refresh_rollup,
+                                                )
+
+                                                with db_session.begin_nested():
+                                                    _refresh_rollup(info["player_api_id"], season, session=db_session)
+                                            except Exception:
+                                                logger.exception(
+                                                    "season-rollup refresh after ghost-delete failed for player=%s",
+                                                    info["player_api_id"],
+                                                )
                                             db_session.commit()
                                             logger.info(f"🗑️ Deleted {ghost_deleted} ghost stats")
                                 except Exception as db_err:

--- a/academy-watch-backend/src/api_football_client.py
+++ b/academy-watch-backend/src/api_football_client.py
@@ -2250,6 +2250,11 @@ class APIFootballClient:
                             f"fixture_id={fixture_id}, player_id={player_id}"
                         )
                         self._upsert_player_fixture_stats(db_session, db_fixture.id, player_id, loan_team_id, pstats)
+                        # FPS choke point: mark this (player, season) rollup dirty
+                        # (deduped in-memory; flushed once after the outer commit).
+                        from src.services.season_rollup_service import queue_player_refresh
+
+                        queue_player_refresh(player_id, season, session=db_session)
                         # Refresh the player_stats_row from what we just stored/updated
                         player_stats_row = (
                             db_session.query(FixturePlayerStats)

--- a/academy-watch-backend/src/main.py
+++ b/academy-watch-backend/src/main.py
@@ -37,6 +37,7 @@ from src.routes.newsletter_deadline import newsletter_deadline_bp
 from src.routes.ops import ops_bp
 from src.routes.players import players_bp
 from src.routes.scout import scout_bp
+from src.routes.season_rollup import season_rollup_bp
 from src.routes.showcase import showcase_bp
 from src.routes.teams import teams_bp
 from src.routes.video import video_bp
@@ -117,6 +118,7 @@ app.register_blueprint(feeder_bp, url_prefix="/api")
 app.register_blueprint(curator_bp, url_prefix="/api")
 app.register_blueprint(video_bp, url_prefix="/api")
 app.register_blueprint(ops_bp, url_prefix="/api")
+app.register_blueprint(season_rollup_bp, url_prefix="/api")
 
 csp = {
     "default-src": ["'self'"],

--- a/academy-watch-backend/src/main.py
+++ b/academy-watch-backend/src/main.py
@@ -13,6 +13,11 @@ from flask_talisman import Talisman
 from sqlalchemy.engine.url import URL, make_url
 from werkzeug.exceptions import HTTPException
 
+# Side-effect import: register the sea02 season-rollup tables in db.metadata so
+# `flask db migrate` autogenerate sees them (no spurious drop/create) and so the
+# tables exist for db.create_all(). D3a has no service consumer yet (that is D3b),
+# so nothing else imports these models — this is the registration site.
+import src.models.season_rollup  # noqa: E402, F401
 from src.extensions import limiter
 from src.models.league import League, Newsletter, Team, UserSubscription, db
 from src.models.tracked_player import TrackedPlayer

--- a/academy-watch-backend/src/models/follow.py
+++ b/academy-watch-backend/src/models/follow.py
@@ -130,4 +130,7 @@ class PlayerShadowStats(db.Model):
     __table_args__ = (
         db.UniqueConstraint("player_api_id", "team_api_id", "season", name="uq_shadow_stats"),
         db.Index("ix_shadow_stats_player", "player_api_id"),
+        # Single-column clock index so the season-rollup /status gauge's
+        # MAX(updated_at) is an index lookup, not a full seq scan. Matches migration sea03.
+        db.Index("ix_pss_updated_at", "updated_at"),
     )

--- a/academy-watch-backend/src/models/journey.py
+++ b/academy-watch-backend/src/models/journey.py
@@ -353,6 +353,10 @@ class PlayerJourneyEntry(db.Model):
         # Denormalized per-player-per-season read path (D1 provenance / D2 aggregation).
         # Named to match migration sea01's create_index_safe so autogenerate keeps it.
         db.Index("ix_pje_player_season", "player_api_id", "season"),
+        # Single-column clock index so the season-rollup /status gauge's
+        # MAX(stats_synced_at) is an index lookup, not a full seq scan of this wide
+        # ~77k-row table. Named to match migration sea03's create_index_safe.
+        db.Index("ix_pje_stats_synced_at", "stats_synced_at"),
         # NB: intentionally no uq_journey_entry UniqueConstraint. x2y3z4a5b6c7 created
         # only the NON-unique ix_journey_entry_lookup on these four columns — the DB has
         # never held a unique constraint here. Dedup is enforced in application code

--- a/academy-watch-backend/src/models/league.py
+++ b/academy-watch-backend/src/models/league.py
@@ -1522,6 +1522,9 @@ class AcademyPlayerSeasonStats(db.Model):
 
     __table_args__ = (
         db.UniqueConstraint("player_api_id", "league_api_id", "season", name="uq_academy_player_season_stats"),
+        # Single-column clock index so the season-rollup /status gauge's
+        # MAX(updated_at) is an index lookup, not a full seq scan. Matches migration sea03.
+        db.Index("ix_apss_updated_at", "updated_at"),
     )
 
     def to_dict(self):

--- a/academy-watch-backend/src/models/season_rollup.py
+++ b/academy-watch-backend/src/models/season_rollup.py
@@ -74,6 +74,9 @@ class PlayerSeasonCell(db.Model):
         ),
         # per-player-per-season read path; named to match migration sea02.
         db.Index("ix_psc_player_season", "player_api_id", "season"),
+        # single-column clock index so the /status gauge's MAX(synced_at) is an
+        # index lookup, not a full seq scan; named to match migration sea02.
+        db.Index("ix_psc_synced_at", "synced_at"),
     )
 
     def to_dict(self):

--- a/academy-watch-backend/src/models/season_rollup.py
+++ b/academy-watch-backend/src/models/season_rollup.py
@@ -1,0 +1,191 @@
+"""Season-rollup models (sea02) — the precomputed per-player-per-season read surface.
+
+The seasons design (ledgers/research/seasons-design-proposal.md §2/§3) makes every
+hot stats surface "one indexed row" instead of a live cross-source aggregation on a
+0.5 CPU box. Two grains plus a per-league calendar config:
+
+- ``player_season_cells``   — FINE grain: one row per SOURCE-contributed cell,
+                              ``(player, season, source, club, competition_tier)``.
+                              Feeders DELETE+INSERT their own source's cells; the
+                              source is IN the unique key so feeders never collide.
+- ``player_season_totals``  — COARSE grain: the single hot-read row per
+                              ``(player, season, level_group)``. Totals NEVER sum
+                              across sources — the larger-minutes source wins the
+                              headline whole (the double-count guard); both raw
+                              ``fixtures_minutes`` / ``journey_minutes`` and a
+                              ``reconcile_flag`` are always carried for provenance.
+- ``league_season_config``  — "what season is NOW" per league (calendar-year vs
+                              Aug-rollover), so calendar leagues (Brazil/MLS/…) label
+                              and resolve their current season correctly.
+
+D3a is SCHEMA ONLY — no service writes these tables yet (that is D3b). These classes
+exist so the tables are registered in ``db.metadata`` (autogenerate parity) and are
+importable by the D3b rollup service. Metadata here matches migration ``sea02``
+column-for-column, name-for-name — a drift would make ``flask db migrate`` propose a
+spurious drop/create (the exact failure the D2 drift fixes guarded against).
+"""
+
+from sqlalchemy.dialects.postgresql import JSONB
+from src.models.league import db
+
+# BigInteger surrogate PK that still works under the SQLite test harness (SQLite
+# only aliases INTEGER PRIMARY KEY to rowid) — mirrors ProductEvent.
+_BIG_PK = db.BigInteger().with_variant(db.Integer, "sqlite")
+
+
+class PlayerSeasonCell(db.Model):
+    """One SOURCE-contributed stat cell for a player-season (fine grain)."""
+
+    __tablename__ = "player_season_cells"
+
+    id = db.Column(_BIG_PK, primary_key=True, autoincrement=True)
+    player_api_id = db.Column(db.Integer, nullable=False)
+    season = db.Column(db.Integer, nullable=False)  # API-Football season start-year (2025 == 2025-26)
+    source = db.Column(db.String(12), nullable=False)  # fixtures|journey|apss|shadow|cache
+    club_api_id = db.Column(db.Integer, nullable=False)
+    club_name = db.Column(db.String(200))
+    competition_tier = db.Column(
+        db.String(20), nullable=False
+    )  # league|domestic_cup|league_cup|continental|other|youth
+    level_group = db.Column(db.String(13), nullable=False)  # senior|youth|international
+
+    appearances = db.Column(db.Integer)
+    goals = db.Column(db.Integer)
+    assists = db.Column(db.Integer)
+    minutes = db.Column(db.Integer)
+    yellows = db.Column(db.Integer)
+    reds = db.Column(db.Integer)
+    saves = db.Column(db.Integer)
+    goals_conceded = db.Column(db.Integer)
+    avg_rating = db.Column(db.Numeric(4, 2))  # minutes-weighted WITHIN this source only
+
+    detail = db.Column(JSONB)  # rich fields: shots/passes/tackles/duels/dribbles
+    synced_at = db.Column(db.DateTime(timezone=True), nullable=False)
+
+    __table_args__ = (
+        # source is IN the grain so feeders never collide (proposal §2/§6 Q1).
+        db.UniqueConstraint(
+            "player_api_id",
+            "season",
+            "source",
+            "club_api_id",
+            "competition_tier",
+            name="uq_psc_player_season_source_club_tier",
+        ),
+        # per-player-per-season read path; named to match migration sea02.
+        db.Index("ix_psc_player_season", "player_api_id", "season"),
+    )
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "player_api_id": self.player_api_id,
+            "season": self.season,
+            "source": self.source,
+            "club": {"id": self.club_api_id, "name": self.club_name},
+            "competition_tier": self.competition_tier,
+            "level_group": self.level_group,
+            "stats": {
+                "appearances": self.appearances,
+                "goals": self.goals,
+                "assists": self.assists,
+                "minutes": self.minutes,
+                "yellows": self.yellows,
+                "reds": self.reds,
+                "saves": self.saves,
+                "goals_conceded": self.goals_conceded,
+                "avg_rating": float(self.avg_rating) if self.avg_rating is not None else None,
+            },
+            "detail": self.detail,
+            "synced_at": self.synced_at.isoformat() if self.synced_at else None,
+        }
+
+
+class PlayerSeasonTotal(db.Model):
+    """The single hot-read totals row per player-season-level_group (coarse grain).
+
+    Totals NEVER sum across sources — the larger-minutes source wins the headline
+    whole (proposal §2 aggregation rule). ``fixtures_minutes`` / ``journey_minutes``
+    and ``reconcile_flag`` are always present so provenance is never lost.
+    """
+
+    __tablename__ = "player_season_totals"
+
+    id = db.Column(_BIG_PK, primary_key=True, autoincrement=True)
+    player_api_id = db.Column(db.Integer, nullable=False)
+    season = db.Column(db.Integer, nullable=False)
+    level_group = db.Column(db.String(13), nullable=False)  # senior|youth|international
+
+    appearances = db.Column(db.Integer)
+    goals = db.Column(db.Integer)
+    assists = db.Column(db.Integer)
+    minutes = db.Column(db.Integer)
+    yellows = db.Column(db.Integer)
+    reds = db.Column(db.Integer)
+    saves = db.Column(db.Integer)
+    goals_conceded = db.Column(db.Integer)
+    avg_rating = db.Column(db.Numeric(4, 2))  # ALWAYS fixtures-sourced, minutes-weighted
+
+    primary_source = db.Column(db.String(12), nullable=False)  # source whose totals won the headline
+    fixtures_minutes = db.Column(db.Integer)
+    journey_minutes = db.Column(db.Integer)
+    reconcile_flag = db.Column(db.String(20))  # NULL|cup-gap|journey-under-sync|fixtures-invisible
+    source_breakdown = db.Column(JSONB)  # per-source minutes
+    clubs = db.Column(JSONB)  # compact per-club render array
+    computed_at = db.Column(db.DateTime(timezone=True), nullable=False)
+
+    __table_args__ = (
+        db.UniqueConstraint("player_api_id", "season", "level_group", name="uq_pst_player_season_group"),
+        # list surfaces scan by (season, level_group); development view by (player, season).
+        db.Index("ix_pst_season_group", "season", "level_group"),
+        db.Index("ix_pst_player", "player_api_id", "season"),
+    )
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "player_api_id": self.player_api_id,
+            "season": self.season,
+            "level_group": self.level_group,
+            "stats": {
+                "appearances": self.appearances,
+                "goals": self.goals,
+                "assists": self.assists,
+                "minutes": self.minutes,
+                "yellows": self.yellows,
+                "reds": self.reds,
+                "saves": self.saves,
+                "goals_conceded": self.goals_conceded,
+                "avg_rating": float(self.avg_rating) if self.avg_rating is not None else None,
+            },
+            "provenance": {
+                "primary_source": self.primary_source,
+                "fixtures_minutes": self.fixtures_minutes,
+                "journey_minutes": self.journey_minutes,
+                "reconcile_flag": self.reconcile_flag,
+                "source_breakdown": self.source_breakdown,
+            },
+            "clubs": self.clubs,
+            "computed_at": self.computed_at.isoformat() if self.computed_at else None,
+        }
+
+
+class LeagueSeasonConfig(db.Model):
+    """Per-league calendar model — "what season is NOW" (proposal §2/§6 Q3).
+
+    ``league_api_id`` is a NATURAL key (the API-Football league id), inserted
+    explicitly, so it carries no sequence (``autoincrement=False``).
+    """
+
+    __tablename__ = "league_season_config"
+
+    league_api_id = db.Column(db.Integer, primary_key=True, autoincrement=False)
+    season_type = db.Column(db.String(12))  # calendar|split (Aug-rollover is the default elsewhere)
+    rollover_month = db.Column(db.Integer)
+
+    def to_dict(self):
+        return {
+            "league_api_id": self.league_api_id,
+            "season_type": self.season_type,
+            "rollover_month": self.rollover_month,
+        }

--- a/academy-watch-backend/src/routes/api.py
+++ b/academy-watch-backend/src/routes/api.py
@@ -1538,6 +1538,16 @@ def _sync_player_club_fixtures(player_id: int, loan_team_api_id: int, season: in
                 FixturePlayerStats.minutes == 0,
             ).delete()
             if ghost_deleted:
+                # Sole-writer contract: those ghost FPS rows fed the rollup under
+                # the OLD id — rebuild that id's rollup from what remains so no
+                # phantom fixtures cell survives (player_id is still the old id here).
+                try:
+                    from src.services.season_rollup_service import refresh_player as _refresh_rollup
+
+                    with db.session.begin_nested():
+                        _refresh_rollup(player_id, season=season)
+                except Exception:
+                    logger.exception("season-rollup refresh after ghost-delete failed for player=%s", player_id)
                 db.session.commit()
                 logger.info(f"🗑️ Deleted {ghost_deleted} ghost stat records with old ID {player_id}")
 
@@ -6653,6 +6663,28 @@ def admin_delete_team_data(team_id: int):
         team.newsletters_active = False
 
         db.session.commit()
+
+        # Season-rollup sole-writer contract: the FPS bulk-delete above fed
+        # player_season_cells/totals — rebuild each affected player's rollup from
+        # the REMAINING sources so no phantom fixtures cell/total survives (the
+        # rows-behind gauge can't detect it once the source rows are gone).
+        # season=None covers every season the deleted rows spanned; one bounded
+        # refresh per player (a team roster, not a platform-wide sweep).
+        affected_pids = {pid for pid in player_api_ids if pid is not None}
+        if affected_pids:
+            try:
+                from src.services.season_rollup_service import refresh_player as _refresh_rollup
+
+                for _pid in affected_pids:
+                    try:
+                        with db.session.begin_nested():
+                            _refresh_rollup(_pid, season=None)
+                    except Exception:
+                        logger.exception("season-rollup refresh after team-delete failed for player=%s", _pid)
+                db.session.commit()
+            except Exception:
+                logger.exception("season-rollup post-delete rebuild failed for team %s", team_id)
+                db.session.rollback()
 
         summary["message"] = f"Successfully deleted all tracking data for {team.name}"
         return jsonify(summary)

--- a/academy-watch-backend/src/routes/api.py
+++ b/academy-watch-backend/src/routes/api.py
@@ -1654,6 +1654,10 @@ def _sync_player_club_fixtures(player_id: int, loan_team_api_id: int, season: in
                     )
                     db.session.add(fps)
                     synced += 1
+                    # FPS choke point: mark this (player, season) rollup dirty.
+                    from src.services.season_rollup_service import queue_player_refresh
+
+                    queue_player_refresh(player_id, season)
                     logger.debug(f"Added stats for fixture {fixture_id_api}: {minutes}' played")
         except Exception as e:
             logger.warning(f"Failed to get player stats for fixture {fixture_id_api}: {e}")
@@ -1661,6 +1665,10 @@ def _sync_player_club_fixtures(player_id: int, loan_team_api_id: int, season: in
 
     if synced > 0:
         db.session.commit()
+        # One refresh per affected player, after the batch commit.
+        from src.services.season_rollup_service import flush_player_refresh_queue
+
+        flush_player_refresh_queue()
         logger.info(f"Synced {synced} fixtures for player {player_id} at team {loan_team_api_id}")
 
     return synced
@@ -5147,6 +5155,10 @@ def admin_sync_player_fixtures(player_id: int):
                         )
                         db.session.add(fps)
                         synced += 1
+                        # FPS choke point: mark this (player, season) rollup dirty.
+                        from src.services.season_rollup_service import queue_player_refresh
+
+                        queue_player_refresh(player_id, season)
                     elif minutes > 0 or games.get("substitute") is not None:
                         synced += 1  # Dry run counts this as would-sync
                     else:
@@ -5159,6 +5171,10 @@ def admin_sync_player_fixtures(player_id: int):
 
         if not dry_run:
             db.session.commit()
+            # One refresh per affected player, after the batch commit.
+            from src.services.season_rollup_service import flush_player_refresh_queue
+
+            flush_player_refresh_queue()
 
         return jsonify(
             {
@@ -5596,6 +5612,10 @@ def _run_batch_fixture_sync(data: dict, job_id: str = None) -> dict:
                                     formation_position=formation_pos,
                                 )
                                 db.session.add(fps)
+                                # FPS choke point: mark (player, season) dirty.
+                                from src.services.season_rollup_service import queue_player_refresh
+
+                                queue_player_refresh(pid, season)
                             team_result["synced"] += 1
                         else:
                             team_result["skipped"] += 1
@@ -5608,6 +5628,10 @@ def _run_batch_fixture_sync(data: dict, job_id: str = None) -> dict:
 
             if not dry_run:
                 db.session.commit()
+                # One refresh per affected player, after this team's batch commit.
+                from src.services.season_rollup_service import flush_player_refresh_queue
+
+                flush_player_refresh_queue()
 
         except Exception as e:
             logger.warning(f"Batch sync error for team {team_api_id}: {e}")
@@ -6189,6 +6213,10 @@ def _run_team_fixtures_sync(team_id: int, data: dict, job_id: str = None) -> dic
                                 )
                                 db.session.add(fps)
                                 player_result["synced"] += 1
+                                # FPS choke point: mark (player, season) dirty.
+                                from src.services.season_rollup_service import queue_player_refresh
+
+                                queue_player_refresh(p_api_id, season)
                             elif minutes > 0 or games.get("substitute") is not None:
                                 player_result["synced"] += 1  # Dry run counts this
                             else:
@@ -6201,6 +6229,10 @@ def _run_team_fixtures_sync(team_id: int, data: dict, job_id: str = None) -> dic
 
                 if not dry_run:
                     db.session.commit()
+                    # One refresh per affected player, after the batch commit.
+                    from src.services.season_rollup_service import flush_player_refresh_queue
+
+                    flush_player_refresh_queue()
 
             except Exception as e:
                 player_result["errors"].append(str(e)[:100])

--- a/academy-watch-backend/src/routes/api.py
+++ b/academy-watch-backend/src/routes/api.py
@@ -6662,29 +6662,32 @@ def admin_delete_team_data(team_id: int):
         team.is_tracked = False
         team.newsletters_active = False
 
-        db.session.commit()
-
         # Season-rollup sole-writer contract: the FPS bulk-delete above fed
         # player_season_cells/totals — rebuild each affected player's rollup from
-        # the REMAINING sources so no phantom fixtures cell/total survives (the
-        # rows-behind gauge can't detect it once the source rows are gone).
-        # season=None covers every season the deleted rows spanned; one bounded
-        # refresh per player (a team roster, not a platform-wide sweep).
+        # the REMAINING sources BEFORE the commit, so the delete and the
+        # cells/totals re-resolution land in ONE transaction. A crash between the
+        # two (the 0.5 CPU box's documented OOM/deploy/restart failure mode) can no
+        # longer leave a phantom fixtures total whose source FPS rows are already
+        # gone — a phantom the rows-behind gauge cannot detect once those source
+        # rows are deleted. Mirrors the two ghost-delete paths (savepoint-wrapped
+        # refresh before the shared commit); a team DELETE is cheap to redo, so
+        # atomicity wins here over the deferred post-commit refresh that exists
+        # only to shield API-expensive fixture writes. season=None covers every
+        # season the deleted rows spanned; one bounded refresh per rostered player
+        # (a team roster, not a platform-wide sweep), each in a SAVEPOINT so one
+        # bad player logs-and-skips without losing the rest of the batch.
         affected_pids = {pid for pid in player_api_ids if pid is not None}
         if affected_pids:
-            try:
-                from src.services.season_rollup_service import refresh_player as _refresh_rollup
+            from src.services.season_rollup_service import refresh_player as _refresh_rollup
 
-                for _pid in affected_pids:
-                    try:
-                        with db.session.begin_nested():
-                            _refresh_rollup(_pid, season=None)
-                    except Exception:
-                        logger.exception("season-rollup refresh after team-delete failed for player=%s", _pid)
-                db.session.commit()
-            except Exception:
-                logger.exception("season-rollup post-delete rebuild failed for team %s", team_id)
-                db.session.rollback()
+            for _pid in affected_pids:
+                try:
+                    with db.session.begin_nested():
+                        _refresh_rollup(_pid, season=None)
+                except Exception:
+                    logger.exception("season-rollup refresh after team-delete failed for player=%s", _pid)
+
+        db.session.commit()
 
         summary["message"] = f"Successfully deleted all tracking data for {team.name}"
         return jsonify(summary)

--- a/academy-watch-backend/src/routes/api.py
+++ b/academy-watch-backend/src/routes/api.py
@@ -6674,18 +6674,16 @@ def admin_delete_team_data(team_id: int):
         # atomicity wins here over the deferred post-commit refresh that exists
         # only to shield API-expensive fixture writes. season=None covers every
         # season the deleted rows spanned; one bounded refresh per rostered player
-        # (a team roster, not a platform-wide sweep), each in a SAVEPOINT so one
-        # bad player logs-and-skips without losing the rest of the batch.
+        # (a team roster, not a platform-wide sweep). Any per-player refresh
+        # failure propagates to the outer handler, which rolls back the WHOLE
+        # cheap-to-redo team delete and returns 500.
         affected_pids = {pid for pid in player_api_ids if pid is not None}
         if affected_pids:
             from src.services.season_rollup_service import refresh_player as _refresh_rollup
 
             for _pid in affected_pids:
-                try:
-                    with db.session.begin_nested():
-                        _refresh_rollup(_pid, season=None)
-                except Exception:
-                    logger.exception("season-rollup refresh after team-delete failed for player=%s", _pid)
+                with db.session.begin_nested():
+                    _refresh_rollup(_pid, season=None)
 
         db.session.commit()
 

--- a/academy-watch-backend/src/routes/season_rollup.py
+++ b/academy-watch-backend/src/routes/season_rollup.py
@@ -4,18 +4,26 @@ Both endpoints are pure database operations. Rebuilds are keyset-paged by
 ``player_api_id`` and delegate every derived-row write to the public
 ``season_rollup_service.refresh_player`` API.
 
-``GET /status`` defaults to a CHEAP rows-behind gauge: one ``MAX`` scan per
-timed source (``PlayerJourneyEntry.stats_synced_at``,
-``AcademyPlayerSeasonStats.updated_at``, ``PlayerShadowStats.updated_at``,
-``PlayerSeasonCell.synced_at``) compared against ``MAX(computed_at)`` — a handful
-of index-assisted aggregates, no per-grain set difference. The exact per-player
-stale count is a full multi-table aggregation, so it is reserved behind
-``?exact=1`` for occasional reconciliation and for the paged ``scope=stale``
-rebuild (which evaluates clocks only for its bounded candidate page). Fixture
-rows carry no clock, so the cheap gauge cannot see a fixture-missing-cell;
-``?exact=1`` and the ``scope=stale`` sweep are the reconciliation paths for that
-blind spot, and ``scope=all`` is the repair fallback for legacy/manual journey
-rows with a null ``stats_synced_at``.
+``GET /status`` defaults to a CHEAP rows-behind gauge whose only per-source cost is
+one index-served ``MAX`` per timed clock: ``PlayerJourneyEntry.stats_synced_at``
+(ix_pje_stats_synced_at), ``AcademyPlayerSeasonStats.updated_at``
+(ix_apss_updated_at), ``PlayerShadowStats.updated_at`` (ix_pss_updated_at) and
+``PlayerSeasonCell.synced_at`` (ix_psc_synced_at) — sea02/sea03 give every one of
+those columns a b-tree so each ``MAX`` is an ORDER BY … LIMIT 1 lookup, not a seq
+scan. Those four are compared against the totals' newest ``computed_at``, which
+rides along the single ``count(id), max(computed_at)`` pass over
+``player_season_totals`` (the smallest rollup table, already scanned for the
+``total_totals_rows`` count) — so the default is four index lookups plus one
+bounded single-table scan, no joins and no per-grain set difference. Everything
+genuinely expensive is behind ``?exact=1``: the exact per-player stale count (a
+full multi-table aggregation) and the ``by_source_cells`` per-source breakdown (a
+full group-by over the largest table, ``player_season_cells``). ``?exact=1`` also
+powers occasional reconciliation and the paged ``scope=stale`` rebuild (which
+evaluates clocks only for its bounded candidate page). Fixture rows carry no clock,
+so the cheap gauge cannot see a fixture-missing-cell; ``?exact=1`` and the
+``scope=stale`` sweep are the reconciliation paths for that blind spot, and
+``scope=all`` is the repair fallback for legacy/manual journey rows with a null
+``stats_synced_at``.
 
 Deleting a timed source row can leave its surviving cell/total pair looking
 fresh when their clocks are equal, so neither ``?exact=1`` nor ``scope=stale``
@@ -383,10 +391,13 @@ def _as_utc(value):
 def _max_source_change():
     """Newest mutation across the timed sources — the cheap freshness clock.
 
-    Each source contributes ONE ``MAX`` scan (no joins, no per-grain group-by),
-    so this stays sub-second on the prod box. Fixture rows carry no clock, so it
-    deliberately cannot see a fixture-missing-cell; ``?exact=1`` or a
-    ``scope=stale`` sweep reconciles that blind spot.
+    Each source contributes ONE ``MAX`` and each of the four clock columns carries
+    a single-column b-tree (``stats_synced_at``/``updated_at``/``synced_at`` via
+    sea01+sea03/sea02), so PostgreSQL serves every ``MAX`` as an ORDER BY … LIMIT 1
+    index lookup — no seq scan, no join, no per-grain group-by — and this stays
+    sub-second on the prod box. Fixture rows carry no clock, so it deliberately
+    cannot see a fixture-missing-cell; ``?exact=1`` or a ``scope=stale`` sweep
+    reconciles that blind spot.
     """
     clocks = [
         db.session.query(func.max(PlayerJourneyEntry.stats_synced_at)).scalar(),
@@ -538,10 +549,16 @@ def admin_rebuild_season_rollup():
 def admin_season_rollup_status():
     """Return the rows-behind gauge.
 
-    Default = the CHEAP gauge: ``behind`` is derived from the newest timed-source
-    clock vs ``MAX(computed_at)`` (a handful of index-assisted ``MAX`` scans, no
-    per-grain set difference). Pass ``?exact=1`` to also run the exact per-player
-    stale count (a full multi-table aggregation) for occasional reconciliation.
+    Default = the CHEAP gauge: ``behind`` compares the newest timed-source clock
+    (four index-served ``MAX`` lookups — sea02/sea03 index every clock column)
+    against the totals' own newest ``computed_at``, which rides along the single
+    ``count(id), max(computed_at)`` pass over the small ``player_season_totals``
+    table (already needed for ``total_totals_rows``) — so the default is four index
+    lookups plus one bounded single-table scan, no joins and no per-grain set
+    difference. Pass ``?exact=1`` for the reconciliation extras that DO scan the
+    largest table: the exact per-player stale count (``stale_players``, a full
+    multi-table aggregation) and the ``by_source_cells`` per-source cell breakdown
+    (a full ``player_season_cells`` group-by).
     """
     exact = (request.args.get("exact") or "").strip().lower() in {"1", "true", "yes", "on"}
     try:
@@ -553,19 +570,22 @@ def admin_season_rollup_status():
         behind = last_source_change_at is not None and (
             last_computed_at is None or _as_utc(last_source_change_at) > _as_utc(last_computed_at)
         )
-        source_counts = (
-            db.session.query(PlayerSeasonCell.source, func.count(PlayerSeasonCell.id))
-            .group_by(PlayerSeasonCell.source)
-            .all()
-        )
         body = {
             "total_totals_rows": int(total_totals_rows or 0),
             "behind": behind,
             "last_computed_at": last_computed_at.isoformat() if last_computed_at else None,
             "last_source_change_at": last_source_change_at.isoformat() if last_source_change_at else None,
-            "by_source_cells": {source: int(count) for source, count in source_counts},
         }
         if exact:
+            # Both scan the largest rollup table, so they stay off the pollable
+            # default path: the per-source cell breakdown (full group-by) and the
+            # exact per-player stale count (full multi-table aggregation).
+            source_counts = (
+                db.session.query(PlayerSeasonCell.source, func.count(PlayerSeasonCell.id))
+                .group_by(PlayerSeasonCell.source)
+                .all()
+            )
+            body["by_source_cells"] = {source: int(count) for source, count in source_counts}
             body["stale_players"] = _count_ids(_stale_player_ids())
         return jsonify(body)
     except Exception as exc:

--- a/academy-watch-backend/src/routes/season_rollup.py
+++ b/academy-watch-backend/src/routes/season_rollup.py
@@ -4,19 +4,22 @@ Both endpoints are pure database operations. Rebuilds are keyset-paged by
 ``player_api_id`` and delegate every derived-row write to the public
 ``season_rollup_service.refresh_player`` API.
 
-Rows-behind uses the mutation clocks the source schema actually exposes:
-``PlayerJourneyEntry.stats_synced_at``,
-``AcademyPlayerSeasonStats.updated_at``, and
-``PlayerShadowStats.updated_at``. ``PlayerSeasonCell.synced_at`` also catches a
-derived cell that is newer than (or missing) its matching total. Fixture rows
-have no created/updated/synced clock, so they can be identified as stale only
-when their player-season has no fixture cell; steady-state fixture freshness is
-enforced by the D3b FPS write choke point. Legacy/manual journey rows with a
-null ``stats_synced_at`` have the same schema-limited blind spot after an
-existing total; ``scope=all`` is the repair fallback for both cases.
+``GET /status`` defaults to a CHEAP rows-behind gauge: one ``MAX`` scan per
+timed source (``PlayerJourneyEntry.stats_synced_at``,
+``AcademyPlayerSeasonStats.updated_at``, ``PlayerShadowStats.updated_at``,
+``PlayerSeasonCell.synced_at``) compared against ``MAX(computed_at)`` — a handful
+of index-assisted aggregates, no per-grain set difference. The exact per-player
+stale count is a full multi-table aggregation, so it is reserved behind
+``?exact=1`` for occasional reconciliation and for the paged ``scope=stale``
+rebuild (which evaluates clocks only for its bounded candidate page). Fixture
+rows carry no clock, so the cheap gauge cannot see a fixture-missing-cell;
+``?exact=1`` and the ``scope=stale`` sweep are the reconciliation paths for that
+blind spot, and ``scope=all`` is the repair fallback for legacy/manual journey
+rows with a null ``stats_synced_at``.
 """
 
 import logging
+from datetime import UTC
 
 from flask import Blueprint, jsonify, request
 from sqlalchemy import DateTime, and_, case, func, literal, or_, select, type_coerce, union_all
@@ -339,6 +342,31 @@ def _count_ids(id_statement) -> int:
     return int(db.session.execute(select(func.count()).select_from(ids)).scalar() or 0)
 
 
+def _as_utc(value):
+    """Order naive (APSS/shadow) and aware (PJE/cell) clocks together as UTC."""
+    if value is not None and value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value
+
+
+def _max_source_change():
+    """Newest mutation across the timed sources — the cheap freshness clock.
+
+    Each source contributes ONE ``MAX`` scan (no joins, no per-grain group-by),
+    so this stays sub-second on the prod box. Fixture rows carry no clock, so it
+    deliberately cannot see a fixture-missing-cell; ``?exact=1`` or a
+    ``scope=stale`` sweep reconciles that blind spot.
+    """
+    clocks = [
+        db.session.query(func.max(PlayerJourneyEntry.stats_synced_at)).scalar(),
+        db.session.query(func.max(AcademyPlayerSeasonStats.updated_at)).scalar(),
+        db.session.query(func.max(PlayerShadowStats.updated_at)).scalar(),
+        db.session.query(func.max(PlayerSeasonCell.synced_at)).scalar(),
+    ]
+    present = [clock for clock in clocks if clock is not None]
+    return max(present, key=_as_utc) if present else None
+
+
 def _batch_size_arg() -> int:
     batch_size = request.args.get("batch_size", _DEFAULT_BATCH_SIZE, type=int)
     if not isinstance(batch_size, int) or batch_size < 1:
@@ -346,33 +374,25 @@ def _batch_size_arg() -> int:
     return min(batch_size, _MAX_BATCH_SIZE)
 
 
-def _cursor_arg() -> tuple[int | None, int, str | None]:
+def _cursor_arg() -> tuple[int | None, str | None]:
+    """Parse the keyset cursor: the last player_api_id scanned by the sweep.
+
+    The cursor only ever moves forward (the max id of the previous page), so a
+    sweep always terminates: once no candidate id remains above it, the endpoint
+    returns ``cursor=null``. A player whose per-row rebuild raises is reported in
+    ``failed`` and retried out-of-band via ``scope=player`` — a failure never
+    rewinds the cursor, so there is no poison-row livelock.
+    """
     raw_cursor = request.args.get("cursor")
     if raw_cursor is None or raw_cursor == "":
-        return 0, 0, None
-
-    # A normal cursor is the last scanned player id. If a per-player savepoint
-    # failed during a batched sweep, the response carries ``<id>:r<count>``.
-    # The retry count is propagated while higher ids are scanned, then causes a
-    # wrap to zero at the end. This keeps a poison row from front-blocking the
-    # population without forgetting that a lower id still needs another sweep.
-    retry_count = 0
-    cursor_part = raw_cursor
-    if ":r" in raw_cursor:
-        cursor_part, retry_part = raw_cursor.rsplit(":r", 1)
-        try:
-            retry_count = int(retry_part)
-        except (TypeError, ValueError):
-            return None, 0, "cursor must be a non-negative player_api_id or server-issued retry cursor"
-        if retry_count < 1:
-            return None, 0, "cursor must be a non-negative player_api_id or server-issued retry cursor"
+        return 0, None
     try:
-        cursor = int(cursor_part)
+        cursor = int(raw_cursor)
     except (TypeError, ValueError):
-        return None, 0, "cursor must be a non-negative player_api_id or server-issued retry cursor"
+        return None, "cursor must be a non-negative integer player_api_id"
     if cursor < 0:
-        return None, 0, "cursor must be a non-negative player_api_id or server-issued retry cursor"
-    return cursor, retry_count, None
+        return None, "cursor must be a non-negative integer player_api_id"
+    return cursor, None
 
 
 def _positive_int_arg(name: str) -> int | None:
@@ -393,14 +413,13 @@ def admin_rebuild_season_rollup():
     - ``scope=stale[&batch_size&cursor]``
     - ``scope=all[&batch_size&cursor]``
 
-    ``cursor`` is normally the last scanned player_api_id and is null when the
-    selected sweep has converged. A server-issued ``<id>:r<count>`` cursor carries
-    retry state past a failed player; callers must pass it back unchanged. A zero
-    cursor restarts a sweep after lower-id stale/failing work is found. Season
-    sweeps are also bounded even though only stale and all require it, keeping
-    every request safe for the production container. ``remaining`` is a bounded
-    continuation gauge: zero means the sweep converged; a positive value is the
-    carried failure count plus one when the capped lookahead found another page.
+    ``cursor`` is the last player_api_id scanned and is null once the sweep has
+    converged. It only moves forward, so the sweep always terminates: a player
+    whose per-row rebuild raises is listed in ``failed`` (retry it out-of-band
+    with ``scope=player``) and never rewinds the cursor. ``remaining`` is a
+    bounded 0/1 hint — one means the capped lookahead saw another page — never a
+    platform-wide count. Season sweeps are bounded like stale/all so every
+    request stays safe for the production container.
     """
     scope = (request.args.get("scope") or "").strip().lower()
     if scope not in _VALID_SCOPES:
@@ -413,7 +432,7 @@ def admin_rebuild_season_rollup():
         try:
             season_rollup_service.refresh_player(player_api_id, season=None, session=db.session)
             db.session.commit()
-            return jsonify({"processed": 1, "remaining": 0, "cursor": None})
+            return jsonify({"processed": 1, "failed": [], "remaining": 0, "cursor": None})
         except Exception as exc:
             db.session.rollback()
             logger.exception("season-rollup player rebuild failed for player=%s", player_api_id)
@@ -425,7 +444,7 @@ def admin_rebuild_season_rollup():
         if season is None:
             return jsonify({"error": "season must be a positive integer start-year"}), 400
 
-    cursor, pending_retries, cursor_error = _cursor_arg()
+    cursor, cursor_error = _cursor_arg()
     if cursor_error:
         return jsonify({"error": cursor_error}), 400
     batch_size = _batch_size_arg()
@@ -452,7 +471,7 @@ def admin_rebuild_season_rollup():
         )
 
         processed = 0
-        failures = 0
+        failed: list[int] = []
         for player_api_id in player_ids:
             try:
                 with db.session.begin_nested():
@@ -463,27 +482,20 @@ def admin_rebuild_season_rollup():
                     )
                 processed += 1
             except Exception:
-                failures += 1
+                failed.append(player_api_id)
                 logger.exception("season-rollup %s rebuild failed for player=%s", scope, player_api_id)
         db.session.commit()
 
+        # Forward-only cursor: null once no candidate id remains above the last
+        # scanned page, so every sweep terminates even when a poison row keeps
+        # failing. ``remaining`` is a bounded 0/1 "another page exists" hint, not
+        # a platform-wide count; ``failed`` carries the ids to retry via
+        # ``scope=player``.
         last_scanned = scanned_ids[-1] if scanned_ids else None
-        retry_count = pending_retries + failures
-        remaining = retry_count + int(has_more)
-        if has_more and last_scanned is not None:
-            next_cursor = f"{last_scanned}:r{retry_count}" if retry_count else last_scanned
-        elif retry_count:
-            next_cursor = 0
-        elif scope == "stale" and not scanned_ids and cursor:
-            # A caller can resume with an obsolete/high cursor. One bounded wrap
-            # makes the operation restartable without a global stale scan; a
-            # normal server-issued terminal page never reaches this branch.
-            remaining = 1
-            next_cursor = 0
-        else:
-            next_cursor = None
+        next_cursor = last_scanned if has_more else None
+        remaining = int(has_more)
 
-        return jsonify({"processed": processed, "remaining": remaining, "cursor": next_cursor})
+        return jsonify({"processed": processed, "failed": failed, "remaining": remaining, "cursor": next_cursor})
     except Exception as exc:
         db.session.rollback()
         logger.exception("season-rollup %s rebuild failed", scope)
@@ -493,26 +505,38 @@ def admin_rebuild_season_rollup():
 @season_rollup_bp.route("/admin/season-rollup/status", methods=["GET"])
 @require_api_key
 def admin_season_rollup_status():
-    """Return the cheap aggregate rows-behind gauge."""
+    """Return the rows-behind gauge.
+
+    Default = the CHEAP gauge: ``behind`` is derived from the newest timed-source
+    clock vs ``MAX(computed_at)`` (a handful of index-assisted ``MAX`` scans, no
+    per-grain set difference). Pass ``?exact=1`` to also run the exact per-player
+    stale count (a full multi-table aggregation) for occasional reconciliation.
+    """
+    exact = (request.args.get("exact") or "").strip().lower() in {"1", "true", "yes", "on"}
     try:
         total_totals_rows, last_computed_at = db.session.query(
             func.count(PlayerSeasonTotal.id),
             func.max(PlayerSeasonTotal.computed_at),
         ).one()
-        stale_players = _count_ids(_stale_player_ids())
+        last_source_change_at = _max_source_change()
+        behind = last_source_change_at is not None and (
+            last_computed_at is None or _as_utc(last_source_change_at) > _as_utc(last_computed_at)
+        )
         source_counts = (
             db.session.query(PlayerSeasonCell.source, func.count(PlayerSeasonCell.id))
             .group_by(PlayerSeasonCell.source)
             .all()
         )
-        return jsonify(
-            {
-                "total_totals_rows": int(total_totals_rows or 0),
-                "stale_players": stale_players,
-                "last_computed_at": last_computed_at.isoformat() if last_computed_at else None,
-                "by_source_cells": {source: int(count) for source, count in source_counts},
-            }
-        )
+        body = {
+            "total_totals_rows": int(total_totals_rows or 0),
+            "behind": behind,
+            "last_computed_at": last_computed_at.isoformat() if last_computed_at else None,
+            "last_source_change_at": last_source_change_at.isoformat() if last_source_change_at else None,
+            "by_source_cells": {source: int(count) for source, count in source_counts},
+        }
+        if exact:
+            body["stale_players"] = _count_ids(_stale_player_ids())
+        return jsonify(body)
     except Exception as exc:
         logger.exception("season-rollup status failed")
         return jsonify(_safe_error_payload(exc, "Failed to read season rollup status")), 500

--- a/academy-watch-backend/src/routes/season_rollup.py
+++ b/academy-watch-backend/src/routes/season_rollup.py
@@ -16,6 +16,10 @@ rows carry no clock, so the cheap gauge cannot see a fixture-missing-cell;
 ``?exact=1`` and the ``scope=stale`` sweep are the reconciliation paths for that
 blind spot, and ``scope=all`` is the repair fallback for legacy/manual journey
 rows with a null ``stats_synced_at``.
+
+Deleting a timed source row can leave its surviving cell/total pair looking
+fresh when their clocks are equal, so neither ``?exact=1`` nor ``scope=stale``
+can see that deletion. Use ``scope=all`` to repair it.
 """
 
 import logging
@@ -170,7 +174,7 @@ def _stale_player_ids(player_ids: tuple[int, ...] | None = None):
 
     Timed sources compare at the exact ``(player, season, level_group)`` grain.
     Fixture rows have no mutation clock, so that branch can only identify a
-    player-season for which no fixture-derived cell exists at all.
+    ``(player, season, level_group)`` for which no fixture-derived cell exists.
     """
     journey_level = case(
         (PlayerJourneyEntry.is_international.is_(True), literal("international")),
@@ -287,25 +291,51 @@ def _stale_player_ids(player_ids: tuple[int, ...] | None = None):
         )
     )
 
-    fixture_keys_query = (
-        select(FixturePlayerStats.player_api_id.label("player_api_id"), Fixture.season.label("season"))
+    fixture_name = func.lower(func.coalesce(Fixture.competition_name, literal("")))
+    fixture_level = case(
+        (
+            or_(*(fixture_name.contains(token, autoescape=True) for token in season_rollup_service._YOUTH_COMP_TOKENS)),
+            literal(season_rollup_service.LEVEL_YOUTH),
+        ),
+        else_=literal(season_rollup_service.LEVEL_SENIOR),
+    )
+    fixture_rows_query = (
+        select(
+            FixturePlayerStats.player_api_id.label("player_api_id"),
+            Fixture.season.label("season"),
+            fixture_level.label("level_group"),
+        )
         .join(Fixture, FixturePlayerStats.fixture_id == Fixture.id)
         .where(
             or_(
                 _has_fixture_stats(),
-                _had_source_cell(FixturePlayerStats.player_api_id, Fixture.season, "fixtures"),
+                _had_source_cell(
+                    FixturePlayerStats.player_api_id,
+                    Fixture.season,
+                    "fixtures",
+                    fixture_level,
+                ),
             )
         )
     )
-    fixture_cell_keys_query = select(PlayerSeasonCell.player_api_id, PlayerSeasonCell.season).where(
-        PlayerSeasonCell.source == "fixtures"
-    )
+    fixture_cell_keys_query = select(
+        PlayerSeasonCell.player_api_id,
+        PlayerSeasonCell.season,
+        PlayerSeasonCell.level_group,
+    ).where(PlayerSeasonCell.source == "fixtures")
     if player_ids is not None:
-        fixture_keys_query = fixture_keys_query.where(FixturePlayerStats.player_api_id.in_(player_ids))
+        fixture_rows_query = fixture_rows_query.where(FixturePlayerStats.player_api_id.in_(player_ids))
         fixture_cell_keys_query = fixture_cell_keys_query.where(PlayerSeasonCell.player_api_id.in_(player_ids))
-    fixture_keys = fixture_keys_query.group_by(FixturePlayerStats.player_api_id, Fixture.season).subquery()
+    fixture_rows = fixture_rows_query.subquery()
+    fixture_keys = (
+        select(fixture_rows.c.player_api_id, fixture_rows.c.season, fixture_rows.c.level_group)
+        .group_by(fixture_rows.c.player_api_id, fixture_rows.c.season, fixture_rows.c.level_group)
+        .subquery()
+    )
     fixture_cell_keys = fixture_cell_keys_query.group_by(
-        PlayerSeasonCell.player_api_id, PlayerSeasonCell.season
+        PlayerSeasonCell.player_api_id,
+        PlayerSeasonCell.season,
+        PlayerSeasonCell.level_group,
     ).subquery()
     fixture_missing_cell = (
         select(fixture_keys.c.player_api_id)
@@ -315,6 +345,7 @@ def _stale_player_ids(player_ids: tuple[int, ...] | None = None):
                 and_(
                     fixture_cell_keys.c.player_api_id == fixture_keys.c.player_api_id,
                     fixture_cell_keys.c.season == fixture_keys.c.season,
+                    fixture_cell_keys.c.level_group == fixture_keys.c.level_group,
                 ),
             )
         )

--- a/academy-watch-backend/src/routes/season_rollup.py
+++ b/academy-watch-backend/src/routes/season_rollup.py
@@ -1,0 +1,518 @@
+"""Admin operations for the season-rollup read surface.
+
+Both endpoints are pure database operations. Rebuilds are keyset-paged by
+``player_api_id`` and delegate every derived-row write to the public
+``season_rollup_service.refresh_player`` API.
+
+Rows-behind uses the mutation clocks the source schema actually exposes:
+``PlayerJourneyEntry.stats_synced_at``,
+``AcademyPlayerSeasonStats.updated_at``, and
+``PlayerShadowStats.updated_at``. ``PlayerSeasonCell.synced_at`` also catches a
+derived cell that is newer than (or missing) its matching total. Fixture rows
+have no created/updated/synced clock, so they can be identified as stale only
+when their player-season has no fixture cell; steady-state fixture freshness is
+enforced by the D3b FPS write choke point. Legacy/manual journey rows with a
+null ``stats_synced_at`` have the same schema-limited blind spot after an
+existing total; ``scope=all`` is the repair fallback for both cases.
+"""
+
+import logging
+
+from flask import Blueprint, jsonify, request
+from sqlalchemy import DateTime, and_, case, func, literal, or_, select, type_coerce, union_all
+from src.auth import _safe_error_payload, require_api_key
+from src.models.follow import PlayerShadowStats
+from src.models.journey import PlayerJourney, PlayerJourneyEntry
+from src.models.league import AcademyPlayerSeasonStats, db
+from src.models.season_rollup import PlayerSeasonCell, PlayerSeasonTotal
+from src.models.weekly import Fixture, FixturePlayerStats
+from src.services import season_rollup_service
+
+season_rollup_bp = Blueprint("season_rollup", __name__)
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BATCH_SIZE = 25
+_MAX_BATCH_SIZE = 100
+_VALID_SCOPES = {"player", "season", "stale", "all"}
+
+
+def _has_stats(model):
+    """Match the rollup service's apps/minutes/goals noise boundary."""
+    return or_(
+        func.coalesce(model.appearances, 0) != 0,
+        func.coalesce(model.minutes, 0) != 0,
+        func.coalesce(model.goals, 0) != 0,
+    )
+
+
+def _has_fixture_stats():
+    """FPS appearances are derived from positive minutes by the feeder."""
+    return or_(
+        func.coalesce(FixturePlayerStats.minutes, 0) != 0,
+        func.coalesce(FixturePlayerStats.goals, 0) != 0,
+    )
+
+
+def _had_source_cell(player_column, season_column, source: str, level_group=None):
+    """Include a zeroed source only while its old cell still needs deletion."""
+    conditions = (
+        PlayerSeasonCell.player_api_id == player_column,
+        PlayerSeasonCell.season == season_column,
+        PlayerSeasonCell.source == source,
+    )
+    if level_group is not None:
+        conditions += (PlayerSeasonCell.level_group == level_group,)
+    return select(literal(1)).select_from(PlayerSeasonCell).where(*conditions).exists()
+
+
+def _utc_source_clock(column):
+    """Interpret legacy naive source clocks as UTC on PostgreSQL.
+
+    The application writes these columns with ``datetime.now(UTC)`` even though
+    APSS/shadow predate timezone-aware column types. PostgreSQL otherwise
+    promotes them to TIMESTAMPTZ using the connection's session timezone when
+    unioned with PJE/cell clocks. SQLite stores all four clocks uniformly and
+    needs the original column expression for portable comparisons.
+    """
+    if db.session.get_bind().dialect.name == "postgresql":
+        return type_coerce(column.op("AT TIME ZONE")(literal("UTC")), DateTime(timezone=True))
+    return column
+
+
+def _candidate_player_ids(
+    season: int | None = None,
+    *,
+    after: int | None = None,
+    per_source_limit: int | None = None,
+):
+    """All rebuildable player ids, including orphan derived rows."""
+    fixture_rows = (
+        select(FixturePlayerStats.player_api_id.label("player_api_id"))
+        .join(Fixture, FixturePlayerStats.fixture_id == Fixture.id)
+        .where(
+            or_(
+                _has_fixture_stats(),
+                _had_source_cell(FixturePlayerStats.player_api_id, Fixture.season, "fixtures"),
+            )
+        )
+    )
+    journey_rows = (
+        select(PlayerJourney.player_api_id.label("player_api_id"))
+        .join(PlayerJourneyEntry, PlayerJourneyEntry.journey_id == PlayerJourney.id)
+        .where(
+            or_(
+                _has_stats(PlayerJourneyEntry),
+                _had_source_cell(PlayerJourney.player_api_id, PlayerJourneyEntry.season, "journey"),
+            )
+        )
+    )
+    apss_rows = select(AcademyPlayerSeasonStats.player_api_id.label("player_api_id")).where(
+        or_(
+            _has_stats(AcademyPlayerSeasonStats),
+            _had_source_cell(
+                AcademyPlayerSeasonStats.player_api_id,
+                AcademyPlayerSeasonStats.season,
+                "apss",
+            ),
+        )
+    )
+    shadow_rows = select(PlayerShadowStats.player_api_id.label("player_api_id")).where(
+        or_(
+            _has_stats(PlayerShadowStats),
+            _had_source_cell(PlayerShadowStats.player_api_id, PlayerShadowStats.season, "shadow"),
+        )
+    )
+    cell_rows = select(PlayerSeasonCell.player_api_id.label("player_api_id"))
+    total_rows = select(PlayerSeasonTotal.player_api_id.label("player_api_id"))
+
+    if season is not None:
+        fixture_rows = fixture_rows.where(Fixture.season == season)
+        journey_rows = journey_rows.where(PlayerJourneyEntry.season == season)
+        apss_rows = apss_rows.where(AcademyPlayerSeasonStats.season == season)
+        shadow_rows = shadow_rows.where(PlayerShadowStats.season == season)
+        cell_rows = cell_rows.where(PlayerSeasonCell.season == season)
+        total_rows = total_rows.where(PlayerSeasonTotal.season == season)
+
+    source_queries = (
+        (fixture_rows, FixturePlayerStats.player_api_id),
+        (journey_rows, PlayerJourney.player_api_id),
+        (apss_rows, AcademyPlayerSeasonStats.player_api_id),
+        (shadow_rows, PlayerShadowStats.player_api_id),
+        (cell_rows, PlayerSeasonCell.player_api_id),
+        (total_rows, PlayerSeasonTotal.player_api_id),
+    )
+    bounded_queries = []
+    for query, player_column in source_queries:
+        if after is not None:
+            query = query.where(player_column > after)
+        if per_source_limit is not None:
+            # DISTINCT is deliberate: these WHERE clauses contain correlated
+            # season checks in ``_had_source_cell``. PostgreSQL rejects the
+            # equivalent GROUP BY shape because that outer season is not a
+            # grouping column, while DISTINCT safely deduplicates the one
+            # projected player id before applying the source-local cap.
+            query = query.distinct().order_by(player_column).limit(per_source_limit)
+            limited = query.subquery()
+            query = select(limited.c.player_api_id)
+        bounded_queries.append(query)
+
+    # A page query reads at most ``per_source_limit`` ids from each indexed
+    # source, then merges/deduplicates at most 6N ids.
+    rows = union_all(*bounded_queries).subquery()
+    return select(rows.c.player_api_id).where(rows.c.player_api_id.is_not(None)).group_by(rows.c.player_api_id)
+
+
+def _stale_player_ids(player_ids: tuple[int, ...] | None = None):
+    """Players with a source cell/row newer than its matching total.
+
+    Timed sources compare at the exact ``(player, season, level_group)`` grain.
+    Fixture rows have no mutation clock, so that branch can only identify a
+    player-season for which no fixture-derived cell exists at all.
+    """
+    journey_level = case(
+        (PlayerJourneyEntry.is_international.is_(True), literal("international")),
+        (PlayerJourneyEntry.is_youth.is_(True), literal("youth")),
+        else_=literal("senior"),
+    )
+
+    journey_rows = (
+        select(
+            PlayerJourney.player_api_id.label("player_api_id"),
+            PlayerJourneyEntry.season.label("season"),
+            journey_level.label("level_group"),
+            PlayerJourneyEntry.stats_synced_at.label("source_updated_at"),
+        )
+        .join(PlayerJourneyEntry, PlayerJourneyEntry.journey_id == PlayerJourney.id)
+        .where(
+            or_(
+                _has_stats(PlayerJourneyEntry),
+                _had_source_cell(
+                    PlayerJourney.player_api_id,
+                    PlayerJourneyEntry.season,
+                    "journey",
+                    journey_level,
+                ),
+            )
+        )
+    )
+    apss_rows = select(
+        AcademyPlayerSeasonStats.player_api_id.label("player_api_id"),
+        AcademyPlayerSeasonStats.season.label("season"),
+        literal("youth").label("level_group"),
+        _utc_source_clock(AcademyPlayerSeasonStats.updated_at).label("source_updated_at"),
+    ).where(
+        or_(
+            _has_stats(AcademyPlayerSeasonStats),
+            _had_source_cell(
+                AcademyPlayerSeasonStats.player_api_id,
+                AcademyPlayerSeasonStats.season,
+                "apss",
+                "youth",
+            ),
+        )
+    )
+    shadow_rows = select(
+        PlayerShadowStats.player_api_id.label("player_api_id"),
+        PlayerShadowStats.season.label("season"),
+        literal("senior").label("level_group"),
+        _utc_source_clock(PlayerShadowStats.updated_at).label("source_updated_at"),
+    ).where(
+        or_(
+            _has_stats(PlayerShadowStats),
+            _had_source_cell(
+                PlayerShadowStats.player_api_id,
+                PlayerShadowStats.season,
+                "shadow",
+                "senior",
+            ),
+        )
+    )
+    cell_rows = select(
+        PlayerSeasonCell.player_api_id.label("player_api_id"),
+        PlayerSeasonCell.season.label("season"),
+        PlayerSeasonCell.level_group.label("level_group"),
+        PlayerSeasonCell.synced_at.label("source_updated_at"),
+    )
+
+    if player_ids is not None:
+        journey_rows = journey_rows.where(PlayerJourney.player_api_id.in_(player_ids))
+        apss_rows = apss_rows.where(AcademyPlayerSeasonStats.player_api_id.in_(player_ids))
+        shadow_rows = shadow_rows.where(PlayerShadowStats.player_api_id.in_(player_ids))
+        cell_rows = cell_rows.where(PlayerSeasonCell.player_api_id.in_(player_ids))
+
+    timed_rows = union_all(journey_rows, apss_rows, shadow_rows, cell_rows).subquery()
+    source_freshness = (
+        select(
+            timed_rows.c.player_api_id,
+            timed_rows.c.season,
+            timed_rows.c.level_group,
+            func.max(timed_rows.c.source_updated_at).label("source_updated_at"),
+        )
+        .group_by(timed_rows.c.player_api_id, timed_rows.c.season, timed_rows.c.level_group)
+        .subquery()
+    )
+    total_freshness_query = select(
+        PlayerSeasonTotal.player_api_id,
+        PlayerSeasonTotal.season,
+        PlayerSeasonTotal.level_group,
+        func.max(PlayerSeasonTotal.computed_at).label("computed_at"),
+    )
+    if player_ids is not None:
+        total_freshness_query = total_freshness_query.where(PlayerSeasonTotal.player_api_id.in_(player_ids))
+    total_freshness = total_freshness_query.group_by(
+        PlayerSeasonTotal.player_api_id,
+        PlayerSeasonTotal.season,
+        PlayerSeasonTotal.level_group,
+    ).subquery()
+    timed_stale = (
+        select(source_freshness.c.player_api_id)
+        .select_from(
+            source_freshness.outerjoin(
+                total_freshness,
+                and_(
+                    total_freshness.c.player_api_id == source_freshness.c.player_api_id,
+                    total_freshness.c.season == source_freshness.c.season,
+                    total_freshness.c.level_group == source_freshness.c.level_group,
+                ),
+            )
+        )
+        .where(
+            or_(
+                total_freshness.c.computed_at.is_(None),
+                source_freshness.c.source_updated_at > total_freshness.c.computed_at,
+            )
+        )
+    )
+
+    fixture_keys_query = (
+        select(FixturePlayerStats.player_api_id.label("player_api_id"), Fixture.season.label("season"))
+        .join(Fixture, FixturePlayerStats.fixture_id == Fixture.id)
+        .where(
+            or_(
+                _has_fixture_stats(),
+                _had_source_cell(FixturePlayerStats.player_api_id, Fixture.season, "fixtures"),
+            )
+        )
+    )
+    fixture_cell_keys_query = select(PlayerSeasonCell.player_api_id, PlayerSeasonCell.season).where(
+        PlayerSeasonCell.source == "fixtures"
+    )
+    if player_ids is not None:
+        fixture_keys_query = fixture_keys_query.where(FixturePlayerStats.player_api_id.in_(player_ids))
+        fixture_cell_keys_query = fixture_cell_keys_query.where(PlayerSeasonCell.player_api_id.in_(player_ids))
+    fixture_keys = fixture_keys_query.group_by(FixturePlayerStats.player_api_id, Fixture.season).subquery()
+    fixture_cell_keys = fixture_cell_keys_query.group_by(
+        PlayerSeasonCell.player_api_id, PlayerSeasonCell.season
+    ).subquery()
+    fixture_missing_cell = (
+        select(fixture_keys.c.player_api_id)
+        .select_from(
+            fixture_keys.outerjoin(
+                fixture_cell_keys,
+                and_(
+                    fixture_cell_keys.c.player_api_id == fixture_keys.c.player_api_id,
+                    fixture_cell_keys.c.season == fixture_keys.c.season,
+                ),
+            )
+        )
+        .where(fixture_cell_keys.c.player_api_id.is_(None))
+    )
+
+    stale_rows = union_all(timed_stale, fixture_missing_cell).subquery()
+    return select(stale_rows.c.player_api_id).group_by(stale_rows.c.player_api_id)
+
+
+def _page_ids(id_statement, cursor: int, batch_size: int) -> list[int]:
+    ids = id_statement.subquery()
+    return list(
+        db.session.execute(
+            select(ids.c.player_api_id)
+            .where(ids.c.player_api_id > cursor)
+            .order_by(ids.c.player_api_id)
+            .limit(batch_size)
+        ).scalars()
+    )
+
+
+def _count_ids(id_statement) -> int:
+    ids = id_statement.subquery()
+    return int(db.session.execute(select(func.count()).select_from(ids)).scalar() or 0)
+
+
+def _batch_size_arg() -> int:
+    batch_size = request.args.get("batch_size", _DEFAULT_BATCH_SIZE, type=int)
+    if not isinstance(batch_size, int) or batch_size < 1:
+        batch_size = _DEFAULT_BATCH_SIZE
+    return min(batch_size, _MAX_BATCH_SIZE)
+
+
+def _cursor_arg() -> tuple[int | None, int, str | None]:
+    raw_cursor = request.args.get("cursor")
+    if raw_cursor is None or raw_cursor == "":
+        return 0, 0, None
+
+    # A normal cursor is the last scanned player id. If a per-player savepoint
+    # failed during a batched sweep, the response carries ``<id>:r<count>``.
+    # The retry count is propagated while higher ids are scanned, then causes a
+    # wrap to zero at the end. This keeps a poison row from front-blocking the
+    # population without forgetting that a lower id still needs another sweep.
+    retry_count = 0
+    cursor_part = raw_cursor
+    if ":r" in raw_cursor:
+        cursor_part, retry_part = raw_cursor.rsplit(":r", 1)
+        try:
+            retry_count = int(retry_part)
+        except (TypeError, ValueError):
+            return None, 0, "cursor must be a non-negative player_api_id or server-issued retry cursor"
+        if retry_count < 1:
+            return None, 0, "cursor must be a non-negative player_api_id or server-issued retry cursor"
+    try:
+        cursor = int(cursor_part)
+    except (TypeError, ValueError):
+        return None, 0, "cursor must be a non-negative player_api_id or server-issued retry cursor"
+    if cursor < 0:
+        return None, 0, "cursor must be a non-negative player_api_id or server-issued retry cursor"
+    return cursor, retry_count, None
+
+
+def _positive_int_arg(name: str) -> int | None:
+    value = request.args.get(name, type=int)
+    if not isinstance(value, int) or value < 1:
+        return None
+    return value
+
+
+@season_rollup_bp.route("/admin/season-rollup/rebuild", methods=["POST"])
+@require_api_key
+def admin_rebuild_season_rollup():
+    """Rebuild rollups for one player or a bounded player-id page.
+
+    Query params:
+    - ``scope=player&player_api_id=<positive int>``
+    - ``scope=season&season=<start-year int>[&batch_size&cursor]``
+    - ``scope=stale[&batch_size&cursor]``
+    - ``scope=all[&batch_size&cursor]``
+
+    ``cursor`` is normally the last scanned player_api_id and is null when the
+    selected sweep has converged. A server-issued ``<id>:r<count>`` cursor carries
+    retry state past a failed player; callers must pass it back unchanged. A zero
+    cursor restarts a sweep after lower-id stale/failing work is found. Season
+    sweeps are also bounded even though only stale and all require it, keeping
+    every request safe for the production container. ``remaining`` is a bounded
+    continuation gauge: zero means the sweep converged; a positive value is the
+    carried failure count plus one when the capped lookahead found another page.
+    """
+    scope = (request.args.get("scope") or "").strip().lower()
+    if scope not in _VALID_SCOPES:
+        return jsonify({"error": "scope must be one of: player, season, stale, all"}), 400
+
+    if scope == "player":
+        player_api_id = _positive_int_arg("player_api_id")
+        if player_api_id is None:
+            return jsonify({"error": "player_api_id must be a positive integer"}), 400
+        try:
+            season_rollup_service.refresh_player(player_api_id, season=None, session=db.session)
+            db.session.commit()
+            return jsonify({"processed": 1, "remaining": 0, "cursor": None})
+        except Exception as exc:
+            db.session.rollback()
+            logger.exception("season-rollup player rebuild failed for player=%s", player_api_id)
+            return jsonify(_safe_error_payload(exc, "Failed to rebuild season rollup")), 500
+
+    season = None
+    if scope == "season":
+        season = _positive_int_arg("season")
+        if season is None:
+            return jsonify({"error": "season must be a positive integer start-year"}), 400
+
+    cursor, pending_retries, cursor_error = _cursor_arg()
+    if cursor_error:
+        return jsonify({"error": cursor_error}), 400
+    batch_size = _batch_size_arg()
+
+    try:
+        # Keyset-page a capped set from every source before any stale aggregate.
+        # The merged input to a rebuild is therefore at most 6N ids; stale scope
+        # evaluates clocks only for that bounded candidate page. One extra id is
+        # a bounded lookahead used to determine whether another page exists;
+        # rebuild requests never run a platform-wide remainder count.
+        scan_limit = batch_size + 1
+        scan_candidates = _candidate_player_ids(
+            season=season,
+            after=cursor,
+            per_source_limit=scan_limit,
+        )
+        scanned_window = _page_ids(scan_candidates, cursor, scan_limit)
+        has_more = len(scanned_window) > batch_size
+        scanned_ids = scanned_window[:batch_size]
+        player_ids = (
+            _page_ids(_stale_player_ids(tuple(scanned_ids)), cursor, batch_size)
+            if scope == "stale" and scanned_ids
+            else ([] if scope == "stale" else scanned_ids)
+        )
+
+        processed = 0
+        failures = 0
+        for player_api_id in player_ids:
+            try:
+                with db.session.begin_nested():
+                    season_rollup_service.refresh_player(
+                        player_api_id,
+                        season=season if scope == "season" else None,
+                        session=db.session,
+                    )
+                processed += 1
+            except Exception:
+                failures += 1
+                logger.exception("season-rollup %s rebuild failed for player=%s", scope, player_api_id)
+        db.session.commit()
+
+        last_scanned = scanned_ids[-1] if scanned_ids else None
+        retry_count = pending_retries + failures
+        remaining = retry_count + int(has_more)
+        if has_more and last_scanned is not None:
+            next_cursor = f"{last_scanned}:r{retry_count}" if retry_count else last_scanned
+        elif retry_count:
+            next_cursor = 0
+        elif scope == "stale" and not scanned_ids and cursor:
+            # A caller can resume with an obsolete/high cursor. One bounded wrap
+            # makes the operation restartable without a global stale scan; a
+            # normal server-issued terminal page never reaches this branch.
+            remaining = 1
+            next_cursor = 0
+        else:
+            next_cursor = None
+
+        return jsonify({"processed": processed, "remaining": remaining, "cursor": next_cursor})
+    except Exception as exc:
+        db.session.rollback()
+        logger.exception("season-rollup %s rebuild failed", scope)
+        return jsonify(_safe_error_payload(exc, "Failed to rebuild season rollup")), 500
+
+
+@season_rollup_bp.route("/admin/season-rollup/status", methods=["GET"])
+@require_api_key
+def admin_season_rollup_status():
+    """Return the cheap aggregate rows-behind gauge."""
+    try:
+        total_totals_rows, last_computed_at = db.session.query(
+            func.count(PlayerSeasonTotal.id),
+            func.max(PlayerSeasonTotal.computed_at),
+        ).one()
+        stale_players = _count_ids(_stale_player_ids())
+        source_counts = (
+            db.session.query(PlayerSeasonCell.source, func.count(PlayerSeasonCell.id))
+            .group_by(PlayerSeasonCell.source)
+            .all()
+        )
+        return jsonify(
+            {
+                "total_totals_rows": int(total_totals_rows or 0),
+                "stale_players": stale_players,
+                "last_computed_at": last_computed_at.isoformat() if last_computed_at else None,
+                "by_source_cells": {source: int(count) for source, count in source_counts},
+            }
+        )
+    except Exception as exc:
+        logger.exception("season-rollup status failed")
+        return jsonify(_safe_error_payload(exc, "Failed to read season rollup status")), 500

--- a/academy-watch-backend/src/services/journey_sync.py
+++ b/academy-watch-backend/src/services/journey_sync.py
@@ -323,6 +323,23 @@ class JourneySyncService:
             journey.last_synced_at = datetime.now(UTC)
             journey.sync_error = None
 
+            # Season-rollup steady-state hook (proposal §3): rebuild this
+            # player's rollup cells + totals for every season re-synced, in the
+            # SAME transaction as the journey write so a club-ID correction can
+            # never orphan a cell. refresh_player does NOT commit — the commit
+            # below persists journey + rollup atomically. Wrapped in a SAVEPOINT
+            # so a rollup bug rolls back only the derived rows, never the
+            # (API-expensive) journey sync itself.
+            try:
+                from src.services.season_rollup_service import refresh_player as _refresh_rollup
+
+                db.session.flush()
+                with db.session.begin_nested():
+                    for _rollup_season in sorted(set(seasons_to_sync)):
+                        _refresh_rollup(player_api_id, season=_rollup_season, session=db.session)
+            except Exception as _rollup_err:
+                logger.warning(f"season-rollup refresh failed for player {player_api_id}: {_rollup_err}")
+
             db.session.commit()
             logger.info(f"Successfully synced journey for player {player_api_id}: {len(all_entries)} entries")
 

--- a/academy-watch-backend/src/services/season_rollup_service.py
+++ b/academy-watch-backend/src/services/season_rollup_service.py
@@ -11,13 +11,19 @@ Sources (feeders)
 -----------------
 - ``fixtures`` — :class:`FixturePlayerStats` joined to :class:`Fixture`, grouped
   per ``(season, team, competition_tier)``; rich per-match detail summed,
-  ``avg_rating`` minutes-weighted; ``level_group`` always ``senior`` (FPS is
-  senior per-match data).
-- ``journey``  — :class:`PlayerJourneyEntry` read by the denormalized
-  ``player_api_id`` (ix_pje_player_season), grouped per ``(season, club,
+  ``avg_rating`` minutes-weighted. ``level_group`` is derived from the fixture's
+  competition NAME: the academy fixture-sync path writes YOUTH-team FPS rows
+  (U18/U21 comps), which fold into ``youth`` like journey ``is_youth`` entries —
+  everything else is ``senior``.
+- ``journey``  — :class:`PlayerJourneyEntry` read via the parent
+  :class:`PlayerJourney` (``journey_id -> player_journeys.player_api_id``, the
+  same join D1 provenance uses), grouped per ``(season, club,
   competition_tier)``; ``level_group`` from ``is_international`` / ``is_youth``
   exactly as the D1 provenance code partitions senior/youth/international; rich
   detail lifted from the sea01 columns when ``stats_source == 'journey-api'``.
+  The join keys off the canonical journey id, NOT the denormalized
+  ``PlayerJourneyEntry.player_api_id`` column (NULL on ~77k legacy rows until the
+  sea01 backfill runs), so the feeder is correct pre- and post-backfill.
 - ``apss``     — :class:`AcademyPlayerSeasonStats` → ``level_group='youth'``.
 - ``shadow``   — :class:`PlayerShadowStats` → ``source='shadow'``.
 
@@ -51,7 +57,7 @@ import logging
 from datetime import UTC, datetime
 
 from src.models.follow import PlayerShadowStats
-from src.models.journey import PlayerJourneyEntry
+from src.models.journey import PlayerJourney, PlayerJourneyEntry
 from src.models.league import AcademyPlayerSeasonStats, db
 from src.models.season_rollup import PlayerSeasonCell, PlayerSeasonTotal
 from src.models.weekly import Fixture, FixturePlayerStats
@@ -134,6 +140,50 @@ def classify_competition_tier(name: str | None) -> str:
     ):
         return TIER_DOMESTIC_CUP
     return TIER_LEAGUE
+
+
+# Youth-competition NAME tokens. FixturePlayerStats is usually senior per-match
+# data, but the academy fixture-sync path (routes/api.py::_run_team_fixtures_sync
+# via _YOUTH_LEVEL_LEAGUES → leagues 702/695/696) also writes YOUTH-team FPS rows
+# for U18/U21 competitions and pushes them through the SAME FPS insert/choke-point
+# loop. Those minutes must fold into the ``youth`` level_group like journey
+# ``is_youth`` entries — never headline as senior — or a pure academy kid ranks on
+# the senior Scout list on U21 minutes (proposal §6 Q10). The Fixture row carries
+# no structural youth flag (no league_api_id column), so classify by name.
+_YOUTH_COMP_TOKENS = (
+    "u18",
+    "u19",
+    "u20",
+    "u21",
+    "u23",
+    "premier league 2",
+    "premier league international",
+    "youth league",
+    "youth alliance",
+    "youth cup",
+    "primavera",
+)
+
+
+def _is_youth_competition(name: str | None) -> bool:
+    """True when a competition NAME is a youth/academy competition."""
+    if not name:
+        return False
+    n = name.lower()
+    return any(tok in n for tok in _YOUTH_COMP_TOKENS)
+
+
+def _fixture_level_and_tier(name: str | None) -> tuple[str, str]:
+    """Partition a fixture's competition into ``(level_group, tier)``.
+
+    Youth competitions fold into ``(youth, youth)`` so youth-team FPS rows join
+    the youth totals row (mirroring ``_journey_level_and_tier`` for is_youth
+    entries); every other competition stays ``senior`` with its normal
+    league/cup/continental tier.
+    """
+    if _is_youth_competition(name):
+        return LEVEL_YOUTH, TIER_YOUTH
+    return LEVEL_SENIOR, classify_competition_tier(name)
 
 
 # ---------------------------------------------------------------------------
@@ -225,7 +275,12 @@ def _finish_cell(
 # Feeders — each returns a list of cell payload dicts for the player[, season]
 # ---------------------------------------------------------------------------
 def _fixture_cells(player_api_id: int, season: int | None, session, now: datetime) -> list[dict]:
-    """Aggregate FixturePlayerStats (joined to fixtures) per (season, team, tier)."""
+    """Aggregate FixturePlayerStats (joined to fixtures) per (season, team, tier).
+
+    ``level_group`` is derived from each fixture's competition (youth-team FPS
+    rows fold into ``youth``), NOT hard-coded to senior — see
+    :func:`_fixture_level_and_tier`.
+    """
     q = (
         session.query(FixturePlayerStats, Fixture.season, Fixture.competition_name)
         .join(Fixture, FixturePlayerStats.fixture_id == Fixture.id)
@@ -236,11 +291,12 @@ def _fixture_cells(player_api_id: int, season: int | None, session, now: datetim
 
     groups: dict[tuple, dict] = {}
     for fps, fx_season, comp_name in q.all():
-        tier = classify_competition_tier(comp_name)
+        level_group, tier = _fixture_level_and_tier(comp_name)
         key = (fx_season, fps.team_api_id, tier)
         agg = groups.get(key)
         if agg is None:
             agg = _blank_agg()
+            agg["_level"] = level_group
             groups[key] = agg
         minutes = fps.minutes or 0
         if minutes > 0:
@@ -285,7 +341,7 @@ def _fixture_cells(player_api_id: int, season: int | None, session, now: datetim
             club_api_id=team_api_id or 0,
             club_name=None,
             competition_tier=tier,
-            level_group=LEVEL_SENIOR,
+            level_group=agg["_level"],
             now=now,
         )
         if cell:
@@ -311,8 +367,22 @@ def _journey_level_and_tier(entry: PlayerJourneyEntry) -> tuple[str, str]:
 
 
 def _journey_cells(player_api_id: int, season: int | None, session, now: datetime) -> list[dict]:
-    """Aggregate PlayerJourneyEntry per (season, club, tier) via ix_pje_player_season."""
-    q = session.query(PlayerJourneyEntry).filter(PlayerJourneyEntry.player_api_id == player_api_id)
+    """Aggregate PlayerJourneyEntry per (season, club, tier) for the player.
+
+    Reads through the parent :class:`PlayerJourney` (``journey_id ->
+    player_journeys.player_api_id``) rather than the denormalized
+    ``PlayerJourneyEntry.player_api_id`` column, which is NULL on ~77k legacy
+    rows until the sea01 backfill endpoint runs. Keying off the canonical
+    (unique-indexed) journey id makes the feeder correct pre- and post-backfill —
+    otherwise a pre-backfill refresh silently drops the entire journey source and
+    writes under-reported totals (the Gore anchor would not hold in prod). This
+    is the same journey join D1's ``_season_provenance`` uses.
+    """
+    q = (
+        session.query(PlayerJourneyEntry)
+        .join(PlayerJourney, PlayerJourneyEntry.journey_id == PlayerJourney.id)
+        .filter(PlayerJourney.player_api_id == player_api_id)
+    )
     if season is not None:
         q = q.filter(PlayerJourneyEntry.season == season)
 

--- a/academy-watch-backend/src/services/season_rollup_service.py
+++ b/academy-watch-backend/src/services/season_rollup_service.py
@@ -1,0 +1,724 @@
+"""Season-rollup service (D3b) — the SOLE writer of the sea02 read surface.
+
+Implements proposal §3 steady state (ledgers/research/seasons-design-proposal.md):
+every hot stats surface reads ONE precomputed indexed row instead of a live
+cross-source aggregation on the 0.5 CPU prod box. This module derives the two
+sea02 grains — ``player_season_cells`` (fine, one row per SOURCE-contributed
+cell) and ``player_season_totals`` (coarse, the hot-read row) — as a pure,
+reconstructable function of the underlying sources.
+
+Sources (feeders)
+-----------------
+- ``fixtures`` — :class:`FixturePlayerStats` joined to :class:`Fixture`, grouped
+  per ``(season, team, competition_tier)``; rich per-match detail summed,
+  ``avg_rating`` minutes-weighted; ``level_group`` always ``senior`` (FPS is
+  senior per-match data).
+- ``journey``  — :class:`PlayerJourneyEntry` read by the denormalized
+  ``player_api_id`` (ix_pje_player_season), grouped per ``(season, club,
+  competition_tier)``; ``level_group`` from ``is_international`` / ``is_youth``
+  exactly as the D1 provenance code partitions senior/youth/international; rich
+  detail lifted from the sea01 columns when ``stats_source == 'journey-api'``.
+- ``apss``     — :class:`AcademyPlayerSeasonStats` → ``level_group='youth'``.
+- ``shadow``   — :class:`PlayerShadowStats` → ``source='shadow'``.
+
+Totals resolution (the double-count guard — proposal §2, non-negotiable)
+-----------------------------------------------------------------------
+Per ``(player, season, level_group)`` totals NEVER sum across sources. Each
+source's own total is computed independently; the HEADLINE is the larger-minutes
+source taken WHOLE (``journey`` wins ties / ``>=`` — the cup-inclusive
+convention; ``fixtures`` wins only when strictly larger →
+``journey-under-sync``). ``fixtures_minutes`` and ``journey_minutes`` are always
+both stored; ``reconcile_flag`` follows the coverage-map buckets; ``avg_rating``
+is ALWAYS fixtures-sourced (NULL when there are no fixtures).
+
+Transactionality
+----------------
+:func:`refresh_player` does DELETE+re-INSERT of a player's cells (scoped to a
+season when given) and re-resolves totals, all on the caller's session and
+WITHOUT committing — it participates in whatever transaction the caller owns:
+
+- journey sync calls it before its own commit (same transaction, so a club-ID
+  correction can never orphan cells);
+- the FPS choke point drains a per-session dirty set AFTER the batch commit via
+  :func:`flush_player_refresh_queue`, which owns its own single commit so a
+  refresh bug can never roll back the expensive fixture writes.
+
+Noise filter: feeders skip any source row with 0 apps AND 0 minutes AND 0 goals
+(kills the ~740 pre-season PJE stubs and near-empty APSS rows).
+"""
+
+import logging
+from datetime import UTC, datetime
+
+from src.models.follow import PlayerShadowStats
+from src.models.journey import PlayerJourneyEntry
+from src.models.league import AcademyPlayerSeasonStats, db
+from src.models.season_rollup import PlayerSeasonCell, PlayerSeasonTotal
+from src.models.weekly import Fixture, FixturePlayerStats
+
+logger = logging.getLogger(__name__)
+
+# ---- source / level / tier vocabularies (mirror sea02 column comments) -------
+SOURCE_FIXTURES = "fixtures"
+SOURCE_JOURNEY = "journey"
+SOURCE_APSS = "apss"
+SOURCE_SHADOW = "shadow"
+
+LEVEL_SENIOR = "senior"
+LEVEL_YOUTH = "youth"
+LEVEL_INTERNATIONAL = "international"
+
+TIER_LEAGUE = "league"
+TIER_DOMESTIC_CUP = "domestic_cup"
+TIER_LEAGUE_CUP = "league_cup"
+TIER_CONTINENTAL = "continental"
+TIER_OTHER = "other"
+TIER_YOUTH = "youth"
+
+# Headline tie-break priority: on EQUAL minutes the higher-priority source wins
+# the headline. journey beats fixtures (cup-inclusive convention, proposal §2);
+# the supplementary sources only win when strictly larger in minutes.
+_SOURCE_PRIORITY = {SOURCE_JOURNEY: 4, SOURCE_FIXTURES: 3, SOURCE_APSS: 2, SOURCE_SHADOW: 1}
+
+# Per-session dirty set (player_api_id, season) awaiting a post-commit refresh.
+_DIRTY_KEY = "_season_rollup_dirty"
+
+# The eight aggregatable stat keys shared by cells and totals.
+_STAT_KEYS = ("appearances", "goals", "assists", "minutes", "yellows", "reds", "saves", "goals_conceded")
+
+
+# ---------------------------------------------------------------------------
+# Competition-tier classification (documented NAME heuristic)
+# ---------------------------------------------------------------------------
+def classify_competition_tier(name: str | None) -> str:
+    """Best-effort ``league|cup|continental`` tier from a competition NAME.
+
+    Fixtures carry only ``competition_name`` and journey entries only
+    ``league_name`` — neither source exposes a structural cup/league flag — so
+    this is a deliberate name heuristic (proposal §2/§3: "if league metadata
+    cannot classify cups vs league reliably, use tier 'league' vs 'other' and
+    document"). Anything not clearly a cup falls back to ``league``; the
+    ambiguous domestic-vs-league-cup split is never guessed beyond the keyword
+    lists below. This only enriches per-cell display — totals fold every tier
+    WITHIN a source, so a misclassification never changes a headline number.
+    """
+    if not name:
+        return TIER_LEAGUE
+    n = name.lower()
+    # League (secondary knockout) cups — checked first because their names also
+    # contain the generic "cup"/"coupe" tokens the domestic branch matches.
+    if any(kw in n for kw in ("efl cup", "carabao", "league cup", "coupe de la ligue", "efl trophy")):
+        return TIER_LEAGUE_CUP
+    # Continental / cross-border club competitions.
+    if any(
+        kw in n
+        for kw in (
+            "champions league",
+            "europa",
+            "conference league",
+            "uefa",
+            "libertadores",
+            "sudamericana",
+            "concacaf",
+            "afc champions",
+            "club world cup",
+            "super cup",
+            "supercopa",
+            "supercup",
+        )
+    ):
+        return TIER_CONTINENTAL
+    # Domestic cups (generic tokens across the big-5 + common locales).
+    if any(
+        kw in n for kw in ("cup", "copa", "coupe", "coppa", "pokal", "taça", "taca", "beker", "trophy", "dfb", "shield")
+    ):
+        return TIER_DOMESTIC_CUP
+    return TIER_LEAGUE
+
+
+# ---------------------------------------------------------------------------
+# Small aggregation helpers
+# ---------------------------------------------------------------------------
+def _is_noise(agg: dict) -> bool:
+    """A source row/cell with 0 apps AND 0 minutes AND 0 goals is noise."""
+    return not (agg.get("appearances") or agg.get("minutes") or agg.get("goals"))
+
+
+def _sum_opt(values) -> int | None:
+    """Sum treating None as absent: return None if every contributor was None,
+    else the sum of the non-None ints (so keeper stats stay NULL for outfielders
+    rather than reading a misleading observed-zero)."""
+    seen = False
+    total = 0
+    for v in values:
+        if v is not None:
+            seen = True
+            total += v
+    return total if seen else None
+
+
+def _blank_agg() -> dict:
+    agg = {k: None for k in _STAT_KEYS}
+    agg["_detail"] = {}
+    agg["_rating_wsum"] = 0.0
+    agg["_rating_min"] = 0
+    return agg
+
+
+def _add(agg: dict, key: str, value):
+    if value is None:
+        return
+    agg[key] = (agg[key] or 0) + value
+
+
+def _add_detail(agg: dict, mapping: dict):
+    detail = agg["_detail"]
+    for out_key, value in mapping.items():
+        if value is None:
+            continue
+        detail[out_key] = (detail.get(out_key) or 0) + value
+
+
+def _add_rating(agg: dict, rating, minutes):
+    if rating is None or not minutes or minutes <= 0:
+        return
+    agg["_rating_wsum"] += float(rating) * minutes
+    agg["_rating_min"] += minutes
+
+
+def _finish_cell(
+    agg: dict,
+    *,
+    player_api_id: int,
+    season: int,
+    source: str,
+    club_api_id: int,
+    club_name: str | None,
+    competition_tier: str,
+    level_group: str,
+    now: datetime,
+) -> dict | None:
+    """Turn an accumulated group into a cell payload (noise-filtered)."""
+    if _is_noise(agg):
+        return None
+    avg_rating = round(agg["_rating_wsum"] / agg["_rating_min"], 2) if agg["_rating_min"] else None
+    detail = agg["_detail"] or None
+    return {
+        "player_api_id": player_api_id,
+        "season": season,
+        "source": source,
+        "club_api_id": club_api_id,
+        "club_name": club_name,
+        "competition_tier": competition_tier,
+        "level_group": level_group,
+        **{k: agg[k] for k in _STAT_KEYS},
+        "avg_rating": avg_rating,
+        "detail": detail,
+        "synced_at": now,
+        # internal fields (dropped before ORM build; used for totals avg_rating)
+        "_rating_wsum": agg["_rating_wsum"],
+        "_rating_min": agg["_rating_min"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Feeders — each returns a list of cell payload dicts for the player[, season]
+# ---------------------------------------------------------------------------
+def _fixture_cells(player_api_id: int, season: int | None, session, now: datetime) -> list[dict]:
+    """Aggregate FixturePlayerStats (joined to fixtures) per (season, team, tier)."""
+    q = (
+        session.query(FixturePlayerStats, Fixture.season, Fixture.competition_name)
+        .join(Fixture, FixturePlayerStats.fixture_id == Fixture.id)
+        .filter(FixturePlayerStats.player_api_id == player_api_id)
+    )
+    if season is not None:
+        q = q.filter(Fixture.season == season)
+
+    groups: dict[tuple, dict] = {}
+    for fps, fx_season, comp_name in q.all():
+        tier = classify_competition_tier(comp_name)
+        key = (fx_season, fps.team_api_id, tier)
+        agg = groups.get(key)
+        if agg is None:
+            agg = _blank_agg()
+            groups[key] = agg
+        minutes = fps.minutes or 0
+        if minutes > 0:
+            _add(agg, "appearances", 1)
+        _add(agg, "goals", fps.goals or 0)
+        _add(agg, "assists", fps.assists or 0)
+        _add(agg, "minutes", minutes)
+        _add(agg, "yellows", fps.yellows or 0)
+        _add(agg, "reds", fps.reds or 0)
+        _add(agg, "saves", fps.saves)
+        _add(agg, "goals_conceded", fps.goals_conceded)
+        _add_rating(agg, fps.rating, minutes)
+        _add_detail(
+            agg,
+            {
+                "shots_total": fps.shots_total,
+                "shots_on": fps.shots_on,
+                "passes_total": fps.passes_total,
+                "passes_key": fps.passes_key,
+                "tackles_total": fps.tackles_total,
+                "tackles_blocks": fps.tackles_blocks,
+                "tackles_interceptions": fps.tackles_interceptions,
+                "duels_total": fps.duels_total,
+                "duels_won": fps.duels_won,
+                "dribbles_attempts": fps.dribbles_attempts,
+                "dribbles_success": fps.dribbles_success,
+                "fouls_drawn": fps.fouls_drawn,
+                "fouls_committed": fps.fouls_committed,
+                "penalty_scored": fps.penalty_scored,
+                "penalty_missed": fps.penalty_missed,
+                "penalty_saved": fps.penalty_saved,
+            },
+        )
+
+    cells = []
+    for (fx_season, team_api_id, tier), agg in groups.items():
+        cell = _finish_cell(
+            agg,
+            player_api_id=player_api_id,
+            season=fx_season,
+            source=SOURCE_FIXTURES,
+            club_api_id=team_api_id or 0,
+            club_name=None,
+            competition_tier=tier,
+            level_group=LEVEL_SENIOR,
+            now=now,
+        )
+        if cell:
+            cells.append(cell)
+    return cells
+
+
+def _journey_level_and_tier(entry: PlayerJourneyEntry) -> tuple[str, str]:
+    """Mirror the D1 provenance senior/youth/international partition.
+
+    D1 (routes/players.py::_season_provenance) treats a journey entry as SENIOR
+    only when ``not is_youth and not is_international``; the youth-window logic
+    keys on ``is_youth and not is_international``. So international wins over
+    youth (international-youth caps read as international). The tier map keeps
+    ``(club, tier)`` a 1:1 proxy for level_group, which the cell unique key
+    requires (senior never maps to 'other'; 'other' therefore == international).
+    """
+    if entry.is_international:
+        return LEVEL_INTERNATIONAL, TIER_OTHER
+    if entry.is_youth:
+        return LEVEL_YOUTH, TIER_YOUTH
+    return LEVEL_SENIOR, classify_competition_tier(entry.league_name)
+
+
+def _journey_cells(player_api_id: int, season: int | None, session, now: datetime) -> list[dict]:
+    """Aggregate PlayerJourneyEntry per (season, club, tier) via ix_pje_player_season."""
+    q = session.query(PlayerJourneyEntry).filter(PlayerJourneyEntry.player_api_id == player_api_id)
+    if season is not None:
+        q = q.filter(PlayerJourneyEntry.season == season)
+
+    groups: dict[tuple, dict] = {}
+    names: dict[tuple, str | None] = {}
+    for e in q.all():
+        level_group, tier = _journey_level_and_tier(e)
+        key = (e.season, e.club_api_id, tier)
+        agg = groups.get(key)
+        if agg is None:
+            agg = _blank_agg()
+            agg["_level"] = level_group
+            groups[key] = agg
+            names[key] = e.club_name
+        minutes = e.minutes or 0
+        _add(agg, "appearances", e.appearances or 0)
+        _add(agg, "goals", e.goals or 0)
+        _add(agg, "assists", e.assists or 0)
+        _add(agg, "minutes", minutes)
+        # Rich fields only exist on journey-api rows; legacy-basic rows leave them NULL.
+        if e.stats_source == "journey-api":
+            _add(agg, "yellows", e.cards_yellow)
+            _add(agg, "reds", e.cards_red)
+            _add(agg, "saves", e.saves)
+            _add(agg, "goals_conceded", e.goals_conceded)
+            _add_rating(agg, e.rating, minutes)
+            _add_detail(
+                agg,
+                {
+                    "shots_total": e.shots_total,
+                    "shots_on": e.shots_on,
+                    "passes_total": e.passes_total,
+                    "passes_key": e.passes_key,
+                    "tackles_total": e.tackles_total,
+                    "tackles_blocks": e.tackles_blocks,
+                    "tackles_interceptions": e.tackles_interceptions,
+                    "duels_total": e.duels_total,
+                    "duels_won": e.duels_won,
+                    "dribbles_attempts": e.dribbles_attempts,
+                    "dribbles_success": e.dribbles_success,
+                    "fouls_drawn": e.fouls_drawn,
+                    "fouls_committed": e.fouls_committed,
+                    "penalty_scored": e.penalty_scored,
+                    "penalty_missed": e.penalty_missed,
+                    "penalty_saved": e.penalty_saved,
+                },
+            )
+
+    cells = []
+    for key, agg in groups.items():
+        fx_season, club_api_id, tier = key
+        cell = _finish_cell(
+            agg,
+            player_api_id=player_api_id,
+            season=fx_season,
+            source=SOURCE_JOURNEY,
+            club_api_id=club_api_id or 0,
+            club_name=names.get(key),
+            competition_tier=tier,
+            level_group=agg["_level"],
+            now=now,
+        )
+        if cell:
+            cells.append(cell)
+    return cells
+
+
+def _apss_cells(player_api_id: int, season: int | None, session, now: datetime) -> list[dict]:
+    """Aggregate AcademyPlayerSeasonStats per (season, team) → level_group youth."""
+    q = session.query(AcademyPlayerSeasonStats).filter(AcademyPlayerSeasonStats.player_api_id == player_api_id)
+    if season is not None:
+        q = q.filter(AcademyPlayerSeasonStats.season == season)
+
+    groups: dict[tuple, dict] = {}
+    names: dict[tuple, str | None] = {}
+    for r in q.all():
+        key = (r.season, r.team_api_id or 0)
+        agg = groups.get(key)
+        if agg is None:
+            agg = _blank_agg()
+            groups[key] = agg
+            names[key] = r.team_name
+        minutes = r.minutes or 0
+        _add(agg, "appearances", r.appearances or 0)
+        _add(agg, "goals", r.goals or 0)
+        _add(agg, "assists", r.assists or 0)
+        _add(agg, "minutes", minutes)
+        _add(agg, "yellows", r.yellow_cards)
+        _add(agg, "reds", r.red_cards)
+        _add_rating(agg, r.rating, minutes)
+        _add_detail(
+            agg,
+            {
+                "shots_total": r.shots_total,
+                "shots_on": r.shots_on,
+                "passes_total": r.passes_total,
+                "passes_key": r.passes_key,
+                "tackles_total": r.tackles_total,
+                "tackles_interceptions": r.interceptions,
+                "duels_total": r.duels_total,
+                "duels_won": r.duels_won,
+                "dribbles_attempts": r.dribbles_attempts,
+                "dribbles_success": r.dribbles_success,
+                "fouls_drawn": r.fouls_drawn,
+                "fouls_committed": r.fouls_committed,
+                "penalty_scored": r.penalty_scored,
+                "penalty_missed": r.penalty_missed,
+            },
+        )
+
+    cells = []
+    for key, agg in groups.items():
+        fx_season, team_api_id = key
+        cell = _finish_cell(
+            agg,
+            player_api_id=player_api_id,
+            season=fx_season,
+            source=SOURCE_APSS,
+            club_api_id=team_api_id,
+            club_name=names.get(key),
+            competition_tier=TIER_YOUTH,
+            level_group=LEVEL_YOUTH,
+            now=now,
+        )
+        if cell:
+            cells.append(cell)
+    return cells
+
+
+def _shadow_cells(player_api_id: int, season: int | None, session, now: datetime) -> list[dict]:
+    """Aggregate PlayerShadowStats per (season, team) → source shadow, senior.
+
+    Shadow rows carry no competition metadata, so the tier is documented as the
+    plain ``league`` default (proposal §2 honest-fallback rule)."""
+    q = session.query(PlayerShadowStats).filter(PlayerShadowStats.player_api_id == player_api_id)
+    if season is not None:
+        q = q.filter(PlayerShadowStats.season == season)
+
+    groups: dict[tuple, dict] = {}
+    names: dict[tuple, str | None] = {}
+    for r in q.all():
+        key = (r.season, r.team_api_id or 0)
+        agg = groups.get(key)
+        if agg is None:
+            agg = _blank_agg()
+            groups[key] = agg
+            names[key] = r.team_name
+        _add(agg, "appearances", r.appearances or 0)
+        _add(agg, "goals", r.goals or 0)
+        _add(agg, "assists", r.assists or 0)
+        _add(agg, "minutes", r.minutes or 0)
+
+    cells = []
+    for key, agg in groups.items():
+        fx_season, team_api_id = key
+        cell = _finish_cell(
+            agg,
+            player_api_id=player_api_id,
+            season=fx_season,
+            source=SOURCE_SHADOW,
+            club_api_id=team_api_id,
+            club_name=names.get(key),
+            competition_tier=TIER_LEAGUE,
+            level_group=LEVEL_SENIOR,
+            now=now,
+        )
+        if cell:
+            cells.append(cell)
+    return cells
+
+
+_FEEDERS = (_fixture_cells, _journey_cells, _apss_cells, _shadow_cells)
+
+
+# ---------------------------------------------------------------------------
+# Totals resolution — never-cross-source-sum (proposal §2)
+# ---------------------------------------------------------------------------
+def _source_subtotal(cells: list[dict]) -> dict:
+    """Sum a single source's cells (WITHIN-source aggregation is allowed)."""
+    sub = {k: _sum_opt([c[k] for c in cells]) for k in _STAT_KEYS}
+    sub["_rating_wsum"] = sum(c["_rating_wsum"] for c in cells)
+    sub["_rating_min"] = sum(c["_rating_min"] for c in cells)
+    return sub
+
+
+def _reconcile_flag(fixtures_minutes: int, journey_minutes: int) -> str | None:
+    """The fixtures-vs-journey provenance axis (identical to D1 _season_provenance)."""
+    if fixtures_minutes == 0 and journey_minutes > 0:
+        return "fixtures-invisible"
+    if journey_minutes > fixtures_minutes > 0:
+        return "cup-gap"
+    if fixtures_minutes > journey_minutes:
+        return "journey-under-sync"
+    return None
+
+
+def _resolve_totals(cells: list[dict], now: datetime) -> list[dict]:
+    """Build one totals payload per (season, level_group) from the cells."""
+    # group cells by (season, level_group) then by source
+    grouped: dict[tuple, dict[str, list[dict]]] = {}
+    for c in cells:
+        gkey = (c["season"], c["level_group"])
+        grouped.setdefault(gkey, {}).setdefault(c["source"], []).append(c)
+
+    totals = []
+    for (season, level_group), by_source in grouped.items():
+        subtotals = {src: _source_subtotal(src_cells) for src, src_cells in by_source.items()}
+
+        fixtures_minutes = (subtotals.get(SOURCE_FIXTURES) or {}).get("minutes") or 0
+        journey_minutes = (subtotals.get(SOURCE_JOURNEY) or {}).get("minutes") or 0
+
+        # Headline = larger-minutes source taken whole; tie → higher priority
+        # (journey > fixtures > apss > shadow). NEVER a cross-source sum.
+        headline_src = max(
+            subtotals.keys(),
+            key=lambda s: ((subtotals[s].get("minutes") or 0), _SOURCE_PRIORITY.get(s, 0)),
+        )
+        headline = subtotals[headline_src]
+
+        # avg_rating is ALWAYS fixtures-sourced (NULL when no fixtures).
+        fx_sub = subtotals.get(SOURCE_FIXTURES)
+        avg_rating = None
+        if fx_sub and fx_sub["_rating_min"]:
+            avg_rating = round(fx_sub["_rating_wsum"] / fx_sub["_rating_min"], 2)
+
+        source_breakdown = {src: {k: sub[k] for k in _STAT_KEYS} for src, sub in subtotals.items()}
+        clubs = _clubs_array(by_source[headline_src])
+
+        totals.append(
+            {
+                "player_api_id": cells and cells[0]["player_api_id"],
+                "season": season,
+                "level_group": level_group,
+                **{k: headline[k] for k in _STAT_KEYS},
+                "avg_rating": avg_rating,
+                "primary_source": headline_src,
+                "fixtures_minutes": fixtures_minutes,
+                "journey_minutes": journey_minutes,
+                "reconcile_flag": _reconcile_flag(fixtures_minutes, journey_minutes),
+                "source_breakdown": source_breakdown,
+                "clubs": clubs,
+                "computed_at": now,
+            }
+        )
+    return totals
+
+
+def _clubs_array(headline_cells: list[dict]) -> list[dict]:
+    """Compact per-club render array for the headline source's cells."""
+    by_club: dict[int, dict] = {}
+    for c in headline_cells:
+        club = by_club.get(c["club_api_id"])
+        if club is None:
+            club = {
+                "id": c["club_api_id"],
+                "name": c["club_name"],
+                "minutes": 0,
+                "appearances": 0,
+                "goals": 0,
+                "assists": 0,
+                "competition_tiers": [],
+            }
+            by_club[c["club_api_id"]] = club
+        club["minutes"] += c["minutes"] or 0
+        club["appearances"] += c["appearances"] or 0
+        club["goals"] += c["goals"] or 0
+        club["assists"] += c["assists"] or 0
+        if c["competition_tier"] not in club["competition_tiers"]:
+            club["competition_tiers"].append(c["competition_tier"])
+    return sorted(by_club.values(), key=lambda x: (-(x["minutes"] or 0), x["id"]))
+
+
+# ---------------------------------------------------------------------------
+# Public write API
+# ---------------------------------------------------------------------------
+def _delete_scope(session, model, player_api_id: int, season: int | None):
+    q = session.query(model).filter(model.player_api_id == player_api_id)
+    if season is not None:
+        q = q.filter(model.season == season)
+    q.delete(synchronize_session=False)
+
+
+def refresh_player(player_api_id: int, season: int | None = None, session=None) -> dict:
+    """Rebuild a player's rollup cells + totals from the sources, in ONE transaction.
+
+    Participates in the caller's session/transaction and does NOT commit — the
+    caller (journey sync, or :func:`flush_player_refresh_queue`) owns the commit.
+
+    DELETEs the player's existing cells and totals (scoped to ``season`` when
+    given), re-INSERTs cells from every feeder, then re-resolves totals from
+    those fresh cells. Idempotent: re-running yields exactly the same rows.
+    """
+    session = session or db.session
+    now = datetime.now(UTC)
+
+    # 1) Clear the slate (scoped). Bulk DELETE executes immediately, so the
+    #    subsequent INSERTs cannot collide with stale rows on the unique keys.
+    _delete_scope(session, PlayerSeasonCell, player_api_id, season)
+    _delete_scope(session, PlayerSeasonTotal, player_api_id, season)
+    session.flush()
+
+    # 2) Rebuild cells from every source.
+    cells: list[dict] = []
+    for feeder in _FEEDERS:
+        cells.extend(feeder(player_api_id, season, session, now))
+
+    for c in cells:
+        session.add(
+            PlayerSeasonCell(
+                player_api_id=c["player_api_id"],
+                season=c["season"],
+                source=c["source"],
+                club_api_id=c["club_api_id"],
+                club_name=c["club_name"],
+                competition_tier=c["competition_tier"],
+                level_group=c["level_group"],
+                appearances=c["appearances"],
+                goals=c["goals"],
+                assists=c["assists"],
+                minutes=c["minutes"],
+                yellows=c["yellows"],
+                reds=c["reds"],
+                saves=c["saves"],
+                goals_conceded=c["goals_conceded"],
+                avg_rating=c["avg_rating"],
+                detail=c["detail"],
+                synced_at=c["synced_at"],
+            )
+        )
+
+    # 3) Re-resolve totals (never cross-source sum).
+    totals = _resolve_totals(cells, now)
+    for t in totals:
+        session.add(
+            PlayerSeasonTotal(
+                player_api_id=t["player_api_id"],
+                season=t["season"],
+                level_group=t["level_group"],
+                appearances=t["appearances"],
+                goals=t["goals"],
+                assists=t["assists"],
+                minutes=t["minutes"],
+                yellows=t["yellows"],
+                reds=t["reds"],
+                saves=t["saves"],
+                goals_conceded=t["goals_conceded"],
+                avg_rating=t["avg_rating"],
+                primary_source=t["primary_source"],
+                fixtures_minutes=t["fixtures_minutes"],
+                journey_minutes=t["journey_minutes"],
+                reconcile_flag=t["reconcile_flag"],
+                source_breakdown=t["source_breakdown"],
+                clubs=t["clubs"],
+                computed_at=t["computed_at"],
+            )
+        )
+
+    session.flush()
+    return {"cells": len(cells), "totals": len(totals)}
+
+
+# ---------------------------------------------------------------------------
+# FPS choke point — one enqueue function + one post-commit drain
+# ---------------------------------------------------------------------------
+def queue_player_refresh(player_api_id, season, session=None) -> None:
+    """Mark a ``(player, season)`` rollup dirty — the ONE function every
+    FixturePlayerStats writer routes through.
+
+    Pure in-memory set insert on the session (no DB work, no mid-transaction
+    refresh), so a batch writing 30 players enqueues at most 30 distinct pairs
+    and a single :func:`flush_player_refresh_queue` after the batch commit
+    refreshes each affected player exactly once.
+    """
+    if player_api_id is None or season is None:
+        return
+    session = session or db.session
+    try:
+        session.info.setdefault(_DIRTY_KEY, set()).add((int(player_api_id), int(season)))
+    except (TypeError, ValueError):
+        return
+
+
+def flush_player_refresh_queue(session=None) -> int:
+    """Drain the dirty set and refresh each ``(player, season)`` once.
+
+    Called AFTER a batch's own commit so a refresh failure can never roll back
+    the expensive fixture writes. Each pair runs inside a SAVEPOINT so one bad
+    player cannot poison the rest; the whole drain lands in a SINGLE commit.
+    Returns the number of pairs refreshed.
+    """
+    session = session or db.session
+    dirty = session.info.get(_DIRTY_KEY)
+    if not dirty:
+        return 0
+
+    pairs = sorted(dirty)
+    dirty.clear()
+
+    refreshed = 0
+    for player_api_id, season in pairs:
+        try:
+            with session.begin_nested():
+                refresh_player(player_api_id, season=season, session=session)
+            refreshed += 1
+        except Exception:
+            logger.exception("season-rollup refresh failed for player=%s season=%s", player_api_id, season)
+
+    session.commit()
+    return refreshed

--- a/academy-watch-backend/src/services/season_rollup_service.py
+++ b/academy-watch-backend/src/services/season_rollup_service.py
@@ -788,6 +788,7 @@ def flush_player_refresh_queue(session=None) -> int:
                 refresh_player(player_api_id, season=season, session=session)
             refreshed += 1
         except Exception:
+            dirty.add((player_api_id, season))
             logger.exception("season-rollup refresh failed for player=%s season=%s", player_api_id, season)
 
     session.commit()

--- a/academy-watch-backend/tests/test_season_data_sea01.py
+++ b/academy-watch-backend/tests/test_season_data_sea01.py
@@ -2,8 +2,9 @@
 
 Locks the four load-bearing guarantees of the PR2 (`sea01`) work:
 
-1. **Migration head stays single** and is `sea01` (chained off `aw23`) — a second
-   head would make `flask db upgrade` ambiguous on deploy.
+1. **Migration head stays single** — `sea01` chains off `aw23`, and D3's `sea02`
+   now chains off `sea01`, so the single tip has advanced to `sea02`; a second head
+   would make `flask db upgrade` ambiguous on deploy.
 2. **`sea01` is idempotent** — every DDL is guarded, so a re-applied or
    partially-applied upgrade is a pure no-op (migrations do NOT auto-run on
    deploy; prod schema has drifted out-of-band, invariants §8).
@@ -49,10 +50,12 @@ def _script_directory():
 
 
 class TestMigrationHead:
-    def test_single_head_is_sea01(self):
-        """The whole chain resolves to exactly one head, and it is sea01."""
+    def test_single_head_is_sea02(self):
+        """The whole chain resolves to exactly one head. D3's sea02 now sits on top
+        of sea01, so the tip has advanced from sea01 to sea02 — a second head would
+        make `flask db upgrade` ambiguous on deploy."""
         heads = _script_directory().get_heads()
-        assert heads == ["sea01"], f"expected the single head to be sea01, got {heads}"
+        assert heads == ["sea02"], f"expected the single head to be sea02, got {heads}"
 
     def test_sea01_chains_off_aw23(self):
         """sea01 branches from the real prod tip (aw23), keeping the line linear."""
@@ -60,6 +63,13 @@ class TestMigrationHead:
         sea01 = script.get_revision("sea01")
         assert sea01.down_revision == "aw23"
         assert script.get_revision("aw23") is not None
+
+    def test_sea02_chains_off_sea01(self):
+        """sea02 (D3 rollup tables) branches from sea01 (D2), keeping the line linear."""
+        script = _script_directory()
+        sea02 = script.get_revision("sea02")
+        assert sea02.down_revision == "sea01"
+        assert script.get_revision("sea01") is not None
 
 
 # ---------------------------------------------------------------------------

--- a/academy-watch-backend/tests/test_season_data_sea01.py
+++ b/academy-watch-backend/tests/test_season_data_sea01.py
@@ -50,12 +50,13 @@ def _script_directory():
 
 
 class TestMigrationHead:
-    def test_single_head_is_sea02(self):
-        """The whole chain resolves to exactly one head. D3's sea02 now sits on top
-        of sea01, so the tip has advanced from sea01 to sea02 — a second head would
-        make `flask db upgrade` ambiguous on deploy."""
+    def test_single_head_is_sea03(self):
+        """The whole chain resolves to exactly one head. D3's sea03 (the /status
+        gauge clock indexes) now sits on top of sea02, so the tip has advanced from
+        sea02 to sea03 — a second head would make `flask db upgrade` ambiguous on
+        deploy."""
         heads = _script_directory().get_heads()
-        assert heads == ["sea02"], f"expected the single head to be sea02, got {heads}"
+        assert heads == ["sea03"], f"expected the single head to be sea03, got {heads}"
 
     def test_sea01_chains_off_aw23(self):
         """sea01 branches from the real prod tip (aw23), keeping the line linear."""
@@ -70,6 +71,13 @@ class TestMigrationHead:
         sea02 = script.get_revision("sea02")
         assert sea02.down_revision == "sea01"
         assert script.get_revision("sea01") is not None
+
+    def test_sea03_chains_off_sea02(self):
+        """sea03 (/status gauge clock indexes) branches from sea02, keeping the line linear."""
+        script = _script_directory()
+        sea03 = script.get_revision("sea03")
+        assert sea03.down_revision == "sea02"
+        assert script.get_revision("sea02") is not None
 
 
 # ---------------------------------------------------------------------------

--- a/academy-watch-backend/tests/test_season_rollup_admin.py
+++ b/academy-watch-backend/tests/test_season_rollup_admin.py
@@ -730,16 +730,21 @@ def test_status_returns_totals_freshness_and_source_cell_counts(client, admin_he
 
     # Default gauge is cheap: newest source clock (shadow NOW) is not later than
     # the newest computed_at (502 senior NOW), so the coarse gauge reads caught up.
+    # The per-source cell breakdown scans the largest table, so it is NOT on the
+    # pollable default path — only the four index-served clocks + the totals scan.
     body = _status(client, admin_headers)
     assert body == {
         "total_totals_rows": 3,
         "behind": False,
         "last_computed_at": NOW.replace(tzinfo=None).isoformat(),
         "last_source_change_at": NOW.replace(tzinfo=None).isoformat(),
-        "by_source_cells": {"fixtures": 2, "journey": 1},
     }
-    # The exact reconciliation count still sees 501 (shadow NOW > its total middle).
-    assert _status(client, admin_headers, exact=True)["stale_players"] == 1
+    assert "by_source_cells" not in body
+    # ?exact=1 adds both reconciliation extras: the per-source cell breakdown and
+    # the exact stale count (still sees 501, shadow NOW > its total middle).
+    exact_body = _status(client, admin_headers, exact=True)
+    assert exact_body["by_source_cells"] == {"fixtures": 2, "journey": 1}
+    assert exact_body["stale_players"] == 1
 
 
 def test_empty_status_is_zeroed(client, admin_headers):
@@ -748,6 +753,7 @@ def test_empty_status_is_zeroed(client, admin_headers):
         "behind": False,
         "last_computed_at": None,
         "last_source_change_at": None,
-        "by_source_cells": {},
     }
-    assert _status(client, admin_headers, exact=True)["stale_players"] == 0
+    exact_body = _status(client, admin_headers, exact=True)
+    assert exact_body["by_source_cells"] == {}
+    assert exact_body["stale_players"] == 0

--- a/academy-watch-backend/tests/test_season_rollup_admin.py
+++ b/academy-watch-backend/tests/test_season_rollup_admin.py
@@ -7,10 +7,12 @@ from flask import Flask
 from sqlalchemy.dialects import postgresql
 from src.models.follow import PlayerShadowStats
 from src.models.journey import PlayerJourney, PlayerJourneyEntry
-from src.models.league import AcademyPlayerSeasonStats, db
+from src.models.league import AcademyPlayerSeasonStats, Team, db
 from src.models.season_rollup import PlayerSeasonCell, PlayerSeasonTotal
+from src.models.tracked_player import TrackedPlayer
 from src.models.weekly import Fixture, FixturePlayerStats
 from src.routes import season_rollup as admin_routes
+from src.routes.api import api_bp
 from src.routes.season_rollup import season_rollup_bp
 
 ADMIN_KEY = "test-admin-key"
@@ -32,6 +34,7 @@ def app(monkeypatch):
         SQLALCHEMY_TRACK_MODIFICATIONS=False,
     )
     db.init_app(application)
+    application.register_blueprint(api_bp, url_prefix="/api")
     application.register_blueprint(season_rollup_bp, url_prefix="/api")
 
     context = application.app_context()
@@ -515,30 +518,103 @@ def test_noise_stub_cannot_borrow_another_journey_level_cell(client, admin_heade
     assert _status(client, admin_headers, exact=True)["stale_players"] == 0
 
 
-def test_fixture_source_without_fixture_cell_is_stale_even_if_other_total_exists(client, admin_headers):
+def test_senior_fixture_cell_does_not_mask_missing_youth_fixture_cell(client, admin_headers):
     player = 395
-    fixture = Fixture(fixture_id_api=395, season=2025, competition_name="Premier League 2 Division One")
-    db.session.add(fixture)
+    senior_fixture = Fixture(fixture_id_api=394, season=2025, competition_name="Premier League")
+    youth_fixture = Fixture(fixture_id_api=395, season=2025, competition_name="Premier League 2 Division One")
+    db.session.add_all([senior_fixture, youth_fixture])
     db.session.flush()
-    db.session.add(
-        FixturePlayerStats(
-            fixture_id=fixture.id,
-            player_api_id=player,
-            team_api_id=3950,
-            minutes=90,
-            goals=0,
-        )
+    db.session.add_all(
+        [
+            FixturePlayerStats(
+                fixture_id=senior_fixture.id,
+                player_api_id=player,
+                team_api_id=3940,
+                minutes=90,
+                goals=0,
+            ),
+            FixturePlayerStats(
+                fixture_id=youth_fixture.id,
+                player_api_id=player,
+                team_api_id=3950,
+                minutes=90,
+                goals=0,
+            ),
+        ]
     )
-    _total(player, level_group="senior", primary_source="shadow")
+    _cell(player, source="fixtures", club=3940, level_group="senior")
+    _total(player, level_group="senior", primary_source="fixtures")
     db.session.commit()
 
     assert _status(client, admin_headers, exact=True)["stale_players"] == 1
     rebuilt = client.post(f"{REBUILD_URL}?scope=stale", headers=admin_headers)
     assert rebuilt.status_code == 200
     assert rebuilt.get_json() == {"processed": 1, "failed": [], "remaining": 0, "cursor": None}
-    assert PlayerSeasonCell.query.filter_by(player_api_id=player, source="fixtures").count() == 1
+    assert (
+        PlayerSeasonCell.query.filter_by(
+            player_api_id=player,
+            source="fixtures",
+            level_group="senior",
+        ).count()
+        == 1
+    )
+    assert (
+        PlayerSeasonCell.query.filter_by(
+            player_api_id=player,
+            source="fixtures",
+            level_group="youth",
+        ).count()
+        == 1
+    )
     assert PlayerSeasonTotal.query.filter_by(player_api_id=player, level_group="youth").count() == 1
     assert _status(client, admin_headers, exact=True)["stale_players"] == 0
+
+
+def test_team_delete_rolls_back_when_rollup_refresh_fails(client, admin_headers, monkeypatch):
+    player = 396
+    team = Team(
+        team_id=3960,
+        name="Atomic FC",
+        country="England",
+        season=2025,
+        is_tracked=True,
+        newsletters_active=True,
+    )
+    db.session.add(team)
+    db.session.flush()
+    db.session.add(TrackedPlayer(player_api_id=player, player_name="Atomic Player", team_id=team.id))
+    fixture = Fixture(fixture_id_api=396, season=2025, competition_name="Premier League")
+    db.session.add(fixture)
+    db.session.flush()
+    db.session.add(
+        FixturePlayerStats(
+            fixture_id=fixture.id,
+            player_api_id=player,
+            team_api_id=team.team_id,
+            minutes=90,
+            goals=0,
+        )
+    )
+    _cell(player, source="fixtures", club=team.team_id)
+    _total(player, primary_source="fixtures")
+    db.session.commit()
+    team_id = team.id
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("simulated rollup failure")
+
+    monkeypatch.setattr(admin_routes.season_rollup_service, "refresh_player", _boom)
+    response = client.delete(f"/api/admin/teams/{team_id}/data", headers=admin_headers)
+
+    assert response.status_code == 500
+    assert response.get_json()["error"] == "Failed to delete team data"
+    db.session.expire_all()
+    assert FixturePlayerStats.query.filter_by(player_api_id=player).count() == 1
+    assert TrackedPlayer.query.filter_by(player_api_id=player, team_id=team_id).count() == 1
+    restored_team = db.session.get(Team, team_id)
+    assert (restored_team.is_tracked, restored_team.newsletters_active) == (True, True)
+    assert PlayerSeasonCell.query.filter_by(player_api_id=player, source="fixtures").count() == 1
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=player).count() == 1
 
 
 def test_stale_cursor_above_all_work_terminates(client, admin_headers):

--- a/academy-watch-backend/tests/test_season_rollup_admin.py
+++ b/academy-watch-backend/tests/test_season_rollup_admin.py
@@ -1,0 +1,633 @@
+"""D3c admin rebuild surface and rows-behind gauge."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from flask import Flask
+from sqlalchemy.dialects import postgresql
+from src.models.follow import PlayerShadowStats
+from src.models.journey import PlayerJourney, PlayerJourneyEntry
+from src.models.league import AcademyPlayerSeasonStats, db
+from src.models.season_rollup import PlayerSeasonCell, PlayerSeasonTotal
+from src.models.weekly import Fixture, FixturePlayerStats
+from src.routes import season_rollup as admin_routes
+from src.routes.season_rollup import season_rollup_bp
+
+ADMIN_KEY = "test-admin-key"
+REBUILD_URL = "/api/admin/season-rollup/rebuild"
+STATUS_URL = "/api/admin/season-rollup/status"
+NOW = datetime(2026, 7, 15, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setenv("ADMIN_API_KEY", ADMIN_KEY)
+    monkeypatch.setenv("ADMIN_IP_WHITELIST", "")
+
+    application = Flask(__name__)
+    application.config.update(
+        TESTING=True,
+        SECRET_KEY="test-secret-key",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+    db.init_app(application)
+    application.register_blueprint(season_rollup_bp, url_prefix="/api")
+
+    context = application.app_context()
+    context.push()
+    db.create_all()
+    yield application
+    db.session.remove()
+    db.drop_all()
+    context.pop()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def admin_headers(app):
+    from src.auth import issue_user_token
+
+    token = issue_user_token("admin@test.com", role="admin")["token"]
+    return {"Authorization": f"Bearer {token}", "X-API-Key": ADMIN_KEY}
+
+
+def _shadow(player: int, *, season: int = 2025, updated_at=NOW, minutes: int = 90):
+    row = PlayerShadowStats(
+        player_api_id=player,
+        team_api_id=player + 1000,
+        team_name=f"Shadow {player}",
+        season=season,
+        appearances=1 if minutes else 0,
+        goals=0,
+        minutes=minutes,
+        updated_at=updated_at,
+    )
+    db.session.add(row)
+    return row
+
+
+def _apss(player: int, *, updated_at=NOW, minutes: int = 90):
+    row = AcademyPlayerSeasonStats(
+        player_api_id=player,
+        player_name=f"Academy {player}",
+        league_api_id=700 + player,
+        league_name="Youth League",
+        team_api_id=player + 2000,
+        team_name=f"Academy {player}",
+        season=2025,
+        appearances=1 if minutes else 0,
+        goals=0,
+        minutes=minutes,
+        updated_at=updated_at,
+    )
+    db.session.add(row)
+    return row
+
+
+def _total(
+    player: int,
+    *,
+    season: int = 2025,
+    level_group: str = "senior",
+    computed_at=NOW,
+    primary_source: str = "shadow",
+    minutes: int = 90,
+):
+    row = PlayerSeasonTotal(
+        player_api_id=player,
+        season=season,
+        level_group=level_group,
+        appearances=1,
+        goals=0,
+        minutes=minutes,
+        primary_source=primary_source,
+        fixtures_minutes=minutes if primary_source == "fixtures" else 0,
+        journey_minutes=minutes if primary_source == "journey" else 0,
+        computed_at=computed_at,
+    )
+    db.session.add(row)
+    return row
+
+
+def _cell(
+    player: int,
+    *,
+    source: str,
+    club: int,
+    level_group: str = "senior",
+    synced_at=NOW,
+):
+    row = PlayerSeasonCell(
+        player_api_id=player,
+        season=2025,
+        source=source,
+        club_api_id=club,
+        competition_tier="league" if level_group == "senior" else "youth",
+        level_group=level_group,
+        appearances=1,
+        goals=0,
+        minutes=90,
+        synced_at=synced_at,
+    )
+    db.session.add(row)
+    return row
+
+
+def _status(client, headers):
+    response = client.get(STATUS_URL, headers=headers)
+    assert response.status_code == 200
+    return response.get_json()
+
+
+def test_endpoints_require_admin_dual_auth(client):
+    assert client.post(f"{REBUILD_URL}?scope=all").status_code == 401
+    assert client.get(STATUS_URL).status_code == 401
+
+
+@pytest.mark.parametrize(
+    "query,error_part",
+    [
+        ("", "scope"),
+        ("?scope=unknown", "scope"),
+        ("?scope=player", "player_api_id"),
+        ("?scope=player&player_api_id=nope", "player_api_id"),
+        ("?scope=season", "season"),
+        ("?scope=season&season=nope", "season"),
+        ("?scope=all&cursor=-1", "cursor"),
+        ("?scope=stale&cursor=nope", "cursor"),
+        ("?scope=all&cursor=1:r0", "cursor"),
+        ("?scope=season&season=2025&cursor=1:rx", "cursor"),
+        ("?scope=all&cursor=x:r1", "cursor"),
+    ],
+)
+def test_rebuild_validates_scope_arguments(client, admin_headers, query, error_part):
+    response = client.post(f"{REBUILD_URL}{query}", headers=admin_headers)
+    assert response.status_code == 400
+    assert error_part in response.get_json()["error"]
+
+
+def test_player_scope_rebuilds_and_is_idempotent(client, admin_headers):
+    player = 101
+    _shadow(player)
+    db.session.commit()
+
+    first = client.post(f"{REBUILD_URL}?scope=player&player_api_id={player}", headers=admin_headers)
+    assert first.status_code == 200
+    assert first.get_json() == {"processed": 1, "remaining": 0, "cursor": None}
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=player).count() == 1
+
+    second = client.post(f"{REBUILD_URL}?scope=player&player_api_id={player}", headers=admin_headers)
+    assert second.status_code == 200
+    assert second.get_json() == {"processed": 1, "remaining": 0, "cursor": None}
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=player).count() == 1
+
+
+def test_season_scope_is_bounded_and_leaves_other_seasons_untouched(client, admin_headers):
+    player = 201
+    _shadow(player, season=2024, minutes=80)
+    _shadow(player, season=2025, minutes=90)
+    db.session.commit()
+    admin_routes.season_rollup_service.refresh_player(player, session=db.session)
+    db.session.commit()
+    old_total = PlayerSeasonTotal.query.filter_by(player_api_id=player, season=2024).one()
+    old_computed_at = old_total.computed_at
+
+    response = client.post(
+        f"{REBUILD_URL}?scope=season&season=2025&batch_size=1",
+        headers=admin_headers,
+    )
+    assert response.status_code == 200
+    assert response.get_json() == {"processed": 1, "remaining": 0, "cursor": None}
+    db.session.expire_all()
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=player, season=2024).one().computed_at == old_computed_at
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=player, season=2025).count() == 1
+
+
+def test_all_scope_pages_every_source_and_orphan_derived_rows(client, admin_headers, monkeypatch):
+    fixture = Fixture(fixture_id_api=10, season=2025, competition_name="Premier League")
+    db.session.add(fixture)
+    db.session.flush()
+    db.session.add(
+        FixturePlayerStats(
+            fixture_id=fixture.id,
+            player_api_id=10,
+            team_api_id=1,
+            minutes=90,
+            goals=0,
+        )
+    )
+    _apss(20)
+    _shadow(30)
+    journey = PlayerJourney(player_api_id=40, player_name="Legacy Journey")
+    db.session.add(journey)
+    db.session.flush()
+    db.session.add(
+        PlayerJourneyEntry(
+            journey_id=journey.id,
+            player_api_id=None,
+            season=2025,
+            club_api_id=400,
+            appearances=1,
+            minutes=90,
+            goals=0,
+            stats_synced_at=NOW,
+        )
+    )
+    _total(50)  # totals-only orphan must be selectable so rebuild can delete it
+    db.session.commit()
+
+    calls = []
+
+    def _record(player_api_id, season=None, session=None):
+        calls.append((player_api_id, season, session))
+        return {"cells": 0, "totals": 0}
+
+    monkeypatch.setattr(admin_routes.season_rollup_service, "refresh_player", _record)
+
+    first = client.post(f"{REBUILD_URL}?scope=all&batch_size=2", headers=admin_headers)
+    assert first.status_code == 200
+    assert first.get_json() == {"processed": 2, "remaining": 1, "cursor": 20}
+
+    second = client.post(f"{REBUILD_URL}?scope=all&batch_size=2&cursor=20", headers=admin_headers)
+    assert second.status_code == 200
+    assert second.get_json() == {"processed": 2, "remaining": 1, "cursor": 40}
+
+    third = client.post(f"{REBUILD_URL}?scope=all&batch_size=2&cursor=40", headers=admin_headers)
+    assert third.status_code == 200
+    assert third.get_json() == {"processed": 1, "remaining": 0, "cursor": None}
+    assert [(player, season) for player, season, _session in calls] == [
+        (10, None),
+        (20, None),
+        (30, None),
+        (40, None),
+        (50, None),
+    ]
+    assert all(session is db.session for _player, _season, session in calls)
+
+
+def test_bounded_candidate_query_is_postgresql_safe(app):
+    statement = admin_routes._candidate_player_ids(after=10, per_source_limit=25)
+    sql = str(
+        statement.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+    # Source-local DISTINCT avoids PostgreSQL's rejection of a GROUP BY player
+    # query whose correlated old-cell EXISTS also references source.season.
+    assert sql.count("SELECT DISTINCT") == 6
+    assert "GROUP BY fixture_player_stats.player_api_id" not in sql
+    assert "GROUP BY player_journeys.player_api_id" not in sql
+    assert "GROUP BY academy_player_season_stats.player_api_id" not in sql
+    assert "GROUP BY player_shadow_stats.player_api_id" not in sql
+
+
+def test_all_scope_caps_batch_size_at_100(client, admin_headers, monkeypatch):
+    for player in range(1, 103):
+        _total(player)
+    db.session.commit()
+    monkeypatch.setattr(
+        admin_routes.season_rollup_service,
+        "refresh_player",
+        lambda *args, **kwargs: {"cells": 0, "totals": 0},
+    )
+
+    response = client.post(f"{REBUILD_URL}?scope=all&batch_size=999", headers=admin_headers)
+    assert response.status_code == 200
+    assert response.get_json() == {"processed": 100, "remaining": 1, "cursor": 100}
+
+
+@pytest.mark.parametrize("batch_query", ["", "&batch_size=0", "&batch_size=-1", "&batch_size=abc"])
+def test_all_scope_uses_bounded_default_for_missing_or_invalid_batch_size(
+    client,
+    admin_headers,
+    monkeypatch,
+    batch_query,
+):
+    for player in range(1, 27):
+        _total(player)
+    db.session.commit()
+    monkeypatch.setattr(
+        admin_routes.season_rollup_service,
+        "refresh_player",
+        lambda *args, **kwargs: {"cells": 0, "totals": 0},
+    )
+
+    response = client.post(f"{REBUILD_URL}?scope=all{batch_query}", headers=admin_headers)
+    assert response.status_code == 200
+    assert response.get_json() == {"processed": 25, "remaining": 1, "cursor": 25}
+
+
+def test_rebuild_scopes_do_not_run_the_global_status_count(client, admin_headers, monkeypatch):
+    _shadow(240)
+    db.session.commit()
+
+    def _unexpected_global_count(*_args, **_kwargs):
+        raise AssertionError("rebuild must not execute the platform-wide status count")
+
+    monkeypatch.setattr(admin_routes, "_count_ids", _unexpected_global_count)
+    response = client.post(f"{REBUILD_URL}?scope=stale&batch_size=1", headers=admin_headers)
+    assert response.status_code == 200
+    assert response.get_json() == {"processed": 1, "remaining": 0, "cursor": None}
+
+
+def test_all_scope_rebuild_deletes_totals_only_orphan_and_rerun_is_noop(client, admin_headers):
+    _total(250)
+    db.session.commit()
+
+    first = client.post(f"{REBUILD_URL}?scope=all", headers=admin_headers)
+    assert first.status_code == 200
+    assert first.get_json() == {"processed": 1, "remaining": 0, "cursor": None}
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=250).count() == 0
+
+    second = client.post(f"{REBUILD_URL}?scope=all", headers=admin_headers)
+    assert second.status_code == 200
+    assert second.get_json() == {"processed": 0, "remaining": 0, "cursor": None}
+
+
+def test_batch_savepoints_keep_successes_and_return_restart_cursor(client, admin_headers, monkeypatch):
+    for player in (261, 262, 263):
+        _total(player)
+    db.session.commit()
+    calls = []
+
+    def _fail_middle_once(player_api_id, **_kwargs):
+        calls.append(player_api_id)
+        if player_api_id == 262:
+            raise RuntimeError("bad player")
+        return {"cells": 0, "totals": 0}
+
+    monkeypatch.setattr(admin_routes.season_rollup_service, "refresh_player", _fail_middle_once)
+    first = client.post(f"{REBUILD_URL}?scope=all&batch_size=3", headers=admin_headers)
+    assert first.status_code == 200
+    assert first.get_json() == {"processed": 2, "remaining": 1, "cursor": 0}
+    assert calls == [261, 262, 263]
+
+    monkeypatch.setattr(
+        admin_routes.season_rollup_service,
+        "refresh_player",
+        lambda *args, **kwargs: {"cells": 0, "totals": 0},
+    )
+    retry = client.post(f"{REBUILD_URL}?scope=all&batch_size=3&cursor=0", headers=admin_headers)
+    assert retry.status_code == 200
+    assert retry.get_json() == {"processed": 3, "remaining": 0, "cursor": None}
+
+
+def test_retry_cursor_carries_persistent_failure_past_later_pages(client, admin_headers, monkeypatch):
+    for player in range(271, 276):
+        _total(player)
+    db.session.commit()
+    calls = []
+
+    def _fail_first(player_api_id, **_kwargs):
+        calls.append(player_api_id)
+        if player_api_id == 271:
+            raise RuntimeError("persistent bad player")
+        return {"cells": 0, "totals": 0}
+
+    monkeypatch.setattr(admin_routes.season_rollup_service, "refresh_player", _fail_first)
+
+    first = client.post(f"{REBUILD_URL}?scope=all&batch_size=2", headers=admin_headers)
+    assert first.status_code == 200
+    assert first.get_json() == {"processed": 1, "remaining": 2, "cursor": "272:r1"}
+
+    second = client.post(
+        f"{REBUILD_URL}?scope=all&batch_size=2&cursor={first.get_json()['cursor']}",
+        headers=admin_headers,
+    )
+    assert second.status_code == 200
+    assert second.get_json() == {"processed": 2, "remaining": 2, "cursor": "274:r1"}
+
+    third = client.post(
+        f"{REBUILD_URL}?scope=all&batch_size=2&cursor={second.get_json()['cursor']}",
+        headers=admin_headers,
+    )
+    assert third.status_code == 200
+    assert third.get_json() == {"processed": 1, "remaining": 1, "cursor": 0}
+    assert calls == [271, 272, 273, 274, 275]
+
+
+def test_stale_scope_uses_exact_source_clocks_and_converges(client, admin_headers):
+    # No total yet: stale regardless of the source clock.
+    _shadow(301, updated_at=NOW - timedelta(days=2))
+
+    # Source clock newer than its senior total: stale.
+    _shadow(302, updated_at=NOW)
+    _total(302, computed_at=NOW - timedelta(days=1))
+
+    # Total newer than the source: fresh.
+    _shadow(303, updated_at=NOW - timedelta(days=2))
+    _total(303, computed_at=NOW - timedelta(days=1))
+
+    # A newer senior total must not mask an older youth total.
+    _apss(304, updated_at=NOW)
+    _shadow(304, updated_at=NOW - timedelta(days=3))
+    _total(304, level_group="youth", primary_source="apss", computed_at=NOW - timedelta(days=1))
+    _total(304, level_group="senior", computed_at=NOW + timedelta(hours=1))
+
+    # Journey freshness resolves the canonical id through the parent when the
+    # sea01 denormalized player_api_id has not been backfilled.
+    journey = PlayerJourney(player_api_id=305, player_name="Legacy")
+    db.session.add(journey)
+    db.session.flush()
+    db.session.add(
+        PlayerJourneyEntry(
+            journey_id=journey.id,
+            player_api_id=None,
+            season=2025,
+            club_api_id=3050,
+            appearances=1,
+            minutes=90,
+            goals=0,
+            stats_synced_at=NOW,
+        )
+    )
+    _total(305, primary_source="journey", computed_at=NOW - timedelta(days=1))
+
+    # Permanent pre-season noise without an old cell is not stale forever.
+    _apss(306, updated_at=NOW, minutes=0)
+    db.session.commit()
+
+    assert _status(client, admin_headers)["stale_players"] == 4
+
+    first = client.post(f"{REBUILD_URL}?scope=stale&batch_size=2", headers=admin_headers)
+    assert first.status_code == 200
+    assert first.get_json() == {"processed": 2, "remaining": 1, "cursor": 302}
+
+    second = client.post(
+        f"{REBUILD_URL}?scope=stale&batch_size=2&cursor={first.get_json()['cursor']}",
+        headers=admin_headers,
+    )
+    assert second.status_code == 200
+    assert second.get_json() == {"processed": 1, "remaining": 1, "cursor": 304}
+
+    third = client.post(
+        f"{REBUILD_URL}?scope=stale&batch_size=2&cursor={second.get_json()['cursor']}",
+        headers=admin_headers,
+    )
+    assert third.status_code == 200
+    assert third.get_json() == {"processed": 1, "remaining": 0, "cursor": None}
+    assert _status(client, admin_headers)["stale_players"] == 0
+
+
+def test_noise_stub_cannot_borrow_another_journey_level_cell(client, admin_headers):
+    player = 390
+    journey = PlayerJourney(player_api_id=player, player_name="Mixed Levels")
+    db.session.add(journey)
+    db.session.flush()
+    db.session.add_all(
+        [
+            PlayerJourneyEntry(
+                journey_id=journey.id,
+                season=2025,
+                club_api_id=3900,
+                appearances=1,
+                minutes=90,
+                goals=0,
+                stats_synced_at=NOW,
+            ),
+            PlayerJourneyEntry(
+                journey_id=journey.id,
+                season=2025,
+                club_api_id=3901,
+                is_youth=True,
+                appearances=0,
+                minutes=0,
+                goals=0,
+                stats_synced_at=NOW,
+            ),
+        ]
+    )
+    db.session.commit()
+
+    built = client.post(f"{REBUILD_URL}?scope=player&player_api_id={player}", headers=admin_headers)
+    assert built.status_code == 200
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=player, level_group="senior").count() == 1
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=player, level_group="youth").count() == 0
+    assert _status(client, admin_headers)["stale_players"] == 0
+
+
+def test_fixture_source_without_fixture_cell_is_stale_even_if_other_total_exists(client, admin_headers):
+    player = 395
+    fixture = Fixture(fixture_id_api=395, season=2025, competition_name="Premier League 2 Division One")
+    db.session.add(fixture)
+    db.session.flush()
+    db.session.add(
+        FixturePlayerStats(
+            fixture_id=fixture.id,
+            player_api_id=player,
+            team_api_id=3950,
+            minutes=90,
+            goals=0,
+        )
+    )
+    _total(player, level_group="senior", primary_source="shadow")
+    db.session.commit()
+
+    assert _status(client, admin_headers)["stale_players"] == 1
+    rebuilt = client.post(f"{REBUILD_URL}?scope=stale", headers=admin_headers)
+    assert rebuilt.status_code == 200
+    assert rebuilt.get_json() == {"processed": 1, "remaining": 0, "cursor": None}
+    assert PlayerSeasonCell.query.filter_by(player_api_id=player, source="fixtures").count() == 1
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=player, level_group="youth").count() == 1
+    assert _status(client, admin_headers)["stale_players"] == 0
+
+
+def test_stale_cursor_wraps_to_zero_when_work_only_exists_below_it(client, admin_headers):
+    _shadow(399, updated_at=NOW)
+    db.session.commit()
+
+    response = client.post(f"{REBUILD_URL}?scope=stale&cursor=999", headers=admin_headers)
+    assert response.status_code == 200
+    assert response.get_json() == {"processed": 0, "remaining": 1, "cursor": 0}
+
+
+def test_stale_scope_advances_bounded_scan_pages_that_contain_no_stale_players(client, admin_headers):
+    old = NOW - timedelta(days=2)
+    fresh_total = NOW - timedelta(days=1)
+    for player in range(1, 31):
+        _shadow(player, updated_at=old)
+        if player < 30:
+            _total(player, computed_at=fresh_total)
+    db.session.commit()
+
+    cursor = None
+    for expected_cursor in (5, 10, 15, 20, 25):
+        cursor_query = "" if cursor is None else f"&cursor={cursor}"
+        response = client.post(
+            f"{REBUILD_URL}?scope=stale&batch_size=5{cursor_query}",
+            headers=admin_headers,
+        )
+        assert response.status_code == 200
+        assert response.get_json() == {
+            "processed": 0,
+            "remaining": 1,
+            "cursor": expected_cursor,
+        }
+        cursor = response.get_json()["cursor"]
+
+    final = client.post(
+        f"{REBUILD_URL}?scope=stale&batch_size=5&cursor={cursor}",
+        headers=admin_headers,
+    )
+    assert final.status_code == 200
+    assert final.get_json() == {"processed": 1, "remaining": 0, "cursor": None}
+
+
+def test_stale_zeroed_source_removes_old_cells_then_converges(client, admin_headers):
+    row = _apss(401, updated_at=NOW - timedelta(days=2))
+    db.session.commit()
+    built = client.post(f"{REBUILD_URL}?scope=player&player_api_id=401", headers=admin_headers)
+    assert built.status_code == 200
+    assert PlayerSeasonCell.query.filter_by(player_api_id=401, source="apss").count() == 1
+    computed_at = PlayerSeasonTotal.query.filter_by(player_api_id=401, level_group="youth").one().computed_at
+
+    row.appearances = 0
+    row.minutes = 0
+    row.goals = 0
+    row.updated_at = computed_at + timedelta(microseconds=1)
+    db.session.commit()
+    assert _status(client, admin_headers)["stale_players"] == 1
+
+    rebuilt = client.post(f"{REBUILD_URL}?scope=stale", headers=admin_headers)
+    assert rebuilt.status_code == 200
+    assert rebuilt.get_json() == {"processed": 1, "remaining": 0, "cursor": None}
+    assert PlayerSeasonCell.query.filter_by(player_api_id=401, source="apss").count() == 0
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=401, level_group="youth").count() == 0
+    assert _status(client, admin_headers)["stale_players"] == 0
+
+
+def test_status_returns_totals_freshness_and_source_cell_counts(client, admin_headers):
+    old = NOW - timedelta(days=2)
+    middle = NOW - timedelta(days=1)
+    _shadow(501, updated_at=NOW)
+    _total(501, computed_at=middle)
+    _total(502, level_group="senior", computed_at=NOW)
+    _total(502, level_group="youth", primary_source="apss", computed_at=old)
+    _cell(501, source="fixtures", club=1, synced_at=old)
+    _cell(502, source="fixtures", club=2, synced_at=old)
+    _cell(502, source="journey", club=3, level_group="youth", synced_at=old)
+    db.session.commit()
+
+    body = _status(client, admin_headers)
+    assert body == {
+        "total_totals_rows": 3,
+        "stale_players": 1,
+        "last_computed_at": NOW.replace(tzinfo=None).isoformat(),
+        "by_source_cells": {"fixtures": 2, "journey": 1},
+    }
+
+
+def test_empty_status_is_zeroed(client, admin_headers):
+    assert _status(client, admin_headers) == {
+        "total_totals_rows": 0,
+        "stale_players": 0,
+        "last_computed_at": None,
+        "by_source_cells": {},
+    }

--- a/academy-watch-backend/tests/test_season_rollup_admin.py
+++ b/academy-watch-backend/tests/test_season_rollup_admin.py
@@ -138,8 +138,9 @@ def _cell(
     return row
 
 
-def _status(client, headers):
-    response = client.get(STATUS_URL, headers=headers)
+def _status(client, headers, *, exact: bool = False):
+    url = f"{STATUS_URL}?exact=1" if exact else STATUS_URL
+    response = client.get(url, headers=headers)
     assert response.status_code == 200
     return response.get_json()
 
@@ -160,9 +161,6 @@ def test_endpoints_require_admin_dual_auth(client):
         ("?scope=season&season=nope", "season"),
         ("?scope=all&cursor=-1", "cursor"),
         ("?scope=stale&cursor=nope", "cursor"),
-        ("?scope=all&cursor=1:r0", "cursor"),
-        ("?scope=season&season=2025&cursor=1:rx", "cursor"),
-        ("?scope=all&cursor=x:r1", "cursor"),
     ],
 )
 def test_rebuild_validates_scope_arguments(client, admin_headers, query, error_part):
@@ -178,12 +176,12 @@ def test_player_scope_rebuilds_and_is_idempotent(client, admin_headers):
 
     first = client.post(f"{REBUILD_URL}?scope=player&player_api_id={player}", headers=admin_headers)
     assert first.status_code == 200
-    assert first.get_json() == {"processed": 1, "remaining": 0, "cursor": None}
+    assert first.get_json() == {"processed": 1, "failed": [], "remaining": 0, "cursor": None}
     assert PlayerSeasonTotal.query.filter_by(player_api_id=player).count() == 1
 
     second = client.post(f"{REBUILD_URL}?scope=player&player_api_id={player}", headers=admin_headers)
     assert second.status_code == 200
-    assert second.get_json() == {"processed": 1, "remaining": 0, "cursor": None}
+    assert second.get_json() == {"processed": 1, "failed": [], "remaining": 0, "cursor": None}
     assert PlayerSeasonTotal.query.filter_by(player_api_id=player).count() == 1
 
 
@@ -202,7 +200,7 @@ def test_season_scope_is_bounded_and_leaves_other_seasons_untouched(client, admi
         headers=admin_headers,
     )
     assert response.status_code == 200
-    assert response.get_json() == {"processed": 1, "remaining": 0, "cursor": None}
+    assert response.get_json() == {"processed": 1, "failed": [], "remaining": 0, "cursor": None}
     db.session.expire_all()
     assert PlayerSeasonTotal.query.filter_by(player_api_id=player, season=2024).one().computed_at == old_computed_at
     assert PlayerSeasonTotal.query.filter_by(player_api_id=player, season=2025).count() == 1
@@ -251,15 +249,15 @@ def test_all_scope_pages_every_source_and_orphan_derived_rows(client, admin_head
 
     first = client.post(f"{REBUILD_URL}?scope=all&batch_size=2", headers=admin_headers)
     assert first.status_code == 200
-    assert first.get_json() == {"processed": 2, "remaining": 1, "cursor": 20}
+    assert first.get_json() == {"processed": 2, "failed": [], "remaining": 1, "cursor": 20}
 
     second = client.post(f"{REBUILD_URL}?scope=all&batch_size=2&cursor=20", headers=admin_headers)
     assert second.status_code == 200
-    assert second.get_json() == {"processed": 2, "remaining": 1, "cursor": 40}
+    assert second.get_json() == {"processed": 2, "failed": [], "remaining": 1, "cursor": 40}
 
     third = client.post(f"{REBUILD_URL}?scope=all&batch_size=2&cursor=40", headers=admin_headers)
     assert third.status_code == 200
-    assert third.get_json() == {"processed": 1, "remaining": 0, "cursor": None}
+    assert third.get_json() == {"processed": 1, "failed": [], "remaining": 0, "cursor": None}
     assert [(player, season) for player, season, _session in calls] == [
         (10, None),
         (20, None),
@@ -300,7 +298,7 @@ def test_all_scope_caps_batch_size_at_100(client, admin_headers, monkeypatch):
 
     response = client.post(f"{REBUILD_URL}?scope=all&batch_size=999", headers=admin_headers)
     assert response.status_code == 200
-    assert response.get_json() == {"processed": 100, "remaining": 1, "cursor": 100}
+    assert response.get_json() == {"processed": 100, "failed": [], "remaining": 1, "cursor": 100}
 
 
 @pytest.mark.parametrize("batch_query", ["", "&batch_size=0", "&batch_size=-1", "&batch_size=abc"])
@@ -321,7 +319,7 @@ def test_all_scope_uses_bounded_default_for_missing_or_invalid_batch_size(
 
     response = client.post(f"{REBUILD_URL}?scope=all{batch_query}", headers=admin_headers)
     assert response.status_code == 200
-    assert response.get_json() == {"processed": 25, "remaining": 1, "cursor": 25}
+    assert response.get_json() == {"processed": 25, "failed": [], "remaining": 1, "cursor": 25}
 
 
 def test_rebuild_scopes_do_not_run_the_global_status_count(client, admin_headers, monkeypatch):
@@ -334,7 +332,7 @@ def test_rebuild_scopes_do_not_run_the_global_status_count(client, admin_headers
     monkeypatch.setattr(admin_routes, "_count_ids", _unexpected_global_count)
     response = client.post(f"{REBUILD_URL}?scope=stale&batch_size=1", headers=admin_headers)
     assert response.status_code == 200
-    assert response.get_json() == {"processed": 1, "remaining": 0, "cursor": None}
+    assert response.get_json() == {"processed": 1, "failed": [], "remaining": 0, "cursor": None}
 
 
 def test_all_scope_rebuild_deletes_totals_only_orphan_and_rerun_is_noop(client, admin_headers):
@@ -343,15 +341,15 @@ def test_all_scope_rebuild_deletes_totals_only_orphan_and_rerun_is_noop(client, 
 
     first = client.post(f"{REBUILD_URL}?scope=all", headers=admin_headers)
     assert first.status_code == 200
-    assert first.get_json() == {"processed": 1, "remaining": 0, "cursor": None}
+    assert first.get_json() == {"processed": 1, "failed": [], "remaining": 0, "cursor": None}
     assert PlayerSeasonTotal.query.filter_by(player_api_id=250).count() == 0
 
     second = client.post(f"{REBUILD_URL}?scope=all", headers=admin_headers)
     assert second.status_code == 200
-    assert second.get_json() == {"processed": 0, "remaining": 0, "cursor": None}
+    assert second.get_json() == {"processed": 0, "failed": [], "remaining": 0, "cursor": None}
 
 
-def test_batch_savepoints_keep_successes_and_return_restart_cursor(client, admin_headers, monkeypatch):
+def test_batch_savepoints_keep_successes_and_report_failed_id(client, admin_headers, monkeypatch):
     for player in (261, 262, 263):
         _total(player)
     db.session.commit()
@@ -366,7 +364,9 @@ def test_batch_savepoints_keep_successes_and_return_restart_cursor(client, admin
     monkeypatch.setattr(admin_routes.season_rollup_service, "refresh_player", _fail_middle_once)
     first = client.post(f"{REBUILD_URL}?scope=all&batch_size=3", headers=admin_headers)
     assert first.status_code == 200
-    assert first.get_json() == {"processed": 2, "remaining": 1, "cursor": 0}
+    # The savepoint keeps 261/263, the sweep TERMINATES (cursor null), and the
+    # failing id is surfaced for an out-of-band scope=player retry.
+    assert first.get_json() == {"processed": 2, "failed": [262], "remaining": 0, "cursor": None}
     assert calls == [261, 262, 263]
 
     monkeypatch.setattr(
@@ -374,12 +374,12 @@ def test_batch_savepoints_keep_successes_and_return_restart_cursor(client, admin
         "refresh_player",
         lambda *args, **kwargs: {"cells": 0, "totals": 0},
     )
-    retry = client.post(f"{REBUILD_URL}?scope=all&batch_size=3&cursor=0", headers=admin_headers)
+    retry = client.post(f"{REBUILD_URL}?scope=player&player_api_id=262", headers=admin_headers)
     assert retry.status_code == 200
-    assert retry.get_json() == {"processed": 3, "remaining": 0, "cursor": None}
+    assert retry.get_json() == {"processed": 1, "failed": [], "remaining": 0, "cursor": None}
 
 
-def test_retry_cursor_carries_persistent_failure_past_later_pages(client, admin_headers, monkeypatch):
+def test_persistent_failure_is_reported_once_and_sweep_terminates(client, admin_headers, monkeypatch):
     for player in range(271, 276):
         _total(player)
     db.session.commit()
@@ -395,21 +395,23 @@ def test_retry_cursor_carries_persistent_failure_past_later_pages(client, admin_
 
     first = client.post(f"{REBUILD_URL}?scope=all&batch_size=2", headers=admin_headers)
     assert first.status_code == 200
-    assert first.get_json() == {"processed": 1, "remaining": 2, "cursor": "272:r1"}
+    assert first.get_json() == {"processed": 1, "failed": [271], "remaining": 1, "cursor": 272}
 
     second = client.post(
         f"{REBUILD_URL}?scope=all&batch_size=2&cursor={first.get_json()['cursor']}",
         headers=admin_headers,
     )
     assert second.status_code == 200
-    assert second.get_json() == {"processed": 2, "remaining": 2, "cursor": "274:r1"}
+    assert second.get_json() == {"processed": 2, "failed": [], "remaining": 1, "cursor": 274}
 
     third = client.post(
         f"{REBUILD_URL}?scope=all&batch_size=2&cursor={second.get_json()['cursor']}",
         headers=admin_headers,
     )
     assert third.status_code == 200
-    assert third.get_json() == {"processed": 1, "remaining": 1, "cursor": 0}
+    # Forward-only cursor: the poison row 271 does not rewind the sweep, which
+    # converges to a null cursor after one pass instead of looping forever.
+    assert third.get_json() == {"processed": 1, "failed": [], "remaining": 0, "cursor": None}
     assert calls == [271, 272, 273, 274, 275]
 
 
@@ -454,26 +456,26 @@ def test_stale_scope_uses_exact_source_clocks_and_converges(client, admin_header
     _apss(306, updated_at=NOW, minutes=0)
     db.session.commit()
 
-    assert _status(client, admin_headers)["stale_players"] == 4
+    assert _status(client, admin_headers, exact=True)["stale_players"] == 4
 
     first = client.post(f"{REBUILD_URL}?scope=stale&batch_size=2", headers=admin_headers)
     assert first.status_code == 200
-    assert first.get_json() == {"processed": 2, "remaining": 1, "cursor": 302}
+    assert first.get_json() == {"processed": 2, "failed": [], "remaining": 1, "cursor": 302}
 
     second = client.post(
         f"{REBUILD_URL}?scope=stale&batch_size=2&cursor={first.get_json()['cursor']}",
         headers=admin_headers,
     )
     assert second.status_code == 200
-    assert second.get_json() == {"processed": 1, "remaining": 1, "cursor": 304}
+    assert second.get_json() == {"processed": 1, "failed": [], "remaining": 1, "cursor": 304}
 
     third = client.post(
         f"{REBUILD_URL}?scope=stale&batch_size=2&cursor={second.get_json()['cursor']}",
         headers=admin_headers,
     )
     assert third.status_code == 200
-    assert third.get_json() == {"processed": 1, "remaining": 0, "cursor": None}
-    assert _status(client, admin_headers)["stale_players"] == 0
+    assert third.get_json() == {"processed": 1, "failed": [], "remaining": 0, "cursor": None}
+    assert _status(client, admin_headers, exact=True)["stale_players"] == 0
 
 
 def test_noise_stub_cannot_borrow_another_journey_level_cell(client, admin_headers):
@@ -510,7 +512,7 @@ def test_noise_stub_cannot_borrow_another_journey_level_cell(client, admin_heade
     assert built.status_code == 200
     assert PlayerSeasonTotal.query.filter_by(player_api_id=player, level_group="senior").count() == 1
     assert PlayerSeasonTotal.query.filter_by(player_api_id=player, level_group="youth").count() == 0
-    assert _status(client, admin_headers)["stale_players"] == 0
+    assert _status(client, admin_headers, exact=True)["stale_players"] == 0
 
 
 def test_fixture_source_without_fixture_cell_is_stale_even_if_other_total_exists(client, admin_headers):
@@ -530,22 +532,25 @@ def test_fixture_source_without_fixture_cell_is_stale_even_if_other_total_exists
     _total(player, level_group="senior", primary_source="shadow")
     db.session.commit()
 
-    assert _status(client, admin_headers)["stale_players"] == 1
+    assert _status(client, admin_headers, exact=True)["stale_players"] == 1
     rebuilt = client.post(f"{REBUILD_URL}?scope=stale", headers=admin_headers)
     assert rebuilt.status_code == 200
-    assert rebuilt.get_json() == {"processed": 1, "remaining": 0, "cursor": None}
+    assert rebuilt.get_json() == {"processed": 1, "failed": [], "remaining": 0, "cursor": None}
     assert PlayerSeasonCell.query.filter_by(player_api_id=player, source="fixtures").count() == 1
     assert PlayerSeasonTotal.query.filter_by(player_api_id=player, level_group="youth").count() == 1
-    assert _status(client, admin_headers)["stale_players"] == 0
+    assert _status(client, admin_headers, exact=True)["stale_players"] == 0
 
 
-def test_stale_cursor_wraps_to_zero_when_work_only_exists_below_it(client, admin_headers):
+def test_stale_cursor_above_all_work_terminates(client, admin_headers):
+    # A caller resuming with a cursor above every remaining id has, by the
+    # forward-only keyset contract, already scanned that work: the sweep
+    # terminates (cursor null) instead of rewinding to zero.
     _shadow(399, updated_at=NOW)
     db.session.commit()
 
     response = client.post(f"{REBUILD_URL}?scope=stale&cursor=999", headers=admin_headers)
     assert response.status_code == 200
-    assert response.get_json() == {"processed": 0, "remaining": 1, "cursor": 0}
+    assert response.get_json() == {"processed": 0, "failed": [], "remaining": 0, "cursor": None}
 
 
 def test_stale_scope_advances_bounded_scan_pages_that_contain_no_stale_players(client, admin_headers):
@@ -567,6 +572,7 @@ def test_stale_scope_advances_bounded_scan_pages_that_contain_no_stale_players(c
         assert response.status_code == 200
         assert response.get_json() == {
             "processed": 0,
+            "failed": [],
             "remaining": 1,
             "cursor": expected_cursor,
         }
@@ -577,7 +583,7 @@ def test_stale_scope_advances_bounded_scan_pages_that_contain_no_stale_players(c
         headers=admin_headers,
     )
     assert final.status_code == 200
-    assert final.get_json() == {"processed": 1, "remaining": 0, "cursor": None}
+    assert final.get_json() == {"processed": 1, "failed": [], "remaining": 0, "cursor": None}
 
 
 def test_stale_zeroed_source_removes_old_cells_then_converges(client, admin_headers):
@@ -593,14 +599,45 @@ def test_stale_zeroed_source_removes_old_cells_then_converges(client, admin_head
     row.goals = 0
     row.updated_at = computed_at + timedelta(microseconds=1)
     db.session.commit()
-    assert _status(client, admin_headers)["stale_players"] == 1
+    assert _status(client, admin_headers, exact=True)["stale_players"] == 1
 
     rebuilt = client.post(f"{REBUILD_URL}?scope=stale", headers=admin_headers)
     assert rebuilt.status_code == 200
-    assert rebuilt.get_json() == {"processed": 1, "remaining": 0, "cursor": None}
+    assert rebuilt.get_json() == {"processed": 1, "failed": [], "remaining": 0, "cursor": None}
     assert PlayerSeasonCell.query.filter_by(player_api_id=401, source="apss").count() == 0
     assert PlayerSeasonTotal.query.filter_by(player_api_id=401, level_group="youth").count() == 0
-    assert _status(client, admin_headers)["stale_players"] == 0
+    assert _status(client, admin_headers, exact=True)["stale_players"] == 0
+
+
+def test_default_status_gauge_skips_exact_stale_enumeration(client, admin_headers, monkeypatch):
+    # A source newer than its total is stale, but the default gauge must decide
+    # ``behind`` from cheap MAX clocks without running the exact enumeration.
+    _shadow(600, updated_at=NOW)
+    _total(600, computed_at=NOW - timedelta(days=1))
+    db.session.commit()
+
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("default /status must not run the exact stale enumeration")
+
+    monkeypatch.setattr(admin_routes, "_stale_player_ids", _boom)
+    body = _status(client, admin_headers)
+    assert body["behind"] is True
+    assert "stale_players" not in body
+
+
+def test_status_exact_flag_reports_stale_player_count(client, admin_headers):
+    _shadow(601, updated_at=NOW)
+    _total(601, computed_at=NOW - timedelta(days=1))  # stale: source newer
+    _shadow(602, updated_at=NOW - timedelta(days=2))
+    _total(602, computed_at=NOW - timedelta(days=1))  # fresh: total newer
+    db.session.commit()
+
+    default_body = _status(client, admin_headers)
+    assert default_body["behind"] is True
+    assert "stale_players" not in default_body
+
+    exact_body = _status(client, admin_headers, exact=True)
+    assert exact_body["stale_players"] == 1
 
 
 def test_status_returns_totals_freshness_and_source_cell_counts(client, admin_headers):
@@ -615,19 +652,26 @@ def test_status_returns_totals_freshness_and_source_cell_counts(client, admin_he
     _cell(502, source="journey", club=3, level_group="youth", synced_at=old)
     db.session.commit()
 
+    # Default gauge is cheap: newest source clock (shadow NOW) is not later than
+    # the newest computed_at (502 senior NOW), so the coarse gauge reads caught up.
     body = _status(client, admin_headers)
     assert body == {
         "total_totals_rows": 3,
-        "stale_players": 1,
+        "behind": False,
         "last_computed_at": NOW.replace(tzinfo=None).isoformat(),
+        "last_source_change_at": NOW.replace(tzinfo=None).isoformat(),
         "by_source_cells": {"fixtures": 2, "journey": 1},
     }
+    # The exact reconciliation count still sees 501 (shadow NOW > its total middle).
+    assert _status(client, admin_headers, exact=True)["stale_players"] == 1
 
 
 def test_empty_status_is_zeroed(client, admin_headers):
     assert _status(client, admin_headers) == {
         "total_totals_rows": 0,
-        "stale_players": 0,
+        "behind": False,
         "last_computed_at": None,
+        "last_source_change_at": None,
         "by_source_cells": {},
     }
+    assert _status(client, admin_headers, exact=True)["stale_players"] == 0

--- a/academy-watch-backend/tests/test_season_rollup_sea02.py
+++ b/academy-watch-backend/tests/test_season_rollup_sea02.py
@@ -1,0 +1,226 @@
+"""sea02 migration replay and partial-application safety pins."""
+
+import importlib
+from collections import Counter
+from contextlib import contextmanager
+
+import pytest
+import sqlalchemy as sa
+from alembic import op as alembic_op
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from src.models.season_rollup import LeagueSeasonConfig, PlayerSeasonCell, PlayerSeasonTotal
+
+_TABLE_COLUMNS = {
+    "player_season_cells": {
+        "id",
+        "player_api_id",
+        "season",
+        "source",
+        "club_api_id",
+        "club_name",
+        "competition_tier",
+        "level_group",
+        "appearances",
+        "goals",
+        "assists",
+        "minutes",
+        "yellows",
+        "reds",
+        "saves",
+        "goals_conceded",
+        "avg_rating",
+        "detail",
+        "synced_at",
+    },
+    "player_season_totals": {
+        "id",
+        "player_api_id",
+        "season",
+        "level_group",
+        "appearances",
+        "goals",
+        "assists",
+        "minutes",
+        "yellows",
+        "reds",
+        "saves",
+        "goals_conceded",
+        "avg_rating",
+        "primary_source",
+        "fixtures_minutes",
+        "journey_minutes",
+        "reconcile_flag",
+        "source_breakdown",
+        "clubs",
+        "computed_at",
+    },
+    "league_season_config": {"league_api_id", "season_type", "rollover_month"},
+}
+_INDEXES = {
+    "player_season_cells": {"ix_psc_player_season"},
+    "player_season_totals": {"ix_pst_season_group", "ix_pst_player"},
+}
+_UNIQUE_CONSTRAINTS = {
+    "player_season_cells": "uq_psc_player_season_source_club_tier",
+    "player_season_totals": "uq_pst_player_season_group",
+}
+_RLS_STATEMENTS = {
+    "ALTER TABLE player_season_cells ENABLE ROW LEVEL SECURITY",
+    "ALTER TABLE player_season_totals ENABLE ROW LEVEL SECURITY",
+    "ALTER TABLE league_season_config ENABLE ROW LEVEL SECURITY",
+}
+_CALENDAR_SEEDS = [
+    (71, "calendar", 1),
+    (98, "calendar", 1),
+    (128, "calendar", 1),
+    (253, "calendar", 1),
+    (262, "calendar", 1),
+]
+
+
+@contextmanager
+def _alembic_ops(engine):
+    """Bind Alembic's operation proxy to a disposable SQLite engine."""
+    conn = engine.connect()
+    trans = conn.begin()
+    context = MigrationContext.configure(conn)
+    operations = Operations(context)
+    original = getattr(alembic_op, "_proxy", None)
+    alembic_op._proxy = operations
+    try:
+        yield
+        trans.commit()
+    finally:
+        alembic_op._proxy = original
+        conn.close()
+
+
+def _sqlite_table_exists(name):
+    return name in sa.inspect(alembic_op.get_bind()).get_table_names()
+
+
+def _sqlite_index_exists(name):
+    inspector = sa.inspect(alembic_op.get_bind())
+    return any(
+        name in {index["name"] for index in inspector.get_indexes(table)} for table in inspector.get_table_names()
+    )
+
+
+def _sqlite_create_index_safe(name, table, columns, **kwargs):
+    if not _sqlite_index_exists(name):
+        alembic_op.create_index(name, table, columns, **kwargs)
+
+
+@pytest.fixture
+def engine():
+    database = sa.create_engine("sqlite:///:memory:")
+    try:
+        yield database
+    finally:
+        database.dispose()
+
+
+@pytest.fixture
+def sea02(monkeypatch):
+    """Run PostgreSQL migration control flow against SQLite and capture RLS."""
+    module = importlib.import_module("migrations.versions.sea02_season_rollup_tables")
+    rls_statements = []
+
+    monkeypatch.setattr(module, "table_exists", _sqlite_table_exists)
+    monkeypatch.setattr(module, "index_exists", _sqlite_index_exists)
+    monkeypatch.setattr(module, "create_index_safe", _sqlite_create_index_safe)
+
+    def _execute(statement):
+        sql = str(statement).strip()
+        if sql.startswith("ALTER TABLE ") and sql.endswith(" ENABLE ROW LEVEL SECURITY"):
+            rls_statements.append(sql)
+            return None
+        return alembic_op.get_bind().execute(sa.text(sql))
+
+    monkeypatch.setattr(module.op, "execute", _execute)
+    return module, rls_statements
+
+
+def _assert_contract(database):
+    inspector = sa.inspect(database)
+    assert set(inspector.get_table_names()) == set(_TABLE_COLUMNS)
+    for table, expected_columns in _TABLE_COLUMNS.items():
+        assert {column["name"] for column in inspector.get_columns(table)} == expected_columns
+    for table, expected_indexes in _INDEXES.items():
+        index_names = [index["name"] for index in inspector.get_indexes(table)]
+        assert set(index_names) == expected_indexes
+        assert all(index_names.count(name) == 1 for name in expected_indexes)
+    for table, expected_name in _UNIQUE_CONSTRAINTS.items():
+        names = {constraint["name"] for constraint in inspector.get_unique_constraints(table)}
+        assert expected_name in names
+
+
+def _config_rows(database):
+    with database.connect() as conn:
+        return [
+            tuple(row)
+            for row in conn.execute(
+                sa.text(
+                    "SELECT league_api_id, season_type, rollover_month FROM league_season_config ORDER BY league_api_id"
+                )
+            )
+        ]
+
+
+def test_sea02_upgrade_twice_is_idempotent(engine, sea02):
+    module, rls_statements = sea02
+
+    with _alembic_ops(engine):
+        module.upgrade()
+    with _alembic_ops(engine):
+        module.upgrade()
+
+    _assert_contract(engine)
+    assert _config_rows(engine) == _CALENDAR_SEEDS
+    assert Counter(rls_statements) == Counter({statement: 2 for statement in _RLS_STATEMENTS})
+
+
+def test_sea02_upgrade_completes_partial_application_without_clobbering(engine, sea02):
+    """Existing tables/indexes/data survive while missing statements complete."""
+    PlayerSeasonCell.__table__.create(engine)
+    PlayerSeasonTotal.__table__.create(engine)
+    LeagueSeasonConfig.__table__.create(engine)
+    with engine.begin() as conn:
+        conn.execute(sa.text("DROP INDEX ix_pst_player"))
+        conn.execute(
+            sa.text(
+                "INSERT INTO player_season_cells "
+                "(id, player_api_id, season, source, club_api_id, competition_tier, level_group, minutes, synced_at) "
+                "VALUES (900, 303010, 2025, 'fixtures', 73, 'league', 'senior', 2941, '2026-07-15')"
+            )
+        )
+        conn.execute(
+            sa.text(
+                "INSERT INTO player_season_totals "
+                "(id, player_api_id, season, level_group, minutes, primary_source, computed_at) "
+                "VALUES (901, 303010, 2025, 'senior', 2941, 'fixtures', '2026-07-15')"
+            )
+        )
+        conn.execute(
+            sa.text(
+                "INSERT INTO league_season_config (league_api_id, season_type, rollover_month) VALUES (71, 'custom', 9)"
+            )
+        )
+
+    module, rls_statements = sea02
+    with _alembic_ops(engine):
+        module.upgrade()
+
+    _assert_contract(engine)
+    with engine.connect() as conn:
+        assert conn.execute(sa.text("SELECT minutes FROM player_season_cells WHERE id = 900")).scalar_one() == 2941
+        assert conn.execute(sa.text("SELECT minutes FROM player_season_totals WHERE id = 901")).scalar_one() == 2941
+    assert _config_rows(engine) == [
+        (71, "custom", 9),
+        (98, "calendar", 1),
+        (128, "calendar", 1),
+        (253, "calendar", 1),
+        (262, "calendar", 1),
+    ]
+    assert Counter(rls_statements) == Counter(_RLS_STATEMENTS)

--- a/academy-watch-backend/tests/test_season_rollup_sea02.py
+++ b/academy-watch-backend/tests/test_season_rollup_sea02.py
@@ -58,7 +58,7 @@ _TABLE_COLUMNS = {
     "league_season_config": {"league_api_id", "season_type", "rollover_month"},
 }
 _INDEXES = {
-    "player_season_cells": {"ix_psc_player_season"},
+    "player_season_cells": {"ix_psc_player_season", "ix_psc_synced_at"},
     "player_season_totals": {"ix_pst_season_group", "ix_pst_player"},
 }
 _UNIQUE_CONSTRAINTS = {

--- a/academy-watch-backend/tests/test_season_rollup_service.py
+++ b/academy-watch-backend/tests/test_season_rollup_service.py
@@ -355,6 +355,79 @@ def test_journey_hook_savepoint_rollback_preserves_journey(app, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# youth-fixture level_group (regression: youth-team FPS must not read senior)
+# ---------------------------------------------------------------------------
+def test_youth_fixture_folds_into_youth_level_group(app):
+    """A youth-team FPS row (academy sync path, e.g. 'Premier League 2') folds
+    into the youth level_group, never senior — a pure academy kid must not rank
+    on the senior Scout list on U21 minutes (proposal §6 Q10)."""
+    player = 606
+    senior_fx = _fixture(30, 2025, comp="Championship")
+    youth_fx = _fixture(31, 2025, comp="Premier League 2 Division One")
+    _fps(senior_fx, player, 100, minutes=900, goals=2, rating=7.0)
+    _fps(youth_fx, player, 101, minutes=800, goals=5, rating=8.0)
+    db.session.commit()
+
+    svc.refresh_player(player, season=2025)
+    db.session.commit()
+
+    groups = {t.level_group: t for t in PlayerSeasonTotal.query.filter_by(player_api_id=player).all()}
+    assert set(groups) == {"senior", "youth"}
+    assert groups["senior"].minutes == 900
+    assert groups["senior"].primary_source == "fixtures"
+    assert groups["youth"].minutes == 800
+    assert groups["youth"].primary_source == "fixtures"
+    youth_cells = PlayerSeasonCell.query.filter_by(player_api_id=player, level_group="youth").all()
+    assert youth_cells and all(c.competition_tier == "youth" for c in youth_cells)
+
+
+def test_youth_competition_classifier():
+    assert svc._is_youth_competition("Premier League 2 Division One") is True
+    assert svc._is_youth_competition("U18 Premier League - North") is True
+    assert svc._is_youth_competition("UEFA Youth League") is True
+    assert svc._is_youth_competition("Premier League") is False
+    assert svc._is_youth_competition("Championship") is False
+    assert svc._is_youth_competition(None) is False
+    assert svc._fixture_level_and_tier("Premier League 2 Division One") == ("youth", "youth")
+    assert svc._fixture_level_and_tier("Premier League") == ("senior", "league")
+
+
+# ---------------------------------------------------------------------------
+# journey feeder robustness (regression: NULL denormalized player_api_id)
+# ---------------------------------------------------------------------------
+def test_journey_feeder_reads_via_journey_join_when_denorm_null(app):
+    """PJE rows with a NULL denormalized player_api_id (every ~77k legacy row
+    pre-sea01-backfill) still feed the rollup, resolved through the parent
+    journey — otherwise a pre-backfill refresh silently drops the journey source
+    and the Gore anchor would not hold in prod."""
+    player = 707
+    j = _journey(player)
+    db.session.add(
+        PlayerJourneyEntry(
+            journey_id=j.id,
+            player_api_id=None,  # legacy row: denormalized column unset
+            season=2025,
+            club_api_id=808,
+            club_name="Legacy FC",
+            league_name="Championship",
+            minutes=1800,
+            goals=4,
+            appearances=20,
+            stats_source="legacy-basic",
+        )
+    )
+    db.session.commit()
+
+    svc.refresh_player(player, season=2025)
+    db.session.commit()
+
+    total = PlayerSeasonTotal.query.filter_by(player_api_id=player, level_group="senior").one()
+    assert total.primary_source == "journey"
+    assert total.minutes == 1800
+    assert total.journey_minutes == 1800
+
+
+# ---------------------------------------------------------------------------
 # tier classifier
 # ---------------------------------------------------------------------------
 def test_competition_tier_classifier():

--- a/academy-watch-backend/tests/test_season_rollup_service.py
+++ b/academy-watch-backend/tests/test_season_rollup_service.py
@@ -390,6 +390,35 @@ def test_choke_flush_commits(app):
     assert PlayerSeasonTotal.query.filter_by(player_api_id=player).count() == 1
 
 
+def test_choke_flush_requeues_failed_pair_for_retry(app, monkeypatch):
+    player = 1004
+    journey = _journey(player)
+    _entry(journey, player, 2025, 100, minutes=600, goals=1)
+    db.session.commit()
+
+    real_refresh = svc.refresh_player
+    calls = []
+
+    def _fail_once(player_api_id, season=None, session=None):
+        calls.append((player_api_id, season))
+        if len(calls) == 1:
+            raise RuntimeError("transient rollup failure")
+        return real_refresh(player_api_id, season=season, session=session)
+
+    monkeypatch.setattr(svc, "refresh_player", _fail_once)
+    svc.queue_player_refresh(player, 2025)
+
+    assert svc.flush_player_refresh_queue() == 0
+    assert db.session.info[svc._DIRTY_KEY] == {(player, 2025)}
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=player).count() == 0
+
+    assert svc.flush_player_refresh_queue() == 1
+    assert not db.session.info[svc._DIRTY_KEY]
+    total = PlayerSeasonTotal.query.filter_by(player_api_id=player, season=2025).one()
+    assert total.minutes == 600
+    assert calls == [(player, 2025), (player, 2025)]
+
+
 # ---------------------------------------------------------------------------
 # real producer hooks + journey savepoint mechanics
 # ---------------------------------------------------------------------------

--- a/academy-watch-backend/tests/test_season_rollup_service.py
+++ b/academy-watch-backend/tests/test_season_rollup_service.py
@@ -1,0 +1,365 @@
+"""D3b season-rollup service — feeders, totals resolution, choke point.
+
+The anchor test (proposal §2, gates everything): Gore-shaped player, season 2025
+senior → minutes = the journey figure taken whole, primary_source=journey,
+fixtures_minutes < journey_minutes, reconcile_flag='cup-gap', avg_rating
+fixtures-sourced. Plus the other coverage-map buckets, level_group split, the
+noise filter, refresh idempotency/transactionality, and choke-point batching.
+"""
+
+import pytest
+from flask import Flask
+
+# Importing the service at module top registers every model it touches (journey,
+# weekly, follow.PlayerShadowStats, league.AcademyPlayerSeasonStats, season_rollup)
+# into db.metadata BEFORE the app fixture's create_all() runs.
+from src.models.follow import PlayerShadowStats
+from src.models.journey import PlayerJourney, PlayerJourneyEntry
+from src.models.league import AcademyPlayerSeasonStats, db
+from src.models.season_rollup import PlayerSeasonCell, PlayerSeasonTotal
+from src.models.weekly import Fixture, FixturePlayerStats
+from src.services import season_rollup_service as svc
+
+
+@pytest.fixture
+def app():
+    flask_app = Flask(__name__)
+    flask_app.config.update(
+        TESTING=True,
+        SECRET_KEY="test-secret",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+    db.init_app(flask_app)
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+        db.drop_all()
+
+
+# ---------------------------------------------------------------------------
+# builders
+# ---------------------------------------------------------------------------
+def _fixture(fid, season, comp="Premier League"):
+    fx = Fixture(fixture_id_api=fid, season=season, competition_name=comp)
+    db.session.add(fx)
+    db.session.flush()
+    return fx
+
+
+def _fps(fx, player, team, minutes, goals=0, assists=0, rating=None, saves=None, gc=None, yellows=0):
+    db.session.add(
+        FixturePlayerStats(
+            fixture_id=fx.id,
+            player_api_id=player,
+            team_api_id=team,
+            minutes=minutes,
+            goals=goals,
+            assists=assists,
+            rating=rating,
+            saves=saves,
+            goals_conceded=gc,
+            yellows=yellows,
+        )
+    )
+
+
+def _journey(player, name="Gore"):
+    j = PlayerJourney(player_api_id=player, player_name=name)
+    db.session.add(j)
+    db.session.flush()
+    return j
+
+
+def _entry(j, player, season, club, minutes, goals=0, assists=0, apps=0, **kw):
+    e = PlayerJourneyEntry(
+        journey_id=j.id,
+        player_api_id=player,
+        season=season,
+        club_api_id=club,
+        club_name=kw.get("club_name", f"Club{club}"),
+        league_name=kw.get("league_name", "Championship"),
+        minutes=minutes,
+        goals=goals,
+        assists=assists,
+        appearances=apps,
+        is_youth=kw.get("is_youth", False),
+        is_international=kw.get("is_international", False),
+        stats_source=kw.get("stats_source", "legacy-basic"),
+    )
+    db.session.add(e)
+    return e
+
+
+# ---------------------------------------------------------------------------
+# anchor + coverage buckets
+# ---------------------------------------------------------------------------
+def test_gore_anchor_cup_gap(app):
+    """fixtures 2583 < journey 2936 → headline journey 2936, flag cup-gap."""
+    player = 303010
+    fx1 = _fixture(1, 2025)
+    fx2 = _fixture(2, 2025)
+    _fps(fx1, player, 100, minutes=1290, goals=5, rating=7.0)
+    _fps(fx2, player, 100, minutes=1293, goals=6, rating=8.0)  # fixtures = 2583 min
+    j = _journey(player)
+    _entry(j, player, 2025, 100, minutes=1468, goals=6, apps=17)
+    _entry(j, player, 2025, 100, minutes=1468, goals=6, apps=17, league_name="FA Cup")  # journey = 2936
+    db.session.commit()
+
+    svc.refresh_player(player, season=2025)
+    db.session.commit()
+
+    total = PlayerSeasonTotal.query.filter_by(player_api_id=player, season=2025, level_group="senior").one()
+    assert total.minutes == 2936
+    assert total.primary_source == "journey"
+    assert total.fixtures_minutes == 2583
+    assert total.journey_minutes == 2936
+    assert total.reconcile_flag == "cup-gap"
+    # avg_rating ALWAYS fixtures-sourced (minutes-weighted 7.0/8.0).
+    assert total.avg_rating is not None
+    assert abs(float(total.avg_rating) - (7.0 * 1290 + 8.0 * 1293) / 2583) < 0.01
+    # both sources visible in the breakdown; headline never a cross-source sum.
+    assert set(total.source_breakdown) == {"fixtures", "journey"}
+
+
+def test_fixtures_invisible(app):
+    player = 555
+    j = _journey(player)
+    _entry(j, player, 2025, 200, minutes=1500, goals=3)
+    db.session.commit()
+    svc.refresh_player(player, season=2025)
+    db.session.commit()
+
+    total = PlayerSeasonTotal.query.filter_by(player_api_id=player, level_group="senior").one()
+    assert total.primary_source == "journey"
+    assert total.minutes == 1500
+    assert total.fixtures_minutes == 0
+    assert total.reconcile_flag == "fixtures-invisible"
+    assert total.avg_rating is None  # no fixtures
+
+
+def test_journey_under_sync(app):
+    """fixtures strictly larger → headline fixtures, flag journey-under-sync."""
+    player = 777
+    fx = _fixture(10, 2025)
+    _fps(fx, player, 300, minutes=2000, goals=4, rating=7.5)
+    j = _journey(player)
+    _entry(j, player, 2025, 300, minutes=1500, goals=3)
+    db.session.commit()
+    svc.refresh_player(player, season=2025)
+    db.session.commit()
+
+    total = PlayerSeasonTotal.query.filter_by(player_api_id=player, level_group="senior").one()
+    assert total.primary_source == "fixtures"
+    assert total.minutes == 2000
+    assert total.fixtures_minutes == 2000
+    assert total.journey_minutes == 1500
+    assert total.reconcile_flag == "journey-under-sync"
+
+
+def test_level_group_split(app):
+    """youth + senior + international journey entries → three totals rows."""
+    player = 888
+    j = _journey(player)
+    _entry(j, player, 2025, 400, minutes=1200, goals=2)  # senior
+    _entry(j, player, 2025, 401, minutes=800, goals=1, is_youth=True, league_name="U21 Premier League")
+    _entry(j, player, 2025, 402, minutes=270, goals=1, is_international=True, league_name="Euro U21")
+    db.session.commit()
+    svc.refresh_player(player, season=2025)
+    db.session.commit()
+
+    groups = {t.level_group: t for t in PlayerSeasonTotal.query.filter_by(player_api_id=player).all()}
+    assert set(groups) == {"senior", "youth", "international"}
+    assert groups["senior"].minutes == 1200
+    assert groups["youth"].minutes == 800
+    assert groups["international"].minutes == 270
+
+
+def test_youth_apss_and_shadow_sources(app):
+    """APSS feeds youth; shadow feeds senior; both appear in source_breakdown."""
+    player = 999
+    db.session.add(
+        AcademyPlayerSeasonStats(
+            player_api_id=player,
+            league_api_id=1,
+            season=2025,
+            team_api_id=500,
+            team_name="Academy",
+            appearances=10,
+            minutes=850,
+            goals=4,
+            rating=7.2,
+        )
+    )
+    db.session.add(
+        PlayerShadowStats(
+            player_api_id=player, team_api_id=600, team_name="Shadow FC", season=2025, minutes=900, goals=2
+        )
+    )
+    db.session.commit()
+    svc.refresh_player(player, season=2025)
+    db.session.commit()
+
+    youth = PlayerSeasonTotal.query.filter_by(player_api_id=player, level_group="youth").one()
+    assert youth.primary_source == "apss"
+    assert youth.minutes == 850
+    senior = PlayerSeasonTotal.query.filter_by(player_api_id=player, level_group="senior").one()
+    assert senior.primary_source == "shadow"
+    assert senior.minutes == 900
+
+
+def test_noise_filter_skips_empty_stub(app):
+    """0 apps AND 0 min AND 0 goals produces no cell and no total (the 740 stubs)."""
+    player = 111
+    j = _journey(player)
+    _entry(j, player, 2026, 700, minutes=0, goals=0, apps=0)  # pre-season stub
+    _entry(j, player, 2025, 700, minutes=900, goals=2, apps=12)  # real
+    db.session.commit()
+    svc.refresh_player(player)  # season=None → all seasons
+    db.session.commit()
+
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=player, season=2026).count() == 0
+    assert PlayerSeasonCell.query.filter_by(player_api_id=player, season=2026).count() == 0
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=player, season=2025).count() == 1
+
+
+def test_refresh_is_idempotent(app):
+    player = 222
+    fx = _fixture(20, 2025)
+    _fps(fx, player, 800, minutes=90, goals=1, rating=7.0)
+    j = _journey(player)
+    _entry(j, player, 2025, 800, minutes=95, goals=1)
+    db.session.commit()
+
+    svc.refresh_player(player, season=2025)
+    db.session.commit()
+    svc.refresh_player(player, season=2025)
+    db.session.commit()
+
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=player, season=2025).count() == 1
+    # one journey cell + one fixtures cell, not duplicated
+    assert PlayerSeasonCell.query.filter_by(player_api_id=player, season=2025).count() == 2
+
+
+def test_refresh_participates_in_caller_transaction(app):
+    """refresh_player does not commit — a caller rollback discards the rollup."""
+    player = 333
+    j = _journey(player)
+    _entry(j, player, 2025, 900, minutes=500, goals=1)
+    db.session.commit()
+
+    svc.refresh_player(player, season=2025)
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=player).count() == 1  # visible pre-commit
+    db.session.rollback()
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=player).count() == 0  # rolled back
+
+
+def test_season_scoped_refresh_leaves_other_seasons(app):
+    player = 444
+    j = _journey(player)
+    _entry(j, player, 2024, 100, minutes=1000, goals=2)
+    _entry(j, player, 2025, 100, minutes=1100, goals=3)
+    db.session.commit()
+    svc.refresh_player(player)  # build both
+    db.session.commit()
+
+    # Re-refresh only 2025 — 2024 totals must remain untouched.
+    svc.refresh_player(player, season=2025)
+    db.session.commit()
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=player, season=2024).count() == 1
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=player, season=2025).count() == 1
+
+
+# ---------------------------------------------------------------------------
+# choke point
+# ---------------------------------------------------------------------------
+def test_choke_queue_dedups_and_batches(app):
+    """Enqueue same (player, season) 3× → one refresh; batch of 2 players → one flush."""
+    p1, p2 = 1001, 1002
+    for p in (p1, p2):
+        j = _journey(p)
+        _entry(j, p, 2025, 100, minutes=800, goals=1)
+    db.session.commit()
+
+    svc.queue_player_refresh(p1, 2025)
+    svc.queue_player_refresh(p1, 2025)
+    svc.queue_player_refresh(p1, 2025)
+    svc.queue_player_refresh(p2, 2025)
+    assert db.session.info[svc._DIRTY_KEY] == {(p1, 2025), (p2, 2025)}
+
+    refreshed = svc.flush_player_refresh_queue()
+    assert refreshed == 2
+    assert not db.session.info[svc._DIRTY_KEY]  # drained
+    assert PlayerSeasonTotal.query.filter_by(season=2025).count() == 2
+
+
+def test_flush_empty_queue_is_noop(app):
+    assert svc.flush_player_refresh_queue() == 0
+
+
+def test_choke_flush_commits(app):
+    """flush owns its own commit — rollup persists without a caller commit."""
+    player = 1003
+    j = _journey(player)
+    _entry(j, player, 2025, 100, minutes=700, goals=1)
+    db.session.commit()
+
+    svc.queue_player_refresh(player, 2025)
+    svc.flush_player_refresh_queue()
+    db.session.remove()  # brand-new session; only committed rows survive
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=player).count() == 1
+
+
+# ---------------------------------------------------------------------------
+# journey hook mechanics (savepoint-wrapped refresh, same transaction)
+# ---------------------------------------------------------------------------
+def test_journey_hook_savepoint_atomic(app):
+    """Mirror JourneySyncService.sync_player's hook: flush entries, refresh
+    inside a SAVEPOINT, then ONE outer commit persists journey + rollup."""
+    player = 2001
+    j = _journey(player)
+    _entry(j, player, 2025, 100, minutes=1000, goals=2)
+    db.session.flush()
+    with db.session.begin_nested():
+        svc.refresh_player(player, season=2025, session=db.session)
+    db.session.commit()
+
+    db.session.remove()  # fresh session — only committed rows survive
+    assert PlayerJourneyEntry.query.filter_by(player_api_id=player).count() == 1
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=player, season=2025).count() == 1
+
+
+def test_journey_hook_savepoint_rollback_preserves_journey(app, monkeypatch):
+    """A refresh failure rolls back ONLY the derived rows (savepoint); the
+    API-expensive journey write still commits."""
+    player = 2002
+    j = _journey(player)
+    _entry(j, player, 2025, 100, minutes=1000, goals=2)
+    db.session.flush()
+
+    def _boom(*a, **k):
+        raise RuntimeError("simulated rollup failure")
+
+    monkeypatch.setattr(svc, "refresh_player", _boom)
+    try:
+        with db.session.begin_nested():
+            svc.refresh_player(player, season=2025, session=db.session)
+    except RuntimeError:
+        pass  # exactly what sync_player's try/except does
+    db.session.commit()
+
+    db.session.remove()
+    assert PlayerJourneyEntry.query.filter_by(player_api_id=player).count() == 1  # journey survived
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=player).count() == 0  # rollup rolled back
+
+
+# ---------------------------------------------------------------------------
+# tier classifier
+# ---------------------------------------------------------------------------
+def test_competition_tier_classifier():
+    assert svc.classify_competition_tier("Premier League") == "league"
+    assert svc.classify_competition_tier("FA Cup") == "domestic_cup"
+    assert svc.classify_competition_tier("Carabao Cup") == "league_cup"
+    assert svc.classify_competition_tier("UEFA Champions League") == "continental"
+    assert svc.classify_competition_tier(None) == "league"

--- a/academy-watch-backend/tests/test_season_rollup_service.py
+++ b/academy-watch-backend/tests/test_season_rollup_service.py
@@ -1,10 +1,10 @@
 """D3b season-rollup service — feeders, totals resolution, choke point.
 
-The anchor test (proposal §2, gates everything): Gore-shaped player, season 2025
-senior → minutes = the journey figure taken whole, primary_source=journey,
-fixtures_minutes < journey_minutes, reconcile_flag='cup-gap', avg_rating
-fixtures-sourced. Plus the other coverage-map buckets, level_group split, the
-noise filter, refresh idempotency/transactionality, and choke-point batching.
+The anchor test (proposal §2, gates everything): a Gore-shaped player flips
+from a 2,941-minute fixtures headline to a 3,000-minute journey headline as the
+journey source catches up, while cells stay source-separated and ``avg_rating``
+stays fixtures-only. Plus the other coverage-map buckets, level_group split,
+the noise filter, refresh idempotency/transactionality, and real sync hooks.
 """
 
 import pytest
@@ -87,6 +87,7 @@ def _entry(j, player, season, club, minutes, goals=0, assists=0, apps=0, **kw):
         is_youth=kw.get("is_youth", False),
         is_international=kw.get("is_international", False),
         stats_source=kw.get("stats_source", "legacy-basic"),
+        rating=kw.get("rating"),
     )
     db.session.add(e)
     return e
@@ -95,38 +96,114 @@ def _entry(j, player, season, club, minutes, goals=0, assists=0, apps=0, **kw):
 # ---------------------------------------------------------------------------
 # anchor + coverage buckets
 # ---------------------------------------------------------------------------
-def test_gore_anchor_cup_gap(app):
-    """fixtures 2583 < journey 2936 → headline journey 2936, flag cup-gap."""
+def test_gore_shaped_anchor_flips_whole_source_on_refresh(app):
+    """Rotherham league+cup cells stay separate while the headline flips whole."""
     player = 303010
-    fx1 = _fixture(1, 2025)
-    fx2 = _fixture(2, 2025)
-    _fps(fx1, player, 100, minutes=1290, goals=5, rating=7.0)
-    _fps(fx2, player, 100, minutes=1293, goals=6, rating=8.0)  # fixtures = 2583 min
+    club = 73
+    league_fx = _fixture(1, 2025, comp="Championship")
+    cup_fx = _fixture(2, 2025, comp="FA Cup")
+    _fps(league_fx, player, club, minutes=2500, goals=5, assists=4, rating=7.0)
+    _fps(cup_fx, player, club, minutes=441, goals=1, assists=1, rating=8.0)
     j = _journey(player)
-    _entry(j, player, 2025, 100, minutes=1468, goals=6, apps=17)
-    _entry(j, player, 2025, 100, minutes=1468, goals=6, apps=17, league_name="FA Cup")  # journey = 2936
+    _entry(
+        j,
+        player,
+        2025,
+        club,
+        minutes=2500,
+        goals=7,
+        assists=6,
+        apps=30,
+        club_name="Rotherham United",
+        stats_source="journey-api",
+        rating=9.0,
+    )
+    journey_cup = _entry(
+        j,
+        player,
+        2025,
+        club,
+        minutes=436,
+        goals=2,
+        assists=1,
+        apps=4,
+        club_name="Rotherham United",
+        league_name="FA Cup",
+        stats_source="journey-api",
+        rating=10.0,
+    )
     db.session.commit()
 
     svc.refresh_player(player, season=2025)
     db.session.commit()
 
+    cells = {
+        (cell.source, cell.competition_tier): cell
+        for cell in PlayerSeasonCell.query.filter_by(player_api_id=player, season=2025).all()
+    }
+    assert set(cells) == {
+        ("fixtures", "league"),
+        ("fixtures", "domestic_cup"),
+        ("journey", "league"),
+        ("journey", "domestic_cup"),
+    }
+    assert {key: cell.minutes for key, cell in cells.items()} == {
+        ("fixtures", "league"): 2500,
+        ("fixtures", "domestic_cup"): 441,
+        ("journey", "league"): 2500,
+        ("journey", "domestic_cup"): 436,
+    }
+    assert all(cell.club_api_id == club for cell in cells.values())
+
     total = PlayerSeasonTotal.query.filter_by(player_api_id=player, season=2025, level_group="senior").one()
-    assert total.minutes == 2936
-    assert total.primary_source == "journey"
-    assert total.fixtures_minutes == 2583
+    assert (total.primary_source, total.minutes, total.reconcile_flag) == (
+        "fixtures",
+        2941,
+        "journey-under-sync",
+    )
+    assert (total.appearances, total.goals, total.assists) == (2, 6, 5)
+    assert total.fixtures_minutes == 2941
     assert total.journey_minutes == 2936
-    assert total.reconcile_flag == "cup-gap"
-    # avg_rating ALWAYS fixtures-sourced (minutes-weighted 7.0/8.0).
-    assert total.avg_rating is not None
-    assert abs(float(total.avg_rating) - (7.0 * 1290 + 8.0 * 1293) / 2583) < 0.01
-    # both sources visible in the breakdown; headline never a cross-source sum.
-    assert set(total.source_breakdown) == {"fixtures", "journey"}
+    assert total.source_breakdown["fixtures"]["minutes"] == 2941
+    assert total.source_breakdown["journey"]["minutes"] == 2936
+    expected_fixture_rating = (7.0 * 2500 + 8.0 * 441) / 2941
+    assert float(total.avg_rating) == pytest.approx(expected_fixture_rating, abs=0.01)
+
+    # Journey catches up: refreshing must replace its cup cell and flip every
+    # headline stat to the journey subtotal, never add the two sources.
+    journey_cup.minutes = 500
+    db.session.commit()
+    db.session.expunge_all()
+    svc.refresh_player(player, season=2025)
+    db.session.commit()
+
+    refreshed_cells = {
+        (cell.source, cell.competition_tier): cell
+        for cell in PlayerSeasonCell.query.filter_by(player_api_id=player, season=2025).all()
+    }
+    assert len(refreshed_cells) == 4
+    assert refreshed_cells[("fixtures", "league")].minutes == 2500
+    assert refreshed_cells[("fixtures", "domestic_cup")].minutes == 441
+    assert refreshed_cells[("journey", "league")].minutes == 2500
+    assert refreshed_cells[("journey", "domestic_cup")].minutes == 500
+
+    refreshed = PlayerSeasonTotal.query.filter_by(player_api_id=player, season=2025, level_group="senior").one()
+    assert (refreshed.primary_source, refreshed.minutes, refreshed.reconcile_flag) == (
+        "journey",
+        3000,
+        "cup-gap",
+    )
+    assert (refreshed.appearances, refreshed.goals, refreshed.assists) == (34, 9, 7)
+    assert (refreshed.fixtures_minutes, refreshed.journey_minutes) == (2941, 3000)
+    assert refreshed.source_breakdown["fixtures"]["minutes"] == 2941
+    assert refreshed.source_breakdown["journey"]["minutes"] == 3000
+    assert float(refreshed.avg_rating) == pytest.approx(expected_fixture_rating, abs=0.01)
 
 
 def test_fixtures_invisible(app):
     player = 555
     j = _journey(player)
-    _entry(j, player, 2025, 200, minutes=1500, goals=3)
+    _entry(j, player, 2025, 200, minutes=1500, goals=3, stats_source="journey-api", rating=9.75)
     db.session.commit()
     svc.refresh_player(player, season=2025)
     db.session.commit()
@@ -136,7 +213,9 @@ def test_fixtures_invisible(app):
     assert total.minutes == 1500
     assert total.fixtures_minutes == 0
     assert total.reconcile_flag == "fixtures-invisible"
-    assert total.avg_rating is None  # no fixtures
+    journey_cell = PlayerSeasonCell.query.filter_by(player_api_id=player, source="journey").one()
+    assert float(journey_cell.avg_rating) == pytest.approx(9.75)
+    assert total.avg_rating is None  # a real journey rating never feeds the total
 
 
 def test_journey_under_sync(app):
@@ -312,8 +391,115 @@ def test_choke_flush_commits(app):
 
 
 # ---------------------------------------------------------------------------
-# journey hook mechanics (savepoint-wrapped refresh, same transaction)
+# real producer hooks + journey savepoint mechanics
 # ---------------------------------------------------------------------------
+def test_journey_sync_hook_builds_cells_and_totals_end_to_end(app):
+    """The real sync_player hook persists journey data and its rollup together."""
+    from src.services.journey_sync import JourneySyncService
+
+    player = 2000
+
+    class FakeJourneyApi:
+        def _make_request(self, endpoint, params):
+            if endpoint == "players/seasons":
+                assert params == {"player": player}
+                return {"response": [2025]}
+            if endpoint == "players":
+                assert params == {"id": player, "season": 2025}
+                return {
+                    "response": [
+                        {
+                            "player": {
+                                "id": player,
+                                "name": "Hook Player",
+                                "birth": {},
+                                "nationality": "England",
+                            },
+                            "statistics": [
+                                {
+                                    "team": {"id": 77, "name": "Rotherham United"},
+                                    "league": {"id": 40, "name": "Championship", "country": "England"},
+                                    "games": {"appearences": 10, "minutes": 900, "rating": "7.40"},
+                                    "goals": {"total": 2, "assists": 3},
+                                }
+                            ],
+                        }
+                    ]
+                }
+            raise AssertionError(f"unexpected API request: {endpoint} {params}")
+
+        def get_player_transfers(self, player_api_id):
+            assert player_api_id == player
+            return []
+
+    journey = JourneySyncService(api_client=FakeJourneyApi()).sync_player(player, force_full=True)
+
+    assert journey is not None
+    entry = PlayerJourneyEntry.query.filter_by(player_api_id=player, season=2025).one()
+    assert (entry.club_api_id, entry.appearances, entry.minutes, entry.goals) == (77, 10, 900, 2)
+    cell = PlayerSeasonCell.query.filter_by(player_api_id=player, season=2025, source="journey").one()
+    assert (cell.club_api_id, cell.appearances, cell.minutes, cell.goals) == (77, 10, 900, 2)
+    total = PlayerSeasonTotal.query.filter_by(player_api_id=player, season=2025, level_group="senior").one()
+    assert (total.primary_source, total.minutes, total.goals, total.reconcile_flag) == (
+        "journey",
+        900,
+        2,
+        "fixtures-invisible",
+    )
+
+
+def test_fps_writer_choke_point_refreshes_player_season(app, monkeypatch):
+    """A real fixture producer queues, commits, and drains the rollup refresh."""
+    from src.routes import api as api_routes
+
+    player = 2003
+    fixture_payload = {
+        "fixture": {
+            "id": 9001,
+            "date": "2025-09-13T15:00:00+00:00",
+            "status": {"short": "FT"},
+        },
+        "league": {"name": "League One", "season": 2025},
+        "teams": {
+            "home": {"id": 77, "name": "Rotherham United"},
+            "away": {"id": 88, "name": "Opponent"},
+        },
+        "goals": {"home": 2, "away": 0},
+    }
+
+    class FakeFixtureApi:
+        def get_fixtures_for_team_cached(self, team_id, season, start, end):
+            assert (team_id, season, start) == (77, 2025, "2025-08-01")
+            assert end >= start
+            return [fixture_payload]
+
+        def get_player_stats_for_fixture(self, player_api_id, season, fixture_id):
+            assert (player_api_id, season, fixture_id) == (player, 2025, 9001)
+            return {
+                "statistics": [
+                    {
+                        "games": {"minutes": 90, "substitute": False, "position": "Midfielder", "rating": 7.6},
+                        "goals": {"total": 1, "assists": 1},
+                    }
+                ]
+            }
+
+        def get_fixture_lineups(self, fixture_id):
+            assert fixture_id == 9001
+            return {"response": []}
+
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: FakeFixtureApi())
+
+    assert api_routes._sync_player_club_fixtures(player, 77, 2025) == 1
+    fps = FixturePlayerStats.query.filter_by(player_api_id=player).one()
+    assert (fps.minutes, fps.goals, fps.assists) == (90, 1, 1)
+    cell = PlayerSeasonCell.query.filter_by(player_api_id=player, season=2025, source="fixtures").one()
+    assert (cell.minutes, cell.goals, cell.assists) == (90, 1, 1)
+    total = PlayerSeasonTotal.query.filter_by(player_api_id=player, season=2025, level_group="senior").one()
+    assert (total.primary_source, total.minutes, total.goals, total.assists) == ("fixtures", 90, 1, 1)
+    assert not db.session.info.get(svc._DIRTY_KEY)
+
+
 def test_journey_hook_savepoint_atomic(app):
     """Mirror JourneySyncService.sync_player's hook: flush entries, refresh
     inside a SAVEPOINT, then ONE outer commit persists journey + rollup."""


### PR DESCRIPTION
## Seasons Phase D3 (proposal §7 PR3)

Third PR of the approved seasons rollout (`ledgers/research/seasons-design-proposal.md`). Builds the precomputed rollup layer the read cutover (D4) and frontend (D5) sit on.

### What's in it
- **sea02**: `player_season_cells` (per player/season/source/club/competition-tier), `player_season_totals` (per player/season/level_group headline w/ `reconcile_flag`), `league_season_config` (+5 seeds). RLS enabled in-migration on all three; guarded DDL; deploy-ordering docstring.
- **sea03**: guarded single-column clock indexes on the three existing source tables so the status gauge's `MAX(clock)` reads are index lookups, not seq scans (no new tables → no RLS statement needed; a missing index degrades, never 500s).
- **`season_rollup_service`**: source feeders (fixtures/journey/APSS/shadow), totals resolution implementing **never-cross-source-sum** + larger-source-wins-whole headline + reconcile-flag buckets, journey-sync hook (post `_merge_corrected_duplicates`), and ONE FPS write choke point with a batched post-commit refresh queue (requeues on failure).
- **Admin surface**: `POST /api/admin/season-rollup/rebuild` (`player|season|stale|all`, keyset-paged, batch ≤100, per-player savepoints, forward-only cursor — a poison row can never livelock a sweep; failures surface in `failed[]`) and `GET /api/admin/season-rollup/status` (cheap index-served gauge; `?exact=1` for the full stale count + per-source cell breakdown).
- **Team-delete atomicity**: FPS bulk-delete + rollup rebuild now commit or roll back together.
- **58 new tests** incl. the Gore-shaped anchor (fixtures 2,941 vs journey 2,936 → fixtures headline, `journey-under-sync` flag; flip journey to 3,000 → journey headline, `cup-gap` flag), fixtures-invisible, noise filter, cross-source-sum ban, hook end-to-ends, rebuild convergence/idempotence, sea02 replay.

### Gates
- ruff check + format: clean
- Full suite failure/error set **byte-identical to merge-base** `5bf95cf` (23F/12E/3S pre-existing on main); 868 passed
- Single alembic head (`sea03`)

### Deploy ordering (already done)
sea02+sea03 DDL **pre-applied to prod** via off-container `flask db upgrade` (pooler, invariants §1/§7): alembic stamped `sea03`, RLS verified on all three tables, indexes + seeds verified. In-container upgrade is a guarded no-op; the RLS security-check sees RLS already enabled.

### Not in this PR (next phases)
D4 cold-build + 20-player pilot + `SEASON_ROLLUP_READS` per-surface cutover; D5 frontend; E1/E2 prod re-syncs (gated on the D4 pilot).

Known pre-existing issues reported during review (not D3 scope): `admin_delete_team_data` 404→500 masking at `api.py:6532`; FPS delete keyed only on `player_api_id` may cross parent-team tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)