### PR TITLE
feat(season-rollup): off-container cold-build runner (D4)

### DIFF
--- a/academy-watch-backend/src/scripts/season_rollup_cold_build.py
+++ b/academy-watch-backend/src/scripts/season_rollup_cold_build.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Cold-build the season-rollup read surface from an off-container checkout.
+
+This is a pure-database runner: it discovers the same player population as the
+admin rebuild endpoint and delegates every write to
+``season_rollup_service.refresh_player``. It must be run from a local checkout
+or dedicated job connected through the Supabase pooler, never in the small
+production web container.
+
+Usage (from ``academy-watch-backend``)::
+
+    python -m src.scripts.season_rollup_cold_build --players 303010,12345
+    python -m src.scripts.season_rollup_cold_build --all --season 2025
+    python -m src.scripts.season_rollup_cold_build --all --after 303010 --limit 500
+    python -m src.scripts.season_rollup_cold_build --all --dry-run
+
+Database configuration comes from the normal application ``DB_*`` environment
+variables. No API-Football client is used.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from time import perf_counter
+
+import dotenv
+from flask import Flask
+from sqlalchemy import func, inspect, select
+from sqlalchemy.engine import URL
+
+# Support both ``python -m src.scripts...`` and direct-file invocation.
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.models.league import db  # noqa: E402
+from src.routes.season_rollup import _candidate_player_ids  # noqa: E402
+from src.services import season_rollup_service  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BATCH_SIZE = 50
+_MAX_BATCH_SIZE = 200
+_CONTAINER_APP_ENV_KEYS = (
+    "CONTAINER_APP_NAME",
+    "CONTAINER_APP_REPLICA_NAME",
+    "CONTAINER_APP_REVISION",
+)
+_REQUIRED_TABLES = {
+    "academy_player_season_stats",
+    "fixture_player_stats",
+    "fixtures",
+    "player_journey_entries",
+    "player_journeys",
+    "player_season_cells",
+    "player_season_totals",
+    "player_shadow_stats",
+}
+
+
+def _positive_int(raw: str) -> int:
+    try:
+        value = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError("must be a positive integer") from exc
+    if value < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return value
+
+
+def _non_negative_int(raw: str) -> int:
+    try:
+        value = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError("must be a non-negative integer player_api_id") from exc
+    if value < 0:
+        raise argparse.ArgumentTypeError("must be a non-negative integer player_api_id")
+    return value
+
+
+def _player_id_list(raw: str) -> tuple[int, ...]:
+    parts = [part.strip() for part in raw.split(",")]
+    if not parts or any(not part for part in parts):
+        raise argparse.ArgumentTypeError("must be a comma-separated list of positive player_api_ids")
+    try:
+        player_ids = {int(part) for part in parts}
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a comma-separated list of positive player_api_ids") from exc
+    if any(player_id < 1 for player_id in player_ids):
+        raise argparse.ArgumentTypeError("player_api_ids must be positive integers")
+    return tuple(sorted(player_ids))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Cold-build player season cells/totals off-container using only the configured database.",
+    )
+    population = parser.add_mutually_exclusive_group(required=True)
+    population.add_argument(
+        "--players",
+        type=_player_id_list,
+        metavar="ID,ID",
+        help="explicit comma-separated player_api_ids (pilot mode)",
+    )
+    population.add_argument(
+        "--all",
+        dest="all_players",
+        action="store_true",
+        help="discover the full rebuild candidate population, including orphan derived rows",
+    )
+    parser.add_argument(
+        "--season",
+        type=_positive_int,
+        help="optional season start-year restriction (for example, 2025 means 2025-26)",
+    )
+    parser.add_argument(
+        "--after",
+        type=_non_negative_int,
+        default=0,
+        metavar="PLAYER_API_ID",
+        help="strict keyset resume cursor (default: 0)",
+    )
+    parser.add_argument("--limit", type=_positive_int, help="stop after attempting this many players")
+    parser.add_argument(
+        "--batch-size",
+        type=_positive_int,
+        default=_DEFAULT_BATCH_SIZE,
+        metavar="N",
+        help=f"players per commit (default: {_DEFAULT_BATCH_SIZE}, capped at {_MAX_BATCH_SIZE})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print candidate count and first/last ids without writing",
+    )
+    return parser
+
+
+def _env_value(key: str, *, allow_inline_comment: bool = False) -> str | None:
+    raw = os.getenv(key)
+    if raw is None:
+        return None
+    value = raw.strip()
+    if allow_inline_comment and "#" in value:
+        for index, character in enumerate(value):
+            if character == "#" and (index == 0 or value[index - 1].isspace()):
+                value = value[:index].rstrip()
+                break
+    return value or None
+
+
+def _build_db_uri_from_components() -> str:
+    """Mirror ``src.main``'s psycopg-v3 ``DB_*`` URL construction."""
+    port_raw = _env_value("DB_PORT", allow_inline_comment=True) or ""
+    port_value = None
+    if port_raw:
+        try:
+            port_value = int(port_raw)
+        except ValueError:
+            logger.warning("DB_PORT value %r is invalid; ignoring port", port_raw)
+    url = URL.create(
+        drivername="postgresql+psycopg",
+        username=_env_value("DB_USER"),
+        password=_env_value("DB_PASSWORD"),
+        host=_env_value("DB_HOST", allow_inline_comment=True),
+        port=port_value,
+        database=_env_value("DB_NAME", allow_inline_comment=True),
+        query={"sslmode": _env_value("DB_SSLMODE") or "require"},
+    )
+    return url.render_as_string(hide_password=False)
+
+
+def _assert_off_container() -> None:
+    if any(_env_value(key) for key in _CONTAINER_APP_ENV_KEYS):
+        raise RuntimeError(
+            "refusing to run inside Azure Container Apps; run this bulk build from an off-container checkout"
+        )
+
+
+def get_app() -> Flask:
+    """Build a database-only app without importing integration-bearing routes."""
+    dotenv.load_dotenv(dotenv.find_dotenv())
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = _build_db_uri_from_components()
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {
+        "pool_pre_ping": True,
+        "pool_recycle": 300,
+    }
+    db.init_app(app)
+
+    return app
+
+
+def _validate_setup() -> None:
+    existing_tables = set(inspect(db.session.get_bind()).get_table_names())
+    missing_tables = sorted(_REQUIRED_TABLES - existing_tables)
+    if missing_tables:
+        raise RuntimeError(f"database is missing required season-rollup tables: {', '.join(missing_tables)}")
+
+
+def _ordered_candidate_select(
+    *,
+    season: int | None,
+    after: int,
+    limit: int | None = None,
+    per_source_limit: int | None = None,
+):
+    candidates = _candidate_player_ids(
+        season=season,
+        after=after,
+        per_source_limit=per_source_limit,
+    ).subquery()
+    statement = (
+        select(candidates.c.player_api_id)
+        .where(candidates.c.player_api_id > after)
+        .order_by(candidates.c.player_api_id)
+    )
+    if limit is not None:
+        statement = statement.limit(limit)
+    return statement
+
+
+def _all_candidate_page(*, season: int | None, after: int, page_size: int) -> list[int]:
+    statement = _ordered_candidate_select(
+        season=season,
+        after=after,
+        limit=page_size,
+        per_source_limit=page_size,
+    )
+    return list(db.session.execute(statement).scalars())
+
+
+def _all_candidate_bounds(*, season: int | None, after: int, limit: int | None) -> tuple[int, int | None, int | None]:
+    candidates = _candidate_player_ids(season=season, after=after).subquery()
+    selected = select(candidates.c.player_api_id).where(candidates.c.player_api_id > after)
+    if limit is not None:
+        selected = selected.order_by(candidates.c.player_api_id).limit(limit)
+        candidates = selected.subquery()
+
+    count, first_id, last_id = db.session.execute(
+        select(
+            func.count(candidates.c.player_api_id),
+            func.min(candidates.c.player_api_id),
+            func.max(candidates.c.player_api_id),
+        )
+    ).one()
+    return int(count or 0), first_id, last_id
+
+
+def _explicit_player_ids(args: argparse.Namespace) -> list[int]:
+    player_ids = [player_id for player_id in args.players if player_id > args.after]
+    if args.limit is not None:
+        player_ids = player_ids[: args.limit]
+    return player_ids
+
+
+def _print_dry_run(args: argparse.Namespace) -> None:
+    if args.players is not None:
+        player_ids = _explicit_player_ids(args)
+        count = len(player_ids)
+        first_id = player_ids[0] if player_ids else None
+        last_id = player_ids[-1] if player_ids else None
+    else:
+        count, first_id, last_id = _all_candidate_bounds(
+            season=args.season,
+            after=args.after,
+            limit=args.limit,
+        )
+    print(f"candidates={count} first_id={first_id} last_id={last_id}", flush=True)
+
+
+def _process_batch(
+    player_ids: list[int],
+    *,
+    season: int | None,
+    started_at: float,
+    successful: int,
+    attempted: int,
+    failed_ids: list[int],
+) -> tuple[int, int]:
+    for player_api_id in player_ids:
+        attempted += 1
+        try:
+            with db.session.begin_nested():
+                season_rollup_service.refresh_player(
+                    player_api_id,
+                    season=season,
+                    session=db.session,
+                )
+            successful += 1
+        except Exception:
+            failed_ids.append(player_api_id)
+            logger.exception(
+                "season-rollup cold-build skipped player=%s season=%s",
+                player_api_id,
+                season,
+            )
+
+    db.session.commit()
+    elapsed = perf_counter() - started_at
+    average_ms = elapsed * 1000 / attempted if attempted else 0.0
+    print(
+        f"processed={successful} failed={len(failed_ids)} last_id={player_ids[-1]} "
+        f"elapsed={elapsed:.1f}s avg_per_player={average_ms:.1f}ms",
+        flush=True,
+    )
+    return successful, attempted
+
+
+def run(args: argparse.Namespace) -> int:
+    _validate_setup()
+    args.batch_size = min(args.batch_size, _MAX_BATCH_SIZE)
+    started_at = perf_counter()
+
+    if args.dry_run:
+        _print_dry_run(args)
+        db.session.rollback()
+        return 0
+
+    successful = 0
+    attempted = 0
+    failed_ids: list[int] = []
+
+    if args.players is not None:
+        player_ids = _explicit_player_ids(args)
+        for start in range(0, len(player_ids), args.batch_size):
+            successful, attempted = _process_batch(
+                player_ids[start : start + args.batch_size],
+                season=args.season,
+                started_at=started_at,
+                successful=successful,
+                attempted=attempted,
+                failed_ids=failed_ids,
+            )
+    else:
+        cursor = args.after
+        remaining = args.limit
+        while remaining is None or remaining > 0:
+            page_size = args.batch_size if remaining is None else min(args.batch_size, remaining)
+            player_ids = _all_candidate_page(
+                season=args.season,
+                after=cursor,
+                page_size=page_size,
+            )
+            if not player_ids:
+                db.session.rollback()
+                break
+            successful, attempted = _process_batch(
+                player_ids,
+                season=args.season,
+                started_at=started_at,
+                successful=successful,
+                attempted=attempted,
+                failed_ids=failed_ids,
+            )
+            cursor = player_ids[-1]
+            if remaining is not None:
+                remaining -= len(player_ids)
+
+    elapsed = perf_counter() - started_at
+    average_ms = elapsed * 1000 / attempted if attempted else 0.0
+    print(
+        f"summary processed={successful} failed={len(failed_ids)} failed_ids={failed_ids} "
+        f"total_elapsed={elapsed:.1f}s avg_per_player={average_ms:.1f}ms",
+        flush=True,
+    )
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        _assert_off_container()
+        app = get_app()
+        with app.app_context():
+            try:
+                return run(args)
+            except Exception:
+                db.session.rollback()
+                raise
+    except Exception:
+        logger.exception("season-rollup cold-build fatal error")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/academy-watch-backend/tests/test_season_rollup_cold_build.py
+++ b/academy-watch-backend/tests/test_season_rollup_cold_build.py
@@ -1,0 +1,364 @@
+"""D4a off-container season-rollup cold-build runner."""
+
+from datetime import UTC, datetime
+
+import pytest
+from flask import Flask
+from sqlalchemy import select
+from sqlalchemy.engine import make_url
+from src.models.follow import PlayerShadowStats
+from src.models.journey import PlayerJourney, PlayerJourneyEntry
+from src.models.league import AcademyPlayerSeasonStats, db
+from src.models.season_rollup import PlayerSeasonCell, PlayerSeasonTotal
+from src.models.weekly import Fixture, FixturePlayerStats
+from src.routes import season_rollup as admin_routes
+from src.scripts import season_rollup_cold_build as runner
+
+SEASON = 2025
+MARKER_TIME = datetime(2020, 1, 1, tzinfo=UTC)
+
+
+@pytest.fixture
+def app():
+    application = Flask(__name__)
+    application.config.update(
+        TESTING=True,
+        SECRET_KEY="test-secret",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+    db.init_app(application)
+
+    context = application.app_context()
+    context.push()
+    db.create_all()
+    yield application
+    db.session.remove()
+    db.drop_all()
+    context.pop()
+
+
+def _shadow(player_api_id: int, *, season: int = SEASON, minutes: int = 90) -> PlayerShadowStats:
+    row = PlayerShadowStats(
+        player_api_id=player_api_id,
+        team_api_id=player_api_id + 1000,
+        team_name=f"Shadow {player_api_id}",
+        season=season,
+        appearances=1,
+        goals=0,
+        assists=0,
+        minutes=minutes,
+    )
+    db.session.add(row)
+    return row
+
+
+def _apss(player_api_id: int) -> AcademyPlayerSeasonStats:
+    row = AcademyPlayerSeasonStats(
+        player_api_id=player_api_id,
+        player_name=f"Academy {player_api_id}",
+        league_api_id=player_api_id + 2000,
+        league_name="Youth League",
+        team_api_id=player_api_id + 3000,
+        team_name=f"Academy {player_api_id}",
+        season=SEASON,
+        appearances=1,
+        goals=0,
+        assists=0,
+        minutes=90,
+    )
+    db.session.add(row)
+    return row
+
+
+def _orphan_total(player_api_id: int) -> PlayerSeasonTotal:
+    row = PlayerSeasonTotal(
+        player_api_id=player_api_id,
+        season=SEASON,
+        level_group="senior",
+        appearances=1,
+        goals=0,
+        assists=0,
+        minutes=90,
+        primary_source="shadow",
+        fixtures_minutes=0,
+        journey_minutes=0,
+        computed_at=MARKER_TIME,
+    )
+    db.session.add(row)
+    return row
+
+
+def _orphan_cell(player_api_id: int) -> PlayerSeasonCell:
+    row = PlayerSeasonCell(
+        player_api_id=player_api_id,
+        season=SEASON,
+        source="shadow",
+        club_api_id=player_api_id + 4000,
+        club_name=f"Orphan {player_api_id}",
+        competition_tier="league",
+        level_group="senior",
+        appearances=1,
+        goals=0,
+        assists=0,
+        minutes=90,
+        synced_at=MARKER_TIME,
+    )
+    db.session.add(row)
+    return row
+
+
+def _invoke(app, monkeypatch, *args: str) -> int:
+    monkeypatch.setattr(runner, "get_app", lambda: app)
+    return runner.main(list(args))
+
+
+def _route_candidate_ids(*, season: int | None = None) -> list[int]:
+    candidates = admin_routes._candidate_player_ids(season=season).subquery()
+    return list(db.session.execute(select(candidates.c.player_api_id).order_by(candidates.c.player_api_id)).scalars())
+
+
+def test_players_mode_builds_only_requested_players(app, monkeypatch, capsys):
+    _shadow(101, season=2024)
+    for player_api_id in (101, 102, 103):
+        _shadow(player_api_id)
+    db.session.commit()
+
+    # Give the unrequested player an old rollup marker so the test catches an
+    # accidental population scan or refresh, not only an accidental insert.
+    runner.season_rollup_service.refresh_player(102, season=SEASON, session=db.session)
+    untouched_total = PlayerSeasonTotal.query.filter_by(player_api_id=102, season=SEASON).one()
+    untouched_cell = PlayerSeasonCell.query.filter_by(player_api_id=102, season=SEASON).one()
+    untouched_total.computed_at = MARKER_TIME
+    untouched_cell.synced_at = MARKER_TIME
+    db.session.commit()
+
+    real_commit = db.session.commit
+    commit_count = 0
+
+    def _counted_commit():
+        nonlocal commit_count
+        commit_count += 1
+        return real_commit()
+
+    monkeypatch.setattr(db.session, "commit", _counted_commit)
+
+    result = _invoke(
+        app,
+        monkeypatch,
+        "--players",
+        "103,101,103",
+        "--season",
+        str(SEASON),
+        "--batch-size",
+        "1",
+    )
+
+    assert result == 0
+    output_lines = capsys.readouterr().out.splitlines()
+    assert len([line for line in output_lines if line.startswith("processed=")]) == 2
+    assert commit_count == 2
+    db.session.expire_all()
+    assert {
+        (row.player_api_id, row.season, row.source)
+        for row in PlayerSeasonCell.query.order_by(PlayerSeasonCell.player_api_id, PlayerSeasonCell.season)
+    } == {
+        (101, SEASON, "shadow"),
+        (102, SEASON, "shadow"),
+        (103, SEASON, "shadow"),
+    }
+    assert {
+        (row.player_api_id, row.season, row.primary_source)
+        for row in PlayerSeasonTotal.query.order_by(PlayerSeasonTotal.player_api_id, PlayerSeasonTotal.season)
+    } == {
+        (101, SEASON, "shadow"),
+        (102, SEASON, "shadow"),
+        (103, SEASON, "shadow"),
+    }
+    assert PlayerSeasonCell.query.filter_by(player_api_id=101, season=2024).count() == 0
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=101, season=2024).count() == 0
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=102).one().computed_at == MARKER_TIME.replace(tzinfo=None)
+    assert PlayerSeasonCell.query.filter_by(player_api_id=102).one().synced_at == MARKER_TIME.replace(tzinfo=None)
+
+
+def test_all_mode_after_limit_resume_matches_endpoint_population(app, monkeypatch):
+    fixture = Fixture(fixture_id_api=10, season=SEASON, competition_name="Premier League")
+    db.session.add(fixture)
+    db.session.flush()
+    db.session.add(
+        FixturePlayerStats(
+            fixture_id=fixture.id,
+            player_api_id=10,
+            team_api_id=1010,
+            minutes=90,
+            goals=0,
+            assists=0,
+        )
+    )
+    _apss(20)
+    _shadow(30)
+    journey = PlayerJourney(player_api_id=40, player_name="Legacy Journey")
+    db.session.add(journey)
+    db.session.flush()
+    db.session.add(
+        PlayerJourneyEntry(
+            journey_id=journey.id,
+            player_api_id=None,
+            season=SEASON,
+            club_api_id=4040,
+            club_name="Journey Club",
+            appearances=1,
+            minutes=90,
+            goals=0,
+        )
+    )
+    _orphan_total(50)
+    _orphan_cell(60)
+    db.session.commit()
+
+    expected = _route_candidate_ids(season=SEASON)
+    assert expected == [10, 20, 30, 40, 50, 60]
+
+    real_refresh = runner.season_rollup_service.refresh_player
+    calls: list[tuple[int, int | None]] = []
+
+    def _recording_refresh(player_api_id, season=None, session=None):
+        calls.append((player_api_id, season))
+        return real_refresh(player_api_id, season=season, session=session)
+
+    monkeypatch.setattr(runner.season_rollup_service, "refresh_player", _recording_refresh)
+
+    cursor = 0
+    for expected_page in ([10, 20], [30, 40], [50, 60]):
+        result = _invoke(
+            app,
+            monkeypatch,
+            "--all",
+            "--season",
+            str(SEASON),
+            "--after",
+            str(cursor),
+            "--limit",
+            "2",
+            "--batch-size",
+            "2",
+        )
+        assert result == 0
+        assert [player_api_id for player_api_id, _season in calls[-2:]] == expected_page
+        cursor = expected_page[-1]
+
+    assert calls == [(player_api_id, SEASON) for player_api_id in expected]
+    db.session.expire_all()
+    assert {row.player_api_id for row in PlayerSeasonTotal.query.all()} == {10, 20, 30, 40}
+    assert {row.player_api_id for row in PlayerSeasonCell.query.all()} == {10, 20, 30, 40}
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=50).count() == 0
+    assert PlayerSeasonCell.query.filter_by(player_api_id=60).count() == 0
+
+
+def test_poison_player_is_skipped_reported_and_batch_commits_survive(app, monkeypatch, capsys):
+    for player_api_id in (201, 202, 203):
+        _shadow(player_api_id)
+    db.session.commit()
+
+    real_refresh = runner.season_rollup_service.refresh_player
+
+    def _poison_after_writes(player_api_id, season=None, session=None):
+        result = real_refresh(player_api_id, season=season, session=session)
+        if player_api_id == 202:
+            raise RuntimeError("poison player")
+        return result
+
+    monkeypatch.setattr(runner.season_rollup_service, "refresh_player", _poison_after_writes)
+
+    result = _invoke(app, monkeypatch, "--players", "203,201,202", "--batch-size", "3")
+
+    assert result == 0
+    output = capsys.readouterr().out
+    assert "processed=2 failed=1 last_id=203" in output
+    assert "summary processed=2 failed=1 failed_ids=[202]" in output
+
+    # A fresh session proves the successful siblings reached the outer commit,
+    # while the poison player's writes were rolled back to its SAVEPOINT.
+    db.session.remove()
+    assert {row.player_api_id for row in PlayerSeasonCell.query.all()} == {201, 203}
+    assert {row.player_api_id for row in PlayerSeasonTotal.query.all()} == {201, 203}
+    assert {row.player_api_id for row in PlayerShadowStats.query.all()} == {201, 202, 203}
+
+
+def test_dry_run_reports_candidate_bounds_without_writes(app, monkeypatch, capsys):
+    _shadow(301)
+    _shadow(303)
+    _orphan_total(305)
+    db.session.commit()
+
+    before = [
+        (row.id, row.player_api_id, row.season, row.computed_at)
+        for row in PlayerSeasonTotal.query.order_by(PlayerSeasonTotal.id)
+    ]
+    source_before = [
+        (row.id, row.player_api_id, row.season, row.minutes)
+        for row in PlayerShadowStats.query.order_by(PlayerShadowStats.id)
+    ]
+
+    def _unexpected_refresh(*_args, **_kwargs):
+        pytest.fail("dry-run must not call refresh_player")
+
+    monkeypatch.setattr(runner.season_rollup_service, "refresh_player", _unexpected_refresh)
+
+    result = _invoke(app, monkeypatch, "--all", "--season", str(SEASON), "--dry-run")
+
+    assert result == 0
+    assert capsys.readouterr().out == "candidates=3 first_id=301 last_id=305\n"
+    after = [
+        (row.id, row.player_api_id, row.season, row.computed_at)
+        for row in PlayerSeasonTotal.query.order_by(PlayerSeasonTotal.id)
+    ]
+    assert after == before
+    assert [
+        (row.id, row.player_api_id, row.season, row.minutes)
+        for row in PlayerShadowStats.query.order_by(PlayerShadowStats.id)
+    ] == source_before
+    assert PlayerSeasonCell.query.count() == 0
+
+
+def test_database_bootstrap_uses_only_app_db_components(monkeypatch):
+    monkeypatch.setattr(runner.dotenv, "load_dotenv", lambda *_args, **_kwargs: False)
+    monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "sqlite:///must-not-win.db")
+    monkeypatch.setenv("DB_USER", "pooler-user")
+    monkeypatch.setenv("DB_PASSWORD", "pooler-password")
+    monkeypatch.setenv("DB_HOST", "pooler.example.test")
+    monkeypatch.setenv("DB_PORT", "6543")
+    monkeypatch.setenv("DB_NAME", "academy-watch")
+    monkeypatch.setenv("DB_SSLMODE", "verify-full")
+
+    application = runner.get_app()
+    url = make_url(application.config["SQLALCHEMY_DATABASE_URI"])
+
+    assert url.drivername == "postgresql+psycopg"
+    assert (url.username, url.password) == ("pooler-user", "pooler-password")
+    assert (url.host, url.port, url.database) == ("pooler.example.test", 6543, "academy-watch")
+    assert url.query["sslmode"] == "verify-full"
+    assert application.config["SQLALCHEMY_ENGINE_OPTIONS"] == {
+        "pool_pre_ping": True,
+        "pool_recycle": 300,
+    }
+
+
+def test_setup_failure_returns_nonzero(monkeypatch):
+    def _fatal_app_setup():
+        raise RuntimeError("database bootstrap failed")
+
+    monkeypatch.setattr(runner, "get_app", _fatal_app_setup)
+
+    assert runner.main(["--all"]) == 1
+
+
+def test_runner_refuses_azure_container_app_environment(monkeypatch):
+    monkeypatch.setenv("CONTAINER_APP_REVISION", "ca-loan-army-backend--revision")
+
+    def _unexpected_app_setup():
+        pytest.fail("container guard must run before database setup")
+
+    monkeypatch.setattr(runner, "get_app", _unexpected_app_setup)
+
+    assert runner.main(["--all"]) == 1


### PR DESCRIPTION
## Seasons Phase D4 — cold-build runner + prod pilot results

Off-container bulk builder for `player_season_cells`/`player_season_totals` (invariants §7: the 0.5 CPU container never runs bulk recompute). Pure DB via the pooler, zero API-Football calls, refuses to run inside ACA, `--dry-run`/`--players`/`--all` with keyset `--after` resume and per-player savepoints. Reuses the endpoint's candidate discovery and `refresh_player` — no logic duplicated.

### 19-player stratified prod pilot (2026-07-15) — PASSED
- **Gore anchor (303010)**: fixtures 2,941 vs journey 2,936 → headline 2,941 whole-from-fixtures, `journey-under-sync` ✓
- **fixtures-invisible ×3**: journey headline, correct senior/international `level_group` split ✓
- **fixtures-heavier ×3**: `journey-under-sync` flagged (incl. journey=14 vs fixtures=825 — the stale-journey class E1 fixes) ✓
- **noise ×2**: zero-stat 2025 stubs created NO cells/totals; same players' real earlier seasons built ✓
- **veterans**: 7–12 seasons each (2015→2026) — development-view raw material ✓
- **Global invariants over all 191 totals/369 cells**: 0 cross-source-sum violations; 0 non-fixtures rating cells ✓
- **Gauge**: exact stale count 7,990 = 8,009 candidates − 19 built (arithmetically exact); cheap gauge 1.5s, `?exact=1` 27.9s on prod (admin-only, keep off polling paths)
- **Feasibility**: 1.25s/player → full cold build ≈ 2.8h, batched + resumable

### Gates
ruff clean; 63 rollup/admin tests pass; full suite failure/error set identical to base (905 passed incl. 7 new).

Full build + `SEASON_ROLLUP_READS` cutover happen after MJ reviews the pilot (next step in the approved rollout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)