### PR TITLE
chore(deps): security-gate frontend dependency restores

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,23 @@ on:
   pull_request:
     branches: ['**']
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
+  dependency-security:
+    name: Frontend Dependency Security
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: |-
+        --lockfile=./academy-watch-frontend/pnpm-lock.yaml
+      fail-on-vuln: true
+
   frontend-build:
     name: Frontend Build & Lint
+    needs: dependency-security
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -24,6 +24,11 @@ on:
       - '.github/workflows/deploy-frontend.yml'
   workflow_dispatch:
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 # Only one frontend deploy may run at a time. If a second commit lands
 # while one is still in progress, the in-flight run is cancelled and the
 # newer one takes its place — there's no value in deploying yesterday's
@@ -38,8 +43,17 @@ env:
   APP_BACKEND: ca-loan-army-backend
 
 jobs:
+  dependency-security:
+    name: Frontend Dependency Security
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: |-
+        --lockfile=./academy-watch-frontend/pnpm-lock.yaml
+      fail-on-vuln: true
+
   deploy-frontend:
     name: Deploy Frontend (no backend rebuild)
+    needs: dependency-security
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,11 @@ on:
         default: false
         type: boolean
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 env:
   SUBSCRIPTION_ID: 63ceeeac-fe3f-4bcb-b6d2-b7aa7fd6bf52
   RESOURCE_GROUP: rg-loan-army-westus2
@@ -52,6 +57,14 @@ env:
   SUPA_DB_PORT: 5432
 
 jobs:
+  dependency-security:
+    name: Frontend Dependency Security
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: |-
+        --lockfile=./academy-watch-frontend/pnpm-lock.yaml
+      fail-on-vuln: true
+
   security-checks:
     name: Security Checks
     runs-on: ubuntu-latest
@@ -231,7 +244,7 @@ jobs:
   deploy-frontend:
     name: Deploy Frontend
     runs-on: ubuntu-latest
-    needs: [deploy-backend]
+    needs: [deploy-backend, dependency-security]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@
 **Stack:** Flask 3.1 + SQLAlchemy (backend), React 19 + Vite 6 + Tailwind (frontend), PostgreSQL
 **Test command:** `cd academy-watch-frontend && pnpm lint && pnpm test:e2e`
 **Dev server:** Backend: `cd academy-watch-backend && python src/main.py` | Frontend: `cd academy-watch-frontend && pnpm dev`
+**Frontend setup:** `./scripts/setup_frontend.sh` (OSV scan first; installs only when missing/stale)
 
 ---
 
@@ -118,6 +119,7 @@ Log one-liner in CONTINUITY.md's "Trivial Log" section.
 ## Quality Bar
 
 Before marking work complete:
+- [ ] Dependency scan passes before any frontend dependency restore or lockfile change
 - [ ] Typecheck passes
 - [ ] Tests pass
 - [ ] Ledger state updated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ React/Vite SPA ──/api proxy──▶ Flask (13 blueprints) ──▶ Supabas
 
 ```bash
 cd academy-watch-backend && python src/main.py        # backend dev (:5001)
+./scripts/setup_frontend.sh                           # OSV scan; restore only if missing/stale
 cd academy-watch-frontend && pnpm dev                 # frontend dev (:5173, proxies /api→:5001)
 ruff check academy-watch-backend && ruff format --check academy-watch-backend   # backend CI lint gates
 cd academy-watch-frontend && pnpm lint && pnpm build  # frontend CI gates (build failure blocks)
@@ -57,7 +58,7 @@ cd academy-watch-frontend && pnpm exec playwright test tests/<file>.mjs   # sing
 ## Iron rules (always active — rationale in docs/agents/)
 
 - **PR flow, never push to main.** `main` is unprotected but the team runs PR → merge → watch-deploy on every change; branch (`feat/` `fix/` `chore/` `refactor/`), and use a worktree when the tree is dirty. Broad staging (`git add -A`/`.`), `--no-verify`, and force-push-main are blocked by the global git hook.
-- **CI gates local defaults miss:** `ruff format --check` is a separate gate from `ruff check`; frontend `pnpm build` must succeed (not just lint); `pnpm install --frozen-lockfile` fails on a stale lockfile; the Deploy job's RLS check **fails the deploy if any new public table lacks Row Level Security**. See `workflow.md`.
+- **CI gates local defaults miss:** `ruff format --check` is a separate gate from `ruff check`; frontend `pnpm build` must succeed (not just lint); `./scripts/setup_frontend.sh` runs the OSV lockfile gate before restoring only missing/stale dependencies; the Deploy job's RLS check **fails the deploy if any new public table lacks Row Level Security**. See `workflow.md`.
 - **Prod DB is reached via the IPv4 pooler + `postgresql+psycopg://` only** — the direct (IPv6) host is unreachable from ACA and a bare `postgresql://` loads the absent psycopg2. See `invariants.md`.
 - **Never reference the deleted `AcademyPlayer`/`SupplementalLoan` models** — use `TrackedPlayer`. **Alembic migrations guard every DDL** (prod schema drifted out-of-band). **Never bulk-sync/recompute against the live prod container** — it's tiny and falls over. See `invariants.md`.
 - **Secrets:** never print secrets or dump env; read live values via `az containerapp secret show`. Prod `SECRET_KEY` is a `kvref:` literal — do NOT "fix"/rotate it without a token-revocation plan (`invariants.md`).

--- a/README.md
+++ b/README.md
@@ -37,12 +37,11 @@ python src/main.py
 ### Frontend
 
 ```bash
-cd loan-army-frontend
-
-pnpm install       # Install dependencies
-pnpm dev           # Dev server (port 5173, proxies /api to :5001)
-pnpm build         # Production build
-pnpm lint          # ESLint
+./scripts/setup_frontend.sh       # Security scan; restore only if missing/stale
+cd academy-watch-frontend
+pnpm dev                         # Dev server (port 5173, proxies /api to :5001)
+pnpm build                       # Production build
+pnpm lint                        # ESLint
 ```
 
 ## Testing

--- a/STRIPE_QUICK_START.md
+++ b/STRIPE_QUICK_START.md
@@ -9,9 +9,8 @@
 cd loan-army-backend
 pip install -r requirements.txt
 
-# Frontend
-cd loan-army-frontend
-pnpm install
+# Frontend (from the repository root)
+./scripts/setup_frontend.sh
 ```
 
 ### 2. Get Stripe Keys
@@ -197,4 +196,3 @@ When ready for production:
 - Stripe Docs: https://stripe.com/docs
 - Stripe Support: https://support.stripe.com
 - Test Mode: https://stripe.com/docs/testing
-

--- a/STRIPE_SETUP_GUIDE.md
+++ b/STRIPE_SETUP_GUIDE.md
@@ -81,8 +81,8 @@ pip install -r requirements.txt
 
 Frontend:
 ```bash
-cd loan-army-frontend
-pnpm install
+# From the repository root: scans first and restores only when needed
+./scripts/setup_frontend.sh
 ```
 
 ### 7. Set Up Webhooks
@@ -363,4 +363,3 @@ The 10% platform fee is used for:
 - Security and compliance
 
 All fees are tracked in the `stripe_platform_revenue` table and displayed transparently in the admin dashboard.
-

--- a/academy-watch-frontend/package.json
+++ b/academy-watch-frontend/package.json
@@ -90,5 +90,12 @@
     "tw-animate-css": "^1.2.9",
     "vite": "^8.1.4"
   },
+  "pnpm": {
+    "overrides": {
+      "@babel/core": "7.29.6",
+      "d3-color": "3.1.0",
+      "lodash-es": "4.18.1"
+    }
+  },
   "packageManager": "pnpm@10.4.1+sha512.c753b6c3ad7afa13af388fa6d808035a008e30ea9993f58c6663e2bc5ff21679aa834db094987129aa4d488b86df57f7b634981b2f827cdcacc698cc0cfb88af"
 }

--- a/academy-watch-frontend/pnpm-lock.yaml
+++ b/academy-watch-frontend/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@babel/core': 7.29.6
+  d3-color: 3.1.0
+  lodash-es: 4.18.1
+
 importers:
 
   .:
@@ -245,12 +250,12 @@ packages:
     resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.29.0':
-    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+  '@babel/core@7.29.6':
+    resolution: {integrity: sha512-QdxmAo/ikZqqRGA8s43ww8lcql6naWRvEz0FFrl6MIlc7Gi6TroXnSdWa5U/kq6fzcpqpHesicQxFZIieZbyIA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.29.1':
-    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.28.6':
@@ -269,14 +274,22 @@ packages:
     resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': 7.29.6
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.27.1':
@@ -292,6 +305,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -302,6 +320,10 @@ packages:
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@date-fns/tz@1.4.1':
@@ -1663,9 +1685,6 @@ packages:
   d3-binarytree@1.0.2:
     resolution: {integrity: sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==}
 
-  d3-color@2.0.0:
-    resolution: {integrity: sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==}
-
   d3-color@3.1.0:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
     engines: {node: '>=12'}
@@ -2165,8 +2184,8 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lodash-es@4.17.23:
-    resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -2904,14 +2923,14 @@ snapshots:
 
   '@babel/compat-data@7.29.0': {}
 
-  '@babel/core@7.29.0':
+  '@babel/core@7.29.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
+      '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.6)
       '@babel/helpers': 7.29.2
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
@@ -2924,10 +2943,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.29.1':
+  '@babel/generator@7.29.7':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -2949,9 +2968,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.6
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
       '@babel/traverse': 7.29.0
@@ -2960,7 +2979,11 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -2973,18 +2996,22 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.7
       '@babel/types': 7.29.0
 
   '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
+      '@babel/generator': 7.29.7
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
       debug: 4.4.3
@@ -2995,6 +3022,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@date-fns/tz@1.4.1': {}
 
@@ -4312,8 +4344,6 @@ snapshots:
 
   d3-binarytree@1.0.2: {}
 
-  d3-color@2.0.0: {}
-
   d3-color@3.1.0: {}
 
   d3-dispatch@2.0.0: {}
@@ -4343,7 +4373,7 @@ snapshots:
 
   d3-interpolate@2.0.1:
     dependencies:
-      d3-color: 2.0.0
+      d3-color: 3.1.0
 
   d3-interpolate@3.0.1:
     dependencies:
@@ -4388,7 +4418,7 @@ snapshots:
 
   d3-transition@2.0.0(d3-selection@2.0.0):
     dependencies:
-      d3-color: 2.0.0
+      d3-color: 3.1.0
       d3-dispatch: 2.0.0
       d3-ease: 2.0.0
       d3-interpolate: 2.0.1
@@ -4458,7 +4488,7 @@ snapshots:
 
   eslint-plugin-react-hooks@7.1.1(eslint@10.7.0(jiti@2.7.0)):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.6
       '@babel/parser': 7.29.2
       eslint: 10.7.0(jiti@2.7.0)
       hermes-parser: 0.25.1
@@ -4593,7 +4623,7 @@ snapshots:
       float-tooltip: 1.7.5
       index-array-by: 1.4.2
       kapsule: 1.16.3
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
 
   framer-motion@12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
@@ -4712,7 +4742,7 @@ snapshots:
 
   kapsule@1.16.3:
     dependencies:
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
 
   keyv@4.5.4:
     dependencies:
@@ -4778,7 +4808,7 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash-es@4.17.23: {}
+  lodash-es@4.18.1: {}
 
   longest-streak@3.1.0: {}
 

--- a/deploy_aca.sh
+++ b/deploy_aca.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # - Grants AcrPull to app identities and updates Container Apps
 # - Sets/updates ingress ports and prints FQDNs
 #
-# Prereqs: az CLI (containerapp, acr), jq, pnpm or npm
+# Prereqs: az CLI (containerapp, acr), jq, pnpm, OSV-Scanner
 # Login: az login; az account set --subscription "$SUBSCRIPTION_ID"
 
 # ---------------------------
@@ -134,6 +134,8 @@ run_security_checks() {
 
 need az
 need jq || true
+need pnpm
+need osv-scanner
 
 # Run security checks before deployment (unless skipped)
 if [[ "$SKIP_SECURITY_CHECKS" != "1" ]]; then
@@ -165,12 +167,11 @@ if [[ -z "${VITE_API_BASE}" ]]; then
   VITE_API_BASE="https://${BACKEND_FQDN}/api"
 fi
 
+log "Security-checking and preparing frontend dependencies"
+"$ROOT_DIR/scripts/setup_frontend.sh"
+
 log "Building frontend with VITE_API_BASE=${VITE_API_BASE}"
-if command -v pnpm >/dev/null 2>&1; then
-  ( cd "$FRONTEND_DIR" && pnpm install --frozen-lockfile && VITE_API_BASE="$VITE_API_BASE" pnpm run build )
-else
-  ( cd "$FRONTEND_DIR" && npm ci && VITE_API_BASE="$VITE_API_BASE" npm run build )
-fi
+( cd "$FRONTEND_DIR" && VITE_API_BASE="$VITE_API_BASE" pnpm run build )
 
 log "Deploying frontend to Static Web App ($SWA_NAME)"
 SWA_TOKEN="$(az staticwebapp secrets list --name "$SWA_NAME" -g "$RG" --query 'properties.apiKey' -o tsv)"

--- a/docs/agents/debugging.md
+++ b/docs/agents/debugging.md
@@ -11,7 +11,7 @@ duplicated mapping key` on every run (fixed PR #420). Git merges YAML without de
 duplicate keys.
 
 ```bash
-git worktree add /tmp/wt origin/main && cd /tmp/wt/academy-watch-frontend && pnpm install --frozen-lockfile
+git worktree add /tmp/wt origin/main && cd /tmp/wt && ./scripts/setup_frontend.sh
 ```
 
 Fix the duplicate block **surgically** by hand. Do NOT run `pnpm install --lockfile-only`

--- a/docs/agents/frontend.md
+++ b/docs/agents/frontend.md
@@ -11,11 +11,16 @@ Stripe.js, framer-motion, `d3-force-3d` for journey maps. Pages in `src/pages/` 
 
 ## CI gates (mirror before pushing)
 
+- `../scripts/security/check_frontend_dependencies.sh` from this directory (or
+  `./scripts/security/check_frontend_dependencies.sh` from repo root) scans the
+  frozen lockfile with OSV-Scanner before dependencies are restored. Use
+  `./scripts/setup_frontend.sh` from repo root for setup; it skips installation
+  when the installed virtual-store lock already matches.
 - `pnpm lint` (ESLint flat config, `eslint.config.js`) **and** `pnpm build` (Vite) both run in
   CI — a build/type error reddens CI even with clean lint. Run the build too.
-- `pnpm install --frozen-lockfile` — a `package.json` change without a matching
-  `pnpm-lock.yaml` fails install. The on-edit hook runs `eslint --fix` on `.js/.jsx/.ts/.tsx`
-  saves.
+- The setup harness uses `pnpm install --frozen-lockfile` only when dependencies
+  are missing/stale. A `package.json` change without a matching `pnpm-lock.yaml`
+  fails install. The on-edit hook runs `eslint --fix` on `.js/.jsx/.ts/.tsx` saves.
 
 ## ESLint / lockfile traps
 

--- a/docs/agents/workflow.md
+++ b/docs/agents/workflow.md
@@ -20,9 +20,11 @@ watch-deploy sequence on **every** change — never a direct push to main.
    verify before push. (`ruff check academy-watch-backend` is the other gate.)
 2. **`cd academy-watch-frontend && pnpm build`** — CI runs `pnpm lint` **and** `pnpm build`;
    a build/type failure reddens CI even when lint is clean. Run the build, not just lint.
-3. **`pnpm install --frozen-lockfile`** — CI installs frozen; a `package.json` change without
-   a matching `pnpm-lock.yaml` update fails install. Never regen the whole lockfile to fix a
-   Dependabot break (debugging.md) — patch surgically.
+3. **`./scripts/setup_frontend.sh`** — scans `pnpm-lock.yaml` with OSV first,
+   skips installation when the installed virtual-store lock already matches,
+   and otherwise restores with `pnpm install --frozen-lockfile`. A
+   `package.json` change without a matching lockfile fails install. Never regen
+   the whole lockfile to fix a Dependabot break (debugging.md) — patch surgically.
 4. **Adding a migration that `CREATE TABLE`s?** Enable RLS in the same migration
    (`ALTER TABLE <t> ENABLE ROW LEVEL SECURITY;`) — the Deploy `security-checks` job fails the
    deploy otherwise (invariants.md §2). And guard all DDL with `_migration_helpers` (§8).

--- a/ledgers/ACADEMY_WATCH_AGENT_DIRECTIVE.md
+++ b/ledgers/ACADEMY_WATCH_AGENT_DIRECTIVE.md
@@ -144,7 +144,8 @@ loan-army-frontend/package.json              # Remove @stripe/stripe-js if prese
 2. In `App.jsx`, remove routes to deleted pages
 3. In `api.js`, remove all methods containing "stripe" (search for "stripe")
 4. Remove StripeContext provider from App.jsx
-5. Run `pnpm install` to update lockfile
+5. Update the lockfile without restoring packages, then run
+   `./scripts/security/check_frontend_dependencies.sh`
 6. Run `pnpm lint` to find any broken imports
 
 **Acceptance:** Frontend builds without Stripe, no import errors

--- a/scripts/security/check_frontend_dependencies.sh
+++ b/scripts/security/check_frontend_dependencies.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOCKFILE="$ROOT_DIR/academy-watch-frontend/pnpm-lock.yaml"
+
+if ! command -v osv-scanner >/dev/null 2>&1; then
+  echo "OSV-Scanner is required before restoring frontend dependencies." >&2
+  echo "Install it from https://google.github.io/osv-scanner/installation/ and rerun this check." >&2
+  exit 127
+fi
+
+if [[ ! -f "$LOCKFILE" ]]; then
+  echo "Frontend lockfile not found: $LOCKFILE" >&2
+  exit 2
+fi
+
+echo "Checking academy-watch-frontend/pnpm-lock.yaml with OSV-Scanner..."
+exec osv-scanner scan source --lockfile="$LOCKFILE"

--- a/scripts/setup_frontend.sh
+++ b/scripts/setup_frontend.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FRONTEND_DIR="$ROOT_DIR/academy-watch-frontend"
+LOCKFILE="$FRONTEND_DIR/pnpm-lock.yaml"
+INSTALLED_LOCKFILE="$FRONTEND_DIR/node_modules/.pnpm/lock.yaml"
+
+"$ROOT_DIR/scripts/security/check_frontend_dependencies.sh"
+
+if [[ -f "$INSTALLED_LOCKFILE" ]] && cmp -s "$LOCKFILE" "$INSTALLED_LOCKFILE"; then
+  echo "Frontend dependencies already match the frozen lockfile; skipping install."
+  exit 0
+fi
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "pnpm is required to restore frontend dependencies." >&2
+  exit 127
+fi
+
+echo "Frontend dependencies are missing or stale; restoring the frozen lockfile."
+cd "$FRONTEND_DIR"
+exec pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- add a local OSV lockfile gate and a setup harness that installs only when the frozen graph is missing or stale
- block PR CI and both frontend deploy workflows on a full OSV scan
- remediate the four current advisories with pinned overrides
- route developer and local deploy instructions through the gated harness

## Reason
Frontend dependency restoration is a supply-chain boundary. Security scanning must happen before any restore, and matching dependencies should skip installation entirely.

## Verification
- OSV: 530 packages scanned, no issues found
- setup run 1: clean scan then frozen restore because node_modules was absent
- setup run 2: clean scan then explicit install skip because the virtual-store lock matched
- resolved versions: @babel/core 7.29.6, d3-color 3.1.0, lodash-es 4.18.1
- eslint errors-only: passed
- Vite production build: passed
- react-simple-maps server-render smoke: passed
- shell syntax and workflow YAML parse: passed

## Existing baseline
The source-contract test runner reports 66 passing and 15 failing tests. This branch changes no frontend source or test files; those failures are existing main-branch drift and are not hidden by this PR.