### PR TITLE
fix(transfers): chronological transfer resolver — loan-vs-sold mislabeling (Hall class)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -180,12 +180,14 @@ Determined by `stats_coverage` field on `AcademyPlayer` and validated via `check
 Transfer types from the API `type` field:
 - `"Loan"` → new loan (player going out)
 - `"Back from Loan"` / `"End of Loan"` etc. → loan return
-- `"Free"` / `"Free Transfer"` / `"Free agent"` → permanent, no fee
+- `"Free"` / `"Free Transfer"` → permanent labels preserved verbatim on a sale
+- `"Free agent"` → permanent departure; released only when no destination exists
 - `"€ 50M"` / `"€ 25.5M"` → permanent with fee amount
 - `"Transfer"` → permanent, fee undisclosed
-- `"N/A"` → treated as `released` (free departure)
+- `"N/A"` → classified from club topology when direction is provable;
+  otherwise retained as unknown evidence with no status mutation
 
-The `extract_transfer_fee()` function returns the raw fee string for non-loan transfers, stored on `TrackedPlayer.sale_fee`.
+The chronological transfer resolver is the single source for permanent-transfer fees. Journey entries use its latest permanent move into that entry's club; `TrackedPlayer.sale_fee` uses its latest permanent departure from the row's academy parent. Both preserve the provider's raw label (for example `€ 33M`, `Free`, or `Transfer`).
 
 ### Player ID Verification
 

--- a/academy-watch-backend/migrations/versions/tre01_player_transfer_events.py
+++ b/academy-watch-backend/migrations/versions/tre01_player_transfer_events.py
@@ -1,0 +1,87 @@
+"""Durable player transfer events
+
+Revision ID: tre01
+Revises: sea03
+Create Date: 2026-07-16
+
+Creates ``player_transfer_events``, the durable evidence surface for the raw
+API-Football transfer objects already fetched by sync paths. One row represents
+one provider event at the natural grain
+``(player, date, out club, in club, raw type)``; repeated observations preserve
+``first_seen_at`` and monotonically advance ``last_seen_at``. PostgreSQL's
+``NULLS NOT DISTINCT`` semantics keep that natural key unique even when the
+provider omits a club id or transfer type.
+
+All DDL is guarded (invariants section 8): table creation uses ``table_exists``,
+the player lookup index uses ``create_index_safe``, and RLS enablement is
+idempotent. The new public table enables ROW LEVEL SECURITY in this same
+migration, as required by the deploy gate (invariants section 2).
+
+DEPLOY ORDERING (migrations do NOT auto-run): prefer PRE-APPLYING ``tre01``
+out-of-band before deploying the writer code. R1 only writes this table from
+transfer-sync paths and no read path SELECTs it, so an unapplied migration has
+no UndefinedTable read-path 500 window. Applying it after the code deploy is
+therefore read-safe; the additive writer also treats a missing table as a
+best-effort persistence miss without changing the transfer payload returned to
+existing consumers. Transfer syncs should still be held until the migration
+lands to avoid an evidence gap. Once applied, re-running the guarded upgrade is
+a clean no-op.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from migrations._migration_helpers import (
+    create_index_safe,
+    index_exists,
+    table_exists,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "tre01"
+down_revision = "sea03"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if not table_exists("player_transfer_events"):
+        op.create_table(
+            "player_transfer_events",
+            sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+            sa.Column("player_api_id", sa.Integer(), nullable=False),
+            sa.Column("transfer_date", sa.Date(), nullable=False),
+            sa.Column("transfer_type", sa.String(), nullable=True),
+            sa.Column("out_club_api_id", sa.Integer(), nullable=True),
+            sa.Column("out_club_name", sa.String(), nullable=True),
+            sa.Column("in_club_api_id", sa.Integer(), nullable=True),
+            sa.Column("in_club_name", sa.String(), nullable=True),
+            sa.Column("first_seen_at", sa.TIMESTAMP(timezone=True), nullable=False),
+            sa.Column("last_seen_at", sa.TIMESTAMP(timezone=True), nullable=False),
+            sa.Column("raw", JSONB(), nullable=True),
+            sa.UniqueConstraint(
+                "player_api_id",
+                "transfer_date",
+                "out_club_api_id",
+                "in_club_api_id",
+                "transfer_type",
+                name="uq_player_transfer_events_natural_key",
+                postgresql_nulls_not_distinct=True,
+            ),
+        )
+
+    create_index_safe(
+        "ix_player_transfer_events_player_api_id",
+        "player_transfer_events",
+        ["player_api_id"],
+    )
+
+    # Idempotent and intentionally unconditional after the table is guaranteed
+    # to exist: the deploy security gate rejects any public table without RLS.
+    op.execute("ALTER TABLE player_transfer_events ENABLE ROW LEVEL SECURITY")
+
+
+def downgrade():
+    if index_exists("ix_player_transfer_events_player_api_id"):
+        op.drop_index("ix_player_transfer_events_player_api_id", table_name="player_transfer_events")
+    if table_exists("player_transfer_events"):
+        op.drop_table("player_transfer_events")

--- a/academy-watch-backend/src/agents/weekly_newsletter_agent.py
+++ b/academy-watch-backend/src/agents/weekly_newsletter_agent.py
@@ -2263,10 +2263,12 @@ def _detect_recent_loan_returns(
     """Find players who returned from loan within the newsletter's date window.
 
     Scans ALL active TrackedPlayers (including those still marked on_loan if
-    status refresh hasn't run) for loan-return transfers landing at the parent club.
+    status refresh hasn't run) for canonically resolved loan returns landing at
+    the parent club or one of its affiliates.
     """
-    from src.api_football_client import LOAN_RETURN_TYPES
+    from src.services.transfer_resolver import resolve_transfer_state
     from src.utils.academy_classifier import flatten_transfers
+    from src.utils.affiliates import is_affiliate
 
     tracked = TrackedPlayer.query.filter(
         TrackedPlayer.team_id == team_db_id,
@@ -2280,36 +2282,48 @@ def _detect_recent_loan_returns(
     raw_map = api_client.batch_get_player_transfers(player_ids)
     window_start = week_start - timedelta(days=lookback_days)
     tp_by_pid = {tp.player_api_id: tp for tp in tracked}
+    parent = db.session.get(Team, team_db_id)
+    parent_name = parent.name if parent else None
+    initial_owner = {"id": parent_api_id, "name": parent_name}
 
     seen: dict[int, dict] = {}  # player_api_id → best return info
-    for pid, raw in raw_map.items():
-        for t in flatten_transfers(raw):
-            t_type = (t.get("type") or "").strip().lower()
-            if t_type not in LOAN_RETURN_TYPES:
+    for pid in player_ids:
+        if pid not in raw_map:
+            logger.warning(
+                "newsletter: transfer batch omitted player %s; preserving failed lookup state",
+                pid,
+            )
+            continue
+        resolution = resolve_transfer_state(
+            flatten_transfers(raw_map[pid]),
+            as_of=week_end,
+            initial_owner=initial_owner,
+        )
+        tp = tp_by_pid.get(pid)
+        if not tp:
+            continue
+
+        for event in resolution.events:
+            if event.kind != "loan_return":
                 continue
-            dest = (t.get("teams") or {}).get("in") or {}
-            source = (t.get("teams") or {}).get("out") or {}
-            if dest.get("id") != parent_api_id:
+            if not is_affiliate(
+                event.in_club.api_id,
+                event.in_club.name,
+                parent_api_id,
+                parent_name,
+            ):
                 continue
-            t_date_str = t.get("date", "")
-            if not t_date_str:
-                continue
-            try:
-                t_date = date.fromisoformat(t_date_str)
-            except (ValueError, TypeError):
-                continue
+            t_date = event.transfer_date
             if not (window_start <= t_date <= week_end):
                 continue
-            tp = tp_by_pid.get(pid)
-            if not tp:
-                continue
+            t_date_str = t_date.isoformat()
             # Keep the most recent return per player
             if pid not in seen or t_date_str > seen[pid]["return_date"]:
                 seen[pid] = {
                     "player_api_id": pid,
                     "player_name": tp.player_name,
-                    "returned_from_club_name": source.get("name"),
-                    "returned_from_club_api_id": source.get("id"),
+                    "returned_from_club_name": event.out_club.name,
+                    "returned_from_club_api_id": event.out_club.api_id,
                     "return_date": t_date_str,
                     "tp": tp,
                 }

--- a/academy-watch-backend/src/api_football_client.py
+++ b/academy-watch-backend/src/api_football_client.py
@@ -29,6 +29,89 @@ ONLY_TEST_TEAM_IDS = {33}  # Manchester United
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
+
+def _record_transfer_payload(
+    transfer_blocks: list[dict[str, Any]] | None,
+    *,
+    fallback_player_api_id: int | None = None,
+) -> None:
+    """Persist an API-Football ``/transfers`` response, best effort.
+
+    Player-scoped responses normally contain one outer player block while
+    team-scoped responses contain many.  Keep that response-shape handling in
+    one place and pass the verbatim inner transfer objects to the durable event
+    writer.
+
+    Persistence uses its own SQLAlchemy session so an API read cannot commit or
+    roll back a caller's pending work.  The helper deliberately no-ops without
+    a Flask application context; batch fetches run their HTTP work in executor
+    threads and call this helper again from the context-owning collector thread.
+    Missing migrations and all other persistence failures remain additive: they
+    are logged but never change the API payload returned to the caller.
+    """
+    if not isinstance(transfer_blocks, list) or not transfer_blocks:
+        return
+
+    batches: list[tuple[int, list[dict[str, Any]]]] = []
+    for block in transfer_blocks:
+        if not isinstance(block, dict):
+            continue
+
+        player = block.get("player") or {}
+        raw_player_api_id = player.get("id") if isinstance(player, dict) else None
+        if raw_player_api_id is None:
+            raw_player_api_id = fallback_player_api_id
+
+        try:
+            player_api_id = int(raw_player_api_id)
+        except (TypeError, ValueError):
+            continue
+        if player_api_id <= 0:
+            continue
+
+        transfers = block.get("transfers")
+        if not isinstance(transfers, list) or not transfers:
+            continue
+        batches.append((player_api_id, transfers))
+
+    if not batches:
+        return
+
+    try:
+        from flask import has_app_context
+
+        if not has_app_context():
+            logger.debug("Transfer event persistence skipped outside a Flask application context")
+            return
+
+        from sqlalchemy.orm import Session
+
+        from src.models.league import db
+        from src.services.transfer_events import record_transfer_events
+
+        session = Session(bind=db.engine)
+    except Exception as exc:
+        logger.warning("Transfer event persistence is unavailable: %s", exc)
+        return
+
+    try:
+        observed_at = datetime.now(UTC)
+        for player_api_id, transfers in batches:
+            record_transfer_events(player_api_id, transfers, session, observed_at=observed_at)
+        session.commit()
+    except Exception as exc:
+        try:
+            session.rollback()
+        except Exception as rollback_exc:
+            logger.debug("Transfer event persistence rollback also failed: %s", rollback_exc)
+        logger.warning("Transfer event persistence failed; API response is unchanged: %s", exc)
+    finally:
+        try:
+            session.close()
+        except Exception as close_exc:
+            logger.debug("Transfer event persistence session close failed: %s", close_exc)
+
+
 # ------------------------------------------------------------------
 # 🔄 Loan transfer type identification
 # ------------------------------------------------------------------
@@ -3405,7 +3488,10 @@ class APIFootballClient:
         try:
             params = {"team": normalized_team_id}
             response = self._make_request("transfers", params)
-            return response.get("response", [])
+            transfers_data = response.get("response", [])
+            if self.mode != "stub":
+                _record_transfer_payload(transfers_data)
+            return transfers_data
         except Exception as e:
             logger.error(f"Error fetching transfers for team {team_id}: {e}")
             return []
@@ -3517,6 +3603,8 @@ class APIFootballClient:
             try:
                 tr = self._make_request("transfers", {"player": player_id})
                 t_resp = tr.get("response", []) or []
+                if self.mode != "stub":
+                    _record_transfer_payload(t_resp, fallback_player_api_id=pid)
                 if t_resp:
                     p = (t_resp[0] or {}).get("player", {})
                     payload = {
@@ -4646,6 +4734,8 @@ class APIFootballClient:
                 logger.info(
                     f"✅ Cache HIT for player {player_id} transfers (age: {cache_age.seconds // 3600}h {(cache_age.seconds // 60) % 60}m)"
                 )
+                if self.mode != "stub":
+                    _record_transfer_payload(cached_data, fallback_player_api_id=player_id)
                 return cached_data
             else:
                 logger.info(f"🔄 Cache EXPIRED for player {player_id} (age: {cache_age.total_seconds() / 3600:.1f}h)")
@@ -4665,6 +4755,9 @@ class APIFootballClient:
                 return []
 
             transfers_data = response.get("response", [])
+
+            if self.mode != "stub":
+                _record_transfer_payload(transfers_data, fallback_player_api_id=player_id)
 
             # Cache the result with timestamp
             self._transfer_cache[player_id] = (transfers_data, datetime.now(UTC))
@@ -5091,6 +5184,10 @@ class APIFootballClient:
                 try:
                     player_id, transfers = future.result()
                     results[player_id] = transfers
+                    if self.mode != "stub":
+                        # Worker threads intentionally have no Flask context;
+                        # persist from the context-owning collector thread.
+                        _record_transfer_payload(transfers, fallback_player_api_id=player_id)
                     completed += 1
 
                     if completed % 10 == 0:

--- a/academy-watch-backend/src/api_football_client.py
+++ b/academy-watch-backend/src/api_football_client.py
@@ -30,6 +30,14 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
+class TransferFetchError(RuntimeError):
+    """A live player-transfer request failed or returned an error payload."""
+
+
+class TeamPlayersFetchError(RuntimeError):
+    """A live team-squad request failed or returned an error payload."""
+
+
 def _record_transfer_payload(
     transfer_blocks: list[dict[str, Any]] | None,
     *,
@@ -115,8 +123,6 @@ def _record_transfer_payload(
 # ------------------------------------------------------------------
 # 🔄 Loan transfer type identification
 # ------------------------------------------------------------------
-# Transfer types that indicate a NEW loan (player going OUT on loan)
-LOAN_START_TYPES = {"loan"}
 # Transfer types that indicate a loan RETURN (player coming BACK from loan)
 LOAN_RETURN_TYPES = {"back from loan", "return from loan", "end of loan", "loan end", "loan return"}
 
@@ -154,21 +160,6 @@ def is_new_loan_transfer(transfer_type: str) -> bool:
     # Now check if it's an actual loan
     # We use exact match to avoid false positives
     return normalized == "loan"
-
-
-def extract_transfer_fee(transfer_type: str) -> str | None:
-    """Extract fee from API-Football transfer type field.
-    Returns raw string like '€50M', 'Free', or None if it's a loan/unknown.
-    """
-    if not transfer_type:
-        return None
-    t = transfer_type.strip()
-    lower = t.lower()
-    if lower in LOAN_START_TYPES | LOAN_RETURN_TYPES:
-        return None
-    if lower in ("n/a", ""):
-        return None
-    return t
 
 
 def _academy_watch_for_team(
@@ -4643,15 +4634,25 @@ class APIFootballClient:
             }
 
     def get_team_players(self, team_id: int, season: int = None) -> list[dict[str, Any]]:
-        """Get all players for a team in a specific season with pagination support."""
+        """Get all players for a team in a specific season with pagination.
+
+        A successful empty provider response returns ``[]``. Live response
+        errors and request exceptions raise ``TeamPlayersFetchError`` so callers
+        can distinguish an unfetched squad from a fetched-and-empty one. Sample
+        rows are returned only in explicitly enabled stub mode.
+        """
         if season is None:
             season = self.current_season_start_year
 
         logger.info(f"👥 Fetching all players for team {team_id}, season {season}")
 
-        if not self.api_key:
-            # Return sample data for testing
+        if self.mode == "stub":
             return self._get_sample_team_players(team_id, season)
+        if not self.api_key:
+            raise TeamPlayersFetchError(
+                "Cannot fetch team players without API_FOOTBALL_KEY; "
+                "enable API_USE_STUB_DATA=true explicitly for sample data"
+            )
 
         try:
             page = 1
@@ -4664,7 +4665,16 @@ class APIFootballClient:
 
                 response = self._make_request("players", {"team": team_id, "season": season, "page": page})
 
-                players_data = response.get("response", [])
+                if response.get("errors"):
+                    raise TeamPlayersFetchError(
+                        f"API-Football returned player errors for team {team_id}, season {season}: {response['errors']}"
+                    )
+
+                players_data = response.get("response")
+                if not isinstance(players_data, list):
+                    raise TeamPlayersFetchError(
+                        f"API-Football returned a malformed player response for team {team_id}, season {season}"
+                    )
                 results_count = response.get("results")
                 paging = response.get("paging", {})
                 current_page = paging.get("current", page)
@@ -4714,9 +4724,12 @@ class APIFootballClient:
             )
             return all_players
 
+        except TeamPlayersFetchError:
+            logger.exception("Failed to fetch team players for team %s, season %s", team_id, season)
+            raise
         except Exception as e:
-            logger.error(f"Error fetching team players: {e}")
-            return self._get_sample_team_players(team_id)
+            logger.exception("Failed to fetch team players for team %s, season %s", team_id, season)
+            raise TeamPlayersFetchError(f"Failed to fetch team players for team {team_id}, season {season}: {e}") from e
 
     def get_player_transfers(self, player_id: int) -> list[dict[str, Any]]:
         """
@@ -4724,6 +4737,12 @@ class APIFootballClient:
 
         🚀 Performance Optimization: Results are cached for 24 hours to reduce
         redundant API calls (typically saves 60% of transfer API calls).
+
+        A successful empty provider response returns ``[]``. Live response
+        errors and request exceptions raise ``TransferFetchError`` so callers
+        can preserve known transfer state instead of treating a failed fetch as
+        an authoritative empty history. Sample data is exclusive to explicit
+        stub mode.
         """
         # Check cache first
         if player_id in self._transfer_cache:
@@ -4743,18 +4762,26 @@ class APIFootballClient:
         # Cache miss or expired - fetch from API
         logger.info(f"🔄 Cache MISS - Fetching transfers for player {player_id} from API")
 
-        if not self.api_key:
-            # Return sample transfer data for testing
+        if self.mode == "stub":
+            # Sample data is valid only when stub mode was explicitly enabled.
             return self._get_sample_transfers(player_id=player_id)
+        if not self.api_key:
+            raise TransferFetchError(
+                "Cannot fetch player transfers without API_FOOTBALL_KEY; "
+                "enable API_USE_STUB_DATA=true explicitly for sample data"
+            )
 
         try:
             response = self._make_request("transfers", {"player": player_id})
 
             if response.get("errors"):
-                logger.warning(f"⚠️ API returned errors: {response['errors']}")
-                return []
+                raise TransferFetchError(
+                    f"API-Football returned transfer errors for player {player_id}: {response['errors']}"
+                )
 
-            transfers_data = response.get("response", [])
+            transfers_data = response.get("response")
+            if not isinstance(transfers_data, list):
+                raise TransferFetchError(f"API-Football returned a malformed transfer response for player {player_id}")
 
             if self.mode != "stub":
                 _record_transfer_payload(transfers_data, fallback_player_api_id=player_id)
@@ -4765,9 +4792,12 @@ class APIFootballClient:
             logger.info(f"✅ Found {len(transfers_data)} transfer records for player {player_id} - CACHED for 24h")
             return transfers_data
 
+        except TransferFetchError:
+            logger.exception("Failed to fetch player transfers for player %s", player_id)
+            raise
         except Exception as e:
-            logger.error(f"Error fetching player transfers: {e}")
-            return self._get_sample_transfers(player_id=player_id)
+            logger.exception("Failed to fetch player transfers for player %s", player_id)
+            raise TransferFetchError(f"Failed to fetch player transfers for player {player_id}: {e}") from e
 
     # Upsert helper functions
     def _get_or_create_fixture(self, db_session, fx, season: int):
@@ -5160,7 +5190,9 @@ class APIFootballClient:
             rate_limit_delay: Delay between requests in seconds (default 0.1s = 10 req/sec)
 
         Returns:
-            Dict mapping player_id to their transfer data
+            Dict mapping successfully fetched player ids to their transfer
+            data. Successful empty histories are included as ``player_id: []``;
+            failed fetches are omitted so callers can distinguish them.
         """
         results = {}
 
@@ -5196,7 +5228,6 @@ class APIFootballClient:
                 except Exception as e:
                     player_id = futures[future]
                     logger.error(f"   Error fetching transfers for player {player_id}: {e}")
-                    results[player_id] = []
 
         logger.info(f"✅ Batch complete: {len(results)}/{len(player_ids)} successful")
         return results

--- a/academy-watch-backend/src/main.py
+++ b/academy-watch-backend/src/main.py
@@ -13,11 +13,11 @@ from flask_talisman import Talisman
 from sqlalchemy.engine.url import URL, make_url
 from werkzeug.exceptions import HTTPException
 
-# Side-effect import: register the sea02 season-rollup tables in db.metadata so
-# `flask db migrate` autogenerate sees them (no spurious drop/create) and so the
-# tables exist for db.create_all(). D3a has no service consumer yet (that is D3b),
-# so nothing else imports these models — this is the registration site.
+# Side-effect imports: register standalone tables in db.metadata so `flask db
+# migrate` autogenerate sees them (no spurious drop/create) and db.create_all()
+# includes them even before a route/service imports the model directly.
 import src.models.season_rollup  # noqa: E402, F401
+import src.models.transfer_event  # noqa: E402, F401
 from src.extensions import limiter
 from src.models.league import League, Newsletter, Team, UserSubscription, db
 from src.models.tracked_player import TrackedPlayer

--- a/academy-watch-backend/src/models/journey.py
+++ b/academy-watch-backend/src/models/journey.py
@@ -43,8 +43,8 @@ class PlayerJourney(db.Model):
     # his academy — e.g. Rijkhoff: Dortmund academy product, on loan from Ajax).
     # current_status overrides the academy-relative status for player-facing
     # surfaces; NULL means "defer to the academy-relative status". Currently set
-    # to 'on_loan' (+ owner) when the current club is a loan. Computed from
-    # STORED journey entries during sync — no extra API call.
+    # to 'on_loan' (+ owner) only for a fresh active resolver loan episode.
+    # Computed from fetched or durably stored chronological transfer evidence.
     current_status = db.Column(db.String(20))
     current_owner_api_id = db.Column(db.Integer)
     current_owner_name = db.Column(db.String(200))
@@ -332,8 +332,8 @@ class PlayerJourneyEntry(db.Model):
     season_phase = db.Column(db.String(12))  # dormant Apertura/Clausura hook
 
     # Transfer date (YYYY-MM-DD) — when the player moved to this club
-    # Populated from transfer API for loan entries; used as tiebreaker
-    # when multiple clubs share the same season and sort_priority.
+    # Populated from the resolver for loan and permanent destination entries;
+    # used as a tiebreaker when clubs share a season and sort_priority.
     transfer_date = db.Column(db.String(20))
 
     # Transfer fee (raw string from API-Football, e.g. "€50M", "Free")

--- a/academy-watch-backend/src/models/transfer_event.py
+++ b/academy-watch-backend/src/models/transfer_event.py
@@ -1,0 +1,41 @@
+"""Durable raw transfer-event evidence (tre01)."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy.dialects.postgresql import JSONB
+from src.models.league import db
+
+# PostgreSQL should use BIGINT for the append-heavy evidence table, while the
+# SQLite test harness needs INTEGER PRIMARY KEY to receive rowid autoincrement.
+_BIG_PK = db.BigInteger().with_variant(db.Integer, "sqlite")
+
+
+class PlayerTransferEvent(db.Model):
+    """One observed API-Football transfer object at its provider natural key."""
+
+    __tablename__ = "player_transfer_events"
+
+    id = db.Column(_BIG_PK, primary_key=True, autoincrement=True)
+    player_api_id = db.Column(db.Integer, nullable=False)
+    transfer_date = db.Column(db.Date, nullable=False)
+    transfer_type = db.Column(db.String, nullable=True)
+    out_club_api_id = db.Column(db.Integer, nullable=True)
+    out_club_name = db.Column(db.String, nullable=True)
+    in_club_api_id = db.Column(db.Integer, nullable=True)
+    in_club_name = db.Column(db.String, nullable=True)
+    first_seen_at = db.Column(db.DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC))
+    last_seen_at = db.Column(db.DateTime(timezone=True), nullable=False, default=lambda: datetime.now(UTC))
+    raw = db.Column(JSONB, nullable=True)
+
+    __table_args__ = (
+        db.UniqueConstraint(
+            "player_api_id",
+            "transfer_date",
+            "out_club_api_id",
+            "in_club_api_id",
+            "transfer_type",
+            name="uq_player_transfer_events_natural_key",
+            postgresql_nulls_not_distinct=True,
+        ),
+        db.Index("ix_player_transfer_events_player_api_id", "player_api_id"),
+    )

--- a/academy-watch-backend/src/routes/api.py
+++ b/academy-watch-backend/src/routes/api.py
@@ -83,7 +83,17 @@ from src.models.league import (
 from src.models.sponsor import Sponsor
 from src.models.tracked_player import TrackedPlayer
 from src.services.email_service import email_service
-from src.utils.academy_classifier import _get_latest_season, classify_tracked_player, flatten_transfers, is_same_club
+from src.services.transfer_resolver import resolve_transfer_state
+from src.utils.academy_classifier import (
+    _club_matches_parent,
+    _get_latest_season,
+    classify_tracked_player,
+    flatten_transfers,
+    is_national_team,
+    is_same_club,
+    latest_parent_permanent_departure,
+    resolved_current_club_is_authoritative,
+)
 from src.utils.background_jobs import (
     STALE_JOB_TIMEOUT,
 )
@@ -5285,8 +5295,6 @@ def _run_batch_fixture_sync(data: dict, job_id: str = None) -> dict:
     api_client = APIFootballClient()
 
     # Sold/released players — discover their current team via API-Football
-    from src.api_football_client import extract_transfer_fee
-
     sold_released = TrackedPlayer.query.filter(
         TrackedPlayer.is_active.is_(True),
         TrackedPlayer.status.in_(["sold", "released", "left"]),
@@ -5297,23 +5305,95 @@ def _run_batch_fixture_sync(data: dict, job_id: str = None) -> dict:
     for tp in sold_released:
         if tp.player_api_id in tracked_api_ids:
             continue
-        # If we already have a team from a prior backfill, use it
+
+        parent_team = db.session.get(Team, tp.team_id) if tp.team_id else None
+        parent_api_id = parent_team.team_id if parent_team else None
+        parent_club_name = parent_team.name if parent_team else None
+        needs_fee = tp.status == "sold" and not tp.sale_fee and not dry_run
+        resolution = None
+        try:
+            transfers_resp = api_client.get_player_transfers(tp.player_api_id)
+            resolution = resolve_transfer_state(
+                flatten_transfers(transfers_resp),
+                as_of=now_utc.date(),
+                initial_owner=({"id": parent_api_id, "name": parent_club_name} if parent_api_id else None),
+            )
+        except Exception as exc:
+            logger.debug(
+                "Batch sync transfer resolution failed for player %s: %s",
+                tp.player_api_id,
+                exc,
+            )
+
+        if needs_fee and resolution is not None and parent_api_id:
+            parent_departure = latest_parent_permanent_departure(
+                resolution,
+                parent_api_id,
+                parent_club_name,
+            )
+            if parent_departure is not None and parent_departure.fee is not None:
+                tp.sale_fee = parent_departure.fee
+                fee_count += 1
+                # Fee propagation is an independent repair.  Persist it before
+                # profile discovery so a later provider/profile failure cannot
+                # silently roll back resolver-derived sale evidence.
+                db.session.commit()
+
+        resolved_team_block = None
+        if resolution is not None and resolution.loan_state != "indeterminate":
+            effective_events = [event for event in resolution.events if event.kind != "unknown"]
+            resolved_club = resolution.current_club
+            resolved_id = (
+                resolved_club.api_id or resolved_club.organization_api_id if resolved_club is not None else None
+            )
+            if (
+                effective_events
+                and resolved_id
+                and resolved_club is not None
+                and not is_national_team(resolved_club.name)
+            ):
+                resolved_team_block = {
+                    "id": resolved_id,
+                    "name": resolved_club.name or f"Team {resolved_id}",
+                }
+
+        # Reconcile a prior backfill with concrete chronological evidence
+        # before the known-club fast path. Transfer failure remains distinct:
+        # without a resolution, the stored club is preserved conservatively.
         if tp.current_club_api_id:
-            team_players[tp.current_club_api_id].append((tp.player_api_id, tp.player_name))
+            use_resolved_team = bool(
+                resolved_team_block is not None
+                and resolution is not None
+                and resolved_current_club_is_authoritative(
+                    resolution,
+                    tp.current_club_api_id,
+                    tp.current_club_name,
+                    latest_season=season,
+                )
+            )
+            effective_team = (resolved_team_block if use_resolved_team else None) or {
+                "id": tp.current_club_api_id,
+                "name": tp.current_club_name,
+            }
+            effective_team_id = effective_team["id"]
+            team_players[effective_team_id].append((tp.player_api_id, tp.player_name))
             tracked_api_ids.add(tp.player_api_id)
+            if not dry_run:
+                if use_resolved_team:
+                    tp.current_club_api_id = effective_team_id
+                    tp.current_club_name = effective_team["name"]
+                db.session.commit()
+            if delay > 0:
+                time.sleep(delay)
             continue
         # Discover team from API-Football /players endpoint
         try:
-            from src.utils.academy_classifier import is_national_team
-
+            best_team_block = None
+            best_stat = None
             player_data = api_client.get_player_by_id(tp.player_api_id, season)
             if player_data and player_data.get("statistics"):
                 # Find the best CLUB team (skip national teams + parent academy, prefer most appearances)
                 # For sold players, we want the club they were sold TO, not the parent
-                parent_team = Team.query.get(tp.team_id) if tp.team_id else None
-                parent_api_id = parent_team.team_id if parent_team else None
-                best_team_block = None
-                best_stat = None
                 best_apps = -1
                 for stat in player_data["statistics"]:
                     team_block = stat.get("team", {})
@@ -5332,56 +5412,36 @@ def _run_batch_fixture_sync(data: dict, job_id: str = None) -> dict:
                         best_team_block = team_block
                         best_stat = stat
 
-                # Cross-reference against transfers before backfilling
-                try:
-                    from src.api_football_client import LOAN_RETURN_TYPES
-                    from src.utils.academy_classifier import flatten_transfers
+            # Determinate chronological state outranks a profile-statistics
+            # guess.  An expired open loan is indeterminate: its old borrower
+            # must not replace newer stored/profile club evidence.
+            profile_club_id = best_team_block.get("id") if best_team_block else None
+            profile_club_name = best_team_block.get("name") if best_team_block else None
+            if (
+                resolved_team_block is not None
+                and resolution is not None
+                and resolved_current_club_is_authoritative(
+                    resolution,
+                    profile_club_id,
+                    profile_club_name,
+                    latest_season=season,
+                )
+            ):
+                best_team_block = resolved_team_block
 
-                    raw_transfers = api_client.get_player_transfers(tp.player_api_id)
-                    flat = flatten_transfers(raw_transfers)
-                    if flat:
-                        most_recent = sorted(flat, key=lambda x: x.get("date", ""), reverse=True)[0]
-                        tr_type = (most_recent.get("type") or "").strip().lower()
-                        dest = most_recent.get("teams", {}).get("in", {})
-                        if dest.get("id") and tr_type not in LOAN_RETURN_TYPES:
-                            best_team_block = {
-                                "id": dest["id"],
-                                "name": dest.get("name", f"Team {dest['id']}"),
-                                "logo": dest.get("logo"),
-                            }
-                except Exception:
-                    pass  # fall through to stats-based result
-
-                if best_team_block:
-                    team_api_id = best_team_block.get("id")
-                    team_players[team_api_id].append((tp.player_api_id, tp.player_name))
-                    tracked_api_ids.add(tp.player_api_id)
-                    # Backfill team on TrackedPlayer
-                    if not dry_run:
-                        tp.current_club_api_id = team_api_id
-                        tp.current_club_name = best_team_block.get("name")
-                        # Also backfill position if missing
-                        if not tp.position:
-                            games = (best_stat or {}).get("games", {}) or {}
-                            tp.position = games.get("position")
-                    discovery_count += 1
-            # Fetch transfer fee for sold players
-            if tp.status == "sold" and not tp.sale_fee and not dry_run:
-                try:
-                    transfers_resp = api_client.get_player_transfers(tp.player_api_id)
-                    # Response is a list: [{player: {...}, transfers: [{date, type, teams}]}]
-                    all_transfers = []
-                    for entry in transfers_resp or []:
-                        all_transfers.extend(entry.get("transfers", []))
-                    # Find the most recent non-loan transfer
-                    for xfer in reversed(all_transfers):
-                        fee = extract_transfer_fee(xfer.get("type", ""))
-                        if fee is not None:
-                            tp.sale_fee = fee
-                            fee_count += 1
-                            break
-                except Exception:
-                    pass
+            if best_team_block:
+                team_api_id = best_team_block.get("id")
+                team_players[team_api_id].append((tp.player_api_id, tp.player_name))
+                tracked_api_ids.add(tp.player_api_id)
+                # Backfill team on TrackedPlayer
+                if not dry_run:
+                    tp.current_club_api_id = team_api_id
+                    tp.current_club_name = best_team_block.get("name")
+                    # Also backfill position if missing
+                    if not tp.position:
+                        games = (best_stat or {}).get("games", {}) or {}
+                        tp.position = games.get("position")
+                discovery_count += 1
             if not dry_run:
                 db.session.commit()
             time.sleep(delay)  # Rate limit API calls
@@ -10875,7 +10935,7 @@ def admin_explain_academy():
     force_sync = data.get("force_sync", False)
 
     try:
-        from src.api_football_client import LOAN_RETURN_TYPES, APIFootballClient, is_new_loan_transfer
+        from src.api_football_client import APIFootballClient
         from src.models.journey import PlayerJourney, PlayerJourneyEntry
         from src.services.journey_sync import JourneySyncService
         from src.utils.academy_classifier import strip_youth_suffix
@@ -10906,24 +10966,43 @@ def admin_explain_academy():
         # Detect permanent transfer destinations
         raw_transfers = api.get_player_transfers(player_api_id)
         transfers = flatten_transfers(raw_transfers)
+        resolver_parent_id = team_api_id or next(
+            iter(journey.academy_club_ids or []),
+            journey.origin_club_api_id,
+        )
+        resolver_parent = (
+            Team.query.filter_by(team_id=resolver_parent_id).order_by(Team.season.desc()).first()
+            if resolver_parent_id
+            else None
+        )
+        transfer_resolution = resolve_transfer_state(
+            transfers,
+            as_of=datetime.now(UTC).date(),
+            initial_owner=(
+                {
+                    "id": resolver_parent_id,
+                    "name": resolver_parent.name if resolver_parent else None,
+                }
+                if resolver_parent_id
+                else None
+            ),
+        )
         permanent_dest_ids = set()
         permanent_dest_info = []
-        for t in transfers or []:
-            ttype = (t.get("type") or "").strip().lower()
-            if not ttype or is_new_loan_transfer(ttype) or ttype in LOAN_RETURN_TYPES:
+        for event in transfer_resolution.events:
+            if event.kind != "permanent":
                 continue
-            teams = t.get("teams", {})
-            dest = teams.get("in", {})
-            dest_id = dest.get("id")
+            dest_id = event.in_club.api_id or event.in_club.organization_api_id
             if dest_id:
                 permanent_dest_ids.add(dest_id)
                 permanent_dest_info.append(
                     {
-                        "date": t.get("date"),
-                        "type": t.get("type"),
-                        "from": teams.get("out", {}).get("name"),
-                        "to": dest.get("name"),
+                        "date": event.transfer_date.isoformat(),
+                        "type": event.raw_type,
+                        "from": event.out_club.name,
+                        "to": event.in_club.name,
                         "to_id": dest_id,
+                        "resolution": event.reason,
                     }
                 )
 
@@ -11364,6 +11443,61 @@ def admin_refresh_tracked_player_statuses():
         return jsonify(_safe_error_payload(e, "Failed to refresh statuses")), 500
 
 
+def _academy_seed_transfer_fallback_eligible(
+    api_client,
+    player_api_id: int,
+    parent_api_id: int,
+    parent_club_name: str | None,
+    *,
+    as_of: date | str | None = None,
+) -> bool:
+    """Return whether transfer evidence safely permits academy fallback.
+
+    A candidate parent is the proposition being tested, not proven owner
+    context. Failed lookups, malformed dropped events, and unresolved N/A
+    topology therefore remain ineligible instead of becoming false evidence
+    that the player was never recruited.
+    """
+    try:
+        transfers = flatten_transfers(api_client.get_player_transfers(player_api_id))
+        resolution = resolve_transfer_state(
+            transfers,
+            as_of=as_of or datetime.now(UTC).date(),
+        )
+    except Exception as exc:
+        logger.warning(
+            "seed: transfer fallback skipped %d because lookup/resolution failed: %s",
+            player_api_id,
+            exc,
+        )
+        return False
+
+    evidence_was_dropped = len(resolution.normalized_events) < len(transfers)
+    has_ambiguous_event = any(event.kind == "unknown" for event in resolution.events)
+    if evidence_was_dropped or has_ambiguous_event:
+        logger.info(
+            "seed: transfer fallback skipped %d because transfer history is ambiguous",
+            player_api_id,
+        )
+        return False
+
+    was_recruited = any(
+        event.kind in {"loan_start", "permanent"}
+        and _club_matches_parent(
+            event.in_club,
+            parent_api_id,
+            parent_club_name,
+        )
+        and not _club_matches_parent(
+            event.out_club,
+            parent_api_id,
+            parent_club_name,
+        )
+        for event in resolution.events
+    )
+    return not was_recruited
+
+
 def _seed_single_team(team, max_age=30, sync_journeys=True, years=4, season=None):
     """Core seed logic: discover academy players and create TrackedPlayer rows.
 
@@ -11464,28 +11598,12 @@ def _seed_single_team(team, max_age=30, sync_journeys=True, years=4, season=None
                     # aren't in API-Football as separate entries)
                     age = player_info.get("age")
                     if age and int(age) <= 22:
-                        was_bought = False
-                        try:
-                            transfers_resp = _api.get_player_transfers(pid)
-                            for tentry in transfers_resp or []:
-                                for xfer in tentry.get("transfers", []):
-                                    teams_in = xfer.get("teams", {}).get("in", {})
-                                    xfer_type = (xfer.get("type") or "").strip().lower()
-                                    if teams_in.get("id") == parent_api_id and xfer_type not in (
-                                        "loan",
-                                        "back from loan",
-                                        "return from loan",
-                                        "end of loan",
-                                        "loan end",
-                                        "loan return",
-                                    ):
-                                        was_bought = True
-                                        break
-                                if was_bought:
-                                    break
-                        except Exception:
-                            pass
-                        if not was_bought:
+                        if _academy_seed_transfer_fallback_eligible(
+                            _api,
+                            pid,
+                            parent_api_id,
+                            team.name,
+                        ):
                             candidate_ids[pid] = journey
                             logger.info(
                                 "seed: transfer-fallback accepted %d (%s) age %s for %s",

--- a/academy-watch-backend/src/routes/journey.py
+++ b/academy-watch-backend/src/routes/journey.py
@@ -148,7 +148,8 @@ def admin_recompute_academy():
     if not isinstance(cursor, int) or isinstance(cursor, bool) or cursor < 0:
         return jsonify({"error": "cursor must be a non-negative integer"}), 400
 
-    service = JourneySyncService()
+    service = JourneySyncService(database_only=True)
+    from src.services.season_rollup_service import refresh_player as refresh_season_rollup
 
     journeys = (
         PlayerJourney.query.filter(
@@ -180,6 +181,9 @@ def admin_recompute_academy():
             )
 
     errors = 0
+    durable_reclassified = 0
+    rollup_seasons_refreshed = 0
+    error_examples = []
     last_processed = cursor
     for journey in journeys:
         journey_id = journey.id
@@ -200,8 +204,26 @@ def admin_recompute_academy():
             # cancelled by the server statement_timeout.
             with db.session.no_autoflush:
                 entries = PlayerJourneyEntry.query.filter_by(journey_id=journey_id).all()
-                service._apply_development_classification(entries, transfers=None, birth_date=journey.birth_date)
-                service._compute_academy_club_ids(journey, entries=entries)
+                durable_result = service.reclassify_from_durable_transfer_events(journey)
+                if durable_result is None:
+                    # tre01 has no successful-empty marker; zero rows are
+                    # unknown evidence, so transfer state remains untouched.
+                    service._apply_development_classification(entries, transfers=None, birth_date=journey.birth_date)
+                    service._compute_academy_club_ids(journey, entries=entries)
+                    affected_seasons = set()
+                else:
+                    affected_seasons = durable_result["entry_seasons"]
+
+                db.session.flush()
+                for affected_season in sorted(affected_seasons):
+                    refresh_season_rollup(
+                        journey.player_api_id,
+                        season=affected_season,
+                        session=db.session,
+                    )
+                rollup_seasons_refreshed += len(affected_seasons)
+                if durable_result is not None:
+                    durable_reclassified += 1
             journeys_processed += 1
             new_ids = sorted(journey.academy_club_ids or [])
             recomputed[journey_id] = set(new_ids)
@@ -225,6 +247,8 @@ def admin_recompute_academy():
             errors += 1
             logger.warning("recompute-academy failed for journey %s: %s", journey_id, exc)
             db.session.rollback()
+            if len(error_examples) < 20:
+                error_examples.append({"journey_id": journey_id, "error": str(exc)})
         last_processed = journey_id
 
     # ── Contradiction sweep ──
@@ -282,6 +306,9 @@ def admin_recompute_academy():
         "journeys_changed": journeys_changed,
         "rows_deactivated": len(deactivated_ids),
         "errors": errors,
+        "error_examples": error_examples,
+        "durable_reclassified": durable_reclassified,
+        "rollup_seasons_refreshed": rollup_seasons_refreshed,
         "examples": examples,
         "dry_run": dry_run,
         "applied": not dry_run,
@@ -294,12 +321,14 @@ def admin_recompute_academy():
 @journey_bp.route("/admin/journeys/backfill-current-status", methods=["POST"])
 @require_api_key
 def admin_backfill_current_status():
-    """Backfill player_journeys.current_status / current_owner_* from STORED
-    journey entries (no API calls, no journey re-sync). Computes the player's
-    actual current situation (on_loan + owner) exactly as a sync would, so the
-    player-facing 'actual status' is correct without a full re-sync.
+    """Backfill player_journeys.current_status / current_owner_* from durable
+    PlayerTransferEvent evidence (no API calls, no journey re-sync).
 
-    Writes ONLY the new current_status / current_owner_* journey columns — it
+    Journeys without stored transfer events are reported and left unchanged;
+    historical journey-entry labels cannot prove a current loan or its owner.
+    Evidence-backed rows use the same chronological resolver as a live sync.
+
+    Writes the evidence-backed journey current club/status/owner atomically. It
     never touches TrackedPlayer.status, so it cannot clobber the per-academy
     statuses. Paged via cursor; one small transaction per journey.
 
@@ -317,17 +346,27 @@ def admin_backfill_current_status():
     if not isinstance(cursor, int) or isinstance(cursor, bool) or cursor < 0:
         return jsonify({"error": "cursor must be a non-negative integer"}), 400
 
-    service = JourneySyncService()
+    service = JourneySyncService(database_only=True)
     journeys = PlayerJourney.query.filter(PlayerJourney.id > cursor).order_by(PlayerJourney.id).limit(limit).all()
 
     processed = 0
     on_loan_set = 0
+    evidence_resolved = 0
+    skipped_no_transfer_evidence = 0
     errors = 0
     last_processed = cursor
     for journey in journeys:
         try:
             entries = PlayerJourneyEntry.query.filter_by(journey_id=journey.id).all()
-            service._set_current_status(journey, entries)
+            resolution = service._resolve_durable_transfer_state(journey, entries)
+            if resolution is None:
+                skipped_no_transfer_evidence += 1
+                processed += 1
+                last_processed = journey.id
+                continue
+
+            service.apply_resolved_current_state(journey, entries, resolution)
+            evidence_resolved += 1
             if journey.current_status == "on_loan":
                 on_loan_set += 1
             processed += 1
@@ -345,6 +384,8 @@ def admin_backfill_current_status():
         {
             "dry_run": dry_run,
             "journeys_processed": processed,
+            "evidence_resolved": evidence_resolved,
+            "skipped_no_transfer_evidence": skipped_no_transfer_evidence,
             "on_loan_set": on_loan_set,
             "errors": errors,
             "next_cursor": last_processed if len(journeys) == limit else None,

--- a/academy-watch-backend/src/services/journey_sync.py
+++ b/academy-watch-backend/src/services/journey_sync.py
@@ -7,12 +7,25 @@ complete journey records with academy, loan, and first team data.
 
 import logging
 import re
-from datetime import UTC, datetime
+from calendar import monthrange
+from collections.abc import Mapping
+from datetime import UTC, date, datetime, timedelta
 
 from sqlalchemy.exc import IntegrityError
-from src.api_football_client import LOAN_RETURN_TYPES, APIFootballClient, is_new_loan_transfer
+from src.api_football_client import APIFootballClient
 from src.models.journey import LEVEL_PRIORITY, YOUTH_LEVELS, ClubLocation, PlayerJourney, PlayerJourneyEntry
 from src.models.league import Team, TeamProfile, db
+from src.models.season_rollup import LeagueSeasonConfig
+from src.models.transfer_event import PlayerTransferEvent
+from src.services.season_rollup_service import refresh_player as refresh_season_rollup
+from src.services.transfer_resolver import (
+    ClubRef,
+    LoanEpisode,
+    TransferResolution,
+    loan_episode_overlaps_season,
+    normalize_transfer_events,
+    resolve_transfer_state,
+)
 from src.utils.academy_classifier import (
     INTERNATIONAL_PATTERNS as _INTERNATIONAL_PATTERNS,
 )
@@ -22,12 +35,97 @@ from src.utils.academy_classifier import (
 from src.utils.academy_classifier import (
     is_international_competition,
     is_national_team,
+    latest_parent_permanent_departure,
+    resolved_current_club_is_authoritative,
     strip_youth_suffix,
 )
+from src.utils.affiliates import resolve_senior_id, senior_base_name
 from src.utils.geocoding import get_team_coordinates
 from src.utils.player_names import clean_name, is_placeholder_name, resolve_player_name
 
 logger = logging.getLogger(__name__)
+
+
+def _transfer_as_of(as_of: date | str | None = None) -> date | str:
+    """Use one explicit UTC date for every resolver consumer in a sync."""
+    return as_of if as_of is not None else datetime.now(UTC).date()
+
+
+def _coerce_transfer_resolution(
+    transfers,
+    *,
+    transfer_resolution: TransferResolution | None = None,
+    as_of: date | str | None = None,
+    season_start_month: int = 7,
+    season_start_day: int = 1,
+) -> TransferResolution | None:
+    """Return a supplied resolution or resolve a fetched transfer payload once.
+
+    ``None`` means transfer evidence was not fetched.  An empty list is a real,
+    successfully-fetched empty history and therefore resolves to an explicit
+    unknown state instead of falling back to stored journey guesses.
+    """
+    if transfer_resolution is not None:
+        return transfer_resolution
+    if isinstance(transfers, TransferResolution):
+        return transfers
+    if transfers is None:
+        return None
+    return resolve_transfer_state(
+        transfers,
+        as_of=_transfer_as_of(as_of),
+        season_start_month=season_start_month,
+        season_start_day=season_start_day,
+    )
+
+
+def _season_bounds(season: int, start_month: int = 7, start_day: int = 1) -> tuple[date, date]:
+    """Return the half-open competition season for a provider season label."""
+    start = date(int(season), int(start_month), int(start_day))
+    return start, date(int(season) + 1, int(start_month), int(start_day))
+
+
+def _season_grace_end(season_end: date, months: int = 3) -> date:
+    """Return the inclusive end of a short post-season transfer grace window."""
+    month_index = season_end.year * 12 + season_end.month - 1 + months - 1
+    year, month_zero = divmod(month_index, 12)
+    month = month_zero + 1
+    return date(year, month, monthrange(year, month)[1])
+
+
+def _metadata_name(value: str | None) -> str:
+    return " ".join((value or "").strip().casefold().split())
+
+
+def _club_ref_matches(ref: ClubRef | None, club_api_id: int | None, club_name: str | None) -> bool:
+    """Match a journey club to a resolver club across senior/youth affiliates."""
+    if ref is None or (club_api_id is None and not club_name):
+        return False
+    if club_api_id is not None:
+        if ref.api_id == club_api_id:
+            return True
+        senior_id = resolve_senior_id(club_api_id, club_name)
+        if ref.organization_api_id is not None and ref.organization_api_id == senior_id:
+            return True
+    base_name = senior_base_name(club_name).strip().casefold()
+    return bool(base_name and ref.organization_key == f"name:{base_name}")
+
+
+def _raw_club_logo(event, direction: str) -> str:
+    """Best-effort logo lookup without sacrificing the resolver's raw IDs."""
+    raw = event.event.raw
+    if not isinstance(raw, Mapping):
+        raw = getattr(raw, "raw", None)
+    if not isinstance(raw, Mapping):
+        return ""
+    teams = raw.get("teams")
+    if not isinstance(teams, Mapping):
+        return ""
+    club = teams.get(direction)
+    if not isinstance(club, Mapping):
+        return ""
+    logo = club.get("logo")
+    return logo if isinstance(logo, str) else ""
 
 
 def _stat_int(value) -> int | None:
@@ -171,9 +269,90 @@ class JourneySyncService:
     # Delegate to shared utility
     INTERNATIONAL_PATTERNS = _INTERNATIONAL_PATTERNS
 
-    def __init__(self, api_client: APIFootballClient | None = None):
-        """Initialize with optional API client"""
-        self.api = api_client or APIFootballClient()
+    def __init__(self, api_client: APIFootballClient | None = None, *, database_only: bool = False):
+        """Initialize with an API client unless this is an explicit DB repair."""
+        if database_only and api_client is not None:
+            raise ValueError("database_only cannot be combined with api_client")
+        self.api = None if database_only else (api_client or APIFootballClient())
+
+    def _competition_start_months(self, entries: list) -> dict[int, int]:
+        """Load configured league boundaries once for a batch of entries."""
+        from flask import has_app_context
+
+        if not has_app_context():
+            return {}
+        league_ids = {
+            int(entry.league_api_id) for entry in entries if getattr(entry, "league_api_id", None) is not None
+        }
+        if not league_ids:
+            return {}
+        rows = LeagueSeasonConfig.query.filter(LeagueSeasonConfig.league_api_id.in_(league_ids)).all()
+        starts = {}
+        for row in rows:
+            if isinstance(row.rollover_month, int) and 1 <= row.rollover_month <= 12:
+                starts[row.league_api_id] = row.rollover_month
+            elif (row.season_type or "").strip().casefold() == "calendar":
+                starts[row.league_api_id] = 1
+        return starts
+
+    @staticmethod
+    def _entry_start_month(entry, start_months: Mapping[int, int] | None = None) -> int:
+        explicit = getattr(entry, "season_start_month", None)
+        if isinstance(explicit, int) and 1 <= explicit <= 12:
+            return explicit
+        league_id = getattr(entry, "league_api_id", None)
+        return (start_months or {}).get(league_id, 7)
+
+    def _resolution_start_month(self, entries: list, start_months: Mapping[int, int] | None = None) -> int:
+        """Use the freshest domestic statistics competition as resolver context."""
+        domestic = [entry for entry in entries if not getattr(entry, "is_international", False)]
+        if not domestic:
+            return 7
+        latest = max(
+            domestic,
+            key=lambda entry: (
+                getattr(entry, "season", 0) or 0,
+                getattr(entry, "sort_priority", 0) or 0,
+                getattr(entry, "transfer_date", None) or "",
+            ),
+        )
+        return self._entry_start_month(latest, start_months)
+
+    @staticmethod
+    def _capture_transfer_metadata(entries: list) -> tuple[dict, dict]:
+        exact = {}
+        by_name = {}
+        for entry in entries:
+            if not (entry.entry_type == "loan" or entry.transfer_date or entry.transfer_fee):
+                continue
+            value = (entry.entry_type == "loan", entry.transfer_date, entry.transfer_fee)
+            exact[(entry.season, entry.club_api_id, entry.league_api_id)] = value
+            name_key = (
+                entry.season,
+                _metadata_name(entry.club_name),
+                _metadata_name(getattr(entry, "league_name", None)),
+            )
+            if name_key[1] and name_key[2]:
+                by_name[name_key] = value
+        return exact, by_name
+
+    @staticmethod
+    def _restore_transfer_metadata(entry, prior_metadata: tuple[dict, dict]) -> None:
+        exact, by_name = prior_metadata
+        prior = exact.get((entry.season, entry.club_api_id, entry.league_api_id))
+        if prior is None:
+            prior = by_name.get(
+                (
+                    entry.season,
+                    _metadata_name(entry.club_name),
+                    _metadata_name(getattr(entry, "league_name", None)),
+                )
+            )
+        if prior is None:
+            return
+        was_loan, entry.transfer_date, entry.transfer_fee = prior
+        if was_loan:
+            entry.entry_type = "loan"
 
     def sync_player(self, player_api_id: int, force_full: bool = False, heartbeat_fn=None) -> PlayerJourney | None:
         """
@@ -226,7 +405,13 @@ class JourneySyncService:
 
             # Fetch transfer history for loan classification
             transfers = self._get_player_transfers(player_api_id)
-            loan_timeline = self._build_transfer_timeline(transfers)
+            sync_as_of = _transfer_as_of()
+            transfer_resolution = None
+            prior_transfer_metadata = ({}, {})
+            if transfers is None:
+                prior_transfer_metadata = self._capture_transfer_metadata(
+                    PlayerJourneyEntry.query.filter_by(journey_id=journey.id).all()
+                )
 
             if heartbeat_fn:
                 heartbeat_fn()
@@ -261,9 +446,26 @@ class JourneySyncService:
                 if heartbeat_fn and (season_idx + 1) % 3 == 0:
                     heartbeat_fn()
 
+            if transfers is not None:
+                calendar_entries = PlayerJourneyEntry.query.filter_by(journey_id=journey.id).all() + all_entries
+                start_months = self._competition_start_months(calendar_entries)
+                resolution_start_month = self._resolution_start_month(calendar_entries, start_months)
+                initial_owner = self._derive_transfer_initial_owner(journey, all_entries, transfers)
+                transfer_resolution = resolve_transfer_state(
+                    transfers,
+                    as_of=sync_as_of,
+                    initial_owner=initial_owner,
+                    season_start_month=resolution_start_month,
+                )
+
             # Correct club IDs for players who transferred — API-Football
             # retroactively returns the current team for historical seasons
-            self._correct_club_ids_from_transfers(all_entries, transfers)
+            self._correct_club_ids_from_transfers(
+                all_entries,
+                transfers,
+                transfer_resolution=transfer_resolution,
+                as_of=sync_as_of,
+            )
 
             # Merge entries that share (club, league, season) after correction
             all_entries = self._merge_corrected_duplicates(all_entries)
@@ -271,12 +473,24 @@ class JourneySyncService:
             # Deduplicate entries with identical stat fingerprints
             all_entries = self._deduplicate_entries(all_entries)
 
-            # Classify loan entries based on transfer history
-            self._apply_loan_classification(all_entries, loan_timeline)
+            if transfer_resolution is not None:
+                # Classify loan entries based on chronological transfer state.
+                self._apply_loan_classification(all_entries, transfer_resolution)
 
-            # Fill in transfer_date from permanent transfers for entries that
-            # don't already have one (ensures current-club tiebreaker works)
-            self._apply_permanent_transfer_dates(all_entries, transfers)
+                # A later permanent move replaces stale loan metadata from an
+                # earlier episode and carries its raw fee into non-loan entries.
+                self._apply_permanent_transfer_dates(
+                    all_entries,
+                    transfers,
+                    transfer_resolution=transfer_resolution,
+                    as_of=sync_as_of,
+                )
+            else:
+                # A failed fetch is not an empty history. Preserve matching
+                # durable entry metadata instead of falsely clearing known
+                # loans/dates/fees while still accepting fresh statistics.
+                for entry in all_entries:
+                    self._restore_transfer_metadata(entry, prior_transfer_metadata)
 
             # Reclassify youth entries as 'development' or 'integration'
             # based on first-team history, transfer records, and age
@@ -284,6 +498,8 @@ class JourneySyncService:
                 all_entries,
                 transfers=transfers,
                 birth_date=(player_info or {}).get("birth", {}).get("date"),
+                transfer_resolution=transfer_resolution,
+                as_of=sync_as_of,
             )
 
             # Update player info
@@ -303,14 +519,33 @@ class JourneySyncService:
                 synced_seasons = set(e.season for e in all_entries)
                 PlayerJourneyEntry.query.filter(
                     PlayerJourneyEntry.journey_id == journey.id, PlayerJourneyEntry.season.in_(synced_seasons)
-                ).delete(synchronize_session=False)
+                ).delete(synchronize_session="fetch")
 
                 for entry in all_entries:
                     entry.journey_id = journey.id
                     db.session.add(entry)
 
-            # Update journey aggregates
-            self._update_journey_aggregates(journey, transfers=transfers)
+            db.session.flush()
+            rollup_seasons = set(seasons_to_sync)
+            if transfer_resolution is not None:
+                persisted_entries = PlayerJourneyEntry.query.filter_by(journey_id=journey.id).all()
+                reclassified = self._reclassify_all_history(
+                    journey,
+                    persisted_entries,
+                    transfers,
+                    transfer_resolution,
+                    as_of=sync_as_of,
+                )
+                rollup_seasons.update(reclassified["changed_seasons"])
+            else:
+                # Failed transfer fetch: accept fresh statistics while preserving
+                # the previously evidenced transfer classification/status.
+                self._update_journey_aggregates(
+                    journey,
+                    transfers=None,
+                    transfer_resolution=None,
+                    as_of=sync_as_of,
+                )
 
             # Auto-geocode missing club locations
             try:
@@ -323,22 +558,24 @@ class JourneySyncService:
             journey.last_synced_at = datetime.now(UTC)
             journey.sync_error = None
 
-            # Season-rollup steady-state hook (proposal §3): rebuild this
-            # player's rollup cells + totals for every season re-synced, in the
-            # SAME transaction as the journey write so a club-ID correction can
-            # never orphan a cell. refresh_player does NOT commit — the commit
-            # below persists journey + rollup atomically. Wrapped in a SAVEPOINT
-            # so a rollup bug rolls back only the derived rows, never the
-            # (API-expensive) journey sync itself.
+            # Keep derived rollup failures isolated from the API-expensive
+            # journey write. The SAVEPOINT rolls back only partial rollup rows;
+            # a later repair/cold-build can reconstruct them from the journey.
             try:
-                from src.services.season_rollup_service import refresh_player as _refresh_rollup
-
                 db.session.flush()
                 with db.session.begin_nested():
-                    for _rollup_season in sorted(set(seasons_to_sync)):
-                        _refresh_rollup(player_api_id, season=_rollup_season, session=db.session)
-            except Exception as _rollup_err:
-                logger.warning(f"season-rollup refresh failed for player {player_api_id}: {_rollup_err}")
+                    for _rollup_season in sorted(rollup_seasons):
+                        refresh_season_rollup(
+                            player_api_id,
+                            season=_rollup_season,
+                            session=db.session,
+                        )
+            except Exception as rollup_err:
+                logger.warning(
+                    "season-rollup refresh failed for player %s: %s",
+                    player_api_id,
+                    rollup_err,
+                )
 
             db.session.commit()
             logger.info(f"Successfully synced journey for player {player_api_id}: {len(all_entries)} entries")
@@ -549,12 +786,14 @@ class JourneySyncService:
 
         return False
 
-    def _get_player_transfers(self, player_api_id: int) -> list:
+    def _get_player_transfers(self, player_api_id: int) -> list | None:
         """
         Get transfer records for a player.
 
         Calls the API client's cached get_player_transfers method.
-        Returns a flat list of transfer dicts on success, [] on error.
+        Returns a flat list on success (including ``[]`` for a successful empty
+        history) and ``None`` on fetch failure. The distinction prevents a
+        transient provider/cache error from clearing known transfer state.
         """
         try:
             data = self.api.get_player_transfers(player_api_id)
@@ -565,72 +804,252 @@ class JourneySyncService:
             return transfers
         except Exception as e:
             logger.warning(f"Failed to get transfers for player {player_api_id}: {e}")
+            return None
+
+    def _resolve_durable_transfer_state(
+        self,
+        journey: PlayerJourney,
+        entries: list,
+        *,
+        as_of: date | str | None = None,
+    ) -> TransferResolution | None:
+        """Resolve locally persisted transfer evidence without provider I/O.
+
+        ``None`` means no durable evidence exists and callers must leave stored
+        status fields unchanged. ORM rows expose the resolver's flattened event
+        attributes directly, so their raw types, endpoints, and dates retain the
+        same chronology/topology semantics as an in-sync provider payload.
+        """
+        rows = (
+            PlayerTransferEvent.query.filter_by(player_api_id=journey.player_api_id)
+            .order_by(PlayerTransferEvent.transfer_date, PlayerTransferEvent.id)
+            .all()
+        )
+        if not rows:
+            return None
+
+        start_months = self._competition_start_months(entries)
+        resolution_start_month = self._resolution_start_month(entries, start_months)
+        initial_owner = self._derive_transfer_initial_owner(journey, entries, rows)
+        return resolve_transfer_state(
+            rows,
+            as_of=_transfer_as_of(as_of),
+            initial_owner=initial_owner,
+            season_start_month=resolution_start_month,
+        )
+
+    @staticmethod
+    def _entry_reclassification_state(entry) -> tuple:
+        return (
+            entry.club_api_id,
+            entry.club_name,
+            entry.league_api_id,
+            entry.league_name,
+            entry.level,
+            entry.entry_type,
+            entry.is_youth,
+            entry.transfer_date,
+            entry.transfer_fee,
+        )
+
+    def _reclassify_all_history(
+        self,
+        journey: PlayerJourney,
+        entries: list,
+        transfers: list,
+        resolution: TransferResolution,
+        *,
+        as_of: date | str | None = None,
+    ) -> dict:
+        """Reclassify every stored entry and recompute all transfer consumers."""
+        before = {
+            entry.id: (entry.season, self._entry_reclassification_state(entry))
+            for entry in entries
+            if entry.id is not None
+        }
+
+        self._correct_club_ids_from_transfers(
+            entries,
+            transfers,
+            transfer_resolution=resolution,
+            as_of=as_of,
+        )
+        merged_entries = self._merge_corrected_duplicates(entries)
+        kept_ids = {entry.id for entry in merged_entries if entry.id is not None}
+        for entry in entries:
+            if entry.id is not None and entry.id not in kept_ids:
+                db.session.delete(entry)
+        entries = merged_entries
+
+        self._apply_loan_classification(entries, resolution)
+        self._apply_permanent_transfer_dates(
+            entries,
+            transfers,
+            transfer_resolution=resolution,
+            as_of=as_of,
+        )
+        self._apply_development_classification(
+            entries,
+            transfers=transfers,
+            birth_date=journey.birth_date,
+            transfer_resolution=resolution,
+            as_of=as_of,
+        )
+        db.session.flush()
+
+        self._update_journey_aggregates(
+            journey,
+            transfers=transfers,
+            transfer_resolution=resolution,
+            as_of=as_of,
+        )
+
+        changed_seasons = {
+            season
+            for entry_id, (season, state) in before.items()
+            if entry_id not in kept_ids
+            or next(
+                (self._entry_reclassification_state(entry) != state for entry in entries if entry.id == entry_id),
+                True,
+            )
+        }
+        entry_seasons = {entry.season for entry in entries if entry.season is not None}
+        return {
+            "resolution": resolution,
+            "changed_seasons": changed_seasons,
+            "entry_seasons": entry_seasons,
+        }
+
+    def reclassify_from_durable_transfer_events(
+        self,
+        journey: PlayerJourney,
+        *,
+        as_of: date | str | None = None,
+    ) -> dict | None:
+        """Run the all-history reclassifier using only locally stored evidence.
+
+        ``None`` is the conservative zero-evidence result: tre01 stores events,
+        not a successful-empty coverage marker, so absence cannot distinguish an
+        authoritative empty history from failure or not-yet-attempted.
+        """
+        entries = PlayerJourneyEntry.query.filter_by(journey_id=journey.id).all()
+        rows = (
+            PlayerTransferEvent.query.filter_by(player_api_id=journey.player_api_id)
+            .order_by(PlayerTransferEvent.transfer_date, PlayerTransferEvent.id)
+            .all()
+        )
+        if not rows:
+            return None
+
+        start_months = self._competition_start_months(entries)
+        initial_owner = self._derive_transfer_initial_owner(journey, entries, rows)
+        resolution = resolve_transfer_state(
+            rows,
+            as_of=_transfer_as_of(as_of),
+            initial_owner=initial_owner,
+            season_start_month=self._resolution_start_month(entries, start_months),
+        )
+        return self._reclassify_all_history(
+            journey,
+            entries,
+            rows,
+            resolution,
+            as_of=as_of,
+        )
+
+    def _derive_transfer_initial_owner(self, journey, entries: list, transfers: list) -> dict | None:
+        """Seed a mid-stream resolver only from corroborated academy evidence.
+
+        A lone first-event ``N/A`` is directional only when we already know
+        which endpoint is the player's owning/origin organisation. Persisted
+        origin/academy attribution and pre-event youth entries are defensible
+        evidence; senior statistics alone are not (they may belong to a
+        borrower). Ambiguous or absent evidence deliberately returns ``None``.
+        """
+        normalized = normalize_transfer_events(transfers).events
+        if not normalized:
+            return None
+        first_event = normalized[0]
+
+        evidence: list[tuple[int | None, str | None]] = []
+        origin_id = getattr(journey, "origin_club_api_id", None)
+        origin_name = getattr(journey, "origin_club_name", None)
+        if origin_id or origin_name:
+            evidence.append((origin_id, origin_name))
+
+        for academy_id in getattr(journey, "academy_club_ids", None) or []:
+            evidence.append((academy_id, None))
+
+        # Only youth evidence strictly predating the first event's year is
+        # safe: same-season destination U21 statistics may be post-signing
+        # integration rather than proof of academy ownership.
+        for entry in entries:
+            if (
+                entry.is_youth
+                and not entry.is_international
+                and entry.season is not None
+                and entry.season < first_event.transfer_date.year
+                and entry.entry_type in ("academy", "development")
+            ):
+                evidence.append((entry.club_api_id, entry.club_name))
+
+        matched: dict[str, ClubRef] = {}
+        for endpoint in (first_event.out_club, first_event.in_club):
+            if any(_club_ref_matches(endpoint, club_id, club_name) for club_id, club_name in evidence):
+                matched[endpoint.organization_key] = endpoint
+
+        if len(matched) != 1:
+            return None
+        owner = next(iter(matched.values()))
+        owner_id = owner.organization_api_id or owner.api_id
+        if owner_id is None:
+            return None
+        return {
+            "id": owner_id,
+            "name": senior_base_name(owner.name) or owner.name,
+        }
+
+    def _build_transfer_timeline(
+        self,
+        transfers: list,
+        *,
+        transfer_resolution: TransferResolution | None = None,
+        as_of: date | str | None = None,
+    ) -> list:
+        """Return the legacy dict projection of chronological loan episodes.
+
+        The public helper shape remains compatible for scripts/tests, but its
+        semantics now come exclusively from ``resolve_transfer_state``: input
+        order is irrelevant, conversions close episodes, and re-loans remain
+        distinct.
+        """
+        resolution = _coerce_transfer_resolution(
+            transfers,
+            transfer_resolution=transfer_resolution,
+            as_of=as_of,
+        )
+        if resolution is None:
             return []
+        return [
+            {
+                "club_id": episode.loan_club.api_id,
+                "club_name": episode.loan_club.name,
+                "parent_club_id": episode.owner.api_id,
+                "start_date": episode.start_date.isoformat(),
+                "end_date": episode.end_date.isoformat() if episode.end_date else None,
+            }
+            for episode in resolution.loan_episodes
+        ]
 
-    def _build_transfer_timeline(self, transfers: list) -> list:
-        """
-        Build a list of loan periods from transfer records.
-
-        Returns list of dicts:
-            [{club_id, club_name, parent_club_id, start_date, end_date}, ...]
-
-        Loan starts are identified by is_new_loan_transfer().
-        Loan ends are identified by LOAN_RETURN_TYPES.
-        """
-        loan_periods = []
-
-        for transfer in transfers:
-            transfer_type = (transfer.get("type") or "").strip().lower()
-            transfer_date = transfer.get("date")
-            teams = transfer.get("teams", {})
-            team_in = teams.get("in", {})
-            team_out = teams.get("out", {})
-
-            if is_new_loan_transfer(transfer_type):
-                # New loan: player goes OUT from parent → IN to loan club
-                loan_periods.append(
-                    {
-                        "club_id": team_in.get("id"),
-                        "club_name": team_in.get("name"),
-                        "parent_club_id": team_out.get("id"),
-                        "start_date": transfer_date,
-                        "end_date": None,  # open-ended until we find a return
-                    }
-                )
-            elif transfer_type in LOAN_RETURN_TYPES:
-                # Loan return: close the most recent open loan for this parent club
-                return_parent_id = team_in.get("id")
-                for period in reversed(loan_periods):
-                    if period["parent_club_id"] == return_parent_id and period["end_date"] is None:
-                        period["end_date"] = transfer_date
-                        break
-
-        return loan_periods
-
-    def _loan_overlaps_season(self, loan: dict, season: int) -> bool:
-        """
-        Check if a loan period overlaps a football season.
-
-        A season (e.g. 2023) runs roughly July 2023 to June 2024.
-        """
-        season_start = f"{season}-07-01"
-        season_end = f"{season + 1}-06-30"
-
-        loan_start = loan.get("start_date") or ""
-        loan_end = loan.get("end_date")
-
-        if not loan_start:
-            return False
-
-        # Loan must start before season ends
-        if loan_start > season_end:
-            return False
-
-        # If loan has an end date, it must end after season starts
-        if loan_end and loan_end < season_start:
-            return False
-
-        return True
+    def _loan_overlaps_season(
+        self,
+        loan: LoanEpisode | Mapping,
+        season: int,
+        *,
+        start_month: int = 7,
+    ) -> bool:
+        """Compatibility wrapper for the resolver's half-open season helper."""
+        return loan_episode_overlaps_season(loan, season, start_month=start_month)
 
     def _deduplicate_entries(self, entries: list) -> list:
         """
@@ -680,85 +1099,146 @@ class JourneySyncService:
 
         return result
 
-    def _apply_loan_classification(self, entries: list, loan_timeline: list):
-        """
-        Set entry_type='loan' and transfer_date for entries at loan clubs.
+    def _apply_loan_classification(self, entries: list, loan_timeline: list | TransferResolution):
+        """Classify entries from distinct resolver loan episodes.
 
-        For each non-international entry, if club_api_id matches a loan period
-        overlapping that season, classify it as a loan and record the
-        transfer start date for ordering purposes.
+        When multiple episodes reach the same borrower, the latest episode
+        overlapping the entry's season wins.  A stale legacy ``loan`` value is
+        cleared when no episode overlaps, allowing a later permanent move to
+        replace both its type and date.
         """
-        if not loan_timeline:
-            return
+        episodes = (
+            list(loan_timeline.loan_episodes)
+            if isinstance(loan_timeline, TransferResolution)
+            else list(loan_timeline or [])
+        )
+        start_months = self._competition_start_months(entries)
 
         for entry in entries:
             if entry.is_international:
                 continue
 
-            for loan in loan_timeline:
-                if entry.club_api_id == loan.get("club_id") and self._loan_overlaps_season(loan, entry.season):
-                    entry.entry_type = "loan"
-                    entry.transfer_date = loan.get("start_date")
-                    break
+            matching = []
+            for episode in episodes:
+                if isinstance(episode, LoanEpisode):
+                    club_matches = _club_ref_matches(episode.loan_club, entry.club_api_id, entry.club_name)
+                    start_date = episode.start_date
+                else:
+                    club_matches = entry.club_api_id == episode.get("club_id")
+                    raw_start = episode.get("start_date")
+                    try:
+                        start_date = date.fromisoformat(str(raw_start))
+                    except (TypeError, ValueError):
+                        continue
+                if club_matches and self._loan_overlaps_season(
+                    episode,
+                    entry.season,
+                    start_month=self._entry_start_month(entry, start_months),
+                ):
+                    matching.append((start_date, episode))
 
-    def _apply_permanent_transfer_dates(self, entries: list, transfers: list):
-        """
-        Fill in transfer_date from permanent transfers for entries that don't
-        already have one (loan entries keep their existing dates from
-        _apply_loan_classification).
-
-        This ensures the current-club tiebreaker in _update_journey_aggregates
-        correctly picks the most recent club when multiple First Team entries
-        share the same season and sort_priority.
-
-        For each entry without a transfer_date, find the most recent transfer
-        where team_in.id matches the entry's club_api_id and the transfer date
-        falls within or before that season.
-        """
-        if not transfers:
-            return
-
-        # Build list of (date, destination_club_id) from ALL transfers
-        all_moves = []
-        for transfer in transfers:
-            transfer_date = transfer.get("date")
-            teams = transfer.get("teams", {})
-            team_in = teams.get("in", {})
-            dest_id = team_in.get("id")
-            if transfer_date and dest_id:
-                all_moves.append((transfer_date, dest_id))
-
-        if not all_moves:
-            return
-
-        # Sort by date ascending so we can find the best match
-        all_moves.sort(key=lambda x: x[0])
-
-        for entry in entries:
-            if entry.transfer_date:
-                continue  # Already set by loan classification
-            if entry.is_international:
+            if not matching:
+                if entry.entry_type == "loan":
+                    entry.entry_type = "academy" if entry.is_youth else "first_team"
+                    entry.transfer_date = None
+                    entry.transfer_fee = None
                 continue
 
-            # Find the most recent transfer TO this club up to the end of
-            # the summer transfer window after the season.  API-Football
-            # sometimes records mid-season moves with a summer date (e.g.
-            # Elanga: Forest→Newcastle recorded as 2025-07-10 but played for
-            # Newcastle in the 2024 season), so we extend to Sep 30.
-            window_end = f"{entry.season + 1}-09-30"
-            best_date = None
-            for move_date, dest_id in all_moves:
-                if dest_id == entry.club_api_id and move_date <= window_end:
-                    best_date = move_date  # Keep updating — last match wins (latest)
+            _, effective_episode = max(matching, key=lambda item: item[0])
+            raw_start = (
+                effective_episode.start_date
+                if isinstance(effective_episode, LoanEpisode)
+                else effective_episode.get("start_date")
+            )
+            entry.entry_type = "loan"
+            entry.transfer_date = raw_start.isoformat() if isinstance(raw_start, date) else raw_start
+            entry.transfer_fee = None
 
-            if best_date:
-                entry.transfer_date = best_date
-                logger.debug(
-                    f"Set transfer_date={best_date} for {entry.club_name} "
-                    f"season {entry.season} (from permanent transfer)"
+    def _apply_permanent_transfer_dates(
+        self,
+        entries: list,
+        transfers: list | TransferResolution,
+        *,
+        transfer_resolution: TransferResolution | None = None,
+        as_of: date | str | None = None,
+    ):
+        """Apply resolver-classified permanent dates and raw fees.
+
+        Existing dates no longer block a later definitive move.  Entries that
+        still overlap a loan episode keep their loan start unless a permanent
+        conversion occurs later inside that same season. Because one entry
+        represents the whole season, the later definitive state wins: the entry
+        becomes non-loan from the conversion date and carries its verbatim fee.
+        A conversion on the next configured season boundary remains outside
+        the prior season.
+        """
+        resolution = _coerce_transfer_resolution(
+            transfers,
+            transfer_resolution=transfer_resolution,
+            as_of=as_of,
+        )
+        if resolution is None:
+            return
+        permanent_moves = [event for event in resolution.events if event.kind == "permanent"]
+        if not permanent_moves:
+            return
+        start_months = self._competition_start_months(entries)
+
+        for entry in entries:
+            if entry.is_international:
+                continue
+            try:
+                season_start, season_end = _season_bounds(
+                    entry.season,
+                    self._entry_start_month(entry, start_months),
                 )
+                window_end = _season_grace_end(season_end)
+            except (TypeError, ValueError):
+                continue
+            candidates = [
+                event
+                for event in permanent_moves
+                if event.transfer_date <= window_end
+                and _club_ref_matches(event.in_club, entry.club_api_id, entry.club_name)
+            ]
+            if not candidates:
+                continue
 
-    def _correct_club_ids_from_transfers(self, entries: list, transfers: list):
+            if entry.entry_type == "loan":
+                try:
+                    loan_start = date.fromisoformat(str(entry.transfer_date))
+                except (TypeError, ValueError):
+                    loan_start = season_start
+                in_season_conversions = [
+                    event
+                    for event in candidates
+                    if season_start <= event.transfer_date < season_end and event.transfer_date >= loan_start
+                ]
+                if not in_season_conversions:
+                    continue
+                best_move = max(in_season_conversions, key=lambda event: event.transfer_date)
+                entry.entry_type = "academy" if entry.is_youth else "first_team"
+            else:
+                best_move = max(candidates, key=lambda event: event.transfer_date)
+
+            entry.transfer_date = best_move.transfer_date.isoformat()
+            entry.transfer_fee = best_move.fee
+            logger.debug(
+                "Set permanent transfer metadata date=%s fee=%r for %s season %s",
+                entry.transfer_date,
+                entry.transfer_fee,
+                entry.club_name,
+                entry.season,
+            )
+
+    def _correct_club_ids_from_transfers(
+        self,
+        entries: list,
+        transfers: list | TransferResolution,
+        *,
+        transfer_resolution: TransferResolution | None = None,
+        as_of: date | str | None = None,
+    ):
         """Correct club_api_id for entries where API-Football returned the
         player's current team instead of the historical team.
 
@@ -766,38 +1246,36 @@ class JourneySyncService:
         new club's ID for historical seasons.  We use the transfer history to
         detect this and override club_api_id with the correct team.
         """
-        if not transfers:
+        resolution = _coerce_transfer_resolution(
+            transfers,
+            transfer_resolution=transfer_resolution,
+            as_of=as_of,
+        )
+        if resolution is None:
             return
 
-        # Build a list of permanent transfers: (date, team_out, team_in)
+        # Only topology-resolved permanent moves correct historical clubs. A
+        # reverse-direction N/A return is excluded; a same-direction N/A
+        # conversion is included by the same policy as every other consumer.
         permanent_moves = []
-        for t in transfers:
-            transfer_date = t.get("date")
-            if not transfer_date:
-                continue
-            teams = t.get("teams", {})
-            team_in = teams.get("in", {})
-            team_out = teams.get("out", {})
-            if not team_in.get("id") or not team_out.get("id"):
-                continue
-            # Skip loans — they're handled by _apply_loan_classification
-            t_type = (t.get("type") or "").lower()
-            if t_type in ("loan", "n/a") or t_type in {lt.lower() for lt in LOAN_RETURN_TYPES}:
+        for event in resolution.events:
+            if event.kind != "permanent" or not event.in_club.api_id or not event.out_club.api_id:
                 continue
             permanent_moves.append(
                 {
-                    "date": transfer_date,
-                    "in_id": team_in["id"],
-                    "in_name": team_in.get("name", ""),
-                    "in_logo": team_in.get("logo", ""),
-                    "out_id": team_out["id"],
-                    "out_name": team_out.get("name", ""),
-                    "out_logo": team_out.get("logo", ""),
+                    "date": event.transfer_date.isoformat(),
+                    "in_id": event.in_club.api_id,
+                    "in_name": event.in_club.name or "",
+                    "in_logo": _raw_club_logo(event, "in"),
+                    "out_id": event.out_club.api_id,
+                    "out_name": event.out_club.name or "",
+                    "out_logo": _raw_club_logo(event, "out"),
                 }
             )
 
         if not permanent_moves:
             return
+        start_months = self._competition_start_months(entries)
 
         # Clubs the player has independent evidence for (journey entries are
         # derived from the statistics feed). Used to reject bogus transfers:
@@ -830,8 +1308,28 @@ class JourneySyncService:
             if entry.is_international:
                 continue
 
-            # Season runs Aug to Jun: entry.season=2024 → Aug 2024 to Jun 2025
-            season_end = f"{entry.season + 1}-06-30"
+            # A conversion immediately after a season must not make the real
+            # borrower statistics look retroactively misattributed (Hall /
+            # Knauff). The resolved historical loan episode is authoritative.
+            if any(
+                _club_ref_matches(episode.loan_club, entry.club_api_id, entry.club_name)
+                and self._loan_overlaps_season(
+                    episode,
+                    entry.season,
+                    start_month=self._entry_start_month(entry, start_months),
+                )
+                for episode in resolution.loan_episodes
+            ):
+                continue
+
+            try:
+                _, season_end_exclusive = _season_bounds(
+                    entry.season,
+                    self._entry_start_month(entry, start_months),
+                )
+            except (TypeError, ValueError):
+                continue
+            season_end = (season_end_exclusive - timedelta(days=1)).isoformat()
 
             # Walk the transfer chain back until the club is no longer the
             # destination of a post-season transfer. A single hop only repairs the
@@ -901,7 +1399,15 @@ class JourneySyncService:
 
         return result
 
-    def _apply_development_classification(self, entries: list, transfers=None, birth_date=None):
+    def _apply_development_classification(
+        self,
+        entries: list,
+        transfers=None,
+        birth_date=None,
+        *,
+        transfer_resolution: TransferResolution | None = None,
+        as_of: date | str | None = None,
+    ):
         """
         Reclassify youth 'academy' entries based on the player's career context.
 
@@ -925,7 +1431,9 @@ class JourneySyncService:
         # Also track total first-team appearances per club for age/experience gate
         first_team_apps_by_club = {}
         for entry in entries:
-            if entry.level == "First Team" and not entry.is_international:
+            # A first-team spell at a borrower is not a prior permanent senior
+            # career and must never disqualify the real parent academy.
+            if entry.level == "First Team" and not entry.is_international and entry.entry_type != "loan":
                 base_name = self._strip_youth_suffix(entry.club_name)
                 existing = first_team_debut_by_club.get(base_name)
                 if existing is None or entry.season < existing:
@@ -940,30 +1448,24 @@ class JourneySyncService:
         # don't need to be transferred in. The year matters for buy-backs:
         # a transfer AFTER a youth entry must not disqualify that entry
         # (academy product sold and later re-signed keeps academy status).
+        resolution = _coerce_transfer_resolution(
+            transfers,
+            transfer_resolution=transfer_resolution,
+            as_of=as_of,
+        )
         permanent_transfer_dest_years = {}
-        if transfers:
-            for transfer in transfers:
-                transfer_type = (transfer.get("type") or "").strip().lower()
-                # Skip loans — loan moves don't disqualify academy status
-                if not transfer_type or is_new_loan_transfer(transfer_type):
+        if resolution is not None:
+            for event in resolution.events:
+                if event.kind != "permanent":
                     continue
-                if transfer_type in LOAN_RETURN_TYPES:
-                    continue
-                # This is a permanent transfer (bought, free agent, swap, etc.)
-                teams = transfer.get("teams", {})
-                dest = teams.get("in", {})
-                dest_id = dest.get("id")
-                if not dest_id:
-                    continue
-                year = None
-                try:
-                    year = int(str(transfer.get("date") or "")[:4])
-                except (ValueError, TypeError):
-                    pass
-                prior = permanent_transfer_dest_years.get(dest_id)
-                if prior is None or (year is not None and year < prior):
-                    permanent_transfer_dest_years[dest_id] = year
-        permanent_transfer_dest_ids = set(permanent_transfer_dest_years)
+                year = event.transfer_date.year
+                for dest_id in {
+                    event.in_club.api_id,
+                    event.in_club.organization_api_id,
+                } - {None}:
+                    prior = permanent_transfer_dest_years.get(dest_id)
+                    if prior is None or year < prior:
+                        permanent_transfer_dest_years[dest_id] = year
 
         # Parse birth year for age-at-entry validation
         birth_year = None
@@ -1075,8 +1577,20 @@ class JourneySyncService:
                             f"season {first_season})"
                         )
 
-    def _update_journey_aggregates(self, journey: PlayerJourney, transfers=None):
+    def _update_journey_aggregates(
+        self,
+        journey: PlayerJourney,
+        transfers=None,
+        *,
+        transfer_resolution: TransferResolution | None = None,
+        as_of: date | str | None = None,
+    ):
         """Update aggregate stats on the journey record"""
+        resolution = _coerce_transfer_resolution(
+            transfers,
+            transfer_resolution=transfer_resolution,
+            as_of=as_of,
+        )
         entries = PlayerJourneyEntry.query.filter_by(journey_id=journey.id).all()
 
         if not entries:
@@ -1149,92 +1663,6 @@ class JourneySyncService:
             journey.current_club_name = current.club_name
             journey.current_level = current.level
 
-        # Cross-reference transfers: if the most recent transfer goes to a
-        # DIFFERENT club than what stats show, override current_club.
-        # Handles cases like "stats still show Real Madrid but player is on
-        # loan at Lyon" — where the transfer is NEWER than the stats window.
-        #
-        # Safety rules (added after the O. Hammond incident, where a stale
-        # 2024 "N/A" return-from-loan transfer was letting the override
-        # overwrite much more recent 2025 entries at a different club):
-        #
-        #   1. Skip the override when the most recent transfer is OLDER
-        #      than the latest domestic journey-entry date. Stats entries
-        #      that post-date the transfer are authoritative — the player
-        #      has moved on since the recorded transfer.
-        #   2. Skip N/A-typed transfers entirely. API-Football uses "N/A"
-        #      for loan-returns they cannot cleanly classify; they are
-        #      too ambiguous to drive aggregation.
-        #   3. Never hardcode current_level='First Team'. Derive the level
-        #      from the destination club name so a return to a youth /
-        #      reserve team is not mislabelled.
-        if transfers and domestic_entries:
-            sorted_transfers = sorted(transfers, key=lambda x: x.get("date", ""), reverse=True)
-            most_recent_transfer = sorted_transfers[0] if sorted_transfers else None
-
-            # Compute latest domestic-entry date for the staleness check.
-            # Prefer explicit transfer_date on entries; fall back to a
-            # start-of-season proxy when entries have no recorded date.
-            dated_entries = [e.transfer_date for e in domestic_entries if e.transfer_date]
-            if dated_entries:
-                latest_entry_date = max(dated_entries)
-            else:
-                latest_entry_season = max(e.season for e in domestic_entries)
-                latest_entry_date = f"{latest_entry_season}-07-01"
-
-            if most_recent_transfer:
-                transfer_type_raw = (most_recent_transfer.get("type") or "").strip()
-                transfer_type = transfer_type_raw.lower()
-                transfer_date = most_recent_transfer.get("date", "") or ""
-                dest = most_recent_transfer.get("teams", {}).get("in", {}) or {}
-
-                stale_override = bool(latest_entry_date and transfer_date and transfer_date < latest_entry_date)
-                ambiguous_type = transfer_type in ("n/a", "")
-
-                if stale_override:
-                    logger.info(
-                        "Journey %d: skipping transfer override — most recent transfer %s older than latest entry %s",
-                        journey.id,
-                        transfer_date,
-                        latest_entry_date,
-                    )
-                elif ambiguous_type:
-                    logger.info(
-                        "Journey %d: skipping ambiguous transfer override (type=%r date=%s)",
-                        journey.id,
-                        transfer_type_raw,
-                        transfer_date,
-                    )
-                elif transfer_type in LOAN_RETURN_TYPES:
-                    # Loan return: player is back at parent club.
-                    if dest.get("id") and dest.get("name") and dest["id"] != journey.current_club_api_id:
-                        derived_level = _derive_current_level_from_club_name(dest.get("name"))
-                        logger.info(
-                            "Journey %d: loan return → updating current_club to %s (level=%s, %s)",
-                            journey.id,
-                            dest["name"],
-                            derived_level,
-                            transfer_date,
-                        )
-                        journey.current_club_api_id = dest["id"]
-                        journey.current_club_name = dest["name"]
-                        journey.current_level = derived_level
-                else:
-                    # Permanent or unspecified non-loan-return transfer.
-                    if dest.get("id") and dest.get("name") and dest["id"] != journey.current_club_api_id:
-                        logger.info(
-                            "Journey %d: overriding current_club from transfer %s → %s (%s, type=%s)",
-                            journey.id,
-                            journey.current_club_name,
-                            dest["name"],
-                            transfer_date,
-                            transfer_type,
-                        )
-                        journey.current_club_api_id = dest["id"]
-                        journey.current_club_name = dest["name"]
-                        if not is_new_loan_transfer(transfer_type):
-                            journey.current_level = _derive_current_level_from_club_name(dest.get("name"))
-
         # Find first team debut
         first_team_entries = [e for e in entries if e.level == "First Team" and not e.is_international]
         if first_team_entries:
@@ -1258,56 +1686,122 @@ class JourneySyncService:
         journey.total_assists = sum(e.assists for e in entries)
 
         # Compute academy connections from youth entries
-        self._compute_academy_club_ids(journey, entries, transfers=transfers)
+        compute_kwargs = {"transfers": transfers}
+        if as_of is not None:
+            compute_kwargs["as_of"] = as_of
+        if resolution is not None:
+            compute_kwargs["transfer_resolution"] = resolution
+        self._compute_academy_club_ids(journey, entries, **compute_kwargs)
 
-        # Player-level current status (actual situation, not academy-relative)
-        self._set_current_status(journey, entries)
+        # Project club + player-level current status from the same resolver
+        # state. A failed fetch leaves all transfer-derived fields untouched.
+        if resolution is not None:
+            self.apply_resolved_current_state(journey, entries, resolution)
 
-    def _set_current_status(self, journey: PlayerJourney, entries: list) -> None:
-        """Set journey.current_status / current_owner_* from STORED entries only
-        (no API). The player's ACTUAL current situation, independent of any
-        tracked academy: when the current-club entry is a loan, mark 'on_loan'
-        and resolve the owning club (the club he is on loan FROM). Otherwise
-        leave NULL so player-facing surfaces fall back to the academy-relative
-        TrackedPlayer.status. Idempotent — safe to call from sync or backfill.
+    def _set_current_status(
+        self,
+        journey: PlayerJourney,
+        entries: list,
+        transfers=None,
+        *,
+        transfer_resolution: TransferResolution | None = None,
+        as_of: date | str | None = None,
+    ) -> bool:
+        """Set player-level loan status from the chronological current state.
+
+        A confirmed, fresh active episode is the only state that populates
+        ``current_status`` and owner. Closed or indeterminate episodes clear
+        both. Without fetched or durable transfer evidence this method is a
+        no-op: historical entry labels cannot prove a current loan or owner.
+
+        Returns ``True`` when resolver evidence was applied (including a clear)
+        and ``False`` when no evidence was available.
         """
-        from src.utils.affiliates import resolve_senior_id
-
         cur_id = journey.current_club_api_id
-        if not cur_id:
+        cur_name = journey.current_club_name
+        if not cur_id and not cur_name:
             journey.current_status = None
             journey.current_owner_api_id = None
             journey.current_owner_name = None
-            return
+            return True
 
-        on_loan_now = any(e.club_api_id == cur_id and e.entry_type == "loan" for e in entries)
-        if not on_loan_now:
-            journey.current_status = None
-            journey.current_owner_api_id = None
-            journey.current_owner_name = None
-            return
-
-        journey.current_status = "on_loan"
-        # Owner = the club he is on loan FROM: most recent senior (first_team,
-        # non-international) club that isn't the loan club, resolved to its
-        # senior org (Jong Ajax -> Ajax).
-        owner_entry = max(
-            (
-                e
-                for e in entries
-                if e.entry_type == "first_team" and not e.is_international and e.club_api_id and e.club_api_id != cur_id
-            ),
-            key=lambda e: e.season or 0,
-            default=None,
+        resolution = _coerce_transfer_resolution(
+            transfers,
+            transfer_resolution=transfer_resolution,
+            as_of=as_of,
         )
-        if owner_entry:
-            owner_id = resolve_senior_id(owner_entry.club_api_id, owner_entry.club_name)
-            owner_team = Team.query.filter_by(team_id=owner_id, is_active=True).order_by(Team.season.desc()).first()
-            journey.current_owner_api_id = owner_id
-            journey.current_owner_name = owner_team.name if owner_team else owner_entry.club_name
-        else:
+        if resolution is None:
+            logger.info(
+                "Journey %s: current status unchanged because no transfer evidence was supplied",
+                getattr(journey, "id", None),
+            )
+            return False
+
+        active_loan = resolution.active_loan if resolution.on_loan is True else None
+        if active_loan is None or not _club_ref_matches(
+            active_loan.loan_club,
+            cur_id,
+            cur_name,
+        ):
+            journey.current_status = None
             journey.current_owner_api_id = None
             journey.current_owner_name = None
+            return True
+
+        owner = resolution.current_owner
+        journey.current_status = "on_loan"
+        owner_id = (owner.organization_api_id or owner.api_id) if owner is not None else None
+        owner_team = (
+            Team.query.filter_by(team_id=owner_id, is_active=True).order_by(Team.season.desc()).first()
+            if owner_id
+            else None
+        )
+        journey.current_owner_api_id = owner_id
+        journey.current_owner_name = owner_team.name if owner_team else (owner.name if owner else None)
+        return True
+
+    def apply_resolved_current_state(
+        self,
+        journey: PlayerJourney,
+        entries: list,
+        resolution: TransferResolution,
+    ) -> bool:
+        """Atomically project a durable resolver state onto journey current fields."""
+        destination = resolution.current_club
+        domestic = [entry for entry in entries if not entry.is_international and entry.season is not None]
+        latest_season = None
+        season_start_month = resolution.season_start_month
+        if domestic:
+            latest_season = max(entry.season for entry in domestic)
+            latest_entries = [entry for entry in domestic if entry.season == latest_season]
+            current_entry = max(
+                latest_entries,
+                key=lambda entry: (entry.sort_priority, entry.transfer_date or ""),
+            )
+            start_months = self._competition_start_months(latest_entries)
+            season_start_month = self._entry_start_month(current_entry, start_months)
+
+        if destination is not None and resolved_current_club_is_authoritative(
+            resolution,
+            journey.current_club_api_id,
+            journey.current_club_name,
+            latest_season=latest_season,
+            season_start_month=season_start_month,
+            season_start_day=resolution.season_start_day,
+        ):
+            destination_id = destination.api_id or destination.organization_api_id
+            journey.current_club_api_id = destination_id
+            journey.current_club_name = destination.name
+            if destination.name:
+                journey.current_level = _derive_current_level_from_club_name(destination.name)
+            else:
+                journey.current_level = None
+
+        return self._set_current_status(
+            journey,
+            entries,
+            transfer_resolution=resolution,
+        )
 
     def _strip_youth_suffix(self, club_name: str) -> str:
         """Strip youth team suffix to get parent club base name."""
@@ -1408,7 +1902,15 @@ class JourneySyncService:
                 retained_seasons[str(cid)] = season
         return sorted(retained_ids), retained_seasons
 
-    def _compute_academy_club_ids(self, journey: PlayerJourney, entries: list | None = None, transfers=None):
+    def _compute_academy_club_ids(
+        self,
+        journey: PlayerJourney,
+        entries: list | None = None,
+        transfers=None,
+        *,
+        transfer_resolution: TransferResolution | None = None,
+        as_of: date | str | None = None,
+    ):
         """
         Derive academy parent club IDs from youth journey entries.
 
@@ -1422,6 +1924,11 @@ class JourneySyncService:
         """
         if entries is None:
             entries = PlayerJourneyEntry.query.filter_by(journey_id=journey.id).all()
+        resolution = _coerce_transfer_resolution(
+            transfers,
+            transfer_resolution=transfer_resolution,
+            as_of=as_of,
+        )
 
         # Capture the journey's PERSISTED academy attribution BEFORE this run
         # overwrites it below. A transient run (API youth-coverage gap or a
@@ -1456,6 +1963,8 @@ class JourneySyncService:
                 journey,
                 set(),
                 transfers=transfers,
+                transfer_resolution=resolution,
+                as_of=as_of,
                 prior_academy_ids=prior_academy_ids,
                 prior_last_seasons=prior_last_seasons,
             )
@@ -1537,6 +2046,8 @@ class JourneySyncService:
                 journey,
                 set(),
                 transfers=transfers,
+                transfer_resolution=resolution,
+                as_of=as_of,
                 prior_academy_ids=prior_academy_ids,
                 prior_last_seasons=prior_last_seasons,
             )
@@ -1597,6 +2108,8 @@ class JourneySyncService:
                 journey,
                 set(),
                 transfers=transfers,
+                transfer_resolution=resolution,
+                as_of=as_of,
                 prior_academy_ids=prior_academy_ids,
                 prior_last_seasons=prior_last_seasons,
             )
@@ -1684,17 +2197,15 @@ class JourneySyncService:
         # ── Transfer gate: remove clubs the player was permanently transferred TO ──
         # Defense-in-depth — _apply_development_classification should have already
         # reclassified entries as 'integration', but if it missed a case this catches it.
-        if transfers and academy_ids:
+        if resolution is not None and academy_ids:
             permanent_dest_ids = set()
-            for t in transfers:
-                transfer_type = (t.get("type") or "").strip().lower()
-                if not transfer_type or is_new_loan_transfer(transfer_type):
+            for event in resolution.events:
+                if event.kind != "permanent":
                     continue
-                if transfer_type in LOAN_RETURN_TYPES:
-                    continue
-                dest_id = t.get("teams", {}).get("in", {}).get("id")
-                if dest_id:
-                    permanent_dest_ids.add(dest_id)
+                if event.in_club.api_id:
+                    permanent_dest_ids.add(event.in_club.api_id)
+                if event.in_club.organization_api_id:
+                    permanent_dest_ids.add(event.in_club.organization_api_id)
 
             removed = academy_ids & permanent_dest_ids
             if removed:
@@ -1710,25 +2221,27 @@ class JourneySyncService:
             str(club_id): season for club_id, season in last_seasons.items() if club_id in academy_ids
         }
 
-        # Auto-upsert TrackedPlayer rows for each academy connection
-        try:
-            self._upsert_tracked_players(
-                journey,
-                academy_ids,
-                transfers=transfers,
-                last_seasons=last_seasons,
-                prior_academy_ids=prior_academy_ids,
-                prior_last_seasons=prior_last_seasons,
-            )
-        except Exception as e:
-            logger.error(f"_upsert_tracked_players failed for player {journey.player_api_id}: {e}")
-            db.session.rollback()
+        # Auto-upsert TrackedPlayer rows for each academy connection. Errors
+        # intentionally propagate to the sync/repair transaction owner.
+        self._upsert_tracked_players(
+            journey,
+            academy_ids,
+            transfers=transfers,
+            transfer_resolution=resolution,
+            as_of=as_of,
+            last_seasons=last_seasons,
+            prior_academy_ids=prior_academy_ids,
+            prior_last_seasons=prior_last_seasons,
+        )
 
     def _upsert_tracked_players(
         self,
         journey: PlayerJourney,
         academy_ids: set,
         transfers=None,
+        *,
+        transfer_resolution: TransferResolution | None = None,
+        as_of: date | str | None = None,
         last_seasons=None,
         prior_academy_ids=None,
         prior_last_seasons=None,
@@ -1756,6 +2269,11 @@ class JourneySyncService:
         last_seasons = last_seasons or {}
         prior_academy_ids = prior_academy_ids or set()
         prior_last_seasons = prior_last_seasons or {}
+        resolution = _coerce_transfer_resolution(
+            transfers,
+            transfer_resolution=transfer_resolution,
+            as_of=as_of,
+        )
 
         # Status (on_loan/sold/released/left) is transfer-driven, so it can only
         # be derived when transfers were actually fetched. Callers that pass
@@ -1764,11 +2282,17 @@ class JourneySyncService:
         # player would collapse to the tentative on_loan / 'left' default and
         # clobber the real status. transfers=[] (a fetched-but-empty list, as in
         # a full journey sync) is a legitimate signal and DOES update status.
-        update_status = transfers is not None
+        update_status = transfers is not None or resolution is not None
 
         # Owning club is still computed for current-club classification
         # context, but it no longer keeps TrackedPlayer rows alive.
-        owning_api_id = self._determine_owning_club_id(journey, transfers, academy_ids)
+        owning_api_id = self._determine_owning_club_id(
+            journey,
+            transfers,
+            academy_ids,
+            transfer_resolution=resolution,
+            as_of=as_of,
+        )
 
         # Window gate: an academy origin only stays tracked while the
         # player's last youth season there is inside the window. A player
@@ -1893,10 +2417,28 @@ class JourneySyncService:
         if not keep_ids:
             return
 
+        parent_resolutions: dict[int, TransferResolution] = {}
+        resolution_as_of = resolution.as_of if resolution is not None else _transfer_as_of(as_of)
         for academy_api_id in keep_ids:
             team = Team.query.filter_by(team_id=academy_api_id, is_active=True).order_by(Team.season.desc()).first()
             if not team:
                 continue
+
+            # Academy-relative state needs that academy as its known initial
+            # owner. Cache one contextualized resolution per parent so status
+            # and the parent's own sale fee use identical chronology.
+            parent_resolution = None
+            if transfers is not None:
+                parent_resolution = parent_resolutions.get(academy_api_id)
+                if parent_resolution is None:
+                    parent_resolution = resolve_transfer_state(
+                        transfers,
+                        as_of=resolution_as_of,
+                        initial_owner={"id": academy_api_id, "name": team.name},
+                        season_start_month=(resolution.season_start_month if resolution is not None else 7),
+                        season_start_day=(resolution.season_start_day if resolution is not None else 1),
+                    )
+                    parent_resolutions[academy_api_id] = parent_resolution
 
             existing = TrackedPlayer.query.filter_by(
                 player_api_id=journey.player_api_id,
@@ -1911,7 +2453,17 @@ class JourneySyncService:
                 parent_club_name=team.name,
                 transfers=transfers,
                 latest_season=_get_latest_season(journey.id, parent_api_id=academy_api_id, parent_club_name=team.name),
+                transfer_resolution=parent_resolution,
+                as_of=resolution_as_of,
+                season_start_month=(parent_resolution.season_start_month if parent_resolution is not None else 7),
+                season_start_day=(parent_resolution.season_start_day if parent_resolution is not None else 1),
             )
+            parent_departure = latest_parent_permanent_departure(
+                parent_resolution,
+                academy_api_id,
+                team.name,
+            )
+            sale_fee = parent_departure.fee if parent_departure is not None and status == "sold" else None
 
             if not existing:
                 tp = TrackedPlayer(
@@ -1927,6 +2479,7 @@ class JourneySyncService:
                     status=status,
                     current_club_api_id=current_club_api_id,
                     current_club_name=current_club_name,
+                    sale_fee=sale_fee,
                     last_academy_season=last_seasons.get(academy_api_id),
                 )
                 db.session.add(tp)
@@ -1965,59 +2518,54 @@ class JourneySyncService:
                     existing.status = status
                     existing.current_club_api_id = current_club_api_id
                     existing.current_club_name = current_club_name
+                    existing.sale_fee = sale_fee
 
-    def _determine_owning_club_id(self, journey, transfers, academy_ids):
-        """Find the club that currently owns the player (last permanent transfer dest).
+    def _determine_owning_club_id(
+        self,
+        journey,
+        transfers,
+        academy_ids,
+        *,
+        transfer_resolution: TransferResolution | None = None,
+        as_of: date | str | None = None,
+    ):
+        """Find the current legal owner from the chronological resolution.
 
         Returns team_api_id or None if the owning club is already in academy_ids
-        or cannot be determined.
-
-        Strategy: transfer history first (most explicit), journey entries fallback.
+        or cannot be determined. Attribution-only repair callers have no
+        transfer evidence, so they retain the established journey-entry
+        fallback used solely to suppress rows at a player's buying club.
         """
-        owning_id = None
-
-        # Strategy 1: Transfer history — last permanent transfer destination
-        if transfers:
-            permanent = []
-            for t in transfers:
-                transfer_type = (t.get("type") or "").strip().lower()
-                if not transfer_type or is_new_loan_transfer(transfer_type):
-                    continue
-                if transfer_type in LOAN_RETURN_TYPES:
-                    continue
-                dest_id = t.get("teams", {}).get("in", {}).get("id")
-                date = t.get("date", "")
-                if dest_id:
-                    permanent.append((date, dest_id))
-            if permanent:
-                permanent.sort(reverse=True)  # Most recent first
-                owning_id = permanent[0][1]
-
-        # Strategy 2: Journey entries fallback — last non-youth permanent entry
-        if not owning_id and journey.id:
-            entry = (
-                PlayerJourneyEntry.query.filter_by(journey_id=journey.id)
-                .filter(PlayerJourneyEntry.is_youth.is_(False))
-                .filter(PlayerJourneyEntry.entry_type.in_(["permanent", "first_team"]))
-                .order_by(PlayerJourneyEntry.season.desc())
-                .first()
-            )
-            if entry and entry.club_api_id:
-                owning_id = entry.club_api_id
+        resolution = _coerce_transfer_resolution(
+            transfers,
+            transfer_resolution=transfer_resolution,
+            as_of=as_of,
+        )
+        if resolution is not None:
+            if resolution.legal_owner is None:
+                return None
+            owning_id = resolution.legal_owner.organization_api_id or resolution.legal_owner.api_id
+        else:
+            # This is not a status/owner projection: recompute-academy has no
+            # provider evidence but still needs to avoid creating a tracker row
+            # at an obvious later buying club. An authoritative empty or
+            # ambiguous resolution never reaches this fallback.
+            owning_id = None
+            if journey.id:
+                entry = (
+                    PlayerJourneyEntry.query.filter_by(journey_id=journey.id)
+                    .filter(PlayerJourneyEntry.is_youth.is_(False))
+                    .filter(PlayerJourneyEntry.entry_type.in_(["permanent", "first_team"]))
+                    .order_by(PlayerJourneyEntry.season.desc())
+                    .first()
+                )
+                if entry and entry.club_api_id:
+                    owning_id = entry.club_api_id
 
         # Skip if owning club is already in academy_ids (already has a tracked row)
         if owning_id and owning_id not in academy_ids:
             return owning_id
         return None
-
-    @staticmethod
-    def _get_latest_departure_type(transfers, parent_api_id):
-        """Find the type of the most recent transfer away from a parent club."""
-        departures = [t for t in transfers if (t.get("teams", {}).get("out", {}).get("id") == parent_api_id)]
-        if not departures:
-            return None
-        departures.sort(key=lambda t: t.get("date", ""), reverse=True)
-        return (departures[0].get("type") or "").strip().lower()
 
     def _auto_geocode_clubs(self, journey: PlayerJourney):
         """Create ClubLocation rows for clubs that don't have one yet.

--- a/academy-watch-backend/src/services/transfer_events.py
+++ b/academy-watch-backend/src/services/transfer_events.py
@@ -1,0 +1,156 @@
+"""Persistence choke point for durable API-Football transfer events."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import UTC, date, datetime
+from typing import Any
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from src.models.transfer_event import PlayerTransferEvent
+
+_NATURAL_KEY_NAMES = (
+    "player_api_id",
+    "transfer_date",
+    "out_club_api_id",
+    "in_club_api_id",
+    "transfer_type",
+)
+
+
+def _transfer_date(value: Any) -> date | None:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if not isinstance(value, str):
+        return None
+    try:
+        return date.fromisoformat(value.strip())
+    except ValueError:
+        return None
+
+
+def _club_id(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _nullable_match(column, value):
+    return column.is_(None) if value is None else column == value
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _update_nullable_key_event(session, values: dict[str, Any]) -> None:
+    """Portable fallback for dialects whose UNIQUE constraints distinguish NULL."""
+
+    existing = session.execute(
+        select(PlayerTransferEvent).where(
+            and_(*(_nullable_match(getattr(PlayerTransferEvent, field), values[field]) for field in _NATURAL_KEY_NAMES))
+        )
+    ).scalar_one_or_none()
+    if existing is None:
+        session.add(PlayerTransferEvent(**values))
+        return
+
+    existing.last_seen_at = max(
+        _as_utc(existing.last_seen_at),
+        _as_utc(values["last_seen_at"]),
+    )
+
+
+def record_transfer_events(
+    player_api_id: int,
+    transfers: list[dict[str, Any]] | None,
+    session,
+    *,
+    observed_at: datetime | None = None,
+) -> int:
+    """Upsert a flat list of raw transfer objects without committing.
+
+    ``first_seen_at`` is insert-only. A repeated natural key advances
+    ``last_seen_at`` while retaining the first-seen names, raw evidence, and
+    row identity. Invalid/missing dates cannot satisfy the table's non-null
+    key and are skipped.
+
+    The caller owns the transaction. PostgreSQL and SQLite use their native
+    ``ON CONFLICT`` forms; a small ORM fallback covers other test dialects and
+    nullable natural-key components (SQL UNIQUE treats NULL values as distinct).
+    """
+
+    try:
+        normalized_player_id = int(player_api_id)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("player_api_id must be an integer") from exc
+
+    seen_at = _as_utc(observed_at or datetime.now(UTC))
+    dialect_name = session.get_bind().dialect.name
+    if dialect_name == "postgresql":
+        insert_factory = postgresql_insert
+    elif dialect_name == "sqlite":
+        insert_factory = sqlite_insert
+    else:
+        insert_factory = None
+
+    recorded = 0
+    for transfer in transfers or []:
+        if not isinstance(transfer, dict):
+            continue
+
+        effective_date = _transfer_date(transfer.get("date"))
+        if effective_date is None:
+            continue
+
+        teams = transfer.get("teams")
+        teams = teams if isinstance(teams, dict) else {}
+        out_club = teams.get("out")
+        out_club = out_club if isinstance(out_club, dict) else {}
+        in_club = teams.get("in")
+        in_club = in_club if isinstance(in_club, dict) else {}
+        raw_type = transfer.get("type")
+        transfer_type = raw_type if isinstance(raw_type, str) else None
+
+        values = {
+            "player_api_id": normalized_player_id,
+            "transfer_date": effective_date,
+            "transfer_type": transfer_type,
+            "out_club_api_id": _club_id(out_club.get("id")),
+            "out_club_name": out_club.get("name") if isinstance(out_club.get("name"), str) else None,
+            "in_club_api_id": _club_id(in_club.get("id")),
+            "in_club_name": in_club.get("name") if isinstance(in_club.get("name"), str) else None,
+            "first_seen_at": seen_at,
+            "last_seen_at": seen_at,
+            "raw": deepcopy(transfer),
+        }
+
+        key_has_null = any(values[field] is None for field in _NATURAL_KEY_NAMES)
+        if insert_factory is None or (key_has_null and dialect_name != "postgresql"):
+            _update_nullable_key_event(session, values)
+        else:
+            statement = insert_factory(PlayerTransferEvent).values(**values)
+            existing_last_seen = PlayerTransferEvent.__table__.c.last_seen_at
+            latest_seen = (
+                func.greatest(existing_last_seen, statement.excluded.last_seen_at)
+                if dialect_name == "postgresql"
+                else func.max(existing_last_seen, statement.excluded.last_seen_at)
+            )
+            statement = statement.on_conflict_do_update(
+                index_elements=list(_NATURAL_KEY_NAMES),
+                set_={"last_seen_at": latest_seen},
+            )
+            session.execute(statement)
+        recorded += 1
+
+    session.flush()
+    return recorded

--- a/academy-watch-backend/src/services/transfer_heal_service.py
+++ b/academy-watch-backend/src/services/transfer_heal_service.py
@@ -17,10 +17,12 @@ from src.models.journey import PlayerJourney
 from src.models.league import Team, db
 from src.models.tracked_player import TrackedPlayer
 from src.services.journey_sync import JourneySyncService
+from src.services.transfer_resolver import resolve_transfer_state
 from src.utils.academy_classifier import (
     _get_latest_season,
     classify_tracked_player,
     flatten_transfers,
+    latest_parent_permanent_departure,
 )
 
 logger = logging.getLogger(__name__)
@@ -152,11 +154,13 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False, cascade_
     updated = 0
     journeys_resynced = 0
     players_changed = []
+    classification_as_of = datetime.now(UTC).date()
 
     # Optionally set up journey sync service
     journey_svc = None
     if resync_journeys:
         journey_svc = JourneySyncService()
+    calendar_svc = journey_svc or JourneySyncService(database_only=True)
 
     # Batch pre-fetch transfers
     api_client = APIFootballClient()
@@ -296,13 +300,26 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False, cascade_
             )
             continue
 
+        player_transfers = transfers_map.get(tp.player_api_id, [])
+        journey_entries = journey.entries.all()
+        start_months = calendar_svc._competition_start_months(journey_entries)
+        season_start_month = calendar_svc._resolution_start_month(
+            journey_entries,
+            start_months,
+        )
+        transfer_resolution = resolve_transfer_state(
+            player_transfers,
+            as_of=classification_as_of,
+            initial_owner={"id": parent_team.team_id, "name": parent_team.name},
+            season_start_month=season_start_month,
+        )
         new_status, new_loan_id, new_loan_name = classify_tracked_player(
             current_club_api_id=journey.current_club_api_id,
             current_club_name=journey.current_club_name,
             current_level=journey.current_level,
             parent_api_id=parent_team.team_id,
             parent_club_name=parent_team.name,
-            transfers=transfers_map.get(tp.player_api_id),
+            transfers=player_transfers,
             player_api_id=tp.player_api_id,
             api_client=api_client,
             latest_season=_get_latest_season(
@@ -311,7 +328,17 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False, cascade_
                 parent_club_name=parent_team.name,
             ),
             squad_members_by_club=squad_members_by_club,
+            transfer_resolution=transfer_resolution,
+            as_of=classification_as_of,
+            season_start_month=season_start_month,
+            season_start_day=1,
         )
+        parent_departure = latest_parent_permanent_departure(
+            transfer_resolution,
+            parent_team.team_id,
+            parent_team.name,
+        )
+        new_sale_fee = parent_departure.fee if new_status == "sold" and parent_departure else None
 
         # Pinned players: skip all automated field changes.
         # Journey data was already resynced above, but status/loan/level
@@ -335,6 +362,9 @@ def refresh_and_heal(team_id=None, resync_journeys=True, dry_run=False, cascade_
             changed = True
         if tp.current_club_name != new_loan_name:
             tp.current_club_name = new_loan_name
+            changed = True
+        if tp.sale_fee != new_sale_fee:
+            tp.sale_fee = new_sale_fee
             changed = True
         if journey.current_level and tp.current_level != journey.current_level:
             tp.current_level = journey.current_level

--- a/academy-watch-backend/src/services/transfer_resolver.py
+++ b/academy-watch-backend/src/services/transfer_resolver.py
@@ -171,6 +171,8 @@ class TransferResolution:
     loan_state: LoanState
     latest_permanent_move: ResolvedTransferEvent | None
     issues: tuple[ResolverIssue, ...]
+    season_start_month: int
+    season_start_day: int
 
     @property
     def loan_owner(self) -> ClubRef | None:
@@ -251,8 +253,29 @@ def _club(api_id: int | None, name: str | None) -> ClubRef:
     )
 
 
+def _context_club(value: ClubRef | Mapping[str, Any] | None, *, field_name: str) -> ClubRef | None:
+    """Coerce optional caller-known state into the resolver's club identity.
+
+    Transfer feeds sometimes begin with a topology-only ``N/A`` event.  A
+    consumer that already knows the preceding owner/current club can provide
+    that context without manufacturing a synthetic transfer event.
+    """
+    if value is None or isinstance(value, ClubRef):
+        return value
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{field_name} must be a ClubRef, mapping, or None")
+
+    api_id = _parse_id(value.get("api_id", value.get("id")))
+    name = _clean_name(value.get("name"))
+    if api_id is None and name is None:
+        raise ValueError(f"{field_name} must include a usable club id or name")
+    return _club(api_id, name)
+
+
 def _same_org(left: ClubRef | None, right: ClubRef | None) -> bool:
     if left is None or right is None:
+        return False
+    if (left.api_id is None and left.name is None) or (right.api_id is None and right.name is None):
         return False
     if left.api_id is not None and left.api_id == right.api_id:
         return True
@@ -412,6 +435,9 @@ def _normalize_transfer_events(events: Iterable[Any]) -> NormalizationResult:
             )
             continue
 
+        transfer_type = raw_type.strip()
+        normalized_type = " ".join(transfer_type.casefold().split())
+
         out_id = _parse_id(raw_out_id)
         out_name = _clean_name(raw_out_name)
         if out_id is None and out_name is None:
@@ -445,8 +471,13 @@ def _normalize_transfer_events(events: Iterable[Any]) -> NormalizationResult:
                     raw_event=raw_event,
                 )
             )
-            continue
-        if in_id is None:
+            # A typed permanent departure with no onward club is still
+            # load-bearing evidence for academy-relative ``released`` status.
+            # Retain it with an explicit unknown destination; loans, returns,
+            # and topology-only N/A events cannot be resolved without one.
+            if normalized_type in _LOAN_TYPES | _RETURN_TYPES | _NA_TYPES:
+                continue
+        if in_id is None and in_name is not None:
             issues.append(
                 ResolverIssue(
                     "missing_in_club_id",
@@ -456,8 +487,6 @@ def _normalize_transfer_events(events: Iterable[Any]) -> NormalizationResult:
                 )
             )
 
-        transfer_type = raw_type.strip()
-        normalized_type = " ".join(transfer_type.casefold().split())
         digest_input = "|".join(
             (
                 transfer_date.isoformat(),
@@ -531,8 +560,13 @@ def _coalesce_events(events: Iterable[NormalizedTransferEvent]) -> list[_Coalesc
             if (
                 day_gap >= 0
                 and event.normalized_type == representative.normalized_type
-                and _same_org(event.out_club, representative.out_club)
-                and _same_org(event.in_club, representative.in_club)
+                and (
+                    event.fingerprint == representative.fingerprint
+                    or (
+                        _same_org(event.out_club, representative.out_club)
+                        and _same_org(event.in_club, representative.in_club)
+                    )
+                )
             ):
                 matching = group
                 break
@@ -810,22 +844,42 @@ def _open_loan_fresh_boundary(start: date, *, start_month: int = 7, start_day: i
     return date(boundary_year, start_month, start_day)
 
 
-def resolve_transfer_state(events: Iterable[Any], *, as_of: date | str) -> TransferResolution:
+def resolve_transfer_state(
+    events: Iterable[Any],
+    *,
+    as_of: date | str,
+    initial_owner: ClubRef | Mapping[str, Any] | None = None,
+    season_start_month: int = 7,
+    season_start_day: int = 1,
+) -> TransferResolution:
     """Resolve transfer events chronologically as of a required date.
 
-    An unclosed loan is confirmed only within the July-to-June season in which
-    its start was observed.  At the next July 1 it becomes ``indeterminate``:
-    absence of a provider return is not evidence that a loan continues forever.
+    An unclosed loan is confirmed only within the competition season in which
+    its start was observed. At the next configured boundary it becomes
+    ``indeterminate``: absence of a provider return is not evidence that a loan
+    continues forever. July 1 remains the compatibility default.
+
+    ``initial_owner`` is optional caller-known state for histories that begin
+    mid-stream (notably a first-event ``N/A``). The player is assumed to start
+    at that owning club.
     """
     parsed_as_of = _parse_date(as_of)
     if parsed_as_of is None:
         raise ValueError("as_of must be a valid date or ISO date string")
+    try:
+        date(2000, season_start_month, season_start_day)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("season start must be a valid month/day") from exc
 
     normalization = _normalize_transfer_events(events)
     applicable = [event for event in normalization.events if event.transfer_date <= parsed_as_of]
     coalesced = _coalesce_events(applicable)
 
-    state = _ReducerState()
+    starting_owner = _context_club(initial_owner, field_name="initial_owner")
+    state = _ReducerState(
+        legal_owner=starting_owner,
+        current_club=starting_owner,
+    )
     episode_builders: list[_EpisodeBuilder] = []
     resolved_events: list[ResolvedTransferEvent] = []
     issues = list(normalization.issues)
@@ -857,7 +911,11 @@ def resolve_transfer_state(events: Iterable[Any], *, as_of: date | str) -> Trans
     active_loan = episodes[-1] if state.active_episode is not None and episodes else None
 
     if state.active_episode is not None and active_loan is not None:
-        if parsed_as_of < _open_loan_fresh_boundary(active_loan.start_date):
+        if parsed_as_of < _open_loan_fresh_boundary(
+            active_loan.start_date,
+            start_month=season_start_month,
+            start_day=season_start_day,
+        ):
             on_loan: bool | None = True
             loan_state: LoanState = "on_loan"
         else:
@@ -886,6 +944,8 @@ def resolve_transfer_state(events: Iterable[Any], *, as_of: date | str) -> Trans
         loan_state=loan_state,
         latest_permanent_move=latest_permanent,
         issues=tuple(issues),
+        season_start_month=season_start_month,
+        season_start_day=season_start_day,
     )
 
 

--- a/academy-watch-backend/src/services/transfer_resolver.py
+++ b/academy-watch-backend/src/services/transfer_resolver.py
@@ -1,0 +1,946 @@
+"""Pure, chronological transfer-state resolution.
+
+API-Football does not guarantee transfer-array order and overloads ``type``
+with both movement labels and fee strings.  This module normalizes that input,
+orders same-day chains from their causal topology, and reduces it into distinct
+loan episodes plus a last-known player state.  It deliberately has no Flask or
+database dependency.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field, replace
+from datetime import date, datetime
+from typing import Any, Literal
+
+from src.utils.affiliates import resolve_senior_id, senior_base_name
+
+EventKind = Literal["loan_start", "loan_return", "permanent", "unknown"]
+LoanEndReason = Literal[
+    "return",
+    "permanent_conversion",
+    "superseded_by_permanent",
+    "reloan",
+    "superseded_by_loan",
+    "subloan",
+    "superseded_by_return",
+]
+LoanState = Literal["on_loan", "not_on_loan", "indeterminate", "unknown"]
+
+_LOAN_TYPES = {"loan"}
+_RETURN_TYPES = {
+    "back from loan",
+    "return from loan",
+    "end of loan",
+    "loan end",
+    "loan return",
+}
+_NA_TYPES = {"n/a", "na"}
+
+
+@dataclass(frozen=True, slots=True)
+class ClubRef:
+    """A provider club plus a stable best-effort organisation identity."""
+
+    api_id: int | None
+    name: str | None
+    organization_key: str
+    organization_api_id: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class ResolverIssue:
+    """A non-fatal validation or event-stream continuity problem."""
+
+    code: str
+    message: str
+    transfer_date: date | None = None
+    raw_event: Any = field(default=None, compare=False, repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizedTransferEvent:
+    """One valid provider event in a canonical, raw-preserving form."""
+
+    transfer_date: date
+    raw_type: str
+    normalized_type: str
+    out_club: ClubRef
+    in_club: ClubRef
+    fingerprint: str
+    raw: Any = field(compare=False, repr=False)
+
+    @property
+    def date(self) -> date:
+        """Short alias used by consumers and tests."""
+        return self.transfer_date
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizationResult:
+    events: tuple[NormalizedTransferEvent, ...]
+    issues: tuple[ResolverIssue, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedTransferEvent:
+    """A canonical effective event after topology-aware classification."""
+
+    event: NormalizedTransferEvent
+    kind: EventKind
+    reason: str
+    evidence: tuple[NormalizedTransferEvent, ...]
+    fee: str | None = None
+
+    @property
+    def transfer_date(self) -> date:
+        return self.event.transfer_date
+
+    @property
+    def date(self) -> date:
+        return self.event.transfer_date
+
+    @property
+    def raw_type(self) -> str:
+        return self.event.raw_type
+
+    @property
+    def out_club(self) -> ClubRef:
+        return self.event.out_club
+
+    @property
+    def in_club(self) -> ClubRef:
+        return self.event.in_club
+
+    @property
+    def fee_string(self) -> str | None:
+        return self.fee
+
+    @property
+    def classification(self) -> str:
+        """Spec-spelled classification while ``kind`` stays Python-friendly."""
+        return {
+            "loan_start": "loan-start",
+            "loan_return": "loan-return",
+            "permanent": "permanent",
+            "unknown": "unknown",
+        }[self.kind]
+
+
+@dataclass(frozen=True, slots=True)
+class LoanEpisode:
+    """A half-open loan interval ``[start_date, end_date)``."""
+
+    owner: ClubRef
+    immediate_source: ClubRef
+    loan_club: ClubRef
+    start_date: date
+    end_date: date | None
+    end_reason: LoanEndReason | None
+    start_event: ResolvedTransferEvent
+    end_event: ResolvedTransferEvent | None
+
+    @property
+    def club(self) -> ClubRef:
+        """Compatibility alias for the playing/borrower club."""
+        return self.loan_club
+
+
+@dataclass(frozen=True, slots=True)
+class TransferResolution:
+    """Resolved transfer history and last-known state at ``as_of``.
+
+    ``legal_owner`` is ownership inferred from the stream.  It is intentionally
+    separate from ``loan_owner``: player-facing journey ``current_owner`` fields
+    should be populated only from a confirmed active loan, not for permanent
+    players whose legal owner is simply their current club.
+    """
+
+    as_of: date
+    normalized_events: tuple[NormalizedTransferEvent, ...]
+    events: tuple[ResolvedTransferEvent, ...]
+    loan_episodes: tuple[LoanEpisode, ...]
+    legal_owner: ClubRef | None
+    current_club: ClubRef | None
+    current_owner: ClubRef | None
+    immediate_loan_source: ClubRef | None
+    active_loan: LoanEpisode | None
+    on_loan: bool | None
+    loan_state: LoanState
+    latest_permanent_move: ResolvedTransferEvent | None
+    issues: tuple[ResolverIssue, ...]
+
+    @property
+    def loan_owner(self) -> ClubRef | None:
+        """Compatibility alias for the player-facing current owner."""
+        return self.current_owner
+
+
+@dataclass(slots=True)
+class _CoalescedEvent:
+    event: NormalizedTransferEvent
+    evidence: list[NormalizedTransferEvent]
+
+
+@dataclass(slots=True)
+class _EpisodeBuilder:
+    owner: ClubRef
+    immediate_source: ClubRef
+    loan_club: ClubRef
+    start_date: date
+    start_event: ResolvedTransferEvent
+    end_date: date | None = None
+    end_reason: LoanEndReason | None = None
+    end_event: ResolvedTransferEvent | None = None
+
+
+@dataclass(slots=True)
+class _ReducerState:
+    legal_owner: ClubRef | None = None
+    current_club: ClubRef | None = None
+    active_episode: _EpisodeBuilder | None = None
+
+
+def _value(event: Any, key: str, default: Any = None) -> Any:
+    if isinstance(event, Mapping):
+        return event.get(key, default)
+    return getattr(event, key, default)
+
+
+def _parse_date(value: Any) -> date | None:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return date.fromisoformat(value.strip())
+    except ValueError:
+        return None
+
+
+def _parse_id(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _clean_name(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _club(api_id: int | None, name: str | None) -> ClubRef:
+    senior_id = resolve_senior_id(api_id, name)
+    base = senior_base_name(name).strip().casefold()
+    organization_key = f"name:{base}" if base else f"id:{senior_id}"
+    return ClubRef(
+        api_id=api_id,
+        name=name,
+        organization_key=organization_key,
+        organization_api_id=senior_id or api_id,
+    )
+
+
+def _same_org(left: ClubRef | None, right: ClubRef | None) -> bool:
+    if left is None or right is None:
+        return False
+    if left.api_id is not None and left.api_id == right.api_id:
+        return True
+    if left.organization_api_id is not None and left.organization_api_id == right.organization_api_id:
+        return True
+    return left.organization_key == right.organization_key
+
+
+def _event_fields(event: Any) -> tuple[Any, Any, Any, Any, Any, Any]:
+    """Read either an API object or a flattened event dict/model row."""
+    transfer_date = _value(event, "date", None)
+    if transfer_date is None:
+        transfer_date = _value(event, "transfer_date", None)
+
+    transfer_type = _value(event, "type", None)
+    if transfer_type is None:
+        transfer_type = _value(event, "transfer_type", None)
+
+    teams = _value(event, "teams", None)
+    if isinstance(teams, Mapping):
+        outgoing = teams.get("out") or {}
+        incoming = teams.get("in") or {}
+        out_id = _value(outgoing, "id", None)
+        out_name = _value(outgoing, "name", None)
+        in_id = _value(incoming, "id", None)
+        in_name = _value(incoming, "name", None)
+    else:
+        out_id = _value(event, "out_club_api_id", None)
+        out_name = _value(event, "out_club_name", None)
+        in_id = _value(event, "in_club_api_id", None)
+        in_name = _value(event, "in_club_name", None)
+
+    return transfer_date, transfer_type, out_id, out_name, in_id, in_name
+
+
+def _canonical_event_key(event: NormalizedTransferEvent) -> tuple[Any, ...]:
+    return (
+        event.transfer_date,
+        event.out_club.organization_key,
+        event.in_club.organization_key,
+        event.normalized_type,
+        event.out_club.api_id or 0,
+        event.in_club.api_id or 0,
+        event.fingerprint,
+    )
+
+
+def _is_senior_named(club: ClubRef) -> bool:
+    if not club.name:
+        return False
+    return club.name.strip().casefold() == senior_base_name(club.name).strip().casefold()
+
+
+def _canonicalize_organizations(
+    events: list[NormalizedTransferEvent],
+) -> list[NormalizedTransferEvent]:
+    """Resolve name-only affiliates to a senior id observed in this stream.
+
+    ``resolve_senior_id`` covers known hardcoded ids.  This pre-scan covers the
+    much larger data-driven case: if the stream includes both Everton and
+    Everton U21 (or Bayern/Atalanta and their II sides), every ref keeps its raw
+    provider ``api_id`` but shares the observed senior ``organization_api_id``.
+    """
+    clubs = [club for event in events for club in (event.out_club, event.in_club)]
+    if not clubs:
+        return events
+
+    parents = list(range(len(clubs)))
+
+    def find(index: int) -> int:
+        while parents[index] != index:
+            parents[index] = parents[parents[index]]
+            index = parents[index]
+        return index
+
+    def union(left: int, right: int) -> None:
+        left_root = find(left)
+        right_root = find(right)
+        if left_root != right_root:
+            parents[right_root] = left_root
+
+    for left in range(len(clubs)):
+        for right in range(left + 1, len(clubs)):
+            if _same_org(clubs[left], clubs[right]):
+                union(left, right)
+
+    groups: dict[int, list[ClubRef]] = {}
+    for index, club in enumerate(clubs):
+        groups.setdefault(find(index), []).append(club)
+
+    canonical: dict[tuple[int | None, str | None], tuple[int | None, str]] = {}
+    for members in groups.values():
+        mapped_ids = {
+            member.organization_api_id
+            for member in members
+            if member.organization_api_id is not None and member.organization_api_id != member.api_id
+        }
+        senior_ids = {member.api_id for member in members if member.api_id is not None and _is_senior_named(member)}
+        observed_ids = {member.organization_api_id for member in members if member.organization_api_id is not None}
+        organization_id = (
+            min(mapped_ids or senior_ids or observed_ids) if mapped_ids or senior_ids or observed_ids else None
+        )
+        named_keys = sorted(
+            {member.organization_key for member in members if member.organization_key.startswith("name:")}
+        )
+        organization_key = named_keys[0] if named_keys else f"id:{organization_id}"
+        for member in members:
+            canonical[(member.api_id, member.name)] = organization_id, organization_key
+
+    result: list[NormalizedTransferEvent] = []
+    for event in events:
+        out_id, out_key = canonical[(event.out_club.api_id, event.out_club.name)]
+        in_id, in_key = canonical[(event.in_club.api_id, event.in_club.name)]
+        result.append(
+            replace(
+                event,
+                out_club=replace(
+                    event.out_club,
+                    organization_api_id=out_id,
+                    organization_key=out_key,
+                ),
+                in_club=replace(
+                    event.in_club,
+                    organization_api_id=in_id,
+                    organization_key=in_key,
+                ),
+            )
+        )
+    return result
+
+
+def _issue_key(issue: ResolverIssue) -> tuple[str, str, date]:
+    return issue.code, issue.message, issue.transfer_date or date.min
+
+
+def _normalize_transfer_events(events: Iterable[Any]) -> NormalizationResult:
+    normalized: list[NormalizedTransferEvent] = []
+    issues: list[ResolverIssue] = []
+
+    for raw_event in events or ():
+        raw_date, raw_type, raw_out_id, raw_out_name, raw_in_id, raw_in_name = _event_fields(raw_event)
+        transfer_date = _parse_date(raw_date)
+        if transfer_date is None:
+            issues.append(
+                ResolverIssue("invalid_date", "Transfer event has a missing or invalid date", raw_event=raw_event)
+            )
+            continue
+
+        if not isinstance(raw_type, str) or not raw_type.strip():
+            issues.append(
+                ResolverIssue(
+                    "missing_type",
+                    "Transfer event has a missing transfer type",
+                    transfer_date=transfer_date,
+                    raw_event=raw_event,
+                )
+            )
+            continue
+
+        out_id = _parse_id(raw_out_id)
+        out_name = _clean_name(raw_out_name)
+        if out_id is None and out_name is None:
+            issues.append(
+                ResolverIssue(
+                    "missing_out_club",
+                    "Transfer event has no usable outgoing club id or name",
+                    transfer_date=transfer_date,
+                    raw_event=raw_event,
+                )
+            )
+            continue
+        if out_id is None:
+            issues.append(
+                ResolverIssue(
+                    "missing_out_club_id",
+                    "Transfer event uses its outgoing club name because its id is missing or invalid",
+                    transfer_date=transfer_date,
+                    raw_event=raw_event,
+                )
+            )
+
+        in_id = _parse_id(raw_in_id)
+        in_name = _clean_name(raw_in_name)
+        if in_id is None and in_name is None:
+            issues.append(
+                ResolverIssue(
+                    "missing_in_club",
+                    "Transfer event has no usable incoming club id or name",
+                    transfer_date=transfer_date,
+                    raw_event=raw_event,
+                )
+            )
+            continue
+        if in_id is None:
+            issues.append(
+                ResolverIssue(
+                    "missing_in_club_id",
+                    "Transfer event uses its incoming club name because its id is missing or invalid",
+                    transfer_date=transfer_date,
+                    raw_event=raw_event,
+                )
+            )
+
+        transfer_type = raw_type.strip()
+        normalized_type = " ".join(transfer_type.casefold().split())
+        digest_input = "|".join(
+            (
+                transfer_date.isoformat(),
+                normalized_type,
+                str(out_id or ""),
+                out_name or "",
+                str(in_id or ""),
+                in_name or "",
+            )
+        )
+        normalized.append(
+            NormalizedTransferEvent(
+                transfer_date=transfer_date,
+                raw_type=transfer_type,
+                normalized_type=normalized_type,
+                out_club=_club(out_id, out_name),
+                in_club=_club(in_id, in_name),
+                fingerprint=hashlib.sha256(digest_input.encode()).hexdigest(),
+                raw=raw_event,
+            )
+        )
+
+    normalized = _canonicalize_organizations(normalized)
+    normalized.sort(key=_canonical_event_key)
+    issues.sort(key=_issue_key)
+    return NormalizationResult(tuple(normalized), tuple(issues))
+
+
+def normalize_transfer_events(events: Iterable[Any]) -> NormalizationResult:
+    """Normalize and strictly date-sort raw API dictionaries or flat rows.
+
+    Invalid events are retained as deterministic ``issues`` rather than
+    raising or manufacturing transfer state.
+    """
+    return _normalize_transfer_events(events)
+
+
+def _type_family(event: NormalizedTransferEvent) -> str:
+    if event.normalized_type in _LOAN_TYPES:
+        return "loan"
+    if event.normalized_type in _RETURN_TYPES:
+        return "return"
+    if event.normalized_type in _NA_TYPES:
+        return "na"
+    return "permanent"
+
+
+def _event_evidence_score(event: NormalizedTransferEvent) -> tuple[int, int, int, str]:
+    """Prefer the richest same-date duplicate without using input order."""
+
+    clubs = (event.out_club, event.in_club)
+    ids = sum(club.api_id is not None for club in clubs)
+    names = sum(club.name is not None for club in clubs)
+    senior_names = sum(
+        bool(club.name) and senior_base_name(club.name).casefold() == club.name.casefold() for club in clubs
+    )
+    return ids, names, senior_names, event.fingerprint
+
+
+def _coalesce_events(events: Iterable[NormalizedTransferEvent]) -> list[_CoalescedEvent]:
+    """Coalesce exact and one-day affiliate-equivalent provider duplicates."""
+    groups: list[_CoalescedEvent] = []
+
+    for event in events:
+        matching: _CoalescedEvent | None = None
+        for group in reversed(groups):
+            representative = group.event
+            day_gap = (event.transfer_date - representative.transfer_date).days
+            if day_gap > 1:
+                break
+            if (
+                day_gap >= 0
+                and event.normalized_type == representative.normalized_type
+                and _same_org(event.out_club, representative.out_club)
+                and _same_org(event.in_club, representative.in_club)
+            ):
+                matching = group
+                break
+
+        if matching is None:
+            groups.append(_CoalescedEvent(event=event, evidence=[event]))
+        else:
+            matching.evidence.append(event)
+            if event.transfer_date == matching.event.transfer_date and _event_evidence_score(
+                event
+            ) > _event_evidence_score(matching.event):
+                matching.event = event
+
+    return groups
+
+
+def _is_matching_return(event: NormalizedTransferEvent, active: _EpisodeBuilder | None) -> bool:
+    return bool(active and _same_org(event.out_club, active.loan_club) and _same_org(event.in_club, active.owner))
+
+
+def _is_matching_conversion(event: NormalizedTransferEvent, active: _EpisodeBuilder | None) -> bool:
+    return bool(active and _same_org(event.out_club, active.owner) and _same_org(event.in_club, active.loan_club))
+
+
+def _is_implied_return(event: NormalizedTransferEvent, state: _ReducerState) -> bool:
+    """Resolve a return whose intervening loan start is absent from the feed."""
+    if state.active_episode is not None or state.legal_owner is None:
+        return False
+    return bool(
+        _same_org(event.in_club, state.legal_owner)
+        and _same_org(state.current_club, state.legal_owner)
+        and not _same_org(event.out_club, state.legal_owner)
+    )
+
+
+def _is_continuity_permanent(event: NormalizedTransferEvent, state: _ReducerState) -> bool:
+    """Resolve concrete N/A from an established outgoing state."""
+    if state.active_episode is not None:
+        active = state.active_episode
+        if _is_matching_conversion(event, active):
+            return True
+        # A definitive owner -> third-club move supersedes the open loan even
+        # when the provider hides the fee/type as N/A.  The reverse
+        # borrower -> owner topology was checked as a return first.
+        return bool(
+            _same_org(event.out_club, active.owner)
+            and not _same_org(event.in_club, active.owner)
+            and not _same_org(event.in_club, active.loan_club)
+        )
+    source = state.current_club or state.legal_owner
+    return bool(source and _same_org(event.out_club, source) and not _same_org(event.in_club, source))
+
+
+def _same_day_order_key(
+    candidate: _CoalescedEvent,
+    pending: list[_CoalescedEvent],
+    state: _ReducerState,
+) -> tuple[Any, ...]:
+    event = candidate.event
+    family = _type_family(event)
+
+    if family in {"return", "na"} and (
+        _is_matching_return(event, state.active_episode) or _is_implied_return(event, state)
+    ):
+        continuity_rank = 0
+    elif family in {"permanent", "na"} and (
+        _is_matching_conversion(event, state.active_episode)
+        or (family == "na" and _is_continuity_permanent(event, state))
+    ):
+        continuity_rank = 1
+    elif _same_org(event.out_club, state.current_club):
+        continuity_rank = 2
+    elif _same_org(event.out_club, state.legal_owner):
+        continuity_rank = 3
+    elif family == "return":
+        continuity_rank = 4
+    else:
+        continuity_rank = 5
+
+    # If another event arrives at this event's source, it is normally the
+    # predecessor in the same-day chain.  State continuity still outranks this
+    # graph hint so a return/departure cycle is resolved from the active loan.
+    predecessor_count = sum(
+        1 for other in pending if other is not candidate and _same_org(other.event.in_club, event.out_club)
+    )
+    family_rank = {"return": 0, "permanent": 1, "loan": 2, "na": 3}[family]
+    return continuity_rank, predecessor_count, family_rank, _canonical_event_key(event)
+
+
+def _classify(event: NormalizedTransferEvent, state: _ReducerState) -> tuple[EventKind, str]:
+    family = _type_family(event)
+    if family == "loan":
+        return "loan_start", "explicit_loan"
+    if family == "return":
+        return "loan_return", "explicit_return"
+    if family == "permanent":
+        return "permanent", "explicit_permanent"
+    if _is_matching_return(event, state.active_episode):
+        return "loan_return", "topology_na_return"
+    if _is_matching_conversion(event, state.active_episode):
+        return "permanent", "topology_na_conversion"
+    if _is_implied_return(event, state):
+        return "loan_return", "topology_na_return_missing_start"
+    if _is_continuity_permanent(event, state):
+        return "permanent", "topology_na_permanent"
+    return "unknown", "ambiguous_na"
+
+
+def _close_episode(
+    active: _EpisodeBuilder,
+    event: ResolvedTransferEvent,
+    reason: LoanEndReason,
+) -> None:
+    active.end_date = event.transfer_date
+    active.end_reason = reason
+    active.end_event = event
+
+
+def _continuity_issue(
+    issues: list[ResolverIssue],
+    code: str,
+    message: str,
+    event: NormalizedTransferEvent,
+) -> None:
+    issues.append(
+        ResolverIssue(
+            code=code,
+            message=message,
+            transfer_date=event.transfer_date,
+            raw_event=event.raw,
+        )
+    )
+
+
+def _apply_event(
+    resolved: ResolvedTransferEvent,
+    state: _ReducerState,
+    episodes: list[_EpisodeBuilder],
+    issues: list[ResolverIssue],
+) -> None:
+    event = resolved.event
+
+    if resolved.kind == "unknown":
+        _continuity_issue(
+            issues,
+            "ambiguous_na",
+            "N/A transfer could not be resolved from active loan topology",
+            event,
+        )
+        return
+
+    if resolved.kind == "loan_start":
+        old_active = state.active_episode
+        owner = event.out_club
+        end_reason: LoanEndReason | None = None
+
+        if old_active is not None:
+            if _same_org(event.out_club, old_active.loan_club):
+                owner = old_active.owner
+                end_reason = "subloan"
+            elif _same_org(event.out_club, old_active.owner) and _same_org(event.in_club, old_active.loan_club):
+                end_reason = "reloan"
+            elif _same_org(event.out_club, old_active.owner):
+                end_reason = "superseded_by_loan"
+            else:
+                end_reason = "superseded_by_loan"
+                _continuity_issue(
+                    issues,
+                    "loan_source_discontinuity",
+                    "New loan source matches neither the active owner nor borrower",
+                    event,
+                )
+            _close_episode(old_active, resolved, end_reason)
+            if end_reason in {"reloan", "superseded_by_loan"}:
+                _continuity_issue(
+                    issues,
+                    "implicit_close_before_reloan",
+                    "A later loan start closed the prior episode because the provider omitted its return",
+                    event,
+                )
+        elif state.current_club is not None and not (
+            _same_org(event.out_club, state.current_club) or _same_org(event.out_club, state.legal_owner)
+        ):
+            _continuity_issue(
+                issues,
+                "loan_source_discontinuity",
+                "Loan source does not match the last-known club or owner",
+                event,
+            )
+
+        active = _EpisodeBuilder(
+            owner=owner,
+            immediate_source=event.out_club,
+            loan_club=event.in_club,
+            start_date=event.transfer_date,
+            start_event=resolved,
+        )
+        episodes.append(active)
+        state.active_episode = active
+        state.legal_owner = owner
+        state.current_club = event.in_club
+        return
+
+    if resolved.kind == "loan_return":
+        active = state.active_episode
+        if active is None:
+            _continuity_issue(
+                issues,
+                "return_without_open_loan",
+                "Return event has no matching open loan (the provider history may omit a re-loan)",
+                event,
+            )
+            state.legal_owner = event.in_club
+        else:
+            if _is_matching_return(event, active):
+                _close_episode(active, resolved, "return")
+                state.legal_owner = active.owner
+            else:
+                _close_episode(active, resolved, "superseded_by_return")
+                _continuity_issue(
+                    issues,
+                    "return_topology_mismatch",
+                    "Return endpoints do not match the open loan",
+                    event,
+                )
+                state.legal_owner = event.in_club
+            state.active_episode = None
+        state.current_club = event.in_club
+        return
+
+    active = state.active_episode
+    if active is not None:
+        reason: LoanEndReason
+        if _is_matching_conversion(event, active):
+            reason = "permanent_conversion"
+        else:
+            reason = "superseded_by_permanent"
+        _close_episode(active, resolved, reason)
+        state.active_episode = None
+    elif state.current_club is not None and not (
+        _same_org(event.out_club, state.current_club) or _same_org(event.out_club, state.legal_owner)
+    ):
+        _continuity_issue(
+            issues,
+            "permanent_source_discontinuity",
+            "Permanent move source does not match the last-known club or owner",
+            event,
+        )
+    state.legal_owner = event.in_club
+    state.current_club = event.in_club
+
+
+def _fee_for(event: NormalizedTransferEvent, kind: EventKind) -> str | None:
+    if kind != "permanent" or event.normalized_type in _NA_TYPES:
+        return None
+    return event.raw_type
+
+
+def _episode_from_builder(builder: _EpisodeBuilder) -> LoanEpisode:
+    return LoanEpisode(
+        owner=builder.owner,
+        immediate_source=builder.immediate_source,
+        loan_club=builder.loan_club,
+        start_date=builder.start_date,
+        end_date=builder.end_date,
+        end_reason=builder.end_reason,
+        start_event=builder.start_event,
+        end_event=builder.end_event,
+    )
+
+
+def _open_loan_fresh_boundary(start: date, *, start_month: int = 7, start_day: int = 1) -> date:
+    """Next end-exclusive season boundary after an unclosed loan start."""
+    boundary_year = start.year + 1 if (start.month, start.day) >= (start_month, start_day) else start.year
+    return date(boundary_year, start_month, start_day)
+
+
+def resolve_transfer_state(events: Iterable[Any], *, as_of: date | str) -> TransferResolution:
+    """Resolve transfer events chronologically as of a required date.
+
+    An unclosed loan is confirmed only within the July-to-June season in which
+    its start was observed.  At the next July 1 it becomes ``indeterminate``:
+    absence of a provider return is not evidence that a loan continues forever.
+    """
+    parsed_as_of = _parse_date(as_of)
+    if parsed_as_of is None:
+        raise ValueError("as_of must be a valid date or ISO date string")
+
+    normalization = _normalize_transfer_events(events)
+    applicable = [event for event in normalization.events if event.transfer_date <= parsed_as_of]
+    coalesced = _coalesce_events(applicable)
+
+    state = _ReducerState()
+    episode_builders: list[_EpisodeBuilder] = []
+    resolved_events: list[ResolvedTransferEvent] = []
+    issues = list(normalization.issues)
+    latest_permanent: ResolvedTransferEvent | None = None
+
+    by_date: dict[date, list[_CoalescedEvent]] = {}
+    for event in coalesced:
+        by_date.setdefault(event.event.transfer_date, []).append(event)
+
+    for transfer_date in sorted(by_date):
+        pending = list(by_date[transfer_date])
+        while pending:
+            chosen = min(pending, key=lambda item: _same_day_order_key(item, pending, state))
+            pending.remove(chosen)
+            kind, reason = _classify(chosen.event, state)
+            resolved = ResolvedTransferEvent(
+                event=chosen.event,
+                kind=kind,
+                reason=reason,
+                evidence=tuple(sorted(chosen.evidence, key=_canonical_event_key)),
+                fee=_fee_for(chosen.event, kind),
+            )
+            resolved_events.append(resolved)
+            _apply_event(resolved, state, episode_builders, issues)
+            if kind == "permanent":
+                latest_permanent = resolved
+
+    episodes = tuple(_episode_from_builder(builder) for builder in episode_builders)
+    active_loan = episodes[-1] if state.active_episode is not None and episodes else None
+
+    if state.active_episode is not None and active_loan is not None:
+        if parsed_as_of < _open_loan_fresh_boundary(active_loan.start_date):
+            on_loan: bool | None = True
+            loan_state: LoanState = "on_loan"
+        else:
+            on_loan = None
+            loan_state = "indeterminate"
+    elif state.legal_owner is None and state.current_club is None:
+        on_loan = None
+        loan_state = "unknown"
+    else:
+        on_loan = False
+        loan_state = "not_on_loan"
+
+    current_owner = active_loan.owner if on_loan is True and active_loan is not None else None
+    issues.sort(key=_issue_key)
+    return TransferResolution(
+        as_of=parsed_as_of,
+        normalized_events=normalization.events,
+        events=tuple(resolved_events),
+        loan_episodes=episodes,
+        legal_owner=state.legal_owner,
+        current_club=state.current_club,
+        current_owner=current_owner,
+        immediate_loan_source=active_loan.immediate_source if active_loan is not None else None,
+        active_loan=active_loan,
+        on_loan=on_loan,
+        loan_state=loan_state,
+        latest_permanent_move=latest_permanent,
+        issues=tuple(issues),
+    )
+
+
+def loan_episode_overlaps_season(
+    episode: LoanEpisode | Mapping[str, Any],
+    season_start_year: int,
+    *,
+    start_month: int = 7,
+    start_day: int = 1,
+) -> bool:
+    """Return whether two half-open intervals overlap.
+
+    ``season_start_year`` is always the season's start year.  The default
+    interval is July 1 through the following July 1; ``start_month=1`` and
+    ``start_day=1`` supports calendar-year competitions.
+    """
+    if isinstance(episode, Mapping):
+        raw_start = episode.get("start_date")
+        raw_end = episode.get("end_date")
+    else:
+        raw_start = episode.start_date
+        raw_end = episode.end_date
+
+    loan_start = _parse_date(raw_start)
+    loan_end = _parse_date(raw_end) if raw_end is not None else None
+    if loan_start is None or (raw_end is not None and loan_end is None):
+        return False
+
+    try:
+        season_start = date(season_start_year, start_month, start_day)
+        season_end = date(season_start_year + 1, start_month, start_day)
+        if raw_end is None:
+            # An unclosed provider loan proves overlap only for the season in
+            # which it began.  Treating it as [start, infinity) would recreate
+            # the production bug for every later season.
+            loan_end = _open_loan_fresh_boundary(
+                loan_start,
+                start_month=start_month,
+                start_day=start_day,
+            )
+    except (TypeError, ValueError):
+        return False
+
+    return loan_start < season_end and loan_end > season_start
+
+
+__all__ = [
+    "ClubRef",
+    "LoanEpisode",
+    "NormalizationResult",
+    "NormalizedTransferEvent",
+    "ResolvedTransferEvent",
+    "ResolverIssue",
+    "TransferResolution",
+    "loan_episode_overlaps_season",
+    "normalize_transfer_events",
+    "resolve_transfer_state",
+]

--- a/academy-watch-backend/src/utils/academy_classifier.py
+++ b/academy-watch-backend/src/utils/academy_classifier.py
@@ -13,9 +13,15 @@ import json
 import logging
 import re
 import time
-from datetime import datetime
+from datetime import UTC, date, datetime
 from typing import Any
 
+from src.services.transfer_resolver import (
+    ClubRef,
+    ResolvedTransferEvent,
+    TransferResolution,
+    resolve_transfer_state,
+)
 from src.utils.academy_window import DEVELOPMENT_AGE_CUTOFF as _DEVELOPMENT_AGE_CUTOFF
 
 # ── regex to strip youth suffixes from club names ──────────────────────
@@ -498,77 +504,393 @@ def derive_player_status_with_reasoning(
     return "on_loan", current_club_api_id, current_club_name, reasoning
 
 
+def _club_matches_parent(
+    club: ClubRef,
+    parent_api_id: int,
+    parent_club_name: str | None,
+) -> bool:
+    """Match a resolved club to an academy parent or one of its affiliates."""
+    from src.utils.affiliates import is_affiliate, resolve_senior_id, senior_base_name
+
+    parent_org_id = resolve_senior_id(parent_api_id, parent_club_name)
+    parent_base = senior_base_name(parent_club_name).strip().casefold()
+
+    return bool(
+        club.api_id == parent_api_id
+        or club.organization_api_id == parent_api_id
+        or (parent_org_id is not None and club.organization_api_id == parent_org_id)
+        or is_affiliate(club.api_id, club.name, parent_api_id, parent_club_name)
+        or (parent_base and club.organization_key == f"name:{parent_base}")
+    )
+
+
+def _club_matches_current(
+    club: ClubRef,
+    club_api_id: int | None,
+    club_name: str | None,
+) -> bool:
+    """Match current statistics to a resolver club across affiliate IDs/names."""
+    if club_api_id is not None and club_api_id in {club.api_id, club.organization_api_id}:
+        return True
+
+    from src.utils.affiliates import resolve_senior_id, senior_base_name
+
+    current_org_id = resolve_senior_id(club_api_id, club_name)
+    if current_org_id is not None and current_org_id == club.organization_api_id:
+        return True
+    current_base = senior_base_name(club_name).strip().casefold()
+    return bool(current_base and club.organization_key == f"name:{current_base}")
+
+
+def _has_defensible_club_identity(club: ClubRef) -> bool:
+    """Return whether a destination has a usable provider ID or real name."""
+    if club.api_id is not None or club.organization_api_id is not None:
+        return True
+    name = (club.name or "").strip().casefold()
+    return bool(name and name not in {"n/a", "na", "unknown", "unknown club", "-"})
+
+
+def _status_at_parent(status: str, current_level: str | None) -> str:
+    """Restore an academy-relative base status after a return or buyback."""
+    if current_level is not None:
+        return _base_status(current_level)
+    return status if status in {"academy", "first_team"} else "first_team"
+
+
+def _current_matches_parent(
+    current_club_api_id: int | None,
+    current_club_name: str | None,
+    parent_api_id: int,
+    parent_club_name: str | None,
+) -> bool:
+    """Match raw journey/current-stat fields to the academy organisation."""
+    from src.utils.affiliates import is_affiliate
+
+    return is_affiliate(
+        current_club_api_id,
+        current_club_name,
+        parent_api_id,
+        parent_club_name,
+    )
+
+
+def _has_defensible_current_club(
+    current_club_api_id: int | None,
+    current_club_name: str | None,
+) -> bool:
+    """Return whether raw current-club fields identify a real club."""
+    if current_club_api_id is not None:
+        return True
+    name = (current_club_name or "").strip().casefold()
+    return bool(name and name not in {"n/a", "na", "unknown", "unknown club", "-"})
+
+
+def _resolution_is_fresh_for_stats(
+    resolution: TransferResolution,
+    latest_season: int | None,
+    *,
+    season_start_month: int = 7,
+    season_start_day: int = 1,
+) -> bool:
+    """Whether resolved movement is at least as recent as statistics evidence."""
+    if latest_season is None:
+        return True
+    try:
+        stats_floor = date(
+            int(latest_season),
+            int(season_start_month),
+            int(season_start_day),
+        )
+    except (TypeError, ValueError):
+        return True
+    latest_event = max(
+        (event.transfer_date for event in resolution.events if event.kind != "unknown"),
+        default=None,
+    )
+    return latest_event is not None and latest_event >= stats_floor
+
+
+def resolved_current_club_is_authoritative(
+    resolution: TransferResolution,
+    current_club_api_id: int | None,
+    current_club_name: str | None,
+    *,
+    latest_season: int | None = None,
+    season_start_month: int = 7,
+    season_start_day: int = 1,
+) -> bool:
+    """Apply one precedence policy to resolver-versus-statistics club state.
+
+    Indeterminate loans never overwrite newer club evidence. A determinate
+    movement may fill missing/matching state, replace its own stale permanent
+    source (the Hall case), or override statistics no newer than the movement.
+    Newer statistics at an unrelated external club win over an older stream.
+    """
+    if resolution.loan_state == "indeterminate":
+        return False
+
+    latest_event = max(
+        (event for event in resolution.events if event.kind != "unknown"),
+        key=lambda event: event.transfer_date,
+        default=None,
+    )
+    if latest_event is None:
+        return False
+
+    current_is_unspecified = not _has_defensible_current_club(
+        current_club_api_id,
+        current_club_name,
+    )
+    if current_is_unspecified:
+        return True
+
+    destination = resolution.current_club
+    if destination is not None and _club_matches_current(
+        destination,
+        current_club_api_id,
+        current_club_name,
+    ):
+        return True
+
+    if latest_event.kind == "permanent" and _club_matches_current(
+        latest_event.out_club,
+        current_club_api_id,
+        current_club_name,
+    ):
+        return True
+
+    return _resolution_is_fresh_for_stats(
+        resolution,
+        latest_season,
+        season_start_month=season_start_month,
+        season_start_day=season_start_day,
+    )
+
+
+def latest_parent_permanent_departure(
+    resolution: TransferResolution | None,
+    parent_api_id: int,
+    parent_club_name: str | None,
+) -> ResolvedTransferEvent | None:
+    """Return the latest permanent exit from this academy parent.
+
+    ``TransferResolution.latest_permanent_move`` is player-global and may be a
+    later resale by another club. ``TrackedPlayer.sale_fee`` belongs to its
+    academy-parent row, so fee consumers must select the parent-relative move.
+    """
+    if resolution is None:
+        return None
+    return next(
+        (
+            event
+            for event in reversed(resolution.events)
+            if event.kind == "permanent"
+            and _club_matches_parent(event.out_club, parent_api_id, parent_club_name)
+            and not _club_matches_parent(event.in_club, parent_api_id, parent_club_name)
+        ),
+        None,
+    )
+
+
+def _resolution_confirms_parent_loan(
+    resolution: TransferResolution | None,
+    parent_api_id: int,
+    parent_club_name: str | None,
+    current_club_api_id: int | None,
+    current_club_name: str | None,
+) -> bool:
+    """Return whether the resolver proves a parent-origin loan active now."""
+    if resolution is None or resolution.on_loan is not True or resolution.active_loan is None:
+        return False
+
+    episode = resolution.active_loan
+    current_is_unspecified = current_club_api_id is None and not current_club_name
+    return (
+        _club_matches_parent(episode.owner, parent_api_id, parent_club_name)
+        and not _club_matches_parent(episode.loan_club, parent_api_id, parent_club_name)
+        and (
+            current_is_unspecified
+            or _club_matches_current(
+                episode.loan_club,
+                current_club_api_id,
+                current_club_name,
+            )
+        )
+    )
+
+
 def upgrade_status_from_transfers(
     status: str,
-    transfers: list,
+    transfers: list | None,
     parent_api_id: int,
     current_club_api_id: int | None = None,
     parent_club_name: str | None = None,
+    *,
+    current_club_name: str | None = None,
+    current_level: str | None = None,
+    transfer_resolution: TransferResolution | None = None,
+    as_of: date | str | None = None,
+    latest_season: int | None = None,
+    season_start_month: int = 7,
+    season_start_day: int = 1,
 ) -> str:
-    """Decide the real status of a player who is at a club other than the
-    parent academy, from transfer evidence. Resolves the tentative 'on_loan'
-    from derive_player_status into one of on_loan / sold / released / left.
+    """Reconcile academy-relative status against resolved transfer evidence.
+
+    The incoming status may be stale journey evidence (including academy,
+    first_team, left, or sold), so definitive transfer state is not gated on
+    the caller first deriving ``on_loan``.
 
     The key inversion: 'on_loan' must be EARNED by a parent loan record; it is
     no longer the fallback. Rules (relative to parent P), in order:
 
-      • current club is a P loan destination (a P→current loan transfer) → on_loan
-      • no departure from P at all, but player is elsewhere            → left
+      • an active resolved P→external loan episode covers now         → on_loan
+      • a later return or permanent buyback ends at P           → academy/first_team
+      • no departure from P at all, but player is elsewhere           → left
       • latest P departure is a loan but current ∉ P loan dests
         (loaned then moved on)                                         → left
       • latest P departure is permanent with a real, non-parent,
         non-national destination                                       → sold
       • latest P departure is permanent with no resolvable destination → released
 
-    Loan destinations and departures are matched against P OR P's own
+    Loan episodes and departures are matched against P OR P's own
     reserve/youth/B side (e.g. Valencia and Valencia II both count as a Valencia
-    loan), and ignore null destination ids and loan-RETURN types.
+    loan). The injected resolution, when supplied, must have been built with
+    this same parent as its initial owner.
     """
-    if status != "on_loan" or not transfers:
+    # ``None`` means transfer evidence was unavailable (for example a provider
+    # failure), while ``[]`` is a successful fetch proving an empty history.
+    # Only the former may preserve the caller's conservative status unchanged.
+    if transfers is None and transfer_resolution is None:
         return status
 
-    from src.api_football_client import is_new_loan_transfer
-    from src.utils.affiliates import is_affiliate
-
-    def _out_is_parent(t: dict) -> bool:
-        o = t.get("teams", {}).get("out", {}) or {}
-        oid = o.get("id")
-        return oid == parent_api_id or is_affiliate(oid, o.get("name"), parent_api_id, parent_club_name)
-
-    # Loan destinations the PARENT (or its B-team) loaned the player to.
-    # Exclude null in.id; is_new_loan_transfer already excludes loan-returns.
-    loan_destinations = {
-        (t.get("teams", {}).get("in", {}) or {}).get("id")
-        for t in transfers
-        if is_new_loan_transfer((t.get("type") or "").strip().lower()) and _out_is_parent(t)
-    }
-    loan_destinations.discard(None)
+    resolution = transfer_resolution or resolve_transfer_state(
+        transfers or [],
+        as_of=as_of or datetime.now(UTC).date(),
+        initial_owner={"id": parent_api_id, "name": parent_club_name},
+        season_start_month=season_start_month,
+        season_start_day=season_start_day,
+    )
 
     # Genuine current loan FROM the parent — transfer-driven, not entry-type
     # driven (a brand-new loan has no synced fixtures yet so its journey entry
-    # is not typed 'loan', but the loan transfer is already present).
-    if current_club_api_id and current_club_api_id in loan_destinations:
-        return "on_loan"
+    # is not typed 'loan', but the loan transfer is already present). Historical
+    # or indeterminate episodes deliberately do not confirm a current loan.
+    active_parent_loan = _resolution_confirms_parent_loan(
+        resolution,
+        parent_api_id,
+        parent_club_name,
+        None,
+        None,
+    )
+    if active_parent_loan and resolution.active_loan is not None:
+        current_is_unspecified = not _has_defensible_current_club(
+            current_club_api_id,
+            current_club_name,
+        )
+        current_is_parent = _current_matches_parent(
+            current_club_api_id,
+            current_club_name,
+            parent_api_id,
+            parent_club_name,
+        )
+        current_is_borrower = _club_matches_current(
+            resolution.active_loan.loan_club,
+            current_club_api_id,
+            current_club_name,
+        )
+        transfer_is_fresh = latest_season is not None and _resolution_is_fresh_for_stats(
+            resolution,
+            latest_season,
+            season_start_month=season_start_month,
+            season_start_day=season_start_day,
+        )
+        if current_is_unspecified or current_is_parent or current_is_borrower or transfer_is_fresh:
+            return "on_loan"
 
-    # The 'left' outcomes require a KNOWN current club (the player is
-    # demonstrably elsewhere). When current_club_api_id is unknown we cannot
-    # assert they left, so we keep the tentative on_loan (callers that classify
-    # without a current club rely on this conservative behaviour).
-    departures = [t for t in transfers if _out_is_parent(t)]
+    effective_events = [event for event in resolution.events if event.kind != "unknown"]
+    if not effective_events and (resolution.normalized_events or resolution.issues):
+        # A non-empty history whose every event is ambiguous or invalid is not
+        # equivalent to a successful empty history. The resolver deliberately
+        # emitted unknown/issues instead of manufacturing state, so preserve
+        # the caller's conservative status until definitive evidence arrives.
+        return status
+
+    departures = [
+        event
+        for event in effective_events
+        if event.kind in {"loan_start", "permanent"}
+        and _club_matches_parent(event.out_club, parent_api_id, parent_club_name)
+        and not _club_matches_parent(event.in_club, parent_api_id, parent_club_name)
+    ]
+
+    # A resolved return or buyback into the parent is newer and more precise
+    # than a stale external journey club. Re-establish the parent's academy /
+    # first-team status before interpreting historical departures.
+    if (
+        departures
+        and effective_events
+        and resolution.current_club is not None
+        and _club_matches_parent(resolution.current_club, parent_api_id, parent_club_name)
+    ):
+        current_is_external = _has_defensible_current_club(
+            current_club_api_id, current_club_name
+        ) and not _current_matches_parent(
+            current_club_api_id,
+            current_club_name,
+            parent_api_id,
+            parent_club_name,
+        )
+        if not current_is_external or _resolution_is_fresh_for_stats(
+            resolution,
+            latest_season,
+            season_start_month=season_start_month,
+            season_start_day=season_start_day,
+        ):
+            return _status_at_parent(status, current_level)
+        # Newer external statistics after an older return/buyback are evidence
+        # of another departure missing from the transfer feed.
+        return "left"
+
     if not departures:
         # The player is at a different club but there is NO recorded departure
         # from the parent (typical of academy-to-academy youth moves). They
         # left the academy without a recorded senior transfer.
-        return "left" if current_club_api_id else status
+        current_is_external = (
+            _has_defensible_current_club(current_club_api_id, current_club_name)
+            and not _current_matches_parent(
+                current_club_api_id,
+                current_club_name,
+                parent_api_id,
+                parent_club_name,
+            )
+            and not is_national_team(current_club_name)
+        )
+        if current_is_external:
+            return "left"
+        # Successful definitive/empty evidence found no departure from the
+        # parent. Do not let a stale tentative ``on_loan`` survive it.
+        return _status_at_parent(status, current_level)
 
-    departures.sort(key=lambda t: t.get("date", ""), reverse=True)
-    dep_type = (departures[0].get("type") or "").strip().lower()
-
-    if not dep_type or is_new_loan_transfer(dep_type):
-        # Latest parent departure is a loan. We already returned on_loan above
-        # if the current club is one of the parent's loan destinations, so a
-        # known current club here means loaned-out-then-moved-on → left.
-        return "left" if current_club_api_id else status
+    latest_departure = departures[-1]
+    if latest_departure.kind == "loan_start":
+        # A fresh parent loan returned above. An unclosed loan becomes
+        # indeterminate at the next season boundary; a current external club
+        # then means the player moved on, while a current parent club is newer
+        # evidence that they returned despite the omitted provider event.
+        if _current_matches_parent(
+            current_club_api_id,
+            current_club_name,
+            parent_api_id,
+            parent_club_name,
+        ):
+            return _status_at_parent(status, current_level)
+        if _has_defensible_current_club(current_club_api_id, current_club_name):
+            return "left"
+        # The resolver deliberately expires an unclosed loan at the next
+        # season boundary. With no newer raw club evidence, the historical
+        # departure still proves the player left the parent, but not that the
+        # loan remains active now.
+        return "left"
 
     # Permanent (non-loan) departure. The transfer TYPE alone cannot tell a
     # free-agency exit from a permanent move to a new club: API-Football
@@ -579,9 +901,12 @@ def upgrade_status_from_transfers(
     # is the other path to 'released'). Read only the departure's teams.in,
     # NOT the journey's current club: an empty teams.in is the free-agency
     # signal, and folding in a stale last-club would manufacture a false 'sold'.
-    dest = departures[0].get("teams", {}).get("in", {}) or {}
-    dest_id = dest.get("id")
-    if dest_id and dest_id != parent_api_id and not is_national_team(dest.get("name")):
+    dest = latest_departure.in_club
+    if (
+        _has_defensible_club_identity(dest)
+        and not _club_matches_parent(dest, parent_api_id, parent_club_name)
+        and not is_national_team(dest.name)
+    ):
         return "sold"
     return "released"
 
@@ -706,14 +1031,19 @@ def classify_tracked_player(
     with_reasoning: bool = False,
     latest_season: int | None = None,
     squad_members_by_club: dict[int, set[int]] | None = None,
+    transfer_resolution: TransferResolution | None = None,
+    as_of: date | str | None = None,
+    season_start_month: int = 7,
+    season_start_day: int = 1,
 ) -> tuple[str, int | None, str | None] | tuple[str, int | None, str | None, list[dict]]:
     """Single source of truth for player status classification.
 
     Applies these rules in order:
     1. Base status derivation (academy / first_team / on_loan)
-    2. Transfer-based upgrade (on_loan → sold / released)
+    2. Transfer-based reconciliation (on_loan / sold / released / left /
+       returned-to-parent)
        — always runs when transfer data is available (core correctness;
-         a permanent departure must never read as a loan)
+         stale journey status must not override definitive transfer state)
     2.5. Squad cross-reference (on_loan players only)
        — if player absent from loan club squad, check parent squad;
          returned to parent → academy/first_team, absent from both → released
@@ -737,6 +1067,13 @@ def classify_tracked_player(
         with_reasoning: Return step-by-step reasoning list.
         latest_season: The player's latest season year — used for the
             inactivity check.
+        season_start_month: First month of the competition season used to
+            compare transfer chronology with latest-season statistics.
+        season_start_day: First day of that competition season.
+        transfer_resolution: Optional parent-contextualized resolver result to
+            reuse. When omitted, this function resolves *transfers* with the
+            academy parent as the initial owner.
+        as_of: Effective date for transfer resolution. Defaults to today.
 
     Returns:
         ``(status, current_club_api_id, current_club_name)`` or
@@ -765,77 +1102,125 @@ def classify_tracked_player(
         )
         reasoning: list[dict] = []
 
-    # ── Step 2: transfer-based upgrade ────────────────────────────────
-    # The loan→sold/released upgrade is core correctness, not a tunable: a
-    # permanent departure (sale or free transfer) must never read as a loan.
+    # ── Step 2: transfer-based reconciliation ─────────────────────────
+    # Transfer reconciliation is core correctness, not a tunable: a permanent
+    # departure must override stale same-parent journey data just as a resolved
+    # return/buyback must override a stale external club.
     # This step therefore always runs when transfer data is available and is
     # NOT gated by config['use_transfers_for_status']. That flag used to
     # suppress this entire step; with the active config storing it False,
     # sold-detection silently died platform-wide — every permanently
     # transferred player (e.g. Garnacho sold to Chelsea) was stuck at
-    # on_loan. The upgrade itself is conservative (only promotes when the
-    # latest parent departure is non-loan), so genuine loans stay on_loan.
-    if status == "on_loan":
-        effective_transfers = transfers
-        if effective_transfers is None and player_api_id and api_client:
-            try:
-                raw = api_client.get_player_transfers(player_api_id)
-                effective_transfers = flatten_transfers(raw)
-            except Exception as exc:
-                logger.warning("Transfer fetch failed for player %s: %s", player_api_id, exc)
-                effective_transfers = []
+    # on_loan. The reconciliation itself requires definitive resolver
+    # evidence, so unknown/failing evidence stays conservative.
+    effective_transfers = transfers
+    effective_resolution = transfer_resolution
+    if effective_transfers is None and effective_resolution is None and player_api_id and api_client:
+        try:
+            raw = api_client.get_player_transfers(player_api_id)
+            effective_transfers = flatten_transfers(raw)
+        except Exception as exc:
+            logger.warning("Transfer fetch failed for player %s: %s", player_api_id, exc)
+            # Keep fetch failure distinct from a successful empty history.
+            # Unknown evidence must not downgrade the conservative status.
+            effective_transfers = None
 
-        if effective_transfers:
-            upgraded = upgrade_status_from_transfers(
-                status,
+    if effective_transfers is not None or effective_resolution is not None:
+        if effective_resolution is None:
+            effective_resolution = resolve_transfer_state(
                 effective_transfers,
-                parent_api_id,
-                current_club_api_id=current_club_api_id,
-                parent_club_name=parent_club_name,
+                as_of=as_of or datetime.now(UTC).date(),
+                initial_owner={"id": parent_api_id, "name": parent_club_name},
+                season_start_month=season_start_month,
+                season_start_day=season_start_day,
             )
-            if upgraded != status:
-                if with_reasoning:
-                    reasoning.append(
-                        {
-                            "rule": "transfer_upgrade",
-                            "result": "match",
-                            "check": f'upgrade_status_from_transfers("{status}")',
-                            "detail": f"Upgraded from {status} to {upgraded}",
-                        }
-                    )
-                status = upgraded
-                # Keep current_club info — loan_id/loan_name are reused as
-                # current_club_api_id/current_club_name in the return value.
-                # For sold/released/left players, this is their destination/current club.
-        elif effective_transfers is not None:
-            # We have transfer data (an empty list) and the player is at a
-            # different club, but there is NO transfer record at all → they
-            # left the academy without a recorded senior transfer. Only treat
-            # an explicit empty list this way; None means transfers were not
-            # fetched, so keep the conservative on_loan default for callers
-            # that classify without transfer data.
-            status = "left"
-            if with_reasoning:
-                reasoning.append(
-                    {
-                        "rule": "no_transfers_left",
-                        "result": "match",
-                        "check": "at a different club with no transfer records",
-                        "detail": "Left the academy (no recorded departure) → left",
-                    }
-                )
+        previous_status = status
+        status = upgrade_status_from_transfers(
+            status,
+            effective_transfers or [],
+            parent_api_id,
+            current_club_api_id=current_club_api_id,
+            parent_club_name=parent_club_name,
+            current_club_name=current_club_name,
+            current_level=current_level,
+            transfer_resolution=effective_resolution,
+            as_of=as_of,
+            latest_season=latest_season,
+            season_start_month=season_start_month,
+            season_start_day=season_start_day,
+        )
+        if status != previous_status and with_reasoning:
+            reasoning.append(
+                {
+                    "rule": "transfer_reconciliation",
+                    "result": "match",
+                    "check": f'upgrade_status_from_transfers("{previous_status}")',
+                    "detail": f"Reconciled from {previous_status} to {status}",
+                }
+            )
 
+        effective_events = [event for event in effective_resolution.events if event.kind != "unknown"]
+        if status == "on_loan" and _resolution_confirms_parent_loan(
+            effective_resolution,
+            parent_api_id,
+            parent_club_name,
+            None,
+            None,
+        ):
+            episode = effective_resolution.active_loan
+            if episode is not None and not _club_matches_current(
+                episode.loan_club,
+                loan_id,
+                loan_name,
+            ):
+                loan_id = episode.loan_club.api_id or episode.loan_club.organization_api_id
+                loan_name = episode.loan_club.name
+        elif status in {"sold", "left"} and effective_events:
+            resolved_current = effective_resolution.current_club
+            if (
+                resolved_current is not None
+                and _has_defensible_club_identity(resolved_current)
+                and not _club_matches_parent(resolved_current, parent_api_id, parent_club_name)
+                and not is_national_team(resolved_current.name)
+            ):
+                raw_matches_resolved = _club_matches_current(
+                    resolved_current,
+                    current_club_api_id,
+                    current_club_name,
+                )
+                if resolved_current_club_is_authoritative(
+                    effective_resolution,
+                    current_club_api_id,
+                    current_club_name,
+                    latest_season=latest_season,
+                    season_start_month=season_start_month,
+                    season_start_day=season_start_day,
+                ):
+                    loan_id = resolved_current.api_id or resolved_current.organization_api_id
+                    loan_name = resolved_current.name or (current_club_name if raw_matches_resolved else None)
+        elif status == "released" or (
+            status in {"academy", "first_team"}
+            and effective_events
+            and effective_resolution.current_club is not None
+            and _club_matches_parent(
+                effective_resolution.current_club,
+                parent_api_id,
+                parent_club_name,
+            )
+        ):
+            loan_id = None
+            loan_name = None
     # ── Step 2.5: squad cross-reference ────────────────────────────────
     # Skip squad check if transfers confirm a loan — transfer data is more
     # authoritative than squad lists (which aren't updated mid-season for loans).
     has_confirmed_loan = False
-    _check_transfers = transfers or []
-    if status == "on_loan" and loan_id:
-        from src.api_football_client import is_new_loan_transfer as _is_loan
-
-        has_confirmed_loan = any(
-            _is_loan((t.get("type") or "").strip().lower()) and t.get("teams", {}).get("in", {}).get("id") == loan_id
-            for t in _check_transfers
+    if status == "on_loan":
+        has_confirmed_loan = _resolution_confirms_parent_loan(
+            effective_resolution,
+            parent_api_id,
+            parent_club_name,
+            loan_id,
+            loan_name,
         )
 
     if (
@@ -845,10 +1230,12 @@ def classify_tracked_player(
         and squad_members_by_club is not None
         and player_api_id
     ):
+        loan_squad_fetched = loan_id in squad_members_by_club
+        parent_squad_fetched = parent_api_id in squad_members_by_club
         loan_squad = squad_members_by_club.get(loan_id)
         parent_squad = squad_members_by_club.get(parent_api_id)
-        in_loan_squad = loan_squad is not None and player_api_id in loan_squad
-        in_parent_squad = parent_squad is not None and player_api_id in parent_squad
+        in_loan_squad = loan_squad_fetched and player_api_id in loan_squad
+        in_parent_squad = parent_squad_fetched and player_api_id in parent_squad
         if not in_loan_squad:
             if in_parent_squad:
                 old_status = status
@@ -867,7 +1254,7 @@ def classify_tracked_player(
                     )
                 loan_id = None
                 loan_name = None
-            else:
+            elif loan_squad_fetched and parent_squad_fetched:
                 if with_reasoning:
                     reasoning.append(
                         {
@@ -882,6 +1269,20 @@ def classify_tracked_player(
                 status = "released"
                 loan_id = None
                 loan_name = None
+            elif with_reasoning:
+                missing_clubs = []
+                if not loan_squad_fetched:
+                    missing_clubs.append(str(loan_id))
+                if not parent_squad_fetched:
+                    missing_clubs.append(str(parent_api_id))
+                reasoning.append(
+                    {
+                        "rule": "squad_cross_reference",
+                        "result": "unknown",
+                        "check": f"squad not fetched for club(s) {', '.join(missing_clubs)}",
+                        "detail": "Incomplete squad coverage — preserving current status",
+                    }
+                )
 
     # ── Step 3: inactivity-based release ──────────────────────────────
     inactivity_years = config.get("inactivity_release_years")

--- a/academy-watch-backend/src/utils/affiliates.py
+++ b/academy-watch-backend/src/utils/affiliates.py
@@ -97,12 +97,11 @@ def is_affiliate(
     Hardcoded id map first (covers NULL-name ids), then data-driven base-name
     equality (covers Jong/U-number/III that the youth-suffix stripper misses).
     """
-    if club_api_id is None or parent_api_id is None:
-        return False
-    if club_api_id == parent_api_id:
-        return True
-    if B_TEAM_TO_SENIOR.get(club_api_id) == parent_api_id:
-        return True
+    if club_api_id is not None and parent_api_id is not None:
+        if club_api_id == parent_api_id:
+            return True
+        if B_TEAM_TO_SENIOR.get(club_api_id) == parent_api_id:
+            return True
     if club_name and parent_club_name:
         base = senior_base_name(club_name).lower()
         pbase = senior_base_name(parent_club_name).lower()

--- a/academy-watch-backend/src/utils/rebuild_runner.py
+++ b/academy-watch-backend/src/utils/rebuild_runner.py
@@ -12,6 +12,112 @@ from datetime import UTC, datetime
 logger = logging.getLogger(__name__)
 
 
+def _classification_season_start(league_api_id, season_configs) -> tuple[int, int]:
+    """Return the configured statistics-season boundary for a league."""
+    season_config = season_configs.get(league_api_id)
+    if season_config is None:
+        return (7, 1)
+
+    season_type = (getattr(season_config, "season_type", None) or "").strip().lower()
+    rollover_month = getattr(season_config, "rollover_month", None)
+    try:
+        rollover_month = int(rollover_month)
+    except (TypeError, ValueError):
+        rollover_month = None
+    if rollover_month is not None and 1 <= rollover_month <= 12:
+        return (rollover_month, 1)
+    if season_type == "calendar":
+        return (1, 1)
+    return (7, 1)
+
+
+def _classification_season_context(journey, season_configs) -> tuple[int | None, int, int]:
+    """Use one domestic entry for both latest-season and calendar evidence."""
+    if journey is None:
+        return (None, 7, 1)
+    from src.models.journey import PlayerJourneyEntry
+
+    latest_entry = journey.entries.filter(PlayerJourneyEntry.is_international.is_not(True)).first()
+    if latest_entry is None:
+        latest_entry = journey.entries.first()
+    if latest_entry is None:
+        return (None, 7, 1)
+    start_month, start_day = _classification_season_start(
+        getattr(latest_entry, "league_api_id", None),
+        season_configs,
+    )
+    return (latest_entry.season, start_month, start_day)
+
+
+def _rebuild_transfer_evidence(
+    api_client,
+    player_api_id: int,
+    transfer_cache: dict[int, list | None],
+    *,
+    parent_api_id: int,
+    parent_club_name: str | None,
+    as_of,
+    season_start_month: int,
+    season_start_day: int,
+):
+    """Fetch once, then resolve the cached history for one academy parent.
+
+    ``None`` in the cache means the provider request failed; an empty list is a
+    successful, authoritative empty history.  Keeping those states distinct
+    prevents Stage 4 and Stage 6 from retrying independently or treating an
+    outage as evidence that a previous fee should be cleared.
+    """
+    from src.services.transfer_resolver import resolve_transfer_state
+    from src.utils.academy_classifier import flatten_transfers
+
+    if player_api_id not in transfer_cache:
+        try:
+            transfer_cache[player_api_id] = flatten_transfers(api_client.get_player_transfers(player_api_id))
+        except Exception as exc:
+            logger.warning(
+                "Transfer fetch failed during rebuild for player %s: %s",
+                player_api_id,
+                exc,
+            )
+            transfer_cache[player_api_id] = None
+
+    transfers = transfer_cache[player_api_id]
+    if transfers is None:
+        return None, None
+
+    resolution = resolve_transfer_state(
+        transfers,
+        as_of=as_of,
+        initial_owner={"id": parent_api_id, "name": parent_club_name},
+        season_start_month=season_start_month,
+        season_start_day=season_start_day,
+    )
+    return transfers, resolution
+
+
+def _rebuild_sale_fee(
+    current_fee: str | None,
+    *,
+    status: str,
+    resolution,
+    parent_api_id: int,
+    parent_club_name: str | None,
+) -> str | None:
+    """Return the academy-parent sale fee, preserving it on fetch failure."""
+    from src.utils.academy_classifier import latest_parent_permanent_departure
+
+    if resolution is None:
+        return current_fee
+    if status != "sold":
+        return None
+    departure = latest_parent_permanent_departure(
+        resolution,
+        parent_api_id,
+        parent_club_name,
+    )
+    return departure.fee if departure is not None else None
+
+
 def run_rebuild_process(job_id, rebuild_type, kwargs):
     """Entry point for the rebuild subprocess.
 
@@ -92,12 +198,13 @@ def _run_full_rebuild(job_id, config):
     from src.models.cohort import AcademyCohort, CohortMember
     from src.models.journey import ClubLocation, PlayerJourney, PlayerJourneyEntry
     from src.models.league import AcademyAppearance, AcademyLeague, Team, db
+    from src.models.season_rollup import LeagueSeasonConfig
     from src.models.tracked_player import TrackedPlayer
     from src.models.weekly import WeeklyLoanAppearance
     from src.services.big6_seeding_service import BIG_6, SEASONS, run_big6_seed
     from src.services.journey_sync import JourneySyncService, seed_club_locations
     from src.services.youth_competition_resolver import build_academy_league_seed_rows
-    from src.utils.academy_classifier import _get_latest_season, classify_tracked_player
+    from src.utils.academy_classifier import classify_tracked_player
     from src.utils.academy_window import is_within_academy_window, last_academy_season_for
     from src.utils.background_jobs import is_job_cancelled, update_job
 
@@ -110,6 +217,7 @@ def _run_full_rebuild(job_id, config):
     seasons = config.get("seasons") or SEASONS
     skip_clean = config.get("skip_clean", False)
     skip_cohorts = config.get("skip_cohorts", False)
+    season_configs = {row.league_api_id: row for row in LeagueSeasonConfig.query.all()}
 
     stage = "starting"
     try:
@@ -268,6 +376,8 @@ def _run_full_rebuild(job_id, config):
         api_client = APIFootballClient()
         journey_svc = JourneySyncService(api_client)
         current_season = max(seasons)
+        rebuild_as_of = datetime.now(UTC).date()
+        transfer_cache: dict[int, list | None] = {}
         total_created = 0
         total_skipped = 0
 
@@ -282,7 +392,6 @@ def _run_full_rebuild(job_id, config):
                 continue
 
             parent_api_id = team.team_id
-
             # Source 1: academy_club_ids
             known_journeys = PlayerJourney.query.filter(
                 PlayerJourney.academy_club_ids.contains(cast([parent_api_id], PG_JSONB))
@@ -371,6 +480,28 @@ def _run_full_rebuild(job_id, config):
                     birth_date = (journey.birth_date if journey else None) or (pi.get("birth") or {}).get("date")
                     position = pi.get("position") or ""
                     age = pi.get("age")
+                    latest_season, season_start_month, season_start_day = _classification_season_context(
+                        journey,
+                        season_configs,
+                    )
+                    transfers, transfer_resolution = _rebuild_transfer_evidence(
+                        api_client,
+                        pid,
+                        transfer_cache,
+                        parent_api_id=parent_api_id,
+                        parent_club_name=team.name,
+                        as_of=rebuild_as_of,
+                        season_start_month=season_start_month,
+                        season_start_day=season_start_day,
+                    )
+                    if transfer_resolution is None:
+                        skipped += 1
+                        logger.warning(
+                            "Skipping rebuild creation for player %s at %s because transfer evidence was not fetched",
+                            pid,
+                            team.name,
+                        )
+                        continue
 
                     status, current_club_api_id, current_club_name = classify_tracked_player(
                         current_club_api_id=journey.current_club_api_id if journey else None,
@@ -378,13 +509,20 @@ def _run_full_rebuild(job_id, config):
                         current_level=journey.current_level if journey else None,
                         parent_api_id=parent_api_id,
                         parent_club_name=team.name,
+                        transfers=transfers,
                         player_api_id=pid,
-                        api_client=api_client,
-                        latest_season=_get_latest_season(
-                            journey.id, parent_api_id=parent_api_id, parent_club_name=team.name
-                        )
-                        if journey
-                        else None,
+                        latest_season=latest_season,
+                        transfer_resolution=transfer_resolution,
+                        as_of=rebuild_as_of,
+                        season_start_month=season_start_month,
+                        season_start_day=season_start_day,
+                    )
+                    sale_fee = _rebuild_sale_fee(
+                        None,
+                        status=status,
+                        resolution=transfer_resolution,
+                        parent_api_id=parent_api_id,
+                        parent_club_name=team.name,
                     )
 
                     current_level = journey.current_level if journey and journey.current_level else None
@@ -407,6 +545,7 @@ def _run_full_rebuild(job_id, config):
                         current_level=current_level,
                         current_club_api_id=current_club_api_id,
                         current_club_name=current_club_name,
+                        sale_fee=sale_fee,
                         data_source="api-football",
                         data_depth="full_stats",
                         journey_id=journey.id if journey else None,
@@ -470,25 +609,61 @@ def _run_full_rebuild(job_id, config):
             if not tp.team:
                 continue
             journey = tp.journey
+            latest_season, season_start_month, season_start_day = _classification_season_context(
+                journey,
+                season_configs,
+            )
+            transfers, transfer_resolution = _rebuild_transfer_evidence(
+                api_client,
+                tp.player_api_id,
+                transfer_cache,
+                parent_api_id=tp.team.team_id,
+                parent_club_name=tp.team.name,
+                as_of=rebuild_as_of,
+                season_start_month=season_start_month,
+                season_start_day=season_start_day,
+            )
+            if transfer_resolution is None:
+                # A failed fetch is not evidence that any stored transfer state
+                # changed. Preserve status, current club, and fee together.
+                status_counts[tp.status] = status_counts.get(tp.status, 0) + 1
+                logger.warning(
+                    "Skipping rebuild transfer refresh for player %s because transfer evidence was not fetched",
+                    tp.player_api_id,
+                )
+                continue
             status, loan_api_id, loan_name = classify_tracked_player(
                 current_club_api_id=journey.current_club_api_id if journey else None,
                 current_club_name=journey.current_club_name if journey else None,
                 current_level=journey.current_level if journey else None,
                 parent_api_id=tp.team.team_id,
                 parent_club_name=tp.team.name,
+                transfers=transfers,
                 player_api_id=tp.player_api_id,
-                api_client=api_client,
-                latest_season=_get_latest_season(
-                    journey.id, parent_api_id=tp.team.team_id, parent_club_name=tp.team.name
-                )
-                if journey
-                else None,
+                latest_season=latest_season,
                 squad_members_by_club=squad_members_by_club,
+                transfer_resolution=transfer_resolution,
+                as_of=rebuild_as_of,
+                season_start_month=season_start_month,
+                season_start_day=season_start_day,
             )
-            if tp.status != status or tp.current_club_api_id != loan_api_id:
+            sale_fee = _rebuild_sale_fee(
+                tp.sale_fee,
+                status=status,
+                resolution=transfer_resolution,
+                parent_api_id=tp.team.team_id,
+                parent_club_name=tp.team.name,
+            )
+            if (
+                tp.status != status
+                or tp.current_club_api_id != loan_api_id
+                or tp.current_club_name != loan_name
+                or tp.sale_fee != sale_fee
+            ):
                 tp.status = status
                 tp.current_club_api_id = loan_api_id
                 tp.current_club_name = loan_name
+                tp.sale_fee = sale_fee
                 updated += 1
             status_counts[status] = status_counts.get(status, 0) + 1
         if updated:

--- a/academy-watch-backend/tests/test_api_transfer_persistence.py
+++ b/academy-watch-backend/tests/test_api_transfer_persistence.py
@@ -3,9 +3,10 @@
 import threading
 from datetime import timedelta
 
+import pytest
 import sqlalchemy.orm
 from src import api_football_client as api_module
-from src.api_football_client import APIFootballClient
+from src.api_football_client import APIFootballClient, TransferFetchError
 
 
 def _block(player_id=123):
@@ -79,7 +80,7 @@ def test_player_transfer_path_records_live_and_memory_cached_payloads(monkeypatc
     assert calls == [(blocks, {"fallback_player_api_id": 123})]
 
 
-def test_stub_and_sample_fallbacks_are_never_persisted(monkeypatch):
+def test_stub_is_sample_only_and_live_failures_raise(monkeypatch):
     calls = []
     monkeypatch.setattr(
         api_module,
@@ -98,16 +99,65 @@ def test_stub_and_sample_fallbacks_are_never_persisted(monkeypatch):
     assert client.get_player_transfers(123) is sample
     assert calls == []
 
-    # Direct mode also returns sample data when no API key exists, and after a
-    # failed live request. Neither fallback is provider evidence.
+    # Sample payloads must never leak into direct mode: both missing credentials
+    # and request failure remain distinguishable from a successful empty result.
     client.mode = "direct"
-    assert client.get_player_transfers(123) is sample
+    with pytest.raises(TransferFetchError, match="API_FOOTBALL_KEY"):
+        client.get_player_transfers(123)
     assert calls == []
 
     client.api_key = "test-key"
     client._make_request = lambda endpoint, params: (_ for _ in ()).throw(RuntimeError("fetch failed"))
-    assert client.get_player_transfers(123) is sample
+    with pytest.raises(TransferFetchError, match="fetch failed"):
+        client.get_player_transfers(123)
     assert calls == []
+
+
+def test_live_response_error_and_successful_empty_are_distinct(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        api_module,
+        "_record_transfer_payload",
+        lambda blocks, **kwargs: calls.append((blocks, kwargs)),
+    )
+
+    client = APIFootballClient.__new__(APIFootballClient)
+    client.mode = "direct"
+    client.api_key = "test-key"
+    client._transfer_cache = {}
+    client._transfer_cache_ttl = timedelta(hours=24)
+    client._make_request = lambda endpoint, params: {
+        "response": [],
+        "errors": {"rateLimit": "quota exceeded"},
+    }
+
+    with pytest.raises(TransferFetchError, match="quota exceeded"):
+        client.get_player_transfers(123)
+    assert 123 not in client._transfer_cache
+    assert calls == []
+
+    client._make_request = lambda endpoint, params: {"response": [], "errors": []}
+    assert client.get_player_transfers(123) == []
+    assert client._transfer_cache[123][0] == []
+    assert calls == [([], {"fallback_player_api_id": 123})]
+
+
+def test_batch_omits_failures_but_keeps_successful_empty_histories(monkeypatch):
+    monkeypatch.setattr(api_module, "_record_transfer_payload", lambda *args, **kwargs: None)
+
+    client = APIFootballClient.__new__(APIFootballClient)
+    client.mode = "direct"
+
+    def fetch(player_id):
+        if player_id == 1:
+            raise TransferFetchError("provider unavailable")
+        return []
+
+    client.get_player_transfers = fetch
+
+    result = client.batch_get_player_transfers([1, 2], max_workers=1, rate_limit_delay=0)
+
+    assert result == {2: []}
 
 
 def test_batch_player_fetch_persists_only_on_context_owning_thread(app, monkeypatch):

--- a/academy-watch-backend/tests/test_api_transfer_persistence.py
+++ b/academy-watch-backend/tests/test_api_transfer_persistence.py
@@ -1,0 +1,215 @@
+"""API-Football transfer payload persistence wiring regressions."""
+
+import threading
+from datetime import timedelta
+
+import sqlalchemy.orm
+from src import api_football_client as api_module
+from src.api_football_client import APIFootballClient
+
+
+def _block(player_id=123):
+    transfer = {
+        "date": "2024-07-01",
+        "type": "Free Transfer",
+        "teams": {
+            "out": {"id": 49, "name": "Chelsea"},
+            "in": {"id": 34, "name": "Newcastle"},
+        },
+    }
+    return {"player": {"id": player_id, "name": "Player"}, "transfers": [transfer]}
+
+
+def test_team_and_profile_transfer_paths_use_payload_adapter(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        api_module,
+        "_record_transfer_payload",
+        lambda blocks, **kwargs: calls.append((blocks, kwargs)),
+    )
+
+    blocks = [_block()]
+    client = APIFootballClient.__new__(APIFootballClient)
+    client.mode = "direct"
+    client.current_season_start_year = 2025
+    client._player_profile_cache = {}
+
+    client._make_request = lambda endpoint, params: {"response": blocks}
+    assert client.get_team_transfers(49) is blocks
+    assert calls == [(blocks, {})]
+
+    calls.clear()
+
+    def profile_request(endpoint, params):
+        if endpoint in {"players", "players/seasons"}:
+            return {"response": []}
+        assert endpoint == "transfers"
+        return {"response": blocks}
+
+    client._make_request = profile_request
+    profile = client.get_player_by_id(123, season=2025)
+
+    assert profile["player"]["name"] == "Player"
+    assert calls == [(blocks, {"fallback_player_api_id": 123})]
+
+
+def test_player_transfer_path_records_live_and_memory_cached_payloads(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        api_module,
+        "_record_transfer_payload",
+        lambda blocks, **kwargs: calls.append((blocks, kwargs)),
+    )
+
+    blocks = [_block()]
+    client = APIFootballClient.__new__(APIFootballClient)
+    client.mode = "direct"
+    client.api_key = "test-key"
+    client._transfer_cache = {}
+    client._transfer_cache_ttl = timedelta(hours=24)
+    client._make_request = lambda endpoint, params: {"response": blocks}
+
+    assert client.get_player_transfers(123) is blocks
+    assert calls == [(blocks, {"fallback_player_api_id": 123})]
+
+    # Re-observing the same response through the in-process API cache is
+    # intentional: the natural-key upsert keeps one row and advances last_seen.
+    calls.clear()
+    assert client.get_player_transfers(123) is blocks
+    assert calls == [(blocks, {"fallback_player_api_id": 123})]
+
+
+def test_stub_and_sample_fallbacks_are_never_persisted(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        api_module,
+        "_record_transfer_payload",
+        lambda blocks, **kwargs: calls.append((blocks, kwargs)),
+    )
+
+    sample = [_block()]
+    client = APIFootballClient.__new__(APIFootballClient)
+    client.mode = "stub"
+    client.api_key = None
+    client._transfer_cache = {}
+    client._transfer_cache_ttl = timedelta(hours=24)
+    client._get_sample_transfers = lambda **kwargs: sample
+
+    assert client.get_player_transfers(123) is sample
+    assert calls == []
+
+    # Direct mode also returns sample data when no API key exists, and after a
+    # failed live request. Neither fallback is provider evidence.
+    client.mode = "direct"
+    assert client.get_player_transfers(123) is sample
+    assert calls == []
+
+    client.api_key = "test-key"
+    client._make_request = lambda endpoint, params: (_ for _ in ()).throw(RuntimeError("fetch failed"))
+    assert client.get_player_transfers(123) is sample
+    assert calls == []
+
+
+def test_batch_player_fetch_persists_only_on_context_owning_thread(app, monkeypatch):
+    from src.services import transfer_events as transfer_events_module
+
+    main_thread_id = threading.get_ident()
+    recorder_calls = []
+
+    class FakeSession:
+        def __init__(self):
+            self.commits = 0
+            self.rollbacks = 0
+            self.closed = False
+
+        def commit(self):
+            self.commits += 1
+
+        def rollback(self):
+            self.rollbacks += 1
+
+        def close(self):
+            self.closed = True
+
+    sessions = []
+
+    def make_session(*, bind):
+        assert bind is not None
+        session = FakeSession()
+        sessions.append(session)
+        return session
+
+    def record(player_api_id, transfers, session, *, observed_at=None):
+        recorder_calls.append((threading.get_ident(), player_api_id, transfers, session, observed_at))
+        return len(transfers)
+
+    monkeypatch.setattr(sqlalchemy.orm, "Session", make_session)
+    monkeypatch.setattr(transfer_events_module, "record_transfer_events", record)
+
+    blocks = [_block()]
+    client = APIFootballClient.__new__(APIFootballClient)
+    client.mode = "direct"
+    client.api_key = "test-key"
+    client._transfer_cache = {}
+    client._transfer_cache_ttl = timedelta(hours=24)
+    client._make_request = lambda endpoint, params: {"response": blocks}
+
+    result = client.batch_get_player_transfers([123], max_workers=1, rate_limit_delay=0)
+
+    assert result[123] is blocks
+    assert len(recorder_calls) == 1
+    thread_id, player_api_id, transfers, session, observed_at = recorder_calls[0]
+    assert thread_id == main_thread_id
+    assert player_api_id == 123
+    assert transfers is blocks[0]["transfers"]
+    assert observed_at is not None
+    assert session is sessions[0]
+    assert sessions[0].commits == 1
+    assert sessions[0].rollbacks == 0
+    assert sessions[0].closed is True
+
+
+def test_transfer_persistence_failure_is_non_fatal(app, monkeypatch):
+    from src.services import transfer_events as transfer_events_module
+
+    class FailingSession:
+        def __init__(self):
+            self.rolled_back = False
+            self.closed = False
+
+        def commit(self):
+            raise RuntimeError("player_transfer_events is not deployed")
+
+        def rollback(self):
+            self.rolled_back = True
+
+        def close(self):
+            self.closed = True
+
+    session = FailingSession()
+    monkeypatch.setattr(sqlalchemy.orm, "Session", lambda *, bind: session)
+    monkeypatch.setattr(transfer_events_module, "record_transfer_events", lambda *args, **kwargs: 1)
+
+    api_module._record_transfer_payload([_block()])
+
+    assert session.rolled_back is True
+    assert session.closed is True
+
+
+def test_transfer_persistence_cleanup_failures_are_non_fatal(app, monkeypatch):
+    from src.services import transfer_events as transfer_events_module
+
+    class BrokenCleanupSession:
+        def commit(self):
+            raise RuntimeError("write failed")
+
+        def rollback(self):
+            raise RuntimeError("rollback failed")
+
+        def close(self):
+            raise RuntimeError("close failed")
+
+    monkeypatch.setattr(sqlalchemy.orm, "Session", lambda *, bind: BrokenCleanupSession())
+    monkeypatch.setattr(transfer_events_module, "record_transfer_events", lambda *args, **kwargs: 1)
+
+    api_module._record_transfer_payload([_block()])

--- a/academy-watch-backend/tests/test_classifier_uncertainty.py
+++ b/academy-watch-backend/tests/test_classifier_uncertainty.py
@@ -1,0 +1,272 @@
+from types import SimpleNamespace
+
+import pytest
+from src.api_football_client import APIFootballClient, TeamPlayersFetchError
+from src.utils.academy_classifier import classify_tracked_player
+from src.utils.rebuild_runner import _classification_season_context, _classification_season_start
+
+PARENT_ID = 100
+OLD_CLUB_ID = 200
+LOAN_CLUB_ID = 300
+PLAYER_ID = 400
+CONFIG = {"inactivity_release_years": None, "use_squad_check": False}
+
+
+def _loan(transfer_date: str) -> dict:
+    return {
+        "date": transfer_date,
+        "type": "Loan",
+        "teams": {
+            "out": {"id": PARENT_ID, "name": "Parent FC"},
+            "in": {"id": LOAN_CLUB_ID, "name": "Loan FC"},
+        },
+    }
+
+
+def _classify_with_loan(transfer_date: str, **kwargs):
+    return classify_tracked_player(
+        current_club_api_id=OLD_CLUB_ID,
+        current_club_name="Prior FC",
+        current_level="First Team",
+        parent_api_id=PARENT_ID,
+        parent_club_name="Parent FC",
+        transfers=[_loan(transfer_date)],
+        latest_season=2026,
+        config=CONFIG,
+        **kwargs,
+    )
+
+
+def test_fresh_active_loan_overrides_stale_external_raw_club():
+    status, club_id, club_name = _classify_with_loan(
+        "2026-07-10",
+        as_of="2026-12-01",
+    )
+
+    assert (status, club_id, club_name) == ("on_loan", LOAN_CLUB_ID, "Loan FC")
+
+
+def test_calendar_year_boundary_makes_current_year_loan_fresh():
+    stale_under_split_calendar = _classify_with_loan(
+        "2026-02-10",
+        as_of="2026-12-01",
+    )
+    calendar_year = _classify_with_loan(
+        "2026-02-10",
+        as_of="2026-12-01",
+        season_start_month=1,
+        season_start_day=1,
+    )
+
+    assert stale_under_split_calendar[0] == "left"
+    assert calendar_year == ("on_loan", LOAN_CLUB_ID, "Loan FC")
+
+
+def test_expired_historical_loan_does_not_replace_newer_external_stats_club():
+    result = classify_tracked_player(
+        current_club_api_id=777,
+        current_club_name="New Current FC",
+        current_level="First Team",
+        parent_api_id=PARENT_ID,
+        parent_club_name="Parent FC",
+        transfers=[_loan("2023-07-10")],
+        latest_season=2026,
+        config=CONFIG,
+        as_of="2026-12-01",
+    )
+
+    assert result == ("left", 777, "New Current FC")
+
+
+def test_hall_permanent_move_replaces_stale_parent_projection():
+    transfers = [
+        {
+            "date": "2023-08-22",
+            "type": "Loan",
+            "teams": {
+                "out": {"id": 49, "name": "Chelsea"},
+                "in": {"id": 34, "name": "Newcastle"},
+            },
+        },
+        {
+            "date": "2024-06-30",
+            "type": "Loan",
+            "teams": {
+                "out": {"id": 34, "name": "Newcastle"},
+                "in": {"id": 49, "name": "Chelsea"},
+            },
+        },
+        {
+            "date": "2024-07-01",
+            "type": "€ 33M",
+            "teams": {
+                "out": {"id": 49, "name": "Chelsea"},
+                "in": {"id": 34, "name": "Newcastle"},
+            },
+        },
+    ]
+
+    result = classify_tracked_player(
+        current_club_api_id=49,
+        current_club_name="Chelsea",
+        current_level="First Team",
+        parent_api_id=49,
+        parent_club_name="Chelsea",
+        transfers=transfers,
+        latest_season=2025,
+        config=CONFIG,
+        as_of="2026-07-01",
+    )
+
+    assert result == ("sold", 34, "Newcastle")
+
+
+class _TransferClient:
+    def __init__(self, result):
+        self.result = result
+
+    def get_player_transfers(self, _player_api_id):
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+def test_transfer_fetch_failure_preserves_conservative_status():
+    result = classify_tracked_player(
+        current_club_api_id=LOAN_CLUB_ID,
+        current_club_name="Loan FC",
+        current_level="First Team",
+        parent_api_id=PARENT_ID,
+        parent_club_name="Parent FC",
+        transfers=None,
+        player_api_id=PLAYER_ID,
+        api_client=_TransferClient(RuntimeError("provider unavailable")),
+        latest_season=2026,
+        config=CONFIG,
+    )
+
+    assert result == ("on_loan", LOAN_CLUB_ID, "Loan FC")
+
+
+def test_successful_empty_transfer_fetch_does_not_preserve_stale_loan():
+    result = classify_tracked_player(
+        current_club_api_id=LOAN_CLUB_ID,
+        current_club_name="Loan FC",
+        current_level="First Team",
+        parent_api_id=PARENT_ID,
+        parent_club_name="Parent FC",
+        transfers=None,
+        player_api_id=PLAYER_ID,
+        api_client=_TransferClient([]),
+        latest_season=2026,
+        config=CONFIG,
+    )
+
+    assert result == ("left", LOAN_CLUB_ID, "Loan FC")
+
+
+@pytest.mark.parametrize(
+    "squads",
+    [
+        {LOAN_CLUB_ID: set()},
+        {PARENT_ID: set()},
+    ],
+)
+def test_partial_squad_coverage_preserves_uncertain_status(squads):
+    result = classify_tracked_player(
+        current_club_api_id=LOAN_CLUB_ID,
+        current_club_name="Loan FC",
+        current_level="First Team",
+        parent_api_id=PARENT_ID,
+        parent_club_name="Parent FC",
+        transfers=None,
+        player_api_id=PLAYER_ID,
+        latest_season=2026,
+        config={"inactivity_release_years": None, "use_squad_check": True},
+        squad_members_by_club=squads,
+    )
+
+    assert result == ("on_loan", LOAN_CLUB_ID, "Loan FC")
+
+
+def test_complete_squad_absence_can_release_player():
+    result = classify_tracked_player(
+        current_club_api_id=LOAN_CLUB_ID,
+        current_club_name="Loan FC",
+        current_level="First Team",
+        parent_api_id=PARENT_ID,
+        parent_club_name="Parent FC",
+        transfers=None,
+        player_api_id=PLAYER_ID,
+        latest_season=2026,
+        config={"inactivity_release_years": None, "use_squad_check": True},
+        squad_members_by_club={LOAN_CLUB_ID: set(), PARENT_ID: set()},
+    )
+
+    assert result == ("released", None, None)
+
+
+def test_rebuild_uses_league_rollover_month_when_configured():
+    config = SimpleNamespace(season_type="calendar", rollover_month=1)
+
+    assert _classification_season_start(71, {71: config}) == (1, 1)
+    assert _classification_season_start(71, {}) == (7, 1)
+
+
+def test_rebuild_calendar_matches_latest_domestic_stats_entry():
+    class _EntriesQuery:
+        def __init__(self, entries):
+            self._entries = entries
+
+        def filter(self, *_criteria):
+            return _EntriesQuery([entry for entry in self._entries if not entry.is_international])
+
+        def first(self):
+            return self._entries[0] if self._entries else None
+
+    entries = [
+        SimpleNamespace(season=2026, league_api_id=999, is_international=True),
+        SimpleNamespace(season=2025, league_api_id=71, is_international=False),
+        SimpleNamespace(season=2024, league_api_id=39, is_international=False),
+    ]
+    journey = SimpleNamespace(entries=_EntriesQuery(entries))
+    calendar_config = SimpleNamespace(season_type="calendar", rollover_month=1)
+
+    assert _classification_season_context(journey, {71: calendar_config}) == (2025, 1, 1)
+
+
+def _live_client(request_result):
+    client = object.__new__(APIFootballClient)
+    client.mode = "direct"
+    client.api_key = "test-key"
+    client.current_season_start_year = 2026
+
+    if isinstance(request_result, Exception):
+
+        def _raise(*_args, **_kwargs):
+            raise request_result
+
+        client._make_request = _raise
+    else:
+        client._make_request = lambda *_args, **_kwargs: request_result
+    return client
+
+
+def test_live_team_squad_failure_is_not_replaced_with_sample_data():
+    client = _live_client(RuntimeError("provider unavailable"))
+
+    with pytest.raises(TeamPlayersFetchError, match="provider unavailable"):
+        client.get_team_players(PARENT_ID, season=2026)
+
+
+def test_successful_empty_team_squad_remains_authoritative_empty():
+    client = _live_client(
+        {
+            "response": [],
+            "errors": [],
+            "results": 0,
+            "paging": {"current": 1, "total": 1},
+        }
+    )
+
+    assert client.get_team_players(PARENT_ID, season=2026) == []

--- a/academy-watch-backend/tests/test_journey.py
+++ b/academy-watch-backend/tests/test_journey.py
@@ -424,11 +424,11 @@ class TestLoanOverlapsSeason:
         loan = {"start_date": "2025-08-01", "end_date": "2026-06-30"}
         assert self.service._loan_overlaps_season(loan, 2023) is False
 
-    def test_open_ended_loan_overlaps_future(self):
-        """Open-ended loan overlaps future seasons"""
+    def test_open_ended_loan_stops_at_next_season_boundary(self):
+        """Missing return evidence must not make a loan active forever."""
         loan = {"start_date": "2023-08-01", "end_date": None}
         assert self.service._loan_overlaps_season(loan, 2023) is True
-        assert self.service._loan_overlaps_season(loan, 2024) is True
+        assert self.service._loan_overlaps_season(loan, 2024) is False
 
     def test_no_start_date(self):
         """Missing start date returns False"""
@@ -436,9 +436,9 @@ class TestLoanOverlapsSeason:
         assert self.service._loan_overlaps_season(loan, 2023) is False
 
     def test_loan_ends_exactly_season_start(self):
-        """Loan ending exactly at season start boundary"""
+        """End-exclusive loan does not overlap a season starting that day."""
         loan = {"start_date": "2022-08-01", "end_date": "2023-07-01"}
-        assert self.service._loan_overlaps_season(loan, 2023) is True
+        assert self.service._loan_overlaps_season(loan, 2023) is False
 
 
 class TestApplyLoanClassification:
@@ -858,7 +858,11 @@ class TestTransferOverrideStaleness:
             patch.object(service, "_compute_academy_club_ids"),
         ):
             MockEntry.query.filter_by.return_value.all.return_value = [entry]
-            service._update_journey_aggregates(journey, transfers=transfers)
+            service._update_journey_aggregates(
+                journey,
+                transfers=transfers,
+                as_of="2026-06-30",
+            )
 
         assert journey.current_club_api_id == 80
         assert journey.current_club_name == "Lyon"
@@ -1002,19 +1006,20 @@ class TestJourneyIntegration:
 class TestUpgradeStatusFromTransfers:
     """Test the upgrade_status_from_transfers shared utility"""
 
-    def test_non_loan_status_unchanged(self):
-        """Non-loan statuses pass through unchanged"""
+    def test_successful_empty_history_resets_to_parent_base_status(self):
+        """Authoritative empty evidence cannot preserve a stale departure."""
         from src.utils.academy_classifier import upgrade_status_from_transfers
 
         assert upgrade_status_from_transfers("academy", [], 33) == "academy"
         assert upgrade_status_from_transfers("first_team", [], 33) == "first_team"
-        assert upgrade_status_from_transfers("sold", [], 33) == "sold"
+        assert upgrade_status_from_transfers("sold", [], 33) == "first_team"
 
-    def test_on_loan_no_transfers_unchanged(self):
-        """on_loan with no transfers stays on_loan"""
+    def test_fetch_failure_preserves_but_successful_empty_clears_stale_loan(self):
+        """Only unavailable transfer evidence preserves an existing loan."""
         from src.utils.academy_classifier import upgrade_status_from_transfers
 
-        assert upgrade_status_from_transfers("on_loan", [], 33) == "on_loan"
+        assert upgrade_status_from_transfers("on_loan", None, 33) == "on_loan"
+        assert upgrade_status_from_transfers("on_loan", [], 33) == "first_team"
 
     def test_on_loan_with_loan_transfer_stays_loan(self):
         """on_loan with a loan departure stays on_loan"""
@@ -1027,7 +1032,15 @@ class TestUpgradeStatusFromTransfers:
                 "teams": {"out": {"id": 33}, "in": {"id": 62}},
             }
         ]
-        assert upgrade_status_from_transfers("on_loan", transfers, 33) == "on_loan"
+        assert (
+            upgrade_status_from_transfers(
+                "on_loan",
+                transfers,
+                33,
+                as_of="2025-06-30",
+            )
+            == "on_loan"
+        )
 
     def test_permanent_transfer_becomes_sold(self):
         """Permanent transfer departure upgrades to sold"""
@@ -1073,9 +1086,8 @@ class TestUpgradeStatusFromTransfers:
         ]
         assert upgrade_status_from_transfers("on_loan", transfers, 33, 200) == "sold"
 
-    def test_na_with_destination_becomes_sold(self):
-        """'N/A' = undisclosed-fee permanent transfer, NOT a free agent. With
-        a concrete destination it is 'sold' (the Rijkhoff Dortmund->Ajax bug)."""
+    def test_parent_departure_na_with_destination_becomes_sold(self):
+        """Parent context makes an N/A departure to another club directional."""
         from src.utils.academy_classifier import upgrade_status_from_transfers
 
         transfers = [
@@ -1102,25 +1114,25 @@ class TestUpgradeStatusFromTransfers:
         assert upgrade_status_from_transfers("on_loan", transfers, 33, None) == "released"
 
     def test_latest_departure_wins(self):
-        """When multiple departures exist, the latest one determines status"""
+        """A permanent conversion to the same loan club replaces the old loan."""
         from src.utils.academy_classifier import upgrade_status_from_transfers
 
         transfers = [
             {
                 "type": "Loan",
                 "date": "2023-08-01",
-                "teams": {"out": {"id": 33}, "in": {"id": 62}},
+                "teams": {"out": {"id": 33}, "in": {"id": 200}},
             },
             {
-                "type": "Transfer",
-                "date": "2026-01-14",
+                "type": "€ 33M",
+                "date": "2024-07-01",
                 "teams": {"out": {"id": 33}, "in": {"id": 200}},
             },
         ]
         assert upgrade_status_from_transfers("on_loan", transfers, 33, 200) == "sold"
 
-    def test_no_departures_from_parent_unchanged(self):
-        """Transfers from other clubs don't affect status"""
+    def test_no_parent_departure_clears_stale_loan(self):
+        """Successful evidence with no active parent loan returns to base status."""
         from src.utils.academy_classifier import upgrade_status_from_transfers
 
         transfers = [
@@ -1130,10 +1142,10 @@ class TestUpgradeStatusFromTransfers:
                 "teams": {"out": {"id": 99}, "in": {"id": 33}},
             }
         ]
-        assert upgrade_status_from_transfers("on_loan", transfers, 33) == "on_loan"
+        assert upgrade_status_from_transfers("on_loan", transfers, 33) == "first_team"
 
-    def test_empty_type_unchanged(self):
-        """Empty departure type doesn't change status"""
+    def test_invalid_departure_type_preserves_uncertain_status(self):
+        """Wholly invalid evidence cannot manufacture replacement state."""
         from src.utils.academy_classifier import upgrade_status_from_transfers
 
         transfers = [
@@ -1209,6 +1221,7 @@ class TestTransferUpgradeIgnoresConfigFlag:
                 }
             ],
             config={"use_transfers_for_status": False, "use_squad_check": False},
+            as_of="2026-06-30",
         )
         assert status == "on_loan"
 

--- a/academy-watch-backend/tests/test_journey_resolver_audit.py
+++ b/academy-watch-backend/tests/test_journey_resolver_audit.py
@@ -1,0 +1,722 @@
+"""Audit regressions for journey consumers of durable transfer state."""
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock, patch
+
+from src.models.journey import LEVEL_PRIORITY, PlayerJourney, PlayerJourneyEntry
+from src.models.league import Team, db
+from src.models.season_rollup import LeagueSeasonConfig, PlayerSeasonCell, PlayerSeasonTotal
+from src.models.tracked_player import TrackedPlayer
+from src.services.journey_sync import JourneySyncService
+from src.services.transfer_events import record_transfer_events
+from src.services.transfer_resolver import resolve_transfer_state
+
+
+def _transfer(transfer_date, transfer_type, out_id, out_name, in_id, in_name):
+    return {
+        "date": transfer_date,
+        "type": transfer_type,
+        "teams": {
+            "out": {"id": out_id, "name": out_name},
+            "in": {"id": in_id, "name": in_name},
+        },
+    }
+
+
+def _entry(
+    *,
+    season,
+    club_api_id,
+    club_name,
+    level="First Team",
+    entry_type="first_team",
+    transfer_date=None,
+    appearances=1,
+):
+    return SimpleNamespace(
+        season=season,
+        club_api_id=club_api_id,
+        club_name=club_name,
+        club_logo=None,
+        league_api_id=39,
+        league_name="Test League",
+        level=level,
+        entry_type=entry_type,
+        is_youth=level != "First Team",
+        is_international=False,
+        appearances=appearances,
+        goals=0,
+        assists=0,
+        minutes=90 if appearances else 0,
+        sort_priority=LEVEL_PRIORITY.get(level, 0),
+        transfer_date=transfer_date,
+        transfer_fee=None,
+        stats_synced_at=datetime(2026, 6, 24, tzinfo=UTC),
+    )
+
+
+class _SingleSeasonAPI:
+    def __init__(self, player_id, stat, *, transfer_error=False):
+        self.player_id = player_id
+        self.stat = stat
+        self.transfer_error = transfer_error
+
+    def _make_request(self, endpoint, params):
+        if endpoint == "players/seasons":
+            return {"response": [2025]}
+        if endpoint == "players":
+            return {
+                "response": [
+                    {
+                        "player": {
+                            "id": self.player_id,
+                            "name": "Audit Player",
+                            "birth": {"date": "2000-01-01", "country": "Test"},
+                            "nationality": "Test",
+                        },
+                        "statistics": [self.stat],
+                    }
+                ]
+            }
+        raise AssertionError((endpoint, params))
+
+    def get_player_transfers(self, player_id):
+        assert player_id == self.player_id
+        if self.transfer_error:
+            raise RuntimeError("transfer provider unavailable")
+        return []
+
+
+def _stat(team_id, league_id, *, minutes=900):
+    return {
+        "team": {"id": team_id, "name": "Stable Club Name"},
+        "league": {"id": league_id, "name": "Stable League Name", "country": "Test"},
+        "games": {"appearences": 10, "minutes": minutes, "position": "Midfielder"},
+        "goals": {"total": 1, "assists": 2},
+    }
+
+
+def test_set_current_status_without_transfer_evidence_does_not_guess_from_entries(app):
+    service = JourneySyncService(api_client=Mock())
+    journey = SimpleNamespace(
+        player_api_id=7001,
+        current_club_api_id=20,
+        current_club_name="Borrower",
+        current_status=None,
+        current_owner_api_id=None,
+        current_owner_name=None,
+    )
+    entries = [
+        _entry(season=2025, club_api_id=20, club_name="Borrower", entry_type="loan"),
+        _entry(season=2024, club_api_id=10, club_name="Owner"),
+    ]
+
+    applied = service._set_current_status(journey, entries)
+
+    assert applied is False
+    assert journey.current_status is None
+    assert journey.current_owner_api_id is None
+    assert journey.current_owner_name is None
+
+
+def test_durable_transfer_rows_resolve_current_status_without_provider_io(app):
+    service = JourneySyncService(api_client=Mock())
+    owner = Team(team_id=10, name="Owner", country="Test", season=2025, is_active=True)
+    db.session.add(owner)
+    journey = PlayerJourney(
+        player_api_id=7002,
+        origin_club_api_id=10,
+        origin_club_name="Owner",
+        current_club_api_id=20,
+        current_club_name="Borrower",
+    )
+    db.session.add(journey)
+    db.session.flush()
+    entry = PlayerJourneyEntry(
+        journey_id=journey.id,
+        season=2025,
+        club_api_id=20,
+        club_name="Borrower",
+        level="First Team",
+        entry_type="loan",
+        is_international=False,
+        appearances=1,
+    )
+    db.session.add(entry)
+    record_transfer_events(
+        journey.player_api_id,
+        [_transfer("2025-08-01", "Loan", 10, "Owner", 20, "Borrower")],
+        db.session,
+    )
+    db.session.commit()
+
+    resolution = service._resolve_durable_transfer_state(
+        journey,
+        [entry],
+        as_of="2026-06-30",
+    )
+    applied = service._set_current_status(
+        journey,
+        [entry],
+        transfer_resolution=resolution,
+    )
+
+    assert resolution is not None
+    assert applied is True
+    assert journey.current_status == "on_loan"
+    assert journey.current_owner_api_id == 10
+    assert journey.current_owner_name == "Owner"
+
+
+def test_calendar_year_borrower_controls_european_parent_loan_boundary(app):
+    service = JourneySyncService(database_only=True)
+    db.session.add(LeagueSeasonConfig(league_api_id=253, season_type="calendar", rollover_month=1))
+    journey = PlayerJourney(
+        player_api_id=7008,
+        origin_club_api_id=49,
+        origin_club_name="European Parent",
+        current_club_api_id=2530,
+        current_club_name="MLS Borrower",
+    )
+    db.session.add(journey)
+    db.session.flush()
+    entry = PlayerJourneyEntry(
+        journey_id=journey.id,
+        season=2024,
+        club_api_id=2530,
+        club_name="MLS Borrower",
+        league_api_id=253,
+        league_name="Major League Soccer",
+        level="First Team",
+        entry_type="first_team",
+        is_international=False,
+        appearances=10,
+    )
+    db.session.add(entry)
+    record_transfer_events(
+        journey.player_api_id,
+        [_transfer("2024-02-01", "Loan", 49, "European Parent", 2530, "MLS Borrower")],
+        db.session,
+    )
+    db.session.commit()
+
+    resolution = service._resolve_durable_transfer_state(journey, [entry], as_of="2024-12-31")
+    service._apply_loan_classification([entry], resolution)
+
+    assert resolution is not None
+    assert resolution.season_start_month == 1
+    assert resolution.on_loan is True
+    assert entry.entry_type == "loan"
+    assert entry.transfer_date == "2024-02-01"
+
+
+def test_current_status_matches_name_only_clubs_from_resolver():
+    service = JourneySyncService(api_client=Mock())
+    journey = SimpleNamespace(
+        player_api_id=7006,
+        current_club_api_id=999,
+        current_club_name="Stale Club",
+        current_level="First Team",
+        current_status=None,
+        current_owner_api_id=None,
+        current_owner_name=None,
+    )
+    resolution = resolve_transfer_state(
+        [_transfer("2026-07-02", "Loan", None, "Owner", None, "Borrower U21")],
+        as_of="2026-07-16",
+    )
+
+    applied = service.apply_resolved_current_state(journey, [], resolution)
+
+    assert applied is True
+    assert journey.current_club_api_id is None
+    assert journey.current_club_name == "Borrower U21"
+    assert journey.current_level == "U21"
+    assert journey.current_status == "on_loan"
+    assert journey.current_owner_api_id is None
+    assert journey.current_owner_name == "Owner"
+
+
+def test_resolved_release_clears_stale_current_club_status_owner_and_level():
+    service = JourneySyncService(api_client=Mock())
+    journey = SimpleNamespace(
+        player_api_id=7007,
+        current_club_api_id=20,
+        current_club_name="Stale Borrower",
+        current_level="First Team",
+        current_status="on_loan",
+        current_owner_api_id=10,
+        current_owner_name="Stale Owner",
+    )
+    resolution = resolve_transfer_state(
+        [_transfer("2026-07-02", "Released", 10, "Owner", None, None)],
+        as_of="2026-07-16",
+        initial_owner={"id": 10, "name": "Owner"},
+    )
+
+    applied = service.apply_resolved_current_state(journey, [], resolution)
+
+    assert applied is True
+    assert journey.current_club_api_id is None
+    assert journey.current_club_name is None
+    assert journey.current_level is None
+    assert journey.current_status is None
+    assert journey.current_owner_api_id is None
+    assert journey.current_owner_name is None
+
+
+def test_admin_status_backfill_uses_durable_evidence_and_skips_missing_evidence(app):
+    from src.routes.journey import admin_backfill_current_status
+
+    today = datetime.now(UTC).date().isoformat()
+    db.session.add(Team(team_id=30, name="Durable Owner", country="Test", season=2025, is_active=True))
+    evidenced = PlayerJourney(
+        player_api_id=7003,
+        origin_club_api_id=30,
+        origin_club_name="Durable Owner",
+        current_club_api_id=31,
+        current_club_name="Current Borrower",
+    )
+    missing = PlayerJourney(
+        player_api_id=7004,
+        current_club_api_id=41,
+        current_club_name="Historical Borrower",
+        current_status="on_loan",
+        current_owner_api_id=40,
+        current_owner_name="Unproven Owner",
+    )
+    db.session.add_all([evidenced, missing])
+    db.session.flush()
+    db.session.add_all(
+        [
+            PlayerJourneyEntry(
+                journey_id=evidenced.id,
+                season=2026,
+                club_api_id=31,
+                club_name="Current Borrower",
+                level="First Team",
+                entry_type="loan",
+                is_international=False,
+                appearances=1,
+            ),
+            PlayerJourneyEntry(
+                journey_id=missing.id,
+                season=2025,
+                club_api_id=41,
+                club_name="Historical Borrower",
+                level="First Team",
+                entry_type="loan",
+                is_international=False,
+                appearances=1,
+            ),
+        ]
+    )
+    record_transfer_events(
+        evidenced.player_api_id,
+        [_transfer(today, "Loan", 30, "Durable Owner", 31, "Current Borrower")],
+        db.session,
+    )
+    db.session.commit()
+
+    with app.test_request_context(json={"dry_run": False, "limit": 200, "cursor": 0}):
+        response = admin_backfill_current_status.__wrapped__()
+
+    payload = response.get_json()
+    db.session.expire_all()
+    evidenced = PlayerJourney.query.filter_by(player_api_id=7003).one()
+    missing = PlayerJourney.query.filter_by(player_api_id=7004).one()
+
+    assert payload["journeys_processed"] == 2
+    assert payload["evidence_resolved"] == 1
+    assert payload["skipped_no_transfer_evidence"] == 1
+    assert payload["on_loan_set"] == 1
+    assert evidenced.current_status == "on_loan"
+    assert evidenced.current_owner_api_id == 30
+    assert missing.current_status == "on_loan"
+    assert missing.current_owner_api_id == 40
+    assert missing.current_owner_name == "Unproven Owner"
+
+
+def test_newer_season_stats_without_transfer_date_beat_historical_transfer_state(app):
+    service = JourneySyncService(api_client=Mock())
+    fresh_stats = _entry(
+        season=2025,
+        club_api_id=1349,
+        club_name="Oldham",
+        transfer_date=None,
+        appearances=16,
+    )
+    historical = _entry(
+        season=2023,
+        club_api_id=19746,
+        club_name="Nottingham Forest U21",
+        level="U21",
+        entry_type="development",
+        transfer_date="2024-01-02",
+    )
+    transfers = [
+        _transfer("2023-08-01", "Loan", 65, "Nottingham Forest", 1943, "Cheltenham"),
+        _transfer("2024-01-02", "N/A", 1943, "Cheltenham", 19746, "Nottingham Forest U21"),
+    ]
+    journey = MagicMock(id=7005, player_api_id=7005)
+
+    with (
+        patch("src.services.journey_sync.PlayerJourneyEntry") as entry_model,
+        patch.object(service, "_compute_academy_club_ids"),
+    ):
+        entry_model.query.filter_by.return_value.all.return_value = [fresh_stats, historical]
+        service._update_journey_aggregates(journey, transfers=transfers, as_of="2026-06-30")
+
+    assert journey.current_club_api_id == 1349
+    assert journey.current_club_name == "Oldham"
+
+
+def test_midseason_permanent_conversion_replaces_loan_classification():
+    service = JourneySyncService(api_client=Mock())
+    entry = _entry(
+        season=2023,
+        club_api_id=20,
+        club_name="Borrower",
+        entry_type="first_team",
+    )
+    transfers = [
+        _transfer("2023-08-01", "Loan", 10, "Owner", 20, "Borrower"),
+        _transfer("2024-01-15", "€ 5M", 10, "Owner", 20, "Borrower"),
+    ]
+    resolution = resolve_transfer_state(transfers, as_of="2024-06-30")
+
+    service._apply_loan_classification([entry], resolution)
+    service._apply_permanent_transfer_dates([entry], resolution)
+
+    assert entry.entry_type == "first_team"
+    assert entry.transfer_date == "2024-01-15"
+    assert entry.transfer_fee == "€ 5M"
+
+
+def test_failed_transfer_fetch_preserves_metadata_across_club_and_league_id_remaps(app):
+    player_id = 7010
+    journey = PlayerJourney(
+        player_api_id=player_id,
+        player_name="Audit Player",
+        current_club_api_id=100,
+        current_club_name="Stable Club Name",
+        current_level="First Team",
+        current_status="on_loan",
+        current_owner_api_id=10,
+        current_owner_name="Owner",
+        seasons_synced=[2025],
+    )
+    db.session.add(journey)
+    db.session.flush()
+    db.session.add(
+        PlayerJourneyEntry(
+            journey_id=journey.id,
+            player_api_id=player_id,
+            season=2025,
+            club_api_id=100,
+            club_name="Stable Club Name",
+            league_api_id=200,
+            league_name="Stable League Name",
+            level="First Team",
+            entry_type="loan",
+            is_international=False,
+            appearances=4,
+            minutes=360,
+            transfer_date="2025-08-01",
+            transfer_fee="Loan fee",
+        )
+    )
+    db.session.commit()
+
+    service = JourneySyncService(_SingleSeasonAPI(player_id, _stat(101, 201), transfer_error=True))
+    service._auto_geocode_clubs = lambda synced_journey: None
+    synced = service.sync_player(player_id, force_full=True)
+
+    assert synced is not None
+    entry = PlayerJourneyEntry.query.filter_by(player_api_id=player_id, season=2025).one()
+    assert (entry.club_api_id, entry.league_api_id) == (101, 201)
+    assert (entry.entry_type, entry.transfer_date, entry.transfer_fee) == (
+        "loan",
+        "2025-08-01",
+        "Loan fee",
+    )
+    assert synced.current_status == "on_loan"
+    assert synced.current_owner_api_id == 10
+
+
+def test_sync_commits_journey_when_affected_rollup_refresh_fails(app, monkeypatch):
+    player_id = 7011
+    journey = PlayerJourney(player_api_id=player_id, player_name="Before", seasons_synced=[2025])
+    db.session.add(journey)
+    db.session.flush()
+    db.session.add(
+        PlayerJourneyEntry(
+            journey_id=journey.id,
+            player_api_id=player_id,
+            season=2025,
+            club_api_id=100,
+            club_name="Old Club",
+            league_api_id=200,
+            league_name="Old League",
+            level="First Team",
+            entry_type="first_team",
+            is_international=False,
+            appearances=1,
+            minutes=90,
+        )
+    )
+    db.session.commit()
+
+    def fail_rollup(*args, **kwargs):
+        raise RuntimeError("simulated rollup failure")
+
+    monkeypatch.setattr("src.services.journey_sync.refresh_season_rollup", fail_rollup)
+    service = JourneySyncService(_SingleSeasonAPI(player_id, _stat(101, 201, minutes=900)))
+    service._auto_geocode_clubs = lambda synced_journey: None
+
+    assert service.sync_player(player_id, force_full=True) is not None
+
+    db.session.expire_all()
+    persisted = PlayerJourney.query.filter_by(player_api_id=player_id).one()
+    entry = PlayerJourneyEntry.query.filter_by(player_api_id=player_id, season=2025).one()
+    assert persisted.player_name == "Audit Player"
+    assert persisted.last_synced_at is not None
+    assert persisted.sync_error is None
+    assert (entry.club_api_id, entry.club_name, entry.minutes) == (
+        101,
+        "Stable Club Name",
+        900,
+    )
+    assert PlayerSeasonCell.query.filter_by(player_api_id=player_id).count() == 0
+    assert PlayerSeasonTotal.query.filter_by(player_api_id=player_id).count() == 0
+
+
+def test_database_repair_surfaces_rollup_failure_and_rolls_back(app, monkeypatch):
+    from src.routes.journey import admin_recompute_academy
+
+    journey = PlayerJourney(
+        player_api_id=7012,
+        player_name="Repair Rollback",
+        total_first_team_apps=999,
+    )
+    db.session.add(journey)
+    db.session.flush()
+    db.session.add(
+        PlayerJourneyEntry(
+            journey_id=journey.id,
+            player_api_id=journey.player_api_id,
+            season=2025,
+            club_api_id=100,
+            club_name="Stable Club Name",
+            league_api_id=200,
+            league_name="Stable League Name",
+            level="First Team",
+            entry_type="first_team",
+            is_international=False,
+            appearances=10,
+            minutes=900,
+        )
+    )
+    record_transfer_events(
+        journey.player_api_id,
+        [_transfer("2025-07-01", "Transfer", 99, "Previous Club", 100, "Stable Club Name")],
+        db.session,
+    )
+    db.session.commit()
+
+    def fail_rollup(*args, **kwargs):
+        raise RuntimeError("repair rollup failed")
+
+    monkeypatch.setattr("src.services.season_rollup_service.refresh_player", fail_rollup)
+    with app.test_request_context(json={"dry_run": False, "limit": 100, "cursor": 0}):
+        response = admin_recompute_academy.__wrapped__()
+
+    payload = response.get_json()
+    db.session.expire_all()
+    persisted = PlayerJourney.query.filter_by(player_api_id=7012).one()
+
+    assert payload["journeys_processed"] == 0
+    assert payload["errors"] == 1
+    assert payload["durable_reclassified"] == 0
+    assert payload["rollup_seasons_refreshed"] == 0
+    assert payload["error_examples"] == [{"journey_id": journey.id, "error": "repair rollup failed"}]
+    assert persisted.total_first_team_apps == 999
+
+
+def test_hall_incremental_state_durable_repair_converges_with_rollups_and_is_idempotent(app, monkeypatch):
+    from src.routes.journey import admin_recompute_academy
+
+    transfers = [
+        _transfer("2024-07-01", "€ 33M", 49, "Chelsea", 34, "Newcastle"),
+        _transfer("2023-08-22", "Loan", 49, "Chelsea", 34, "Newcastle"),
+    ]
+    chelsea = Team(team_id=49, name="Chelsea", country="England", season=2025, is_active=True)
+    newcastle = Team(team_id=34, name="Newcastle", country="England", season=2025, is_active=True)
+    db.session.add_all([chelsea, newcastle])
+    db.session.flush()
+    journey = PlayerJourney(
+        player_api_id=7013,
+        player_name="L. Hall",
+        birth_date="2004-01-01",
+        origin_club_api_id=49,
+        origin_club_name="Chelsea",
+        current_club_api_id=34,
+        current_club_name="Newcastle",
+        current_level="First Team",
+        current_status="on_loan",
+        current_owner_api_id=49,
+        current_owner_name="Chelsea",
+        academy_club_ids=[49],
+        academy_last_seasons={"49": 2022},
+        seasons_synced=[2022, 2023, 2024, 2025],
+        total_loan_apps=103,
+    )
+    db.session.add(journey)
+    db.session.flush()
+
+    def stored_entry(season, club_id, club_name, apps, minutes, *, youth=False):
+        return PlayerJourneyEntry(
+            journey_id=journey.id,
+            player_api_id=journey.player_api_id,
+            season=season,
+            club_api_id=club_id,
+            club_name=club_name,
+            league_api_id=699 if youth else 39,
+            league_name="Premier League 2" if youth else "Premier League",
+            league_country="England",
+            level="U21" if youth else "First Team",
+            entry_type="academy" if youth else "loan",
+            is_youth=youth,
+            is_international=False,
+            appearances=apps,
+            minutes=minutes,
+            goals=0,
+            assists=0,
+            sort_priority=LEVEL_PRIORITY["U21" if youth else "First Team"],
+            transfer_date=None if youth else "2023-08-22",
+        )
+
+    db.session.add_all(
+        [
+            stored_entry(2022, 49, "Chelsea U21", 6, 500, youth=True),
+            stored_entry(2023, 34, "Newcastle", 24, 1009),
+            stored_entry(2024, 34, "Newcastle", 34, 2660),
+            stored_entry(2025, 34, "Newcastle", 45, 3263),
+            TrackedPlayer(
+                player_api_id=journey.player_api_id,
+                player_name="L. Hall",
+                team_id=chelsea.id,
+                journey_id=journey.id,
+                status="on_loan",
+                current_club_api_id=34,
+                current_club_name="Newcastle",
+                data_source="journey-sync",
+                last_academy_season=2022,
+                is_active=True,
+            ),
+            TrackedPlayer(
+                player_api_id=journey.player_api_id,
+                player_name="L. Hall",
+                team_id=newcastle.id,
+                journey_id=journey.id,
+                status="first_team",
+                current_club_api_id=34,
+                current_club_name="Newcastle",
+                data_source="owning-club",
+                is_active=True,
+            ),
+        ]
+    )
+    record_transfer_events(journey.player_api_id, transfers, db.session)
+    db.session.commit()
+
+    # A DB-only repair must never instantiate or handshake an API client.
+    monkeypatch.setattr(
+        "src.services.journey_sync.APIFootballClient",
+        lambda: (_ for _ in ()).throw(AssertionError("database repair attempted API setup")),
+    )
+
+    def run_repair():
+        with app.test_request_context(json={"dry_run": False, "limit": 100, "cursor": 0}):
+            return admin_recompute_academy.__wrapped__().get_json()
+
+    first_payload = run_repair()
+    db.session.expire_all()
+
+    repaired = PlayerJourney.query.filter_by(player_api_id=journey.player_api_id).one()
+    entries = PlayerJourneyEntry.query.filter_by(journey_id=repaired.id).order_by(PlayerJourneyEntry.season).all()
+    academy_row = TrackedPlayer.query.filter_by(player_api_id=repaired.player_api_id, team_id=chelsea.id).one()
+    buyer_row = TrackedPlayer.query.filter_by(player_api_id=repaired.player_api_id, team_id=newcastle.id).one()
+    entry_state = [(e.season, e.entry_type, e.transfer_date, e.transfer_fee) for e in entries]
+
+    assert first_payload["errors"] == 0
+    assert first_payload["durable_reclassified"] == 1
+    assert first_payload["rollup_seasons_refreshed"] == 4
+    assert entry_state == [
+        (2022, "academy", None, None),
+        (2023, "loan", "2023-08-22", None),
+        (2024, "first_team", "2024-07-01", "€ 33M"),
+        (2025, "first_team", "2024-07-01", "€ 33M"),
+    ]
+    assert (academy_row.status, academy_row.sale_fee, academy_row.is_active) == ("sold", "€ 33M", True)
+    assert buyer_row.is_active is False
+    assert (
+        repaired.current_club_api_id,
+        repaired.current_club_name,
+        repaired.current_status,
+        repaired.current_owner_api_id,
+        repaired.current_owner_name,
+        repaired.total_loan_apps,
+    ) == (34, "Newcastle", None, None, None, 24)
+
+    for season, appearances, minutes in (
+        (2023, 24, 1009),
+        (2024, 34, 2660),
+        (2025, 45, 3263),
+    ):
+        cell = PlayerSeasonCell.query.filter_by(
+            player_api_id=repaired.player_api_id,
+            season=season,
+            source="journey",
+            club_api_id=34,
+        ).one()
+        total = PlayerSeasonTotal.query.filter_by(
+            player_api_id=repaired.player_api_id,
+            season=season,
+            level_group="senior",
+        ).one()
+        assert (cell.appearances, cell.minutes) == (appearances, minutes)
+        assert (total.appearances, total.minutes, total.primary_source) == (
+            appearances,
+            minutes,
+            "journey",
+        )
+
+    first_snapshot = (
+        entry_state,
+        academy_row.status,
+        academy_row.sale_fee,
+        buyer_row.is_active,
+        repaired.total_loan_apps,
+        [(row.season, row.source, row.club_api_id, row.minutes) for row in PlayerSeasonCell.query.all()],
+        [(row.season, row.level_group, row.minutes) for row in PlayerSeasonTotal.query.all()],
+    )
+    second_payload = run_repair()
+    db.session.expire_all()
+    second_snapshot = (
+        [
+            (e.season, e.entry_type, e.transfer_date, e.transfer_fee)
+            for e in PlayerJourneyEntry.query.filter_by(journey_id=repaired.id)
+            .order_by(PlayerJourneyEntry.season)
+            .all()
+        ],
+        TrackedPlayer.query.filter_by(player_api_id=repaired.player_api_id, team_id=chelsea.id).one().status,
+        TrackedPlayer.query.filter_by(player_api_id=repaired.player_api_id, team_id=chelsea.id).one().sale_fee,
+        TrackedPlayer.query.filter_by(player_api_id=repaired.player_api_id, team_id=newcastle.id).one().is_active,
+        PlayerJourney.query.filter_by(player_api_id=repaired.player_api_id).one().total_loan_apps,
+        [(row.season, row.source, row.club_api_id, row.minutes) for row in PlayerSeasonCell.query.all()],
+        [(row.season, row.level_group, row.minutes) for row in PlayerSeasonTotal.query.all()],
+    )
+    assert second_payload["errors"] == 0
+    assert first_snapshot == second_snapshot

--- a/academy-watch-backend/tests/test_rebuild_transfer_consumer.py
+++ b/academy-watch-backend/tests/test_rebuild_transfer_consumer.py
@@ -1,0 +1,139 @@
+from src.utils.academy_classifier import classify_tracked_player
+from src.utils.rebuild_runner import _rebuild_sale_fee, _rebuild_transfer_evidence
+
+PARENT_ID = 100
+PLAYER_ID = 400
+CONFIG = {"inactivity_release_years": None, "use_squad_check": False}
+
+
+def _transfer(transfer_date, transfer_type, out_id, out_name, in_id, in_name):
+    return {
+        "date": transfer_date,
+        "type": transfer_type,
+        "teams": {
+            "out": {"id": out_id, "name": out_name},
+            "in": {"id": in_id, "name": in_name},
+        },
+    }
+
+
+class _TransferClient:
+    def __init__(self, response=None, error=None):
+        self.response = response
+        self.error = error
+        self.calls = 0
+
+    def get_player_transfers(self, player_api_id):
+        assert player_api_id == PLAYER_ID
+        self.calls += 1
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+
+def _evidence(client, cache, **overrides):
+    kwargs = {
+        "parent_api_id": PARENT_ID,
+        "parent_club_name": "Parent FC",
+        "as_of": "2026-12-01",
+        "season_start_month": 7,
+        "season_start_day": 1,
+    }
+    kwargs.update(overrides)
+    return _rebuild_transfer_evidence(client, PLAYER_ID, cache, **kwargs)
+
+
+def test_rebuild_fetches_once_and_shares_parent_resolution_with_classifier():
+    transfers = [
+        _transfer("2024-07-01", "€ 33M", PARENT_ID, "Parent FC", 200, "Buyer FC"),
+        _transfer("2025-07-01", "€ 50M", 200, "Buyer FC", 300, "Later FC"),
+    ]
+    client = _TransferClient([{"player": {"id": PLAYER_ID}, "transfers": transfers}])
+    cache = {}
+
+    flat, resolution = _evidence(client, cache)
+    second_flat, second_resolution = _evidence(client, cache)
+    status, club_id, club_name = classify_tracked_player(
+        current_club_api_id=PARENT_ID,
+        current_club_name="Parent FC",
+        current_level="First Team",
+        parent_api_id=PARENT_ID,
+        parent_club_name="Parent FC",
+        transfers=flat,
+        player_api_id=PLAYER_ID,
+        transfer_resolution=resolution,
+        as_of="2026-12-01",
+        config=CONFIG,
+    )
+
+    assert client.calls == 1
+    assert second_flat is flat
+    assert second_resolution.events == resolution.events
+    assert (status, club_id, club_name) == ("sold", 300, "Later FC")
+    assert (
+        _rebuild_sale_fee(
+            None,
+            status=status,
+            resolution=resolution,
+            parent_api_id=PARENT_ID,
+            parent_club_name="Parent FC",
+        )
+        == "€ 33M"
+    )
+
+
+def test_rebuild_uses_the_journey_season_calendar_for_loan_freshness():
+    loan = _transfer("2026-02-10", "Loan", PARENT_ID, "Parent FC", 200, "Loan FC")
+    client = _TransferClient([{"player": {"id": PLAYER_ID}, "transfers": [loan]}])
+
+    _, resolution = _evidence(
+        client,
+        {},
+        season_start_month=1,
+        season_start_day=1,
+    )
+
+    assert resolution.season_start_month == 1
+    assert resolution.season_start_day == 1
+    assert resolution.on_loan is True
+
+
+def test_rebuild_failed_fetch_is_cached_and_preserves_existing_fee():
+    client = _TransferClient(error=RuntimeError("provider unavailable"))
+    cache = {}
+
+    first = _evidence(client, cache)
+    second = _evidence(client, cache)
+
+    assert first == (None, None)
+    assert second == (None, None)
+    assert client.calls == 1
+    assert (
+        _rebuild_sale_fee(
+            "€ 33M",
+            status="first_team",
+            resolution=None,
+            parent_api_id=PARENT_ID,
+            parent_club_name="Parent FC",
+        )
+        == "€ 33M"
+    )
+
+
+def test_rebuild_successful_empty_history_clears_stale_fee():
+    client = _TransferClient([])
+
+    transfers, resolution = _evidence(client, {})
+
+    assert transfers == []
+    assert resolution is not None
+    assert (
+        _rebuild_sale_fee(
+            "€ 33M",
+            status="first_team",
+            resolution=resolution,
+            parent_api_id=PARENT_ID,
+            parent_club_name="Parent FC",
+        )
+        is None
+    )

--- a/academy-watch-backend/tests/test_released_classification.py
+++ b/academy-watch-backend/tests/test_released_classification.py
@@ -77,10 +77,12 @@ class TestUpgradeStatusFromTransfers:
         transfers = [{"date": "2023-06-30", "type": "Free agent", "teams": {"in": {}, "out": {"id": DORTMUND}}}]
         assert upgrade_status_from_transfers("on_loan", transfers, DORTMUND, 999) == "released"
 
-    def test_destination_equal_to_parent_is_released(self):
-        # A departure whose "in" is the parent itself is not a sale away.
+    def test_na_self_move_preserves_uncertain_status(self):
+        # A topology-only event from the parent back to itself is not a
+        # definitive departure. The resolver emits unknown evidence, so the
+        # consumer must not manufacture either a release or a return.
         transfers = [_t("2023-06-30", DORTMUND, "Borussia Dortmund", DORTMUND, "Borussia Dortmund", "N/A")]
-        assert upgrade_status_from_transfers("on_loan", transfers, DORTMUND, None) == "released"
+        assert upgrade_status_from_transfers("on_loan", transfers, DORTMUND, None) == "on_loan"
 
     def test_national_team_destination_is_not_sold(self):
         transfers = [_t("2023-06-30", 10, "England", DORTMUND, "Borussia Dortmund", "N/A")]
@@ -88,13 +90,13 @@ class TestUpgradeStatusFromTransfers:
 
     def test_genuine_loan_to_loan_destination_stays_on_loan(self):
         transfers = [_t("2025-07-01", 700, "Loan Club", DORTMUND, "Borussia Dortmund", "Loan")]
-        assert upgrade_status_from_transfers("on_loan", transfers, DORTMUND, 700) == "on_loan"
+        assert upgrade_status_from_transfers("on_loan", transfers, DORTMUND, 700, as_of="2026-06-30") == "on_loan"
 
     def test_loan_typed_but_current_club_not_a_loan_destination_is_left(self):
         # Loan-typed departure to 700, but the player's current club is 999 (not
         # a parent loan destination) -> loaned out then moved on -> left.
         transfers = [_t("2025-07-01", 700, "Loan Club", DORTMUND, "Borussia Dortmund", "Loan")]
-        assert upgrade_status_from_transfers("on_loan", transfers, DORTMUND, 999) == "left"
+        assert upgrade_status_from_transfers("on_loan", transfers, DORTMUND, 999, as_of="2026-06-30") == "left"
 
     def test_no_parent_departure_with_current_club_is_left(self):
         # Berry@Man United: player is at another club (Al Kholood 10509) but has
@@ -102,16 +104,46 @@ class TestUpgradeStatusFromTransfers:
         transfers = [_t("2026-01-25", 10509, "Al Kholood", 65, "Nottingham Forest", "Transfer")]
         assert upgrade_status_from_transfers("on_loan", transfers, DORTMUND, 10509) == "left"
 
-    def test_no_parent_departure_without_current_club_stays_on_loan(self):
-        # Conservative: with no known current club we cannot assert departure.
+    def test_no_parent_departure_without_current_club_clears_stale_loan(self):
+        # A successful history with no parent departure cannot earn on_loan.
         transfers = [_t("2026-01-25", 10509, "Al Kholood", 65, "Nottingham Forest", "Transfer")]
-        assert upgrade_status_from_transfers("on_loan", transfers, DORTMUND, None) == "on_loan"
+        assert upgrade_status_from_transfers("on_loan", transfers, DORTMUND, None) == "first_team"
 
-    def test_non_on_loan_status_unchanged(self):
-        assert upgrade_status_from_transfers("academy", RIJKHOFF_TRANSFERS, DORTMUND, 419) == "academy"
+    def test_definitive_departure_overrides_stale_academy_status(self):
+        assert upgrade_status_from_transfers("academy", RIJKHOFF_TRANSFERS, DORTMUND, 419) == "sold"
 
-    def test_no_transfers_unchanged(self):
-        assert upgrade_status_from_transfers("on_loan", [], DORTMUND, 419) == "on_loan"
+    def test_active_parent_loan_overrides_stale_left_status(self):
+        transfers = [_t("2026-07-10", 700, "Loan Club", DORTMUND, "Borussia Dortmund", "Loan")]
+        assert (
+            upgrade_status_from_transfers(
+                "left",
+                transfers,
+                DORTMUND,
+                DORTMUND,
+                as_of="2026-12-01",
+            )
+            == "on_loan"
+        )
+
+    def test_successful_empty_history_marks_external_player_left(self):
+        assert upgrade_status_from_transfers("on_loan", [], DORTMUND, 419) == "left"
+
+    def test_unavailable_transfer_history_preserves_conservative_status(self):
+        assert upgrade_status_from_transfers("on_loan", None, DORTMUND, 419) == "on_loan"
+
+    def test_expired_historical_loan_without_current_club_is_not_current_loan(self):
+        transfers = [_t("2023-07-01", 700, "Loan Club", DORTMUND, "Borussia Dortmund", "Loan")]
+
+        assert (
+            upgrade_status_from_transfers(
+                "on_loan",
+                transfers,
+                DORTMUND,
+                None,
+                as_of="2026-12-01",
+            )
+            == "left"
+        )
 
 
 class TestClassifyTrackedPlayerEndToEnd:
@@ -225,6 +257,9 @@ class TestAffiliateResolver:
         # "Jong Ajax" normalises to "Ajax" == parent "Ajax"
         assert is_affiliate(99999, "Jong Ajax", 194, "Ajax") is True
 
+    def test_is_affiliate_via_name_when_provider_ids_are_missing(self):
+        assert is_affiliate(None, "Chelsea U21", None, "Chelsea") is True
+
     def test_is_affiliate_via_hardcoded_id_when_name_missing(self):
         # 425 (Jong Ajax) -> 194, even with no name loaded
         assert is_affiliate(425, None, 194, "Ajax") is True
@@ -248,6 +283,7 @@ class TestClassifyEvidenceBasedModel:
             transfers=transfers,
             latest_season=latest_season,
             config=self.CONFIG,
+            as_of="2026-06-30",
         )
 
     def test_berry_under_man_united_is_left(self):
@@ -302,7 +338,8 @@ class TestClassifyEvidenceBasedModel:
 
 class TestJourneyCurrentStatus:
     """PlayerJourney.current_status is the player's ACTUAL current situation
-    (on_loan + owner), computed from stored entries — independent of academy."""
+    (on_loan + owner), computed only from chronological transfer evidence;
+    stored entry labels alone cannot infer it."""
 
     def _journey(self, current_club_api_id, entries):
         from src.models.journey import PlayerJourney, PlayerJourneyEntry
@@ -331,8 +368,9 @@ class TestJourneyCurrentStatus:
 
         return JourneySyncService()
 
-    def test_on_loan_sets_status_and_owner(self, app):
-        # Rijkhoff-shaped: current club Almere (419) is a loan; owner = Ajax (194).
+    def test_entry_only_loan_does_not_set_status_or_guess_owner(self, app):
+        # Historical entry labels do not prove that the loan remains active or
+        # that an earlier first-team club is still the legal owner.
         j, entries = self._journey(
             419,
             [
@@ -340,13 +378,14 @@ class TestJourneyCurrentStatus:
                 (2024, 194, "Ajax", "first_team", False),
             ],
         )
-        self._svc()._set_current_status(j, entries)
-        assert j.current_status == "on_loan"
-        assert j.current_owner_api_id == 194
-        assert j.current_owner_name == "Ajax"
+        assert self._svc()._set_current_status(j, entries) is False
+        assert j.current_status is None
+        assert j.current_owner_api_id is None
+        assert j.current_owner_name is None
 
-    def test_owner_resolves_b_team_to_senior(self, app):
-        # Owner recorded as Jong Ajax (425) resolves to Ajax (194).
+    def test_entry_only_b_team_does_not_guess_a_senior_owner(self, app):
+        # Affiliate normalization is valid only after transfer evidence proves
+        # ownership; a Jong Ajax journey entry alone is insufficient.
         j, entries = self._journey(
             419,
             [
@@ -354,9 +393,10 @@ class TestJourneyCurrentStatus:
                 (2024, 425, "Jong Ajax", "first_team", False),
             ],
         )
-        self._svc()._set_current_status(j, entries)
-        assert j.current_status == "on_loan"
-        assert j.current_owner_api_id == 194  # Jong Ajax -> Ajax via affiliate map
+        assert self._svc()._set_current_status(j, entries) is False
+        assert j.current_status is None
+        assert j.current_owner_api_id is None
+        assert j.current_owner_name is None
 
     def test_not_on_loan_leaves_status_null(self, app):
         # Current club entry is first_team (not a loan) -> defer to academy status.

--- a/academy-watch-backend/tests/test_season_data_sea01.py
+++ b/academy-watch-backend/tests/test_season_data_sea01.py
@@ -2,9 +2,9 @@
 
 Locks the four load-bearing guarantees of the PR2 (`sea01`) work:
 
-1. **Migration head stays single** — `sea01` chains off `aw23`, and D3's `sea02`
-   now chains off `sea01`, so the single tip has advanced to `sea02`; a second head
-   would make `flask db upgrade` ambiguous on deploy.
+1. **Migration head stays single** — `sea01` chains off `aw23`, followed by
+   `sea02`, `sea03`, and transfer-event migration `tre01`; a second head would
+   make `flask db upgrade` ambiguous on deploy.
 2. **`sea01` is idempotent** — every DDL is guarded, so a re-applied or
    partially-applied upgrade is a pure no-op (migrations do NOT auto-run on
    deploy; prod schema has drifted out-of-band, invariants §8).
@@ -50,13 +50,10 @@ def _script_directory():
 
 
 class TestMigrationHead:
-    def test_single_head_is_sea03(self):
-        """The whole chain resolves to exactly one head. D3's sea03 (the /status
-        gauge clock indexes) now sits on top of sea02, so the tip has advanced from
-        sea02 to sea03 — a second head would make `flask db upgrade` ambiguous on
-        deploy."""
+    def test_single_head_is_tre01(self):
+        """The whole chain resolves to exactly one head at tre01."""
         heads = _script_directory().get_heads()
-        assert heads == ["sea03"], f"expected the single head to be sea03, got {heads}"
+        assert heads == ["tre01"], f"expected the single head to be tre01, got {heads}"
 
     def test_sea01_chains_off_aw23(self):
         """sea01 branches from the real prod tip (aw23), keeping the line linear."""
@@ -78,6 +75,13 @@ class TestMigrationHead:
         sea03 = script.get_revision("sea03")
         assert sea03.down_revision == "sea02"
         assert script.get_revision("sea02") is not None
+
+    def test_tre01_chains_off_sea03(self):
+        """tre01 (durable transfer events) extends the existing single head."""
+        script = _script_directory()
+        tre01 = script.get_revision("tre01")
+        assert tre01.down_revision == "sea03"
+        assert script.get_revision("sea03") is not None
 
 
 # ---------------------------------------------------------------------------

--- a/academy-watch-backend/tests/test_transfer_api_consumer.py
+++ b/academy-watch-backend/tests/test_transfer_api_consumer.py
@@ -1,0 +1,626 @@
+"""Focused regressions for transfer consumers in API routes and classifier."""
+
+import src.routes.api as api_routes
+from src.models.league import Team, db
+from src.models.tracked_player import TrackedPlayer
+from src.routes.api import _academy_seed_transfer_fallback_eligible, _run_batch_fixture_sync
+from src.services.transfer_resolver import resolve_transfer_state as real_resolve_transfer_state
+from src.utils.academy_classifier import classify_tracked_player
+
+
+def _transfer(transfer_date, transfer_type, out_id, out_name, in_id, in_name):
+    return {
+        "date": transfer_date,
+        "type": transfer_type,
+        "teams": {
+            "out": {"id": out_id, "name": out_name},
+            "in": {"id": in_id, "name": in_name},
+        },
+    }
+
+
+def _payload(player_id, transfers):
+    return [{"player": {"id": player_id}, "transfers": transfers}]
+
+
+def _parent_team(team_id=49, name="Chelsea"):
+    team = Team(
+        team_id=team_id,
+        name=name,
+        country="England",
+        season=2025,
+        is_active=True,
+    )
+    db.session.add(team)
+    db.session.flush()
+    return team
+
+
+class _BatchAPI:
+    def __init__(self, player_id, transfers, *, profile=None):
+        self.player_id = player_id
+        self.transfers = transfers
+        self.profile = profile
+        self.fixture_team_ids = []
+        self.transfer_calls = 0
+
+    def get_player_transfers(self, player_id):
+        assert player_id == self.player_id
+        self.transfer_calls += 1
+        return _payload(player_id, self.transfers)
+
+    def get_player_by_id(self, player_id, season):
+        assert player_id == self.player_id
+        assert season == 2025
+        if self.profile is None:
+            raise AssertionError("known current club must not trigger profile discovery")
+        return self.profile
+
+    def get_fixtures_for_team_cached(self, team_id, season, start, end):
+        self.fixture_team_ids.append(team_id)
+        return []
+
+
+def test_batch_fee_uses_parent_departure_even_after_later_resale(app, monkeypatch):
+    """A known current club must not skip or replace the academy's sale fee."""
+    parent = _parent_team()
+    player_id = 284492
+    db.session.add(
+        TrackedPlayer(
+            player_api_id=player_id,
+            player_name="L. Hall",
+            team_id=parent.id,
+            status="sold",
+            current_club_api_id=66,
+            current_club_name="Aston Villa",
+            sale_fee=None,
+            data_source="journey-sync",
+            is_active=True,
+        )
+    )
+    db.session.commit()
+
+    fake = _BatchAPI(
+        player_id,
+        [
+            _transfer("2024-07-01", "€ 33M", 49, "Chelsea", 34, "Newcastle"),
+            _transfer("2026-07-01", "€ 50M", 34, "Newcastle", 66, "Aston Villa"),
+        ],
+    )
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+
+    _run_batch_fixture_sync({"season": 2025, "delay": 0})
+
+    tracked = TrackedPlayer.query.filter_by(player_api_id=player_id).one()
+    assert tracked.sale_fee == "€ 33M"
+    assert fake.transfer_calls == 1
+    assert fake.fixture_team_ids == [66]
+
+
+def test_batch_current_club_ignores_later_ambiguous_na(app, monkeypatch):
+    """Parent context resolves the first N/A while unrelated N/A stays inert."""
+    parent = _parent_team()
+    player_id = 900002
+    db.session.add(
+        TrackedPlayer(
+            player_api_id=player_id,
+            player_name="Topology Player",
+            team_id=parent.id,
+            status="sold",
+            current_club_api_id=None,
+            current_club_name=None,
+            data_source="journey-sync",
+            is_active=True,
+        )
+    )
+    db.session.commit()
+
+    fake = _BatchAPI(
+        player_id,
+        [
+            _transfer("2024-07-01", "N/A", 49, "Chelsea", 34, "Newcastle"),
+            _transfer("2025-07-01", "N/A", 777, "Unrelated", 888, "Wrong Club"),
+        ],
+        profile={"statistics": []},
+    )
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+
+    _run_batch_fixture_sync({"season": 2025, "delay": 0})
+
+    tracked = TrackedPlayer.query.filter_by(player_api_id=player_id).one()
+    assert (tracked.current_club_api_id, tracked.current_club_name) == (34, "Newcastle")
+    assert fake.transfer_calls == 1
+    assert fake.fixture_team_ids == [34]
+
+
+def test_batch_reconciles_stale_stored_club_before_early_continue(app, monkeypatch):
+    """Fresh resolver state must replace a contradictory prior backfill."""
+    parent = _parent_team()
+    player_id = 900004
+    db.session.add(
+        TrackedPlayer(
+            player_api_id=player_id,
+            player_name="Stale Destination",
+            team_id=parent.id,
+            status="sold",
+            current_club_api_id=66,
+            current_club_name="Aston Villa",
+            sale_fee="Undisclosed",
+            data_source="journey-sync",
+            is_active=True,
+        )
+    )
+    db.session.commit()
+
+    fake = _BatchAPI(
+        player_id,
+        [_transfer("2025-07-01", "Transfer", 49, "Chelsea", 34, "Newcastle")],
+    )
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+
+    _run_batch_fixture_sync({"season": 2025, "delay": 0})
+
+    tracked = TrackedPlayer.query.filter_by(player_api_id=player_id).one()
+    assert (tracked.current_club_api_id, tracked.current_club_name) == (34, "Newcastle")
+    assert fake.transfer_calls == 1
+    assert fake.fixture_team_ids == [34]
+
+
+def test_batch_indeterminate_historical_loan_preserves_newer_stored_club(app, monkeypatch):
+    """An expired open loan is not proof the old borrower is current."""
+    parent = _parent_team()
+    player_id = 900006
+    db.session.add(
+        TrackedPlayer(
+            player_api_id=player_id,
+            player_name="Old Open Loan",
+            team_id=parent.id,
+            status="sold",
+            current_club_api_id=66,
+            current_club_name="Aston Villa",
+            data_source="journey-sync",
+            is_active=True,
+        )
+    )
+    db.session.commit()
+
+    fake = _BatchAPI(
+        player_id,
+        [_transfer("2023-07-01", "Loan", 49, "Chelsea", 34, "Newcastle")],
+    )
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+
+    _run_batch_fixture_sync({"season": 2025, "delay": 0})
+
+    tracked = TrackedPlayer.query.filter_by(player_api_id=player_id).one()
+    assert (tracked.current_club_api_id, tracked.current_club_name) == (66, "Aston Villa")
+    assert fake.fixture_team_ids == [66]
+
+
+def test_batch_old_permanent_move_preserves_newer_unrelated_stored_club(app, monkeypatch):
+    """An old sale cannot erase later statistics/backfill at a third club."""
+    parent = _parent_team()
+    player_id = 900010
+    db.session.add(
+        TrackedPlayer(
+            player_api_id=player_id,
+            player_name="Later Third Club",
+            team_id=parent.id,
+            status="sold",
+            current_club_api_id=66,
+            current_club_name="Aston Villa",
+            data_source="journey-sync",
+            is_active=True,
+        )
+    )
+    db.session.commit()
+
+    fake = _BatchAPI(
+        player_id,
+        [_transfer("2023-07-01", "Transfer", 49, "Chelsea", 34, "Newcastle")],
+    )
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+
+    _run_batch_fixture_sync({"season": 2025, "delay": 0})
+
+    tracked = TrackedPlayer.query.filter_by(player_api_id=player_id).one()
+    assert (tracked.current_club_api_id, tracked.current_club_name) == (
+        66,
+        "Aston Villa",
+    )
+    assert fake.fixture_team_ids == [66]
+
+
+def test_batch_indeterminate_historical_loan_preserves_newer_profile_club(app, monkeypatch):
+    """Current-season profile evidence wins over an expired open loan."""
+    parent = _parent_team()
+    player_id = 900007
+    db.session.add(
+        TrackedPlayer(
+            player_api_id=player_id,
+            player_name="Profile Club",
+            team_id=parent.id,
+            status="sold",
+            data_source="journey-sync",
+            is_active=True,
+        )
+    )
+    db.session.commit()
+
+    fake = _BatchAPI(
+        player_id,
+        [_transfer("2023-07-01", "Loan", 49, "Chelsea", 34, "Newcastle")],
+        profile={
+            "statistics": [
+                {
+                    "team": {"id": 66, "name": "Aston Villa"},
+                    "games": {"appearences": 12, "position": "Defender"},
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+
+    _run_batch_fixture_sync({"season": 2025, "delay": 0})
+
+    tracked = TrackedPlayer.query.filter_by(player_api_id=player_id).one()
+    assert (tracked.current_club_api_id, tracked.current_club_name) == (66, "Aston Villa")
+    assert fake.fixture_team_ids == [66]
+
+
+def test_batch_commits_resolver_fee_before_profile_failure(app, monkeypatch):
+    """A later profile error cannot discard an academy sale-fee repair."""
+    parent = _parent_team()
+    player_id = 900008
+    db.session.add(
+        TrackedPlayer(
+            player_api_id=player_id,
+            player_name="Fee Repair",
+            team_id=parent.id,
+            status="sold",
+            sale_fee=None,
+            data_source="journey-sync",
+            is_active=True,
+        )
+    )
+    db.session.commit()
+
+    fake = _BatchAPI(
+        player_id,
+        [_transfer("2024-07-01", "€ 12M", 49, "Chelsea", 34, "Newcastle")],
+    )
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+
+    _run_batch_fixture_sync({"season": 2025, "delay": 0})
+
+    # Expire ORM state to prove the value survived the independent commit.
+    db.session.expire_all()
+    tracked = TrackedPlayer.query.filter_by(player_api_id=player_id).one()
+    assert tracked.sale_fee == "€ 12M"
+
+
+class _SeedTransferAPI:
+    def __init__(self, player_id, *, transfers=None, transfer_error=None):
+        self.player_id = player_id
+        self.transfers = transfers
+        self.transfer_error = transfer_error
+
+    def get_player_transfers(self, player_id):
+        assert player_id == self.player_id
+        if self.transfer_error is not None:
+            raise self.transfer_error
+        return _payload(player_id, self.transfers or [])
+
+
+def test_seed_fallback_skips_candidate_when_transfer_fetch_fails():
+    player_id = 900005
+    fake = _SeedTransferAPI(
+        player_id,
+        transfer_error=RuntimeError("provider unavailable"),
+    )
+
+    assert not _academy_seed_transfer_fallback_eligible(
+        fake,
+        player_id,
+        49,
+        "Chelsea",
+        as_of="2026-06-30",
+    )
+
+
+def test_seed_fallback_accepts_successful_empty_transfer_history():
+    player_id = 900005
+    fake = _SeedTransferAPI(player_id, transfers=[])
+
+    assert _academy_seed_transfer_fallback_eligible(
+        fake,
+        player_id,
+        49,
+        "Chelsea",
+        as_of="2026-06-30",
+    )
+
+
+def test_seed_fallback_does_not_invent_parent_owner_for_ambiguous_na(monkeypatch):
+    resolver_kwargs = []
+
+    def _capture_resolver(events, **kwargs):
+        resolver_kwargs.append(kwargs)
+        return real_resolve_transfer_state(events, **kwargs)
+
+    monkeypatch.setattr(api_routes, "resolve_transfer_state", _capture_resolver)
+    player_id = 900005
+    fake = _SeedTransferAPI(
+        player_id,
+        transfers=[
+            _transfer(
+                "2025-07-01",
+                "N/A",
+                700,
+                "Other Club",
+                49,
+                "Chelsea",
+            )
+        ],
+    )
+
+    assert not _academy_seed_transfer_fallback_eligible(
+        fake,
+        player_id,
+        49,
+        "Chelsea",
+        as_of="2026-06-30",
+    )
+    assert len(resolver_kwargs) == 1
+    assert "initial_owner" not in resolver_kwargs[0]
+
+
+def test_seed_fallback_rejects_external_loan_arrival_into_parent():
+    """Borrowing a prospect does not make that prospect an academy product."""
+    player_id = 900009
+    fake = _SeedTransferAPI(
+        player_id,
+        transfers=[
+            _transfer(
+                "2025-07-01",
+                "Loan",
+                700,
+                "Other Club",
+                49,
+                "Chelsea",
+            )
+        ],
+    )
+
+    assert not _academy_seed_transfer_fallback_eligible(
+        fake,
+        player_id,
+        49,
+        "Chelsea",
+        as_of="2026-06-30",
+    )
+
+
+def test_classifier_matches_active_borrower_across_reverse_affiliate_id(app):
+    """Stats may expose Jong Ajax while the transfer names senior Ajax."""
+    status, club_id, club_name = classify_tracked_player(
+        current_club_api_id=425,
+        current_club_name="Jong Ajax",
+        current_level="First Team",
+        parent_api_id=165,
+        parent_club_name="Borussia Dortmund",
+        transfers=[
+            _transfer(
+                "2025-07-01",
+                "Loan",
+                165,
+                "Borussia Dortmund",
+                194,
+                "Ajax",
+            )
+        ],
+        latest_season=2025,
+        as_of="2026-06-30",
+    )
+
+    assert (status, club_id, club_name) == ("on_loan", 425, "Jong Ajax")
+
+
+def test_classifier_fetch_failure_is_not_a_successful_empty_history(app):
+    """Provider failure preserves uncertainty; a real empty response means left."""
+
+    class _FailingAPI:
+        def get_player_transfers(self, player_id):
+            raise RuntimeError("provider unavailable")
+
+    class _EmptyAPI:
+        def get_player_transfers(self, player_id):
+            return _payload(player_id, [])
+
+    kwargs = {
+        "current_club_api_id": 700,
+        "current_club_name": "Other Club",
+        "current_level": "First Team",
+        "parent_api_id": 165,
+        "parent_club_name": "Borussia Dortmund",
+        "player_api_id": 900003,
+        "latest_season": 2025,
+        "as_of": "2026-06-30",
+    }
+
+    failed = classify_tracked_player(api_client=_FailingAPI(), transfers=None, **kwargs)
+    empty = classify_tracked_player(api_client=_EmptyAPI(), transfers=None, **kwargs)
+
+    assert failed[0] == "on_loan"
+    assert empty[0] == "left"
+
+
+def test_classifier_same_parent_fetch_failure_stays_conservative(app):
+    """Unknown transfer evidence must not invent a same-parent departure."""
+
+    class _FailingAPI:
+        def get_player_transfers(self, player_id):
+            raise RuntimeError("provider unavailable")
+
+    result = classify_tracked_player(
+        current_club_api_id=49,
+        current_club_name="Chelsea",
+        current_level="First Team",
+        parent_api_id=49,
+        parent_club_name="Chelsea",
+        transfers=None,
+        player_api_id=284492,
+        api_client=_FailingAPI(),
+        latest_season=2025,
+        config={"inactivity_release_years": 2, "use_squad_check": False},
+        as_of="2026-06-30",
+    )
+
+    assert result == ("first_team", 49, "Chelsea")
+
+
+_CLASSIFIER_CONFIG = {"inactivity_release_years": 2, "use_squad_check": False}
+
+
+def test_classifier_hall_sale_overrides_stale_same_parent_journey(app):
+    """Hall-shaped parent stats must not hide the later permanent conversion."""
+    result = classify_tracked_player(
+        current_club_api_id=49,
+        current_club_name="Chelsea",
+        current_level="First Team",
+        parent_api_id=49,
+        parent_club_name="Chelsea",
+        transfers=[
+            _transfer("2023-08-22", "Loan", 49, "Chelsea", 34, "Newcastle"),
+            _transfer("2024-07-01", "€ 33M", 49, "Chelsea", 34, "Newcastle"),
+        ],
+        latest_season=2025,
+        config=_CLASSIFIER_CONFIG,
+        as_of="2026-06-30",
+    )
+
+    assert result == ("sold", 34, "Newcastle")
+
+
+def test_classifier_release_overrides_stale_same_parent_journey(app):
+    """A definitive parent-to-free-agent event clears stale parent fields."""
+    result = classify_tracked_player(
+        current_club_api_id=49,
+        current_club_name="Chelsea",
+        current_level="First Team",
+        parent_api_id=49,
+        parent_club_name="Chelsea",
+        transfers=[
+            _transfer("2025-07-01", "Free agent", 49, "Chelsea", None, None),
+        ],
+        latest_season=2025,
+        config=_CLASSIFIER_CONFIG,
+        as_of="2026-06-30",
+    )
+
+    assert result == ("released", None, None)
+
+
+def test_classifier_active_loan_overrides_stale_same_parent_journey(app):
+    """A fresh resolved parent loan supplies the borrower even before stats move."""
+    result = classify_tracked_player(
+        current_club_api_id=49,
+        current_club_name="Chelsea",
+        current_level="First Team",
+        parent_api_id=49,
+        parent_club_name="Chelsea",
+        transfers=[
+            _transfer("2026-07-10", "Loan", 49, "Chelsea", 44, "Burnley"),
+        ],
+        latest_season=2026,
+        config=_CLASSIFIER_CONFIG,
+        as_of="2026-12-01",
+    )
+
+    assert result == ("on_loan", 44, "Burnley")
+
+
+def test_classifier_name_only_parent_and_destination_can_be_sold(app):
+    """Provider IDs are enrichment, not a prerequisite for a named sale."""
+    result = classify_tracked_player(
+        current_club_api_id=49,
+        current_club_name="Chelsea",
+        current_level="First Team",
+        parent_api_id=49,
+        parent_club_name="Chelsea",
+        transfers=[
+            _transfer(
+                "2024-07-01",
+                "Transfer",
+                None,
+                "Chelsea U21",
+                None,
+                "Newcastle United",
+            ),
+        ],
+        latest_season=2025,
+        config=_CLASSIFIER_CONFIG,
+        as_of="2026-06-30",
+    )
+
+    assert result == ("sold", None, "Newcastle United")
+
+
+def test_classifier_permanent_buyback_restores_parent_status(app):
+    """A later permanent move back to the parent supersedes its old sale."""
+    result = classify_tracked_player(
+        current_club_api_id=34,
+        current_club_name="Newcastle",
+        current_level="First Team",
+        parent_api_id=49,
+        parent_club_name="Chelsea",
+        transfers=[
+            _transfer("2023-07-01", "Transfer", 49, "Chelsea", 34, "Newcastle"),
+            _transfer("2025-07-01", "Transfer", 34, "Newcastle", 49, "Chelsea"),
+        ],
+        latest_season=2025,
+        config=_CLASSIFIER_CONFIG,
+        as_of="2026-06-30",
+    )
+
+    assert result == ("first_team", 49, "Chelsea")
+
+
+def test_classifier_older_loan_return_does_not_override_newer_external_stats(app):
+    """A return predating the latest stats season cannot erase its current club."""
+    result = classify_tracked_player(
+        current_club_api_id=34,
+        current_club_name="Newcastle",
+        current_level="First Team",
+        parent_api_id=49,
+        parent_club_name="Chelsea",
+        transfers=[
+            _transfer("2023-07-01", "Loan", 49, "Chelsea", 34, "Newcastle"),
+            _transfer("2024-07-01", "Back from Loan", 34, "Newcastle", 49, "Chelsea"),
+        ],
+        latest_season=2025,
+        config=_CLASSIFIER_CONFIG,
+        as_of="2026-06-30",
+    )
+
+    assert result == ("left", 34, "Newcastle")
+
+
+def test_classifier_current_season_loan_return_restores_parent_status(app):
+    """A return in the latest stats season supersedes stale borrower fields."""
+    result = classify_tracked_player(
+        current_club_api_id=34,
+        current_club_name="Newcastle",
+        current_level="First Team",
+        parent_api_id=49,
+        parent_club_name="Chelsea",
+        transfers=[
+            _transfer("2024-07-01", "Loan", 49, "Chelsea", 34, "Newcastle"),
+            _transfer("2025-07-01", "Back from Loan", 34, "Newcastle", 49, "Chelsea"),
+        ],
+        latest_season=2025,
+        config=_CLASSIFIER_CONFIG,
+        as_of="2026-06-30",
+    )
+
+    assert result == ("first_team", 49, "Chelsea")

--- a/academy-watch-backend/tests/test_transfer_consumer_integration.py
+++ b/academy-watch-backend/tests/test_transfer_consumer_integration.py
@@ -1,0 +1,687 @@
+"""Consumer-level regressions for chronological transfer state.
+
+These tests deliberately enter through ``JourneySyncService.sync_player`` with
+an in-memory database and an API client that cannot perform I/O.  The pure
+resolver has its own exhaustive unit suite; this module pins the values written
+by its three consumers: journey entries, academy-relative tracked status/fee,
+and journey-level current club/status/owner.
+"""
+
+from copy import deepcopy
+
+import pytest
+from src.models.journey import PlayerJourney, PlayerJourneyEntry
+from src.models.league import Team, db
+from src.models.season_rollup import PlayerSeasonCell, PlayerSeasonTotal
+from src.models.tracked_player import TrackedPlayer
+from src.services.journey_sync import JourneySyncService
+
+
+@pytest.fixture(autouse=True)
+def _freeze_transfer_resolution_date(monkeypatch):
+    monkeypatch.setattr(
+        "src.services.journey_sync._transfer_as_of",
+        lambda as_of=None: as_of or "2026-07-16",
+    )
+
+
+def _transfer(transfer_date, transfer_type, out_id, out_name, in_id, in_name):
+    return {
+        "date": transfer_date,
+        "type": transfer_type,
+        "teams": {
+            "out": {"id": out_id, "name": out_name},
+            "in": {"id": in_id, "name": in_name},
+        },
+    }
+
+
+def _stat(team_id, team_name, appearances, minutes, *, youth=False):
+    return {
+        "team": {"id": team_id, "name": team_name},
+        "league": {
+            "id": 699 if youth else 39,
+            "name": "Premier League 2" if youth else "Premier League",
+            "country": "Test Country",
+        },
+        "games": {
+            "appearences": appearances,
+            "minutes": minutes,
+            "position": "Midfielder",
+        },
+        "goals": {"total": 0, "assists": 0},
+    }
+
+
+class _FakeAPI:
+    """The only API surface the real sync may use; every other call fails."""
+
+    def __init__(self, player_id, player_name, seasons, transfers):
+        self.player_id = player_id
+        self.player_name = player_name
+        self.seasons = seasons
+        self.transfers = transfers
+        self.player_seasons_requested = []
+
+    def _make_request(self, endpoint, params):
+        if endpoint == "players/seasons":
+            assert params == {"player": self.player_id}
+            return {"response": sorted(self.seasons)}
+        if endpoint == "players":
+            assert params["id"] == self.player_id
+            season = params["season"]
+            self.player_seasons_requested.append(season)
+            return {
+                "response": [
+                    {
+                        "player": {
+                            "id": self.player_id,
+                            "name": self.player_name,
+                            "birth": {"date": "2004-01-01", "country": "Test Country"},
+                            "nationality": "Test Country",
+                        },
+                        "statistics": deepcopy(self.seasons[season]),
+                    }
+                ]
+            }
+        raise AssertionError(f"unexpected endpoint: {endpoint} {params}")
+
+    def get_player_transfers(self, player_id):
+        assert player_id == self.player_id
+        return [
+            {
+                "player": {"id": player_id, "name": self.player_name},
+                "transfers": deepcopy(self.transfers),
+            }
+        ]
+
+
+class _FailingTransferAPI(_FakeAPI):
+    def get_player_transfers(self, player_id):
+        assert player_id == self.player_id
+        raise RuntimeError("provider transfer endpoint unavailable")
+
+
+def _seed_transfer_teams(transfers):
+    clubs = {}
+    for event in transfers:
+        for direction in ("out", "in"):
+            club = event["teams"][direction]
+            clubs[club["id"]] = club["name"]
+
+    for club_id, club_name in clubs.items():
+        if Team.query.filter_by(team_id=club_id, season=2025).first() is None:
+            db.session.add(
+                Team(
+                    team_id=club_id,
+                    name=club_name,
+                    country="Test Country",
+                    season=2025,
+                    is_active=True,
+                )
+            )
+    db.session.commit()
+
+
+def _sync(player_id, player_name, parent_id, seasons, transfers):
+    _seed_transfer_teams(transfers)
+    service = JourneySyncService(_FakeAPI(player_id, player_name, seasons, transfers))
+    # Geocoding is unrelated to transfer consumers and must never escape the
+    # hermetic test boundary.
+    service._auto_geocode_clubs = lambda journey: None
+    journey = service.sync_player(player_id, force_full=True)
+    assert journey is not None
+    assert journey.sync_error is None
+
+    parent = Team.query.filter_by(team_id=parent_id, season=2025).one()
+    entries = PlayerJourneyEntry.query.filter_by(journey_id=journey.id).all()
+    tracked = TrackedPlayer.query.filter_by(player_api_id=player_id, team_id=parent.id).one_or_none()
+    assert tracked is not None, {
+        "academy_club_ids": journey.academy_club_ids,
+        "entries": [
+            (
+                entry.season,
+                entry.club_api_id,
+                entry.club_name,
+                entry.entry_type,
+                entry.is_youth,
+            )
+            for entry in entries
+        ],
+        "tracked_rows": [
+            (row.team.team_id, row.status, row.is_active)
+            for row in TrackedPlayer.query.filter_by(player_api_id=player_id).all()
+        ],
+    }
+    return journey, tracked, entries
+
+
+def _entry(entries, season, club_id):
+    matches = [entry for entry in entries if entry.season == season and entry.club_api_id == club_id]
+    assert len(matches) == 1
+    return matches[0]
+
+
+HALL_TRANSFERS = [
+    _transfer("2024-07-01", "€ 33M", 49, "Chelsea", 34, "Newcastle"),
+    _transfer("2023-08-22", "Loan", 49, "Chelsea", 34, "Newcastle"),
+]
+
+
+def test_hall_full_sync_canary_replaces_the_loan_on_the_july_first_conversion(app):
+    """Hall's exact transfer payload repairs all three persisted consumers."""
+    seasons = {
+        2022: [_stat(49, "Chelsea U21", 6, 500, youth=True)],
+        2023: [_stat(34, "Newcastle", 24, 1009)],
+        2024: [_stat(34, "Newcastle", 34, 2660)],
+        2025: [_stat(34, "Newcastle", 45, 3263)],
+    }
+    _seed_transfer_teams(HALL_TRANSFERS)
+    chelsea = Team.query.filter_by(team_id=49, season=2025).one()
+    newcastle = Team.query.filter_by(team_id=34, season=2025).one()
+    db.session.add_all(
+        [
+            TrackedPlayer(
+                id=21704,
+                player_api_id=284492,
+                player_name="L. Hall",
+                team_id=chelsea.id,
+                status="on_loan",
+                current_club_api_id=34,
+                current_club_name="Newcastle",
+                data_source="journey-sync",
+                last_academy_season=2022,
+                is_active=True,
+            ),
+            TrackedPlayer(
+                id=21705,
+                player_api_id=284492,
+                player_name="L. Hall",
+                team_id=newcastle.id,
+                status="first_team",
+                current_club_api_id=34,
+                current_club_name="Newcastle",
+                data_source="owning-club",
+                is_active=True,
+            ),
+        ]
+    )
+    db.session.commit()
+
+    journey, tracked, entries = _sync(284492, "L. Hall", 49, seasons, HALL_TRANSFERS)
+    buying_club_row = TrackedPlayer.query.filter_by(id=21705).one()
+    loan_entry = _entry(entries, 2023, 34)
+    newcastle_entries = [_entry(entries, season, 34) for season in (2024, 2025)]
+
+    assert tracked.id == 21704
+    assert tracked.is_active is True
+    assert tracked.status == "sold"
+    assert tracked.current_club_api_id == 34
+    assert tracked.current_club_name == "Newcastle"
+    assert tracked.sale_fee == "€ 33M"
+    assert buying_club_row.is_active is False
+
+    assert [entry.entry_type for entry in newcastle_entries] == ["first_team", "first_team"]
+    assert [entry.transfer_date for entry in newcastle_entries] == ["2024-07-01", "2024-07-01"]
+    assert [entry.transfer_fee for entry in newcastle_entries] == ["€ 33M", "€ 33M"]
+    assert (loan_entry.entry_type, loan_entry.transfer_date, loan_entry.transfer_fee) == (
+        "loan",
+        "2023-08-22",
+        None,
+    )
+    assert journey.current_club_api_id == 34
+    assert journey.current_club_name == "Newcastle"
+    assert journey.current_status is None
+    assert journey.current_owner_api_id is None
+    assert journey.current_owner_name is None
+    assert journey.total_loan_apps == 24
+
+    for season, appearances, minutes in (
+        (2023, 24, 1009),
+        (2024, 34, 2660),
+        (2025, 45, 3263),
+    ):
+        cell = PlayerSeasonCell.query.filter_by(
+            player_api_id=284492,
+            season=season,
+            source="journey",
+            club_api_id=34,
+        ).one()
+        total = PlayerSeasonTotal.query.filter_by(
+            player_api_id=284492,
+            season=season,
+            level_group="senior",
+        ).one()
+        assert (cell.appearances, cell.minutes) == (appearances, minutes)
+        assert (total.appearances, total.minutes, total.primary_source) == (
+            appearances,
+            minutes,
+            "journey",
+        )
+
+
+def test_hall_incremental_sync_converges_with_full_sync_and_repairs_older_history(app):
+    """A current-season refresh also repairs an older stale Hall loan row."""
+    seasons = {
+        2022: [_stat(49, "Chelsea U21", 6, 500, youth=True)],
+        2023: [_stat(34, "Newcastle", 24, 1009)],
+        2024: [_stat(34, "Newcastle", 34, 2660)],
+        2025: [_stat(34, "Newcastle", 45, 3263)],
+    }
+    player_id = 284493
+    journey, tracked, _entries = _sync(
+        player_id,
+        "L. Hall Incremental",
+        49,
+        seasons,
+        HALL_TRANSFERS,
+    )
+
+    def persisted_state():
+        entries = PlayerJourneyEntry.query.filter_by(journey_id=journey.id).all()
+        return {
+            "tracked": (
+                tracked.status,
+                tracked.current_club_api_id,
+                tracked.current_club_name,
+                tracked.sale_fee,
+                tracked.is_active,
+            ),
+            "journey": (
+                journey.current_club_api_id,
+                journey.current_club_name,
+                journey.current_status,
+                journey.current_owner_api_id,
+                journey.current_owner_name,
+                journey.total_loan_apps,
+            ),
+            "entries": {
+                season: (
+                    _entry(entries, season, 34).entry_type,
+                    _entry(entries, season, 34).transfer_date,
+                    _entry(entries, season, 34).transfer_fee,
+                )
+                for season in (2023, 2024, 2025)
+            },
+            "rollups": {
+                season: (
+                    PlayerSeasonTotal.query.filter_by(
+                        player_api_id=player_id,
+                        season=season,
+                        level_group="senior",
+                    )
+                    .one()
+                    .appearances,
+                    PlayerSeasonTotal.query.filter_by(
+                        player_api_id=player_id,
+                        season=season,
+                        level_group="senior",
+                    )
+                    .one()
+                    .minutes,
+                )
+                for season in (2023, 2024, 2025)
+            },
+        }
+
+    full_state = persisted_state()
+    assert full_state["entries"] == {
+        2023: ("loan", "2023-08-22", None),
+        2024: ("first_team", "2024-07-01", "€ 33M"),
+        2025: ("first_team", "2024-07-01", "€ 33M"),
+    }
+
+    stale_entry = PlayerJourneyEntry.query.filter_by(
+        journey_id=journey.id,
+        season=2024,
+        club_api_id=34,
+    ).one()
+    stale_entry.entry_type = "loan"
+    stale_entry.transfer_date = "2023-08-22"
+    stale_entry.transfer_fee = None
+    tracked.status = "on_loan"
+    tracked.sale_fee = None
+    journey.current_status = "on_loan"
+    journey.current_owner_api_id = 49
+    journey.current_owner_name = "Chelsea"
+    journey.total_loan_apps = 58
+    stale_total = PlayerSeasonTotal.query.filter_by(
+        player_api_id=player_id,
+        season=2024,
+        level_group="senior",
+    ).one()
+    stale_total.appearances = -1
+    stale_total.minutes = -1
+    db.session.commit()
+
+    incremental_api = _FakeAPI(player_id, "L. Hall Incremental", seasons, HALL_TRANSFERS)
+    service = JourneySyncService(incremental_api)
+    service._auto_geocode_clubs = lambda synced_journey: None
+    synced = service.sync_player(player_id, force_full=False)
+
+    assert synced is not None
+    assert synced.sync_error is None
+    # In 2026 only 2025 is re-fetched, while all persisted seasons are still
+    # reclassified against the single chronological resolution.
+    assert incremental_api.player_seasons_requested == [2025]
+    assert persisted_state() == full_state
+
+
+def test_transfer_fetch_failure_preserves_existing_tracked_transfer_state(app, caplog):
+    seasons = {
+        2023: [_stat(49, "Chelsea U21", 6, 500, youth=True)],
+        2025: [_stat(34, "Newcastle", 45, 3263)],
+    }
+    _seed_transfer_teams(HALL_TRANSFERS)
+    chelsea = Team.query.filter_by(team_id=49, season=2025).one()
+    journey = PlayerJourney(
+        player_api_id=884492,
+        player_name="Transfer Fetch Canary",
+        current_club_api_id=34,
+        current_club_name="Newcastle",
+        current_level="First Team",
+        academy_club_ids=[49],
+        academy_last_seasons={"49": 2023},
+        seasons_synced=[2023, 2025],
+    )
+    db.session.add(journey)
+    db.session.flush()
+    tracked = TrackedPlayer(
+        player_api_id=884492,
+        player_name="Transfer Fetch Canary",
+        team_id=chelsea.id,
+        journey_id=journey.id,
+        status="sold",
+        current_club_api_id=34,
+        current_club_name="Newcastle",
+        sale_fee="€ 33M",
+        data_source="journey-sync",
+        last_academy_season=2023,
+        is_active=True,
+    )
+    db.session.add(tracked)
+    db.session.commit()
+
+    service = JourneySyncService(_FailingTransferAPI(884492, "Transfer Fetch Canary", seasons, []))
+    service._auto_geocode_clubs = lambda synced_journey: None
+    synced = service.sync_player(884492, force_full=True)
+    db.session.refresh(tracked)
+
+    assert synced is not None
+    assert synced.sync_error is None
+    assert synced.last_synced_at is not None
+    assert "Failed to get transfers for player 884492" in caplog.text
+    assert tracked.is_active is True
+    assert tracked.status == "sold"
+    assert tracked.sale_fee == "€ 33M"
+    assert tracked.current_club_api_id == 34
+    assert tracked.current_club_name == "Newcastle"
+
+
+def test_fresh_active_loan_populates_borrower_and_current_owner(app):
+    transfers = [
+        _transfer("2026-07-10", "Loan", 49, "Chelsea", 44, "Burnley"),
+    ]
+    seasons = {
+        2024: [_stat(49, "Chelsea U21", 6, 500, youth=True)],
+        2026: [_stat(44, "Burnley", 2, 140)],
+    }
+
+    journey, tracked, entries = _sync(
+        884495,
+        "Active Loan Canary",
+        49,
+        seasons,
+        transfers,
+    )
+    borrower = _entry(entries, 2026, 44)
+
+    assert tracked.status == "on_loan"
+    assert tracked.current_club_api_id == 44
+    assert tracked.current_club_name == "Burnley"
+    assert tracked.sale_fee is None
+    assert (borrower.entry_type, borrower.transfer_date, borrower.transfer_fee) == (
+        "loan",
+        "2026-07-10",
+        None,
+    )
+    assert journey.current_club_api_id == 44
+    assert journey.current_club_name == "Burnley"
+    assert journey.current_status == "on_loan"
+    assert journey.current_owner_api_id == 49
+    assert journey.current_owner_name == "Chelsea"
+
+
+def test_mills_reverse_na_return_clears_status_owner_and_moves_home(app):
+    transfers = [
+        _transfer("2024-01-08", "N/A", 1338, "Oxford United", 7193, "Everton U21"),
+        _transfer("2023-07-27", "Loan", 45, "Everton", 1338, "Oxford United"),
+    ]
+    seasons = {
+        2022: [_stat(45, "Everton U21", 6, 500, youth=True)],
+        2023: [_stat(1338, "Oxford United", 10, 800)],
+        2025: [_stat(45, "Everton U21", 6, 500, youth=True)],
+    }
+
+    journey, tracked, entries = _sync(284187, "S. Mills", 45, seasons, transfers)
+    oxford = _entry(entries, 2023, 1338)
+
+    assert tracked.status == "academy"
+    assert tracked.sale_fee is None
+    assert (oxford.entry_type, oxford.transfer_date, oxford.transfer_fee) == (
+        "loan",
+        "2023-07-27",
+        None,
+    )
+    # The resolver preserves the provider's raw affiliate id while matching it
+    # to Everton's owning organisation for academy-relative classification.
+    assert journey.current_club_api_id == 7193
+    assert journey.current_club_name == "Everton U21"
+    assert journey.current_status is None
+    assert journey.current_owner_api_id is None
+    assert journey.current_owner_name is None
+
+
+def test_saadi_same_day_return_then_free_transfer_becomes_permanent(app):
+    transfers = [
+        _transfer("2024-09-09", "Loan", 67, "Blackburn", 3412, "Ethnikos Achna"),
+        _transfer("2025-07-01", "Free Transfer", 67, "Blackburn", 3412, "Ethnikos Achna"),
+        _transfer("2025-07-01", "Back from Loan", 3412, "Ethnikos Achna", 67, "Blackburn"),
+    ]
+    seasons = {
+        2023: [_stat(67, "Blackburn U21", 6, 500, youth=True)],
+        2024: [_stat(3412, "Ethnikos Achna", 20, 1400)],
+        2025: [_stat(3412, "Ethnikos Achna", 24, 1800)],
+    }
+
+    journey, tracked, entries = _sync(298095, "J. Saadi", 67, seasons, transfers)
+    loan_season = _entry(entries, 2024, 3412)
+    permanent_season = _entry(entries, 2025, 3412)
+
+    assert tracked.status == "sold"
+    assert tracked.sale_fee == "Free Transfer"
+    assert (loan_season.entry_type, loan_season.transfer_date, loan_season.transfer_fee) == (
+        "loan",
+        "2024-09-09",
+        None,
+    )
+    assert (
+        permanent_season.entry_type,
+        permanent_season.transfer_date,
+        permanent_season.transfer_fee,
+    ) == ("first_team", "2025-07-01", "Free Transfer")
+    assert (journey.current_club_api_id, journey.current_club_name) == (3412, "Ethnikos Achna")
+    assert journey.current_status is None
+    assert journey.current_owner_api_id is None
+    assert journey.current_owner_name is None
+
+
+def test_zuccon_reloan_uses_the_new_episode_without_claiming_it_is_current_forever(app):
+    transfers = [
+        _transfer("2024-08-23", "Loan", 499, "Atalanta", 863, "Juve Stabia"),
+        _transfer("2025-09-01", "Loan", 22104, "Atalanta II", 863, "Juve Stabia"),
+        _transfer("2025-08-31", "Loan", 499, "Atalanta", 863, "Juve Stabia"),
+    ]
+    seasons = {
+        2023: [_stat(499, "Atalanta U21", 6, 500, youth=True)],
+        2024: [_stat(863, "Juve Stabia", 18, 1200)],
+        2025: [_stat(863, "Juve Stabia", 22, 1600)],
+    }
+
+    journey, tracked, entries = _sync(336639, "F. Zuccon", 499, seasons, transfers)
+    first_loan = _entry(entries, 2024, 863)
+    reloan = _entry(entries, 2025, 863)
+
+    assert tracked.status == "left"
+    assert tracked.sale_fee is None
+    assert (first_loan.entry_type, first_loan.transfer_date, first_loan.transfer_fee) == (
+        "loan",
+        "2024-08-23",
+        None,
+    )
+    assert (reloan.entry_type, reloan.transfer_date, reloan.transfer_fee) == (
+        "loan",
+        "2025-08-31",
+        None,
+    )
+    assert (journey.current_club_api_id, journey.current_club_name) == (863, "Juve Stabia")
+    assert journey.current_status is None
+    assert journey.current_owner_api_id is None
+    assert journey.current_owner_name is None
+
+
+def test_aseko_affiliate_return_clears_hannover_as_current_loan(app):
+    transfers = [
+        _transfer("2025-07-01", "N/A", 166, "Hannover 96", 4674, "Bayern München II"),
+        _transfer("2025-02-03", "Loan", 4674, "Bayern München II", 166, "Hannover 96"),
+        _transfer("2026-06-29", "Return from loan", 166, "Hannover 96", 157, "Bayern München"),
+    ]
+    seasons = {
+        2023: [_stat(157, "Bayern München U21", 6, 500, youth=True)],
+        2024: [_stat(166, "Hannover 96", 11, 850)],
+    }
+
+    journey, tracked, entries = _sync(342171, "N. Aséko Nkili", 157, seasons, transfers)
+    hannover = _entry(entries, 2024, 166)
+
+    assert tracked.status == "first_team"
+    assert tracked.sale_fee is None
+    assert (hannover.entry_type, hannover.transfer_date, hannover.transfer_fee) == (
+        "loan",
+        "2025-02-03",
+        None,
+    )
+    assert (journey.current_club_api_id, journey.current_club_name) == (157, "Bayern München")
+    assert journey.current_status is None
+    assert journey.current_owner_api_id is None
+    assert journey.current_owner_name is None
+
+
+def test_knauff_and_asllani_conversions_preserve_historical_loans_and_clear_current_owners(app, monkeypatch):
+    # Keep the older academy evidence in scope so this regression exercises
+    # transfer conversion, not the independently tested academy-window gate.
+    monkeypatch.setenv("ACADEMY_WINDOW_YEARS", "5")
+    knauff_transfers = [
+        _transfer(
+            "2023-07-01",
+            "€ 5M",
+            165,
+            "Borussia Dortmund",
+            169,
+            "Eintracht Frankfurt",
+        ),
+        _transfer(
+            "2022-01-20",
+            "Loan",
+            165,
+            "Borussia Dortmund",
+            169,
+            "Eintracht Frankfurt",
+        ),
+    ]
+    knauff_seasons = {
+        2021: [_stat(165, "Borussia Dortmund U21", 6, 500, youth=True)],
+        2022: [_stat(169, "Eintracht Frankfurt", 25, 1800)],
+        2023: [_stat(169, "Eintracht Frankfurt", 30, 2200)],
+    }
+    knauff_journey, knauff, knauff_entries = _sync(
+        161922,
+        "A. Knauff",
+        165,
+        knauff_seasons,
+        knauff_transfers,
+    )
+
+    assert (knauff.status, knauff.sale_fee) == ("sold", "€ 5M")
+    assert (
+        _entry(knauff_entries, 2022, 169).entry_type,
+        _entry(knauff_entries, 2022, 169).transfer_date,
+        _entry(knauff_entries, 2022, 169).transfer_fee,
+    ) == ("loan", "2022-01-20", None)
+    assert (
+        _entry(knauff_entries, 2023, 169).entry_type,
+        _entry(knauff_entries, 2023, 169).transfer_date,
+        _entry(knauff_entries, 2023, 169).transfer_fee,
+    ) == ("first_team", "2023-07-01", "€ 5M")
+    assert (knauff_journey.current_club_api_id, knauff_journey.current_club_name) == (
+        169,
+        "Eintracht Frankfurt",
+    )
+    assert knauff_journey.current_status is None
+    assert knauff_journey.current_owner_api_id is None
+    assert knauff_journey.current_owner_name is None
+
+    asllani_transfers = [
+        _transfer("2023-07-01", "€ 10M", 511, "Empoli", 505, "Inter"),
+        _transfer("2022-07-01", "Loan", 511, "Empoli", 505, "Inter"),
+        _transfer("2025-08-25", "Loan", 505, "Inter", 503, "Torino"),
+        _transfer("2026-01-29", "Return from loan", 503, "Torino", 505, "Inter"),
+        _transfer("2026-01-29", "Loan", 505, "Inter", 549, "Beşiktaş"),
+        _transfer("2026-06-29", "Return from loan", 549, "Beşiktaş", 505, "Inter"),
+    ]
+    asllani_seasons = {
+        2021: [_stat(511, "Empoli U21", 6, 500, youth=True)],
+        2022: [_stat(505, "Inter", 20, 1400)],
+        2023: [_stat(505, "Inter", 28, 1900)],
+        2025: [
+            _stat(503, "Torino", 12, 800),
+            _stat(549, "Beşiktaş", 9, 600),
+        ],
+    }
+    asllani_journey, asllani, asllani_entries = _sync(
+        275776,
+        "K. Asllani",
+        511,
+        asllani_seasons,
+        asllani_transfers,
+    )
+
+    inter_loan = _entry(asllani_entries, 2022, 505)
+    inter_permanent = _entry(asllani_entries, 2023, 505)
+    torino = _entry(asllani_entries, 2025, 503)
+    besiktas = _entry(asllani_entries, 2025, 549)
+    assert (asllani.status, asllani.sale_fee) == ("sold", "€ 10M")
+    assert (inter_loan.entry_type, inter_loan.transfer_date, inter_loan.transfer_fee) == (
+        "loan",
+        "2022-07-01",
+        None,
+    )
+    assert (
+        inter_permanent.entry_type,
+        inter_permanent.transfer_date,
+        inter_permanent.transfer_fee,
+    ) == ("first_team", "2023-07-01", "€ 10M")
+    assert (torino.entry_type, torino.transfer_date, torino.transfer_fee) == (
+        "loan",
+        "2025-08-25",
+        None,
+    )
+    assert (besiktas.entry_type, besiktas.transfer_date, besiktas.transfer_fee) == (
+        "loan",
+        "2026-01-29",
+        None,
+    )
+    assert (asllani_journey.current_club_api_id, asllani_journey.current_club_name) == (505, "Inter")
+    assert asllani_journey.current_status is None
+    assert asllani_journey.current_owner_api_id is None
+    assert asllani_journey.current_owner_name is None

--- a/academy-watch-backend/tests/test_transfer_events.py
+++ b/academy-watch-backend/tests/test_transfer_events.py
@@ -1,0 +1,168 @@
+"""Durable transfer-event persistence regressions."""
+
+import importlib
+from copy import deepcopy
+from datetime import UTC, datetime
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from src.models.league import db
+from src.models.transfer_event import PlayerTransferEvent
+from src.services.transfer_events import record_transfer_events
+
+PLAYER_ID = 284492
+HALL_TRANSFERS = [
+    {
+        "date": "2023-08-22",
+        "type": "Loan",
+        "teams": {
+            "out": {"id": 49, "name": "Chelsea", "logo": "chelsea.png"},
+            "in": {"id": 34, "name": "Newcastle", "logo": "newcastle.png"},
+        },
+    },
+    {
+        "date": "2024-07-01",
+        "type": "€ 33M",
+        "teams": {
+            "out": {"id": 49, "name": "Chelsea", "logo": "chelsea.png"},
+            "in": {"id": 34, "name": "Newcastle", "logo": "newcastle.png"},
+        },
+    },
+]
+
+
+def _utc(value):
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
+
+
+def test_tre01_migration_matches_model_metadata(monkeypatch):
+    migration = importlib.import_module("migrations.versions.tre01_player_transfer_events")
+    captured = {}
+
+    def capture_table(name, *elements):
+        captured["table"] = sa.Table(name, sa.MetaData(), *elements)
+
+    def capture_index(name, table_name, columns, **kwargs):
+        captured["index"] = (name, table_name, tuple(columns), kwargs)
+
+    monkeypatch.setattr(migration, "table_exists", lambda table_name: False)
+    monkeypatch.setattr(migration.op, "create_table", capture_table)
+    monkeypatch.setattr(migration, "create_index_safe", capture_index)
+    monkeypatch.setattr(migration.op, "execute", lambda statement: captured.setdefault("rls", statement))
+
+    migration.upgrade()
+
+    migration_table = captured["table"]
+    model_table = PlayerTransferEvent.__table__
+    dialect = postgresql.dialect()
+
+    assert migration_table.name == model_table.name == "player_transfer_events"
+    assert list(migration_table.c.keys()) == list(model_table.c.keys())
+    for name in migration_table.c.keys():
+        migration_column = migration_table.c[name]
+        model_column = model_table.c[name]
+        assert migration_column.type.compile(dialect=dialect) == model_column.type.compile(dialect=dialect)
+        assert migration_column.nullable == model_column.nullable
+        assert migration_column.primary_key == model_column.primary_key
+        assert migration_column.autoincrement == model_column.autoincrement
+
+    def unique_contract(table):
+        return {
+            (
+                constraint.name,
+                tuple(column.name for column in constraint.columns),
+                constraint.dialect_options["postgresql"].get("nulls_not_distinct"),
+            )
+            for constraint in table.constraints
+            if isinstance(constraint, sa.UniqueConstraint)
+        }
+
+    assert unique_contract(migration_table) == unique_contract(model_table)
+
+    model_indexes = {(index.name, tuple(column.name for column in index.columns)) for index in model_table.indexes}
+    index_name, table_name, columns, kwargs = captured["index"]
+    assert (index_name, columns) in model_indexes
+    assert table_name == model_table.name
+    assert kwargs == {}
+    assert captured["rls"] == "ALTER TABLE player_transfer_events ENABLE ROW LEVEL SECURITY"
+
+
+def test_record_transfer_events_is_idempotent_and_advances_last_seen(app):
+    first_observation = datetime(2026, 7, 16, 9, 0, tzinfo=UTC)
+    second_observation = datetime(2026, 7, 16, 10, 0, tzinfo=UTC)
+
+    assert record_transfer_events(PLAYER_ID, HALL_TRANSFERS, db.session, observed_at=first_observation) == 2
+    db.session.commit()
+
+    original = PlayerTransferEvent.query.order_by(PlayerTransferEvent.transfer_date).all()
+    original_ids = [row.id for row in original]
+    assert len(original) == 2
+    assert all(_utc(row.first_seen_at) == first_observation for row in original)
+    assert all(_utc(row.last_seen_at) == first_observation for row in original)
+    assert [row.raw for row in original] == HALL_TRANSFERS
+
+    assert record_transfer_events(PLAYER_ID, HALL_TRANSFERS, db.session, observed_at=second_observation) == 2
+    db.session.commit()
+
+    repeated = PlayerTransferEvent.query.order_by(PlayerTransferEvent.transfer_date).all()
+    assert PlayerTransferEvent.query.count() == 2
+    assert [row.id for row in repeated] == original_ids
+    assert all(_utc(row.first_seen_at) == first_observation for row in repeated)
+    assert all(_utc(row.last_seen_at) == second_observation for row in repeated)
+
+
+def test_provider_revision_conflict_only_advances_last_seen(app):
+    initial = datetime(2026, 7, 16, 9, 0, tzinfo=UTC)
+    revised = datetime(2026, 7, 16, 11, 0, tzinfo=UTC)
+    event = deepcopy(HALL_TRANSFERS[1])
+    record_transfer_events(PLAYER_ID, [event], db.session, observed_at=initial)
+    db.session.commit()
+
+    event["teams"]["out"]["name"] = "Chelsea FC"
+    event["teams"]["in"]["name"] = "Newcastle United"
+    event["provider_revision"] = 2
+    record_transfer_events(PLAYER_ID, [event], db.session, observed_at=revised)
+    db.session.commit()
+
+    row = PlayerTransferEvent.query.one()
+    assert row.out_club_name == "Chelsea"
+    assert row.in_club_name == "Newcastle"
+    assert row.raw == HALL_TRANSFERS[1]
+    assert _utc(row.first_seen_at) == initial
+    assert _utc(row.last_seen_at) == revised
+
+
+def test_older_observation_cannot_move_last_seen_backward(app):
+    newer = datetime(2026, 7, 16, 12, 0, tzinfo=UTC)
+    older = datetime(2026, 7, 16, 8, 0, tzinfo=UTC)
+
+    record_transfer_events(PLAYER_ID, [HALL_TRANSFERS[1]], db.session, observed_at=newer)
+    db.session.commit()
+    record_transfer_events(PLAYER_ID, [HALL_TRANSFERS[1]], db.session, observed_at=older)
+    db.session.commit()
+
+    row = PlayerTransferEvent.query.one()
+    assert _utc(row.last_seen_at) == newer
+
+
+def test_nullable_natural_key_remains_idempotent(app):
+    """Malformed evidence remains durable under SQLite's NULL-distinct UNIQUE."""
+
+    first_observation = datetime(2026, 7, 16, 9, 0, tzinfo=UTC)
+    second_observation = datetime(2026, 7, 16, 12, 0, tzinfo=UTC)
+    incomplete = {
+        "date": "2025-07-01",
+        "type": None,
+        "teams": {"out": {"name": "Unknown"}, "in": {"id": 34, "name": "Newcastle"}},
+    }
+
+    record_transfer_events(PLAYER_ID, [incomplete], db.session, observed_at=first_observation)
+    db.session.commit()
+    record_transfer_events(PLAYER_ID, [incomplete], db.session, observed_at=second_observation)
+    db.session.commit()
+    record_transfer_events(PLAYER_ID, [incomplete], db.session, observed_at=first_observation)
+    db.session.commit()
+
+    row = PlayerTransferEvent.query.one()
+    assert _utc(row.first_seen_at) == first_observation
+    assert _utc(row.last_seen_at) == second_observation

--- a/academy-watch-backend/tests/test_transfer_heal_fee_consistency.py
+++ b/academy-watch-backend/tests/test_transfer_heal_fee_consistency.py
@@ -1,0 +1,276 @@
+"""Hermetic transfer-heal regressions for parent-relative sale fees."""
+
+from src.models.journey import PlayerJourney, PlayerJourneyEntry
+from src.models.league import Team, db
+from src.models.season_rollup import LeagueSeasonConfig
+from src.models.tracked_player import TrackedPlayer
+from src.services import transfer_heal_service
+
+
+def _transfer(transfer_date, transfer_type, out_id, out_name, in_id, in_name):
+    return {
+        "date": transfer_date,
+        "type": transfer_type,
+        "teams": {
+            "out": {"id": out_id, "name": out_name},
+            "in": {"id": in_id, "name": in_name},
+        },
+    }
+
+
+class _FakeAPI:
+    def __init__(self, raw_transfers_by_player, squad_player_ids):
+        self.raw_transfers_by_player = raw_transfers_by_player
+        self.squad_player_ids = set(squad_player_ids)
+
+    def batch_get_player_transfers(self, player_ids):
+        assert set(player_ids) == self.squad_player_ids
+        return self.raw_transfers_by_player
+
+    def get_team_players(self, club_id):
+        assert club_id > 0
+        return [{"player": {"id": player_id}} for player_id in self.squad_player_ids]
+
+
+def _team(team_api_id, name):
+    team = Team(
+        team_id=team_api_id,
+        name=name,
+        country="Test Country",
+        season=2025,
+        is_active=True,
+    )
+    db.session.add(team)
+    db.session.flush()
+    return team
+
+
+def _tracked_player(
+    player_api_id,
+    parent,
+    *,
+    journey_club_id,
+    journey_club_name,
+    journey_level,
+    status,
+    current_club_id,
+    current_club_name,
+    sale_fee,
+):
+    journey = PlayerJourney(
+        player_api_id=player_api_id,
+        player_name=f"Player {player_api_id}",
+        current_club_api_id=journey_club_id,
+        current_club_name=journey_club_name,
+        current_level=journey_level,
+        academy_club_ids=[parent.team_id],
+        academy_last_seasons={str(parent.team_id): 2025},
+    )
+    db.session.add(journey)
+    db.session.flush()
+    tracked = TrackedPlayer(
+        player_api_id=player_api_id,
+        player_name=f"Player {player_api_id}",
+        team_id=parent.id,
+        journey_id=journey.id,
+        status=status,
+        current_club_api_id=current_club_id,
+        current_club_name=current_club_name,
+        sale_fee=sale_fee,
+        data_source="journey-sync",
+        last_academy_season=2025,
+        is_active=True,
+    )
+    db.session.add(tracked)
+    db.session.commit()
+    return tracked
+
+
+def _install_api(monkeypatch, raw_transfers_by_player, *player_api_ids):
+    fake = _FakeAPI(raw_transfers_by_player, player_api_ids)
+    monkeypatch.setattr(transfer_heal_service, "APIFootballClient", lambda: fake)
+    return fake
+
+
+def test_heal_writes_the_parent_departure_fee_not_a_later_resale(app, monkeypatch):
+    parent = _team(49, "Chelsea")
+    _team(34, "Newcastle")
+    _team(529, "Barcelona")
+    tracked = _tracked_player(
+        884492,
+        parent,
+        journey_club_id=529,
+        journey_club_name="Barcelona",
+        journey_level="First Team",
+        status="on_loan",
+        current_club_id=529,
+        current_club_name="Barcelona",
+        sale_fee=None,
+    )
+    transfers = [
+        _transfer("2025-07-01", "€ 55M", 34, "Newcastle", 529, "Barcelona"),
+        _transfer("2024-07-01", "€ 33M", 49, "Chelsea", 34, "Newcastle"),
+    ]
+    _install_api(
+        monkeypatch,
+        {884492: [{"player": {"id": 884492}, "transfers": transfers}]},
+        884492,
+    )
+
+    real_resolve = transfer_heal_service.resolve_transfer_state
+    real_classify = transfer_heal_service.classify_tracked_player
+    built_resolutions = []
+    injected_resolutions = []
+
+    def recording_resolve(*args, **kwargs):
+        resolution = real_resolve(*args, **kwargs)
+        built_resolutions.append(resolution)
+        return resolution
+
+    def recording_classify(*args, **kwargs):
+        injected_resolutions.append(kwargs.get("transfer_resolution"))
+        return real_classify(*args, **kwargs)
+
+    monkeypatch.setattr(transfer_heal_service, "resolve_transfer_state", recording_resolve)
+    monkeypatch.setattr(transfer_heal_service, "classify_tracked_player", recording_classify)
+
+    result = transfer_heal_service.refresh_and_heal(
+        resync_journeys=False,
+        cascade_fixtures=False,
+    )
+    db.session.refresh(tracked)
+
+    assert result["updated"] == 1
+    assert tracked.status == "sold"
+    assert tracked.current_club_api_id == 529
+    assert tracked.current_club_name == "Barcelona"
+    assert tracked.sale_fee == "€ 33M"
+    assert len(built_resolutions) == 1
+    assert injected_resolutions == built_resolutions
+
+
+def test_heal_clears_a_stale_sale_fee_when_status_becomes_non_sold(app, monkeypatch):
+    parent = _team(49, "Chelsea")
+    _team(34, "Newcastle")
+    tracked = _tracked_player(
+        884493,
+        parent,
+        journey_club_id=49,
+        journey_club_name="Chelsea",
+        journey_level="First Team",
+        status="sold",
+        current_club_id=34,
+        current_club_name="Newcastle",
+        sale_fee="€ 33M",
+    )
+    _install_api(monkeypatch, {884493: []}, 884493)
+
+    result = transfer_heal_service.refresh_and_heal(
+        resync_journeys=False,
+        cascade_fixtures=False,
+    )
+    db.session.refresh(tracked)
+
+    assert result["updated"] == 1
+    assert tracked.status == "first_team"
+    assert tracked.current_club_api_id == 49
+    assert tracked.current_club_name == "Chelsea"
+    assert tracked.sale_fee is None
+
+
+def test_heal_missing_transfer_prefetch_leaves_transfer_fields_untouched(app, monkeypatch):
+    parent = _team(49, "Chelsea")
+    _team(34, "Newcastle")
+    tracked = _tracked_player(
+        884494,
+        parent,
+        journey_club_id=49,
+        journey_club_name="Chelsea",
+        journey_level="First Team",
+        status="sold",
+        current_club_id=34,
+        current_club_name="Newcastle",
+        sale_fee="€ 33M",
+    )
+    _install_api(monkeypatch, {}, 884494)
+
+    def unexpected_resolution(*args, **kwargs):
+        raise AssertionError("missing transfer prefetch must skip resolution")
+
+    monkeypatch.setattr(
+        transfer_heal_service,
+        "resolve_transfer_state",
+        unexpected_resolution,
+    )
+
+    result = transfer_heal_service.refresh_and_heal(
+        resync_journeys=False,
+        cascade_fixtures=False,
+    )
+    db.session.refresh(tracked)
+
+    assert result["updated"] == 0
+    assert result["skipped_by_failed_prefetch"] == 1
+    assert tracked.status == "sold"
+    assert tracked.current_club_api_id == 34
+    assert tracked.current_club_name == "Newcastle"
+    assert tracked.sale_fee == "€ 33M"
+
+
+def test_heal_uses_calendar_year_boundary_for_active_loan(app, monkeypatch):
+    parent = _team(49, "Chelsea")
+    _team(44, "Burnley")
+    tracked = _tracked_player(
+        884496,
+        parent,
+        journey_club_id=44,
+        journey_club_name="Burnley",
+        journey_level="First Team",
+        status="left",
+        current_club_id=44,
+        current_club_name="Burnley",
+        sale_fee=None,
+    )
+    db.session.add(
+        LeagueSeasonConfig(
+            league_api_id=999,
+            season_type="calendar",
+            rollover_month=1,
+        )
+    )
+    db.session.add(
+        PlayerJourneyEntry(
+            journey_id=tracked.journey_id,
+            player_api_id=884496,
+            season=2026,
+            club_api_id=44,
+            club_name="Burnley",
+            league_api_id=999,
+            league_name="Calendar League",
+            level="First Team",
+            entry_type="first_team",
+            is_youth=False,
+            is_international=False,
+            appearances=2,
+            minutes=180,
+            sort_priority=100,
+        )
+    )
+    db.session.commit()
+    transfers = [_transfer("2026-02-01", "Loan", 49, "Chelsea", 44, "Burnley")]
+    _install_api(
+        monkeypatch,
+        {884496: [{"player": {"id": 884496}, "transfers": transfers}]},
+        884496,
+    )
+
+    result = transfer_heal_service.refresh_and_heal(
+        resync_journeys=False,
+        cascade_fixtures=False,
+    )
+    db.session.refresh(tracked)
+
+    assert result["updated"] == 1
+    assert tracked.status == "on_loan"
+    assert tracked.current_club_api_id == 44
+    assert tracked.current_club_name == "Burnley"

--- a/academy-watch-backend/tests/test_transfer_resolver.py
+++ b/academy-watch-backend/tests/test_transfer_resolver.py
@@ -389,6 +389,58 @@ def test_concrete_na_without_active_episode_uses_state_continuity_not_the_string
     assert "ambiguous_na" in {issue.code for issue in no_topology.issues}
 
 
+def test_first_na_uses_explicit_initial_owner_context():
+    event = transfer("2025-06-30", "N/A", 33, "Parent", 200, "Destination")
+
+    without_context = resolve_transfer_state([event], as_of="2026-07-16")
+    with_context = resolve_transfer_state(
+        [event],
+        as_of="2026-07-16",
+        initial_owner={"id": 33, "name": "Parent"},
+    )
+
+    assert without_context.events[0].kind == "unknown"
+    assert with_context.events[0].kind == "permanent"
+    assert with_context.events[0].reason == "topology_na_permanent"
+    assert with_context.current_club.api_id == 200
+    assert with_context.legal_owner.api_id == 200
+    assert with_context.on_loan is False
+
+
+def test_permanent_departure_without_destination_remains_resolvable_evidence():
+    event = transfer("2025-06-30", "Free agent", 33, "Parent", None, None)
+
+    result = resolve_transfer_state(
+        [event],
+        as_of="2026-07-16",
+        initial_owner={"id": 33, "name": "Parent"},
+    )
+
+    assert result.events[0].kind == "permanent"
+    assert result.latest_permanent_move is result.events[0]
+    assert result.current_club.api_id is None
+    assert result.current_club.name is None
+    assert result.on_loan is False
+    assert "missing_in_club" in {issue.code for issue in result.issues}
+
+
+def test_exact_duplicate_release_without_destination_is_coalesced_without_false_name_fallback():
+    event = transfer("2025-06-30", "Free agent", 33, "Parent", None, None)
+
+    result = resolve_transfer_state(
+        [deepcopy(event), deepcopy(event)],
+        as_of="2026-07-16",
+        initial_owner={"id": 33, "name": "Parent"},
+    )
+
+    assert len(result.normalized_events) == 2
+    assert len(result.events) == 1
+    assert len(result.events[0].evidence) == 2
+    assert result.events[0].kind == "permanent"
+    assert "missing_in_club" in {issue.code for issue in result.issues}
+    assert "missing_in_club_id" not in {issue.code for issue in result.issues}
+
+
 def test_owner_to_third_club_na_supersedes_an_open_loan():
     result = resolve_transfer_state(
         [

--- a/academy-watch-backend/tests/test_transfer_resolver.py
+++ b/academy-watch-backend/tests/test_transfer_resolver.py
@@ -1,0 +1,488 @@
+"""Regression tests for the pure chronological transfer resolver."""
+
+from copy import deepcopy
+from datetime import date
+from random import Random
+from types import SimpleNamespace
+
+import pytest
+from src.services.transfer_resolver import (
+    loan_episode_overlaps_season,
+    normalize_transfer_events,
+    resolve_transfer_state,
+)
+
+
+def transfer(
+    transfer_date,
+    transfer_type,
+    out_id,
+    out_name,
+    in_id,
+    in_name,
+):
+    return {
+        "date": transfer_date,
+        "type": transfer_type,
+        "teams": {
+            "out": {"id": out_id, "name": out_name},
+            "in": {"id": in_id, "name": in_name},
+        },
+    }
+
+
+HALL = [
+    transfer("2023-08-22", "Loan", 49, "Chelsea", 34, "Newcastle"),
+    transfer("2024-07-01", "€ 33M", 49, "Chelsea", 34, "Newcastle"),
+]
+
+
+def test_hall_is_identical_in_original_reversed_and_shuffled_order():
+    shuffled = deepcopy(HALL)
+    Random(284492).shuffle(shuffled)
+    variants = (HALL, list(reversed(HALL)), shuffled)
+
+    resolutions = [resolve_transfer_state(events, as_of=date(2026, 7, 16)) for events in variants]
+
+    assert resolutions[0] == resolutions[1] == resolutions[2]
+    result = resolutions[0]
+    assert [event.kind for event in result.events] == ["loan_start", "permanent"]
+    assert len(result.loan_episodes) == 1
+    episode = result.loan_episodes[0]
+    assert (episode.start_date, episode.end_date, episode.end_reason) == (
+        date(2023, 8, 22),
+        date(2024, 7, 1),
+        "permanent_conversion",
+    )
+    assert result.current_club.api_id == 34
+    assert result.current_owner is None
+    assert result.legal_owner.api_id == 34
+    assert result.on_loan is False
+    assert result.loan_state == "not_on_loan"
+    assert result.latest_permanent_move.date == date(2024, 7, 1)
+    assert result.latest_permanent_move.fee == "€ 33M"
+
+
+@pytest.mark.parametrize(
+    ("permanent_type", "expected_fee"),
+    [
+        ("€ 5M", "€ 5M"),
+        ("Transfer", "Transfer"),
+        ("Free", "Free"),
+        ("Free Transfer", "Free Transfer"),
+        ("N/A", None),
+    ],
+)
+def test_same_destination_permanent_variants_close_the_loan(permanent_type, expected_fee):
+    result = resolve_transfer_state(
+        [
+            transfer("2023-01-10", "Loan", 10, "Parent", 20, "Borrower"),
+            transfer("2024-01-10", permanent_type, 10, "Parent", 20, "Borrower"),
+        ],
+        as_of="2024-01-10",
+    )
+
+    assert [event.kind for event in result.events] == ["loan_start", "permanent"]
+    assert result.events[-1].classification == "permanent"
+    assert result.loan_episodes[0].end_date == date(2024, 1, 10)
+    assert result.loan_episodes[0].end_reason == "permanent_conversion"
+    assert result.latest_permanent_move.fee == expected_fee
+    assert result.current_club.api_id == 20
+    assert result.current_owner is None
+    assert result.on_loan is False
+
+
+def test_hall_as_of_filters_future_state_and_uses_end_exclusive_conversion_day():
+    before = resolve_transfer_state(HALL, as_of="2024-06-30")
+    converted = resolve_transfer_state(HALL, as_of="2024-07-01")
+    before_history = resolve_transfer_state(HALL, as_of="2023-08-21")
+
+    assert before.on_loan is True
+    assert before.current_owner.api_id == 49
+    assert before.current_club.api_id == 34
+    assert before.latest_permanent_move is None
+    assert [event.kind for event in before.events] == ["loan_start"]
+    assert converted.on_loan is False
+    assert converted.current_owner is None
+    assert converted.latest_permanent_move.fee == "€ 33M"
+    assert before_history.current_club is None
+    assert before_history.current_owner is None
+    assert before_history.loan_state == "unknown"
+
+
+def test_knauff_july_first_fee_conversion_uses_the_real_adjudicated_shape():
+    result = resolve_transfer_state(
+        [
+            transfer("2022-01-20", "Loan", 165, "Borussia Dortmund", 169, "Eintracht Frankfurt"),
+            transfer("2023-07-01", "€ 5M", 165, "Borussia Dortmund", 169, "Eintracht Frankfurt"),
+        ],
+        as_of="2026-07-16",
+    )
+
+    episode = result.loan_episodes[0]
+    assert episode.end_date == date(2023, 7, 1)
+    assert episode.end_reason == "permanent_conversion"
+    assert loan_episode_overlaps_season(episode, 2022) is True
+    assert loan_episode_overlaps_season(episode, 2023) is False
+    assert result.current_club.api_id == 169
+    assert result.current_owner is None
+    assert result.latest_permanent_move.fee == "€ 5M"
+
+
+def test_explicit_returns_are_order_independent_and_date_sorted():
+    oldest_first = [
+        transfer("2024-01-01", "Loan", 1, "Owner", 2, "Borrower"),
+        transfer("2024-06-30", "Return from loan", 2, "Borrower", 1, "Owner"),
+    ]
+    newest_first = list(reversed(oldest_first))
+
+    old = resolve_transfer_state(oldest_first, as_of="2024-07-01")
+    new = resolve_transfer_state(newest_first, as_of="2024-07-01")
+
+    assert old == new
+    assert [event.date for event in old.events] == [date(2024, 1, 1), date(2024, 6, 30)]
+    assert [event.kind for event in old.events] == ["loan_start", "loan_return"]
+    assert old.loan_episodes[0].end_date == date(2024, 6, 30)
+    assert old.current_club.api_id == 1
+    assert old.current_owner is None
+    assert old.on_loan is False
+
+
+def test_july_first_is_end_exclusive_and_open_loans_do_not_reach_future_seasons():
+    closed = {"start_date": "2023-08-22", "end_date": "2024-07-01"}
+    open_old = {"start_date": "2023-08-22", "end_date": None}
+
+    assert loan_episode_overlaps_season(closed, 2023) is True
+    assert loan_episode_overlaps_season(closed, 2024) is False
+    assert loan_episode_overlaps_season(open_old, 2023) is True
+    assert loan_episode_overlaps_season(open_old, 2024) is False
+
+
+def test_season_helper_supports_calendar_years_and_june_thirty_end():
+    calendar_loan = {"start_date": "2024-02-01", "end_date": None}
+    june_end = {"start_date": "2023-09-01", "end_date": "2024-06-30"}
+
+    assert loan_episode_overlaps_season(calendar_loan, 2024, start_month=1) is True
+    assert loan_episode_overlaps_season(calendar_loan, 2025, start_month=1) is False
+    assert loan_episode_overlaps_season(june_end, 2023) is True
+    assert loan_episode_overlaps_season({"start_date": "2024-01-01", "end_date": "invalid"}, 2024) is False
+
+
+def test_midseason_conversion_still_overlaps_that_season():
+    episode = {"start_date": "2024-01-10", "end_date": "2024-02-10"}
+    assert loan_episode_overlaps_season(episode, 2023) is True
+
+
+def test_saadi_same_day_return_precedes_free_departure_even_when_reversed():
+    events = [
+        transfer("2024-09-09", "Loan", 67, "Blackburn", 7001, "Ethnikos Achna"),
+        transfer("2025-07-01", "Free Transfer", 67, "Blackburn", 7001, "Ethnikos Achna"),
+        transfer("2025-07-01", "Back from Loan", 7001, "Ethnikos Achna", 67, "Blackburn"),
+    ]
+
+    result = resolve_transfer_state(list(reversed(events)), as_of="2026-07-16")
+    same_day = [event for event in result.events if event.date == date(2025, 7, 1)]
+
+    assert [event.kind for event in same_day] == ["loan_return", "permanent"]
+    assert [(event.out_club.name, event.in_club.name) for event in same_day] == [
+        ("Ethnikos Achna", "Blackburn"),
+        ("Blackburn", "Ethnikos Achna"),
+    ]
+    assert result.loan_episodes[0].end_date == date(2025, 7, 1)
+    assert result.current_club.name == "Ethnikos Achna"
+    assert result.current_owner is None
+    assert result.latest_permanent_move.fee == "Free Transfer"
+
+
+def test_missing_reloan_return_precedes_same_day_free_departure():
+    events = [
+        transfer("2024-01-01", "Transfer", 1, "Previous", 10, "Parent"),
+        transfer("2025-07-01", "Free Transfer", 10, "Parent", 30, "Next Club"),
+        transfer("2025-07-01", "Return from loan", 20, "Missing Borrower", 10, "Parent"),
+    ]
+
+    normal = resolve_transfer_state(events, as_of="2025-07-01")
+    reversed_result = resolve_transfer_state(list(reversed(events)), as_of="2025-07-01")
+
+    assert normal == reversed_result
+    same_day = [event for event in normal.events if event.date == date(2025, 7, 1)]
+    assert [event.kind for event in same_day] == ["loan_return", "permanent"]
+    assert [(event.out_club.name, event.in_club.name) for event in same_day] == [
+        ("Missing Borrower", "Parent"),
+        ("Parent", "Next Club"),
+    ]
+    assert normal.current_club.api_id == 30
+    assert normal.legal_owner.api_id == 30
+    assert normal.current_owner is None
+    assert normal.on_loan is False
+    assert normal.latest_permanent_move.fee == "Free Transfer"
+    assert "return_without_open_loan" in {issue.code for issue in normal.issues}
+
+
+def test_mills_reverse_na_to_owner_affiliate_is_a_return():
+    result = resolve_transfer_state(
+        [
+            transfer("2023-07-27", "Loan", 45, "Everton", 1338, "Oxford United"),
+            transfer("2024-01-08", "N/A", 1338, "Oxford United", 99945, "Everton U21"),
+        ],
+        as_of="2026-07-16",
+    )
+
+    assert [event.kind for event in result.events] == ["loan_start", "loan_return"]
+    assert result.events[-1].reason == "topology_na_return"
+    assert result.current_club.organization_key == result.loan_episodes[0].owner.organization_key
+    assert result.current_owner is None
+    assert result.latest_permanent_move is None
+    assert result.on_loan is False
+
+
+@pytest.mark.parametrize(
+    ("owner", "borrower", "start", "conversion"),
+    [
+        ((505, "Inter"), (9991, "Pro Patria"), "2023-07-20", "2024-07-03"),
+        ((157, "Bayern Munich"), (785, "Karlsruhe SC"), "2023-07-01", "2024-07-01"),
+    ],
+)
+def test_same_direction_na_is_a_permanent_conversion(owner, borrower, start, conversion):
+    result = resolve_transfer_state(
+        [
+            transfer(start, "Loan", *owner, *borrower),
+            transfer(conversion, "N/A", *owner, *borrower),
+        ],
+        as_of="2025-01-01",
+    )
+
+    assert result.events[-1].kind == "permanent"
+    assert result.events[-1].reason == "topology_na_conversion"
+    assert result.loan_episodes[0].end_date == date.fromisoformat(conversion)
+    assert result.current_club.api_id == borrower[0]
+    assert result.current_owner is None
+
+
+def test_herold_near_date_duplicate_is_coalesced_before_latest_permanent():
+    events = [
+        transfer("2023-07-01", "Loan", 157, "Bayern Munich", 785, "Karlsruhe SC"),
+        transfer("2024-07-01", "N/A", 157, "Bayern Munich", 785, "Karlsruhe SC"),
+        transfer("2026-06-30", "Transfer", 785, "Karlsruhe SC", 163, "Borussia Monchengladbach"),
+        transfer("2026-06-29", "Transfer", 785, "Karlsruhe SC", 163, "Borussia Monchengladbach"),
+    ]
+
+    result = resolve_transfer_state(events, as_of="2026-07-16")
+
+    assert len(result.normalized_events) == 4
+    assert len(result.events) == 3
+    assert len(result.events[-1].evidence) == 2
+    assert result.events[-1].date == date(2026, 6, 29)
+    assert result.current_club.api_id == 163
+    assert result.latest_permanent_move == result.events[-1]
+
+
+def test_asllani_shaped_same_day_return_then_new_loan_and_later_return():
+    events = [
+        transfer("2026-06-29", "Return from loan", 549, "Besiktas", 505, "Inter"),
+        transfer("2025-07-01", "Loan", 505, "Inter", 549, "Besiktas"),
+        transfer("2025-07-01", "Return from loan", 503, "Torino", 505, "Inter"),
+        transfer("2025-01-10", "Loan", 505, "Inter", 503, "Torino"),
+    ]
+
+    result = resolve_transfer_state(events, as_of="2026-07-16")
+    same_day = [event for event in result.events if event.date == date(2025, 7, 1)]
+
+    assert [event.kind for event in same_day] == ["loan_return", "loan_start"]
+    assert len(result.loan_episodes) == 2
+    assert result.loan_episodes[0].end_date == date(2025, 7, 1)
+    assert result.loan_episodes[1].start_date == date(2025, 7, 1)
+    assert result.loan_episodes[1].end_date == date(2026, 6, 29)
+    assert result.current_club.api_id == 505
+    assert result.current_owner is None
+    assert result.on_loan is False
+
+
+def test_zuccon_reloan_is_a_new_episode_and_affiliate_duplicate_is_coalesced():
+    events = [
+        transfer("2024-08-23", "Loan", 499, "Atalanta", 1720, "Juve Stabia"),
+        transfer("2025-08-31", "Loan", 499, "Atalanta", 1720, "Juve Stabia"),
+        transfer("2025-09-01", "Loan", 990499, "Atalanta II", 1720, "Juve Stabia"),
+    ]
+
+    result = resolve_transfer_state(list(reversed(events)), as_of="2026-07-16")
+
+    assert len(result.normalized_events) == 3
+    assert len(result.events) == 2
+    assert len(result.loan_episodes) == 2
+    first, second = result.loan_episodes
+    assert (first.start_date, first.end_date) == (date(2024, 8, 23), date(2025, 8, 31))
+    assert second.start_date == date(2025, 8, 31)
+    assert second.end_date is None
+    assert first.owner.organization_api_id == second.owner.organization_api_id == 499
+    assert len(second.start_event.evidence) == 2
+    assert result.loan_state == "indeterminate"
+    assert result.on_loan is None
+    assert result.current_owner is None
+    assert result.legal_owner.organization_api_id == 499
+    assert "implicit_close_before_reloan" in {issue.code for issue in result.issues}
+
+
+def test_pierobon_former_borrowers_never_become_owners():
+    events = [
+        transfer("2022-08-01", "Loan", 504, "Verona", 1739, "Mantova"),
+        transfer("2023-08-01", "Loan", 504, "Verona", 1735, "Triestina"),
+        transfer("2024-01-31", "Loan", 504, "Verona", 1720, "Juve Stabia"),
+        transfer("2024-07-07", "N/A", 504, "Verona", 1720, "Juve Stabia"),
+    ]
+
+    result = resolve_transfer_state(events, as_of="2026-07-16")
+
+    assert len(result.loan_episodes) == 3
+    assert {episode.owner.api_id for episode in result.loan_episodes} == {504}
+    assert result.current_club.api_id == 1720
+    assert result.current_owner is None
+    assert result.legal_owner.api_id == 1720
+    assert result.latest_permanent_move.reason == "topology_na_conversion"
+
+
+def test_aseko_affiliate_return_after_missing_reloan_clears_current_loan_and_flags_conflict():
+    events = [
+        transfer("2025-02-03", "Loan", 990157, "Bayern Munich II", 166, "Hannover 96"),
+        transfer("2025-07-01", "N/A", 166, "Hannover 96", 990157, "Bayern Munich II"),
+        transfer("2026-06-29", "Return from loan", 166, "Hannover 96", 157, "Bayern Munich"),
+    ]
+
+    result = resolve_transfer_state(events, as_of="2026-07-16")
+
+    assert [event.kind for event in result.events] == ["loan_start", "loan_return", "loan_return"]
+    assert result.events[1].reason == "topology_na_return"
+    assert len(result.loan_episodes) == 1
+    assert result.loan_episodes[0].end_date == date(2025, 7, 1)
+    assert result.current_club.organization_api_id == 157
+    assert result.current_owner is None
+    assert result.on_loan is False
+    assert "return_without_open_loan" in {issue.code for issue in result.issues}
+
+
+def test_concrete_na_without_active_episode_uses_state_continuity_not_the_string():
+    permanent = resolve_transfer_state(
+        [
+            transfer("2024-01-01", "Transfer", 1, "A", 2, "B"),
+            transfer("2025-01-01", "N/A", 2, "B", 3, "C"),
+        ],
+        as_of="2025-01-01",
+    )
+    missing_start_return = resolve_transfer_state(
+        [
+            transfer("2024-01-01", "Transfer", 1, "A", 2, "B"),
+            transfer("2025-01-01", "N/A", 3, "C", 2, "B"),
+        ],
+        as_of="2025-01-01",
+    )
+    no_topology = resolve_transfer_state(
+        [transfer("2025-01-01", "N/A", 1, "A", 2, "B")],
+        as_of="2025-01-01",
+    )
+
+    assert permanent.events[-1].kind == "permanent"
+    assert permanent.events[-1].reason == "topology_na_permanent"
+    assert missing_start_return.events[-1].kind == "loan_return"
+    assert missing_start_return.events[-1].reason == "topology_na_return_missing_start"
+    assert "return_without_open_loan" in {issue.code for issue in missing_start_return.issues}
+    assert no_topology.events[-1].kind == "unknown"
+    assert "ambiguous_na" in {issue.code for issue in no_topology.issues}
+
+
+def test_owner_to_third_club_na_supersedes_an_open_loan():
+    result = resolve_transfer_state(
+        [
+            transfer("2024-08-01", "Loan", 1, "Owner", 2, "Borrower"),
+            transfer("2025-01-10", "N/A", 1, "Owner", 3, "Buyer"),
+        ],
+        as_of="2025-01-10",
+    )
+
+    assert [event.kind for event in result.events] == ["loan_start", "permanent"]
+    assert result.events[-1].reason == "topology_na_permanent"
+    assert result.loan_episodes[0].end_date == date(2025, 1, 10)
+    assert result.loan_episodes[0].end_reason == "superseded_by_permanent"
+    assert result.current_club.api_id == 3
+    assert result.legal_owner.api_id == 3
+    assert result.current_owner is None
+    assert result.on_loan is False
+
+
+def test_open_loan_becomes_indeterminate_at_evidence_boundary():
+    events = [transfer("2024-08-23", "Loan", 1, "Owner", 2, "Borrower")]
+
+    fresh = resolve_transfer_state(events, as_of="2025-06-30")
+    stale = resolve_transfer_state(events, as_of="2025-07-01")
+
+    assert fresh.on_loan is True
+    assert fresh.current_owner.api_id == 1
+    assert stale.on_loan is None
+    assert stale.loan_state == "indeterminate"
+    assert stale.current_owner is None
+    assert stale.legal_owner.api_id == 1
+
+
+def test_invalid_fields_are_deterministic_and_name_only_teams_still_resolve():
+    events = [
+        transfer("2024-01-01junk", "Loan", 1, "Owner", 2, "Borrower"),
+        transfer("2024-01-02", None, 1, "Owner", 2, "Borrower"),
+        transfer("2024-01-03", "Loan", None, None, 2, "Borrower"),
+        transfer("2024-01-04", "Loan", 1, "Owner", None, "Borrower"),
+        transfer("2024-06-30", "Return from loan", None, "Borrower", 1, "Owner"),
+    ]
+
+    normal = resolve_transfer_state(events, as_of="2024-07-01")
+    reversed_result = resolve_transfer_state(list(reversed(events)), as_of="2024-07-01")
+
+    assert normal == reversed_result
+    assert [event.kind for event in normal.events] == ["loan_start", "loan_return"]
+    assert normal.current_club.api_id == 1
+    assert normal.on_loan is False
+    codes = {issue.code for issue in normal.issues}
+    assert {"invalid_date", "missing_type", "missing_out_club", "missing_in_club_id", "missing_out_club_id"} <= codes
+
+
+def test_flat_row_objects_are_accepted_without_database_imports():
+    row = SimpleNamespace(
+        transfer_date=date(2024, 1, 1),
+        transfer_type="Transfer",
+        out_club_api_id=1,
+        out_club_name="A",
+        in_club_api_id=2,
+        in_club_name="B",
+    )
+
+    result = resolve_transfer_state([row], as_of="2024-01-01")
+
+    assert result.events[0].kind == "permanent"
+    assert result.current_club.api_id == 2
+    assert result.current_owner is None
+
+
+def test_exact_duplicate_is_one_effective_event_but_keeps_raw_evidence():
+    event = transfer("2024-01-01", "Transfer", 1, "A", 2, "B")
+    result = resolve_transfer_state([deepcopy(event), deepcopy(event)], as_of="2024-01-01")
+
+    assert len(result.normalized_events) == 2
+    assert len(result.events) == 1
+    assert len(result.events[0].evidence) == 2
+
+
+def test_normalizer_handles_empty_history_and_reports_unknown_state():
+    normalization = normalize_transfer_events([])
+    resolution = resolve_transfer_state([], as_of="2026-07-16")
+
+    assert normalization.events == ()
+    assert normalization.issues == ()
+    assert resolution.current_club is None
+    assert resolution.current_owner is None
+    assert resolution.legal_owner is None
+    assert resolution.loan_state == "unknown"
+    assert resolution.on_loan is None
+
+
+def test_as_of_is_required_and_must_be_a_strict_iso_date():
+    with pytest.raises(TypeError):
+        resolve_transfer_state(HALL)  # type: ignore[call-arg]
+    with pytest.raises(ValueError, match="as_of"):
+        resolve_transfer_state(HALL, as_of="2024-07-01T00:00:00")

--- a/academy-watch-backend/tests/test_weekly_newsletter_transfer_returns.py
+++ b/academy-watch-backend/tests/test_weekly_newsletter_transfer_returns.py
@@ -1,0 +1,207 @@
+"""Focused regressions for resolver-backed newsletter loan returns."""
+
+from datetime import date
+
+import src.agents.weekly_newsletter_agent as agent
+from src.models.league import Team, db
+from src.models.tracked_player import TrackedPlayer
+from src.services import transfer_resolver
+
+
+def _transfer(transfer_date, transfer_type, out_id, out_name, in_id, in_name):
+    return {
+        "date": transfer_date,
+        "type": transfer_type,
+        "teams": {
+            "out": {"id": out_id, "name": out_name},
+            "in": {"id": in_id, "name": in_name},
+        },
+    }
+
+
+class _BatchTransferAPI:
+    def __init__(self, events_by_player, omitted_player_ids=()):
+        self.events_by_player = events_by_player
+        self.omitted_player_ids = set(omitted_player_ids)
+
+    def batch_get_player_transfers(self, player_ids):
+        assert set(player_ids) == set(self.events_by_player) | self.omitted_player_ids
+        return {
+            player_id: [
+                {
+                    "player": {"id": player_id},
+                    "transfers": list(events),
+                }
+            ]
+            for player_id, events in self.events_by_player.items()
+        }
+
+
+def _seed_parent(team_api_id, name):
+    parent = Team(
+        team_id=team_api_id,
+        name=name,
+        country="Test Country",
+        season=2025,
+        is_active=True,
+    )
+    db.session.add(parent)
+    db.session.flush()
+    return parent
+
+
+def _seed_player(parent, player_api_id, name):
+    player = TrackedPlayer(
+        player_api_id=player_api_id,
+        player_name=name,
+        team_id=parent.id,
+        status="on_loan",
+        is_active=True,
+    )
+    db.session.add(player)
+    db.session.flush()
+    return player
+
+
+def _detect(
+    monkeypatch,
+    parent,
+    events_by_player,
+    week_start,
+    week_end,
+    *,
+    omitted_player_ids=(),
+):
+    monkeypatch.setattr(
+        agent,
+        "api_client",
+        _BatchTransferAPI(events_by_player, omitted_player_ids),
+    )
+    return agent._detect_recent_loan_returns(
+        team_db_id=parent.id,
+        parent_api_id=parent.team_id,
+        week_start=week_start,
+        week_end=week_end,
+        lookback_days=0,
+    )
+
+
+def test_mills_topology_na_return_to_parent_affiliate_is_included(app, monkeypatch):
+    parent = _seed_parent(45, "Everton")
+    player = _seed_player(parent, 1001, "Stanley Mills")
+    events = [
+        _transfer("2023-07-27", "Loan", 45, "Everton", 1338, "Oxford United"),
+        _transfer("2024-01-08", "N/A", 1338, "Oxford United", 99945, "Everton U21"),
+        # Provider duplicates must collapse to one newsletter return.
+        _transfer("2024-01-08", "N/A", 1338, "Oxford United", 99945, "Everton U21"),
+    ]
+
+    returns = _detect(
+        monkeypatch,
+        parent,
+        {player.player_api_id: events},
+        date(2024, 1, 8),
+        date(2024, 1, 14),
+    )
+
+    assert len(returns) == 1
+    assert returns[0]["player_api_id"] == player.player_api_id
+    assert returns[0]["returned_from_club_api_id"] == 1338
+    assert returns[0]["returned_from_club_name"] == "Oxford United"
+    assert returns[0]["return_date"] == "2024-01-08"
+
+
+def test_aseko_na_return_without_loan_start_uses_parent_as_initial_owner(app, monkeypatch):
+    parent = _seed_parent(157, "Bayern Munich")
+    player = _seed_player(parent, 1002, "Noel Aseko")
+    events = [
+        _transfer(
+            "2025-07-01",
+            "N/A",
+            166,
+            "Hannover 96",
+            990157,
+            "Bayern Munich II",
+        )
+    ]
+
+    returns = _detect(
+        monkeypatch,
+        parent,
+        {player.player_api_id: events},
+        date(2025, 7, 1),
+        date(2025, 7, 7),
+    )
+
+    assert len(returns) == 1
+    assert returns[0]["player_api_id"] == player.player_api_id
+    assert returns[0]["returned_from_club_name"] == "Hannover 96"
+    assert returns[0]["return_date"] == "2025-07-01"
+
+
+def test_latest_resolved_parent_return_wins_and_other_destinations_are_excluded(app, monkeypatch):
+    parent = _seed_parent(49, "Chelsea")
+    returned = _seed_player(parent, 1003, "Latest Return")
+    wrong_destination = _seed_player(parent, 1004, "Wrong Destination")
+    events_by_player = {
+        returned.player_api_id: [
+            _transfer("2023-12-01", "Loan", 49, "Chelsea", 300, "Hull City"),
+            _transfer("2024-01-02", "Return from loan", 300, "Hull City", 49, "Chelsea"),
+            _transfer("2024-01-04", "Loan", 49, "Chelsea", 301, "Crystal Palace"),
+            _transfer("2024-01-10", "Back from loan", 301, "Crystal Palace", 9949, "Chelsea U21"),
+            # Future events must not affect an as-of newsletter report.
+            _transfer("2024-01-20", "Return from loan", 302, "Future FC", 49, "Chelsea"),
+        ],
+        wrong_destination.player_api_id: [
+            _transfer("2023-12-01", "Loan", 49, "Chelsea", 303, "Loan FC"),
+            _transfer("2024-01-09", "Return from loan", 303, "Loan FC", 42, "Arsenal"),
+        ],
+    }
+
+    returns = _detect(
+        monkeypatch,
+        parent,
+        events_by_player,
+        date(2024, 1, 1),
+        date(2024, 1, 12),
+    )
+
+    assert len(returns) == 1
+    assert returns[0]["player_api_id"] == returned.player_api_id
+    assert returns[0]["returned_from_club_name"] == "Crystal Palace"
+    assert returns[0]["return_date"] == "2024-01-10"
+
+
+def test_batch_failure_omission_is_not_resolved_as_empty_history(app, monkeypatch, caplog):
+    parent = _seed_parent(49, "Chelsea")
+    covered = _seed_player(parent, 1005, "Covered Return")
+    omitted = _seed_player(parent, 1006, "Failed Lookup")
+    events_by_player = {
+        covered.player_api_id: [
+            _transfer("2024-01-01", "Loan", 49, "Chelsea", 300, "Hull City"),
+            _transfer("2024-01-08", "Back from loan", 300, "Hull City", 49, "Chelsea"),
+        ]
+    }
+
+    real_resolver = transfer_resolver.resolve_transfer_state
+    resolved_histories = []
+
+    def _capture_resolver(events, **kwargs):
+        resolved_histories.append(list(events))
+        return real_resolver(events, **kwargs)
+
+    monkeypatch.setattr(transfer_resolver, "resolve_transfer_state", _capture_resolver)
+    returns = _detect(
+        monkeypatch,
+        parent,
+        events_by_player,
+        date(2024, 1, 8),
+        date(2024, 1, 14),
+        omitted_player_ids={omitted.player_api_id},
+    )
+
+    assert [item["player_api_id"] for item in returns] == [covered.player_api_id]
+    assert len(resolved_histories) == 1
+    assert resolved_histories[0]
+    assert str(omitted.player_api_id) in caplog.text
+    assert "omitted" in caplog.text

--- a/ledgers/research/hall-loan-mislabel-investigation.md
+++ b/ledgers/research/hall-loan-mislabel-investigation.md
@@ -1,0 +1,395 @@
+# Lewis Hall loan mislabeling — final investigation report
+
+**Investigation completed:** 2026-07-16  
+**Code examined:** detached `main` at `8aac25f`  
+**Mode:** read-only repository investigation; no network, database access, commits, or tracked-file changes  
+**Production evidence:** supplied read-only query results plus fresh API-Football histories for the 13 proxy rows
+
+## Executive finding
+
+Lewis Hall is mislabeled because three independent consumers give an old loan precedence over later transfer state. The API fee string `€ 33M` is valid permanent-transfer evidence; fee parsing is not the cause. Current code opens Hall's 2023 Newcastle loan, never closes it on the 2024 permanent conversion, lets the old loan date block the later transfer date, returns `on_loan` because Newcastle was *ever* a Chelsea loan destination, and sets player-level status from *any* historical Newcastle loan entry.
+
+The production timestamps now settle the June 24 question: Hall received an **incremental** journey sync. Seasons 2020–2024 retain their June 20 creation cluster, while only 2025–2026 were recreated at the June 24 `last_synced_at`. The exact trigger/actor is unrecoverable: `background_jobs` has no matching row, and `updated_at` is generic rather than provenance.
+
+The 13-player durable proxy produced **10 confirmed current mislabels, 0 loans proven ongoing as of 2026-07-16, and 3 indeterminate old/unclosed loans**. Eight of the ten are the same loan-to-permanent precedence defect as Hall. Nine rows also have a definitely wrong current owner field. This is a strong lower bound, not a prevalence estimate: the proxy is deliberately enriched for one journey shape and fresh transfer-cache coverage of the active population was 0%.
+
+Code must be fixed before data repair. The planned B2 pass is only a 2025–26 incremental sync; by itself it cannot repair older journey entries or their rollups. The preferred design is to persist the full transfer event stream during B2, drive all transfer consumers through one chronological resolver, and run a database-only all-history journey-entry reclassifier plus affected-season rollup refresh.
+
+## 1. Symptom and established facts
+
+The reported app label was:
+
+```text
+Lewis Hall — on loan · from Chelsea
+```
+
+The durable state behind it was:
+
+- canonical Chelsea academy-origin `tracked_players.id=21704`: active, `status='on_loan'`, current club Newcastle, `sale_fee=NULL`;
+- deprecated Newcastle owning-club `tracked_players.id=21705`: inactive;
+- Newcastle journey entries in seasons 2024 and 2025: `entry_type='loan'`, `transfer_date='2023-08-22'`;
+- journey player-level state: `current_status='on_loan'`, owner Chelsea.
+
+The transfer history is unambiguous:
+
+```text
+2023-08-22  Loan    Chelsea (49) -> Newcastle (34)
+2024-07-01  € 33M   Chelsea (49) -> Newcastle (34)
+```
+
+The correct canonical result is therefore:
+
+```text
+Chelsea academy-origin row 21704: active, sold/permanently departed,
+current club Newcastle, sale_fee='€ 33M'
+
+Newcastle owning-club row 21705: inactive
+
+Newcastle entries from the conversion onward: not loan,
+effective transfer date 2024-07-01, fee '€ 33M'
+
+journey.current_status/current_owner: NULL/cleared
+```
+
+The inactive Newcastle row is not itself an inversion bug. The platform intentionally keeps one canonical row per academy parent and deprecates buying-club duplicates (`docs/agents/invariants.md:31-37`). Journey upsert deactivation is at `academy-watch-backend/src/services/journey_sync.py:1829-1891`; the recompute sweep is at `academy-watch-backend/src/routes/journey.py:243-278`; transfer-heal duplicate cleanup is at `academy-watch-backend/src/services/transfer_heal_service.py:412-435`. The Chelsea row's **status** is wrong; its role as the active academy-origin row is correct.
+
+Round 1 also ran the exact Hall payload through the real `JourneySyncService.sync_player(..., force_full=True)` path with in-memory SQLite and fake API methods. Current `main` reproduced all of the production corruption: active Chelsea row, tracked status `on_loan`, Newcastle 2024/2025 entries typed `loan` with the 2023 date, journey status `on_loan`/owner Chelsea, and both fee fields null. A full sync on current code is therefore not a remedy.
+
+## 2. Root cause: three stale-precedence paths
+
+### 2.1 It is not a fee-string parser defect
+
+`academy-watch-backend/src/api_football_client.py:35-38` defines exact loan and return types. `is_new_loan_transfer()` at lines 41–73 accepts only exact `loan` after excluding returns. `extract_transfer_fee()` at lines 76–88 returns `€ 33M` unchanged; it excludes loans, returns, blank values, and `N/A`.
+
+The status classifier also treats a typed, non-loan parent departure with a concrete destination as permanent/sold at `academy-watch-backend/src/utils/academy_classifier.py:573-586`. The permanent event is valid. It is simply reached too late—or ignored—by the three consumers below.
+
+### 2.2 Precedence bug 1: journey-entry classification
+
+The sync fetches transfers and builds the loan timeline at `academy-watch-backend/src/services/journey_sync.py:227-229`, then applies loan classification before transfer dates at lines 274–279.
+
+The failure trace is:
+
+1. `_build_transfer_timeline()` (`journey_sync.py:570-608`) iterates provider order without sorting.
+2. It opens exact loans at lines 589–599 and closes them only on recognized explicit return strings at lines 600–606.
+3. Hall's later `€ 33M` Chelsea→Newcastle event is neither a new loan nor an explicit return, so it is ignored. The 2023 loan remains open with `end_date=None`.
+4. `_loan_overlaps_season()` (`journey_sync.py:610-633`) lets an open loan overlap every future season.
+5. `_apply_loan_classification()` (`journey_sync.py:683-702`) writes `entry_type='loan'` and `transfer_date='2023-08-22'` to Newcastle entries.
+6. `_apply_permanent_transfer_dates()` actually collects **all** moves and sorts them at lines 721–735, so it could find `2024-07-01`. But lines 737–739 skip every entry whose loan pass already populated a date. The old loan date prevents the later event from replacing either state or date.
+
+This path also explains stale dates on genuine re-loans: the first still-open matching episode wins, so a new loan to the same club can retain the earlier episode's date.
+
+### 2.3 Precedence bug 2: academy-relative `TrackedPlayer.status`
+
+`upgrade_status_from_transfers()` builds a set of **every historical** parent-to-loan destination at `academy-watch-backend/src/utils/academy_classifier.py:538-545`. If the current club is in that set, lines 547–551 immediately return `on_loan`.
+
+For Hall, Newcastle is in the historical set, so the later date-sorted parent-departure logic at lines 557–586 never gets to classify the 2024 conversion as permanent. The existing `test_latest_departure_wins` at `academy-watch-backend/tests/test_journey.py:1104-1120` misses this shape: its historical loan destination differs from the later/current permanent destination.
+
+A second historical-loan check at `academy_classifier.py:831-839` sets `has_confirmed_loan` and can suppress the squad-return safety net. It must use the same resolved active episode rather than `any()` historical destination.
+
+### 2.4 Precedence bug 3: player-level current status and reverse owner
+
+`_set_current_status()` at `academy-watch-backend/src/services/journey_sync.py:1266-1310` receives stored entries, not the transfer state. Line 1283 asks whether **any** entry at the current club is loan-typed. One old Newcastle entry therefore sets `journey.current_status='on_loan'` at line 1290 even if the loan ended years ago.
+
+The owner is then guessed at lines 1291–1307 from the maximum-season non-current `first_team` journey entry. It is not read from an active loan event's `teams.out`, and ties have no transfer-date ordering. That is why a prior borrower can be displayed as the current owner in chained or repeated histories.
+
+This field is load-bearing: the profile route overrides academy-relative status with it at `academy-watch-backend/src/routes/players.py:427-451`, and the frontend renders `from {owner}` at `academy-watch-frontend/src/pages/PlayerPage.jsx:624-627`. Fixing only `TrackedPlayer.status` would leave the reported UI symptom.
+
+### 2.5 July 1 is incorrectly inclusive
+
+`_loan_overlaps_season()` defines a season start as `YYYY-07-01` at `journey_sync.py:616-617`, but rejects a closed loan only when:
+
+```python
+loan_end < season_start
+```
+
+Equality still overlaps. A conversion or return on `2024-07-01` would therefore leave season 2024 loan-typed even after the timeline learned to close the loan. `academy-watch-backend/tests/test_journey.py:438-441` explicitly pins this incorrect behavior.
+
+Loan episodes must be half-open intervals, `[start, end)`, so the comparison is effectively `loan_end <= season_start`. Seven of the ten confirmed histories have a decisive July 1 transition, making this an active amplifier rather than a theoretical edge case. A global implementation should also use the competition's season calendar where available; a universal July–June boundary is wrong for calendar-year leagues.
+
+## 3. What happened on June 24
+
+Production evidence for `player_journeys` player 284492 is:
+
+```text
+seasons_synced = [2020, 2021, 2022, 2023, 2024, 2025, 2026]
+last_synced_at = 2026-06-24 03:54:25
+updated_at     = 2026-06-24 08:06:16
+sync_error     = NULL
+
+entry created_at:
+2020–2024  all 2026-06-20 11:06:23
+2025–2026  all 2026-06-24 03:54:24
+```
+
+`sync_player()` selects every season only when `force_full=True`; otherwise, in calendar year 2026, it selects unsynced seasons plus `season >= 2025` (`journey_sync.py:218-225`). It builds only those selected seasons at lines 238–255 and deletes/reinserts only rebuilt seasons at lines 301–310. `PlayerJourneyEntry.created_at` is insert-only (`academy-watch-backend/src/models/journey.py:345`).
+
+The two creation clusters are therefore the signature of an **incremental sync**: the June 20 rows through 2024 survived, while 2025 and 2026 were rebuilt immediately before `last_synced_at`. This also explains why both old and new-season corruption coexist:
+
+- season 2024 was not touched;
+- season 2025 was regenerated, but current code regenerated the same wrong loan state.
+
+The 08:06 `updated_at` is a generic SQLAlchemy `onupdate` field (`academy-watch-backend/src/models/journey.py:76-77`), not an actor or operation tag. The supplied `background_jobs` query returned no rows for either time window or Hall's player ID. The trigger/actor is consequently unrecoverable from retained database state; only retained application/platform logs or a future row-change audit could identify it.
+
+## 4. Thirteen-player adjudication
+
+Method: events were date-sorted independently of the raw API order. Same-day chains were ordered by causal direction—for example, a return to the parent must precede a new departure from that parent. `N/A` is interpreted using topology, not as universally permanent or universally ignorable. Classification is as of the fresh fetch on **2026-07-16**.
+
+`A` means a later definitive event proves the stored current loan label false. `B` would require evidence that the loan is still current on the adjudication date. `C` means the event stream lacks a loan end/contract term or fresh registration evidence, so current state cannot be proved.
+
+| Tracked ID / player | Decisive chronological evidence | Class and corrected state | Owner adjudication |
+|---|---|---|---|
+| 19101 — A. Knauff (161922) | `2022-01-20 Loan` Dortmund→Frankfurt; **`2023-07-01 € 5M` Dortmund→Frankfurt** | **A — confirmed.** Permanent at Frankfurt; the 2023–2025 old-loan entries are contradicted. | Dortmund is stale; current owner fields must clear. |
+| 23289 — K. Asllani (275776) | `2022-07-01 Loan` Empoli→Inter; **`2023-07-01 € 10M` Empoli→Inter**. Inter later loaned him to Torino and Beşiktaş; latest **`2026-06-29 Return from loan` Beşiktaş→Inter**. | **A — confirmed.** Inter has owned him since 2023 and is his latest location after return. | Empoli is stale; current owner fields must clear. Later loans themselves corroborate Inter ownership. |
+| 18561 — D. Herold (162536) | `2023-07-01 Loan` Bayern→Karlsruhe; **`2024-07-01 N/A` Bayern→Karlsruhe**; then **`2026-06-29/30 Transfer` Karlsruhe→Mönchengladbach** (near-duplicate provider rows). | **A — confirmed.** The loan converted in 2024; the latest current club is Gladbach, not Karlsruhe. | SCR Altach appears nowhere in the supplied history and is not a sub-loan owner. Clear owner. |
+| 23554 — F. Christophe (200827) | Only `2023-07-17 Loan` Strasbourg→Châteauroux. | **C — indeterminate.** A three-year-old start has no closure, conversion, renewal, term, or 2026 registration evidence. It cannot prove an ongoing loan. | If active, owner should be Strasbourg, so null is incomplete; if expired, status/owner should clear. |
+| 19872 — W. Rovida (336703) | `2023-07-20 Loan` Inter→Pro Patria; **`2024-07-03 N/A` Inter→Pro Patria**. | **A — confirmed.** Same-direction non-loan move supersedes the loan; permanent at Pro Patria. | Inter is stale; current owner fields must clear. |
+| 18564 — J. Schenk (203331) | `2023-07-26 Loan` Bayern→Preußen Münster; **`2024-07-01 Free` Bayern→Preußen Münster**. | **A — confirmed.** Permanent/free move to Münster. | Bayern is stale; current owner fields must clear. |
+| 20577 — S. Mills (284187) | `2023-07-27 Loan` Everton→Oxford; **`2024-01-08 N/A` Oxford→Everton U21**. | **A — confirmed.** Reverse direction to the owner's affiliate is an end/return; no later Oxford re-loan exists. Current club should resolve to the Everton organization. | Everton was the historical owner, but there is no current loan; owner fields must clear. |
+| 21704 — L. Hall (284492) | `2023-08-22 Loan` Chelsea→Newcastle; **`2024-07-01 € 33M` Chelsea→Newcastle**. | **A — confirmed.** Permanent Newcastle player. | Chelsea is stale; current owner fields must clear. |
+| 22797 — C. Pierobon (265552) | Earlier Verona loans to Mantova and Triestina; `2024-01-31 Loan` Verona→Juve Stabia; **`2024-07-07 N/A` Verona→Juve Stabia**. | **A — confirmed.** Permanent/definitive move to Juve Stabia. | Triestina was a former borrower, never the owner of the Juve loan. Clear owner. |
+| 22780 — D. Tufekcic (406483) | Only `2024-06-17 Loan` Brann→Kristiansund. | **C — indeterminate.** No end, return, conversion, renewal, contract term, or 2026 registration evidence; two loan-typed seasons do not prove July 2026 state. | Brann is correct only if the loan remains active. |
+| 19671 — F. Zuccon (336639) | `2024-08-23 Loan` Atalanta→Juve Stabia; fresh **`2025-08-31 Loan` Atalanta→Juve Stabia** and **`2025-09-01 Loan` Atalanta II→Juve Stabia** show a real re-loan represented through senior/reserve affiliates. No later closure is present. | **C — indeterminate as of 2026-07-16.** The 2025 season's loan status is supported, but the stored 2024 date is wrong and the events contain no term proving that the 2025–26 loan survived season end. | Mantova is unsupported and definitely wrong. If active, owner is the Atalanta organization; if expired, owner is null. |
+| 24661 — Jalil Saadi (298095) | `2024-09-09 Loan` Blackburn→Ethnikos; on **`2025-07-01`**, `Back from Loan` Ethnikos→Blackburn followed causally by `Free Transfer` Blackburn→Ethnikos. | **A — confirmed.** Loan ended and Ethnikos then acquired him permanently. | Null owner is correct for the corrected permanent state; `on_loan` is not. |
+| 18622 — N. Aséko Nkili (342171) | `2025-02-03 Loan` Bayern II→Hannover; `2025-07-01 N/A` Hannover→Bayern II; latest **`2026-06-29 Return from loan` Hannover→Bayern**. The missing intervening re-loan makes the history internally incomplete, but both later directions end rather than extend a Hannover loan. | **A — confirmed current-state error.** Latest state is back in the Bayern organization, not at Hannover. The explicit return postdates the June 24 journey sync, so part of this row is ordinary freshness lag. | Null is correct after return; the stored `on_loan` status/current club are not. |
+
+### Adjudication totals
+
+- **10 confirmed current mislabels**
+  - 8 same-destination loan→permanent/definitive conversions: Knauff, Asllani, Herold, Rovida, Schenk, Hall, Pierobon, Saadi;
+  - 2 return/end cases: Mills and Aséko Nkili.
+- **0 proven genuine ongoing loans as of 2026-07-16.** Absence of a return event is not a contract end date.
+- **3 indeterminate:** Christophe, Tufekcic, Zuccon.
+- **9 definite owner-field errors:** the eight confirmed non-loan rows retaining a named owner, plus Zuccon. Herold's SCR Altach, Pierobon's Triestina, and Zuccon's Mantova are prior/unsupported journey clubs, not evidence of sub-loans.
+- At least three current-club fields are also superseded: Herold (Gladbach), Mills (Everton organization), and Aséko (Bayern organization). Herold's and Aséko's latest events occurred after the June 24 sync, so current-club freshness and historical classifier correctness must be measured separately.
+
+## 5. Systemic verdict
+
+### 5.1 What is proven
+
+The fresh-cache coverage query reported:
+
+```text
+active tracked players:       3,544
+fresh transfer-cache rows:        3
+distinct cached player IDs:       2
+active-population coverage:    0.00%
+```
+
+The exact raw-cache census was therefore correctly skipped. Transfer cache is not evidence storage: summer transfer TTL is 24 hours (`academy-watch-backend/src/api_football_client.py:471-477`), and expired rows are deleted daily (`academy-watch-backend/migrations/maintenance/api_cache_purge_cron.sql:25-32`).
+
+The durable proxy selects a narrow journey shape: an active `on_loan` row whose current club differs from the academy parent and whose journey repeats the same dated loan at that club across at least two seasons. It found 13 rows. Fresh histories then confirmed 10 current errors.
+
+Those ten are the minimum demonstrated exposure:
+
+- 10 / 3,544 active players ≈ **0.28%**;
+- 10 / 8,009 candidates ≈ **0.12%**, only if `8,009` has a compatible player grain.
+
+These percentages are lower-bound fractions, **not prevalence estimates**. The 13 rows are not a random sample, so its 10/13 hit rate must not be extrapolated to 8,009.
+
+### 5.2 Relative exposure classes in the observed proxy
+
+| Overlapping class | Observed count | Relative conclusion |
+|---|---:|---|
+| Same destination: loan followed by permanent/definitive move | 8 | Dominant confirmed mechanism; Hall's exact class |
+| Later return/end while current state remains loan | 2 | Smaller confirmed class; includes topology-aware `N/A` and post-sync freshness |
+| Old/unclosed loan lacking expiry/current-registration evidence | 3 | Indeterminate queue, not proof of either correctness or corruption |
+| Definitely wrong current owner | 9 | Broad cross-cutting defect that also affects real re-loans |
+| Definitely superseded current club | at least 3 | Mix of reducer defects and ordinary sync freshness |
+
+The provider histories expose inconsistent `N/A` handling as another contributor. Academy status currently treats `N/A` plus a real destination as a permanent move (`academy_classifier.py:573-585` and tests 1076–1088), while journey current-club override skips all `N/A` as ambiguous (`journey_sync.py:1165-1202`) and club-ID correction excludes it (`journey_sync.py:783-786`). Mills and Aséko show why direction and active topology—not the string alone—must decide whether `N/A` is a permanent move or a return.
+
+### 5.3 What the proxy misses
+
+The true total is necessarily unknown because the proxy has unknown recall. It misses at least:
+
+- conversions represented in only one journey season;
+- players who have since moved to a third club;
+- return-only histories without a repeated loan date;
+- rows where `TrackedPlayer.status` was fixed but `journey.current_status` still overrides it;
+- stale historical loan entries when the current tracked status is no longer `on_loan`;
+- new/repeated loans whose second episode has a different date;
+- affiliate/B-team chains whose raw IDs differ;
+- owner errors on otherwise genuine loans;
+- inactive candidates, players without a journey, and players whose season fetch returned no entries.
+
+The best defensible platform verdict is therefore:
+
+> At least ten active rows are currently wrong. Same-destination loan conversion is the modal observed failure, and owner inference is a broad overlapping risk. The total across 8,009 candidates cannot be estimated responsibly from current durable data and is likely higher than the demonstrated lower bound.
+
+## 6. Requirements for a definitive census
+
+A definitive census needs durable transfer evidence for every player in the chosen denominator, not a 24-hour cache sample.
+
+### 6.1 Persist evidence during the API pass
+
+Add two durable concepts:
+
+1. **Per-player fetch/snapshot audit**
+   - player ID, requested/fetched time, source/batch ID;
+   - success with events, successful empty history, failure, or not attempted;
+   - response/event count, response hash, error category, resolver version.
+2. **Normalized transfer event**
+   - player ID and effective date;
+   - raw type and normalized kind;
+   - raw incoming/outgoing IDs and names plus normalized organization IDs;
+   - raw JSON or immutable snapshot reference;
+   - deterministic fingerprint, first/last seen, and source fetch ID.
+
+The distinction between successful-empty, failed, and not-fetched is mandatory. Current journey flow returns before fetching transfers when no seasons exist (`journey_sync.py:206-228`), and several fetch paths collapse errors into an empty list. Without an audit row, apparent coverage cannot be trusted.
+
+Raw events should be preserved even when normalized duplicates are coalesced. The supplied histories contain same-day causal chains, consecutive duplicate transfers, affiliate-equivalent records, and provider gaps; future adjudication must be reproducible after the provider revises its payload.
+
+Any new public table must enable RLS in its migration per `docs/agents/invariants.md:22-29`.
+
+### 6.2 Resolve and compare every axis
+
+For every successfully covered player, the census must compare the resolved event state with:
+
+1. each academy-relative `TrackedPlayer.status`, destination, and fee;
+2. journey current club, active-loan status, owner organization, and immediate loan source;
+3. every journey entry's effective loan episode, type, transfer date, and fee;
+4. aggregate `total_loan_apps` and affected season-rollup cells;
+5. an explicit unresolved/conflict class rather than forcing incomplete histories to `on_loan` or `sold`.
+
+Transfer events alone still cannot certify whether an old unclosed loan is current. Christophe, Tufekcic, and Zuccon demonstrate the need for a contract end date or a fresh registration/current-squad source. Until then, those cases must remain indeterminate.
+
+### 6.3 Denominator and B2 scope
+
+The documented B2 scope is a 2025–26 journey re-sync of about 3,544 active players (`ledgers/research/seasons-design-proposal.md:133-136,230,243-244`). If 8,009 is the intended platform denominator, B2 must be explicitly widened or followed by a bounded transfer-only fetch for every distinct uncovered player ID. Coverage is definitive only when every denominator member has a success/empty/error/not-attempted audit outcome.
+
+## 7. Remediation design — code first, data second
+
+### 7.1 Build one chronological transfer-state resolver
+
+The resolver should be pure, deterministic, and independent of API array order.
+
+It must:
+
+1. normalize type strings and validate dates/teams once;
+2. sort by effective date and resolve same-day events from state continuity and direction, not provider order;
+3. preserve raw IDs while normalizing senior/reserve/youth affiliates to an owning organization;
+4. deduplicate exact, near-date, and affiliate-equivalent provider records without discarding audit evidence;
+5. represent separately:
+   - academy parent/provenance;
+   - legal owning organization;
+   - current registered/playing club;
+   - immediate loan source;
+   - active loan episode and confidence;
+6. emit conflicts/unknowns rather than manufacture a state from incomplete data.
+
+Permanent moves change ownership and location. Loans change location while retaining ownership. Returns restore location. If a real sub-loan produces an immediate source different from legal owner, preserve both and flag the chain; do not infer owner from whichever club supplied the latest journey statistics.
+
+### 7.2 Model distinct, end-exclusive loan episodes
+
+Open a new episode for every genuine re-loan. Close an active episode on:
+
+- a recognized explicit return;
+- a reverse-direction move to the owner or its affiliate, including directionally clear `N/A`;
+- a later permanent owner→loan-destination conversion;
+- another definitive ownership/location event that supersedes it.
+
+Use `[start, end)` intervals. Select the episode effective for a journey entry's season/calendar; do not let an older matching destination win. An unclosed event without expiry/current evidence is unresolved, not automatically open forever.
+
+### 7.3 Replace every ad hoc consumer
+
+The resolver must feed all of these together:
+
+- journey entry loan classification and effective transfer date;
+- academy-relative `TrackedPlayer.status`;
+- journey current status, current club, legal owner, and immediate source;
+- current-club transfer override and historical club-ID correction;
+- squad-check loan confirmation (`academy_classifier.py:831-839`);
+- owning-club determination;
+- fee propagation and any transfer-heal decision.
+
+Later effective state must replace older fields. Remove the `if entry.transfer_date: continue` precedence. A permanent conversion must clear loan state, set the effective permanent date, and propagate fee to both `PlayerJourneyEntry.transfer_fee` and `TrackedPlayer.sale_fee`. The separate fee backfill at `academy-watch-backend/src/routes/api.py:5368-5381` should use the resolver; it currently says “most recent” but iterates raw transfers in reverse, another provider-order dependency.
+
+### 7.4 Repair all history, not only B2 seasons
+
+This is the key refinement from the production timestamps.
+
+B2 is documented as a **2025–26 incremental** pass. In 2026, `sync_player(force_full=False)` selects seasons 2025+ (`journey_sync.py:218-225`), deletes/recreates only successfully rebuilt seasons (`journey_sync.py:301-310`), and refreshes rollups only for `seasons_to_sync` (`journey_sync.py:326-343`). Hall's June 20/June 24 creation clusters prove that behavior in production.
+
+Therefore, resolver fix + ordinary B2 would still leave Hall's 2024 rows, other older loan dates/types, `total_loan_apps`, and historical rollups corrupt.
+
+Preferred repair:
+
+1. deploy the durable event schema, resolver, consumer changes, and regressions;
+2. force-full sync Hall as a canary and verify every axis below;
+3. run B2 off-container/scaled while persisting complete transfer snapshots for its active cohort;
+4. extend transfer collection to the remaining 8,009-denominator players if platform-wide census is required;
+5. run a batched **database-only all-history journey-entry reclassifier** from persisted events;
+6. recompute journey aggregates and refresh every changed season's rollup, not only 2025–26;
+7. re-run the census and require zero determinate contradictions; retain unresolved histories as unresolved.
+
+The alternative is an all-season `force_full` sync for every player, which costs many more API calls and still needs durable event coverage for auditing. A data-first sync on current code would merely rewrite the corruption.
+
+Hall canary acceptance criteria:
+
+```text
+row 21704: active, sold/permanently departed, Newcastle, sale_fee='€ 33M'
+row 21705: inactive
+Newcastle 2024/2025 entries: non-loan, date 2024-07-01, fee '€ 33M'
+journey.current_club: Newcastle
+journey.current_status/current_owner: NULL
+total_loan_apps and all affected 2024/2025 rollups: recomputed
+profile, Scout, compare, team, and journey surfaces: mutually consistent
+```
+
+Rollup failures are isolated by a savepoint and logged while the journey may still commit (`journey_sync.py:326-343`), so the repair must monitor warnings and retry failed derived refreshes.
+
+## 8. Regression list
+
+### Pure resolver and event normalization
+
+- Hall's exact payload in original, reversed, and shuffled order.
+- Same-destination loan→permanent for `€ fee`, `Transfer`, `Free`, `Free Transfer`, and topology-resolved `N/A`.
+- Hall/Knauff July 1 conversions.
+- Herold's later move to a third club plus consecutive duplicate records.
+- Mills's reverse-direction `N/A` return to Everton U21.
+- Saadi's same-day return then permanent departure even when raw order is reversed.
+- Asllani's same-day return then new loan, followed by a later return.
+- Zuccon's same-destination re-loan, new episode/date, and Atalanta/Atalanta II normalization.
+- Pierobon's former borrowers never becoming owners.
+- Aséko's Bayern II/Bayern affiliate return and missing-event conflict: no active current Hannover loan.
+- Explicit returns in newest-first and oldest-first arrays.
+- Missing/invalid date, type, incoming ID, or outgoing ID.
+- Successful empty history distinct from fetch failure and not-attempted coverage.
+- Idempotent event upsert and provider-revision audit behavior.
+
+### Intervals and seasons
+
+- A loan ending on July 1 does **not** overlap the season starting July 1; replace the current expectation at `test_journey.py:438-441`.
+- A June 30 end preserves prior-season loan classification under the configured calendar.
+- A re-loan to the same destination creates a distinct episode and uses the new date.
+- Calendar-year competition boundaries.
+- Explicit policy for a mid-season loan→permanent conversion.
+- An old open loan without expiry/current evidence resolves indeterminate, not “active forever.”
+
+### End-to-end integration
+
+- Strengthen `test_latest_departure_wins` so the old loan destination and later permanent/current destination are the **same club**.
+- Full and incremental Hall syncs converge on the same current state.
+- Incremental B2 plus the database repair corrects pre-existing older journey entries.
+- Assert tracked status/current club/fee; journey status/current club/owner; entry type/date/fee; and canonical row activation together.
+- Assert `total_loan_apps` and every affected rollup cell after reclassification.
+- Canonical academy-origin row remains active; deprecated buying-club row remains inactive.
+- Profile, Scout list/filter, Scout compare, team, and journey payloads agree.
+- Repeated sync/repair is idempotent.
+- A failed transfer fetch does not clear or falsely “repair” known state and is visible in coverage.
+
+## 9. Open questions and rollout decisions
+
+1. What is the grain of `8,009`: unique players, candidate rows, or player×academy relationships? The census denominator and dedup key depend on it.
+2. Is the required definitive scope the 3,544 active/displayed players, all 8,009 candidates, or both with separate metrics?
+3. What source certifies an unclosed loan as current: contractual expiry, current registration/squad, provider player profile, or an explicit product-level `unknown` state?
+4. Should legal owner and immediate loan source be stored separately for genuine sub-loans and affiliate chains?
+5. What is the canonical ordering policy when same-day events remain irreconcilable after direction/state analysis?
+6. How should one season entry be labeled when a loan converts permanently mid-season? A separate movement-status dimension may be cleaner than overloading `entry_type`, which also carries academy/development/first-team semantics.
+7. How long should raw provider snapshots and event revisions be retained?
+8. What current-state refresh cadence is acceptable during transfer windows? Herold and Aséko show that correct historical logic still needs freshness.
+9. The June 24 actor is unrecoverable from current DB state. Should future background syncs write a run ID/actor/source to the journey and tracked rows?
+
+## Final conclusion
+
+Hall is not an isolated fee-format edge case. He is the clearest instance of a chronology/state-model defect repeated across journey entries, academy-relative status, and player-level status/owner. The 13-player audit confirms that same-destination loan conversions are the largest observed class and that reverse-owner inference is independently unsafe. Fix one shared transfer resolver, bank the evidence, then repair every historical entry and affected rollup. Running B2 first—or limiting the repair to B2's recent seasons—would leave known corruption behind.


### PR DESCRIPTION
## Fixes the systemic loan-vs-sold mislabeling (Lewis Hall class)

Investigation (committed here as `ledgers/research/hall-loan-mislabel-investigation.md`): 10 confirmed active players mislabeled `on_loan` after permanent transfers, 9 wrong owner fields. Root cause = three stale-loan precedence paths + an inclusive July-1 season boundary — NOT API-Football data and NOT fee-string parsing. A full re-sync on old main *reproduces* the corruption (proven by hermetic end-to-end repro), so this code fix must precede any journey re-sync (B2/E1).

### R1 — evidence + resolver (`dda016f`)
- `player_transfer_events` durable table (migration `tre01`, guarded, RLS in-migration, single head) — transfer payloads previously evaporated from a 24h cache, making audits impossible.
- Persistence choke point wired into all 5 transfer-fetch paths (including cache hits).
- `transfer_resolver.py`: strictly date-sorted chronological resolution; END-EXCLUSIVE loan episodes (loan → closed by return OR same-pair permanent conversion OR superseding definitive event); topology-aware `N/A` (direction + episode context, never the string); explicit indeterminacy.

### R2 — consumer swap (`48980c5`)
- Journey entry classification, academy-relative `TrackedPlayer.status` (kills the unreachable-`sold` early return), and player-level current status/owner (kills the `any(historical loan)` scan) all route through the ONE resolver.
- Fee propagation: `sale_fee`/entry `transfer_fee` from the latest parent permanent departure (Hall → `€ 33M`).
- Fetch-failure ≠ empty-history: typed failures preserve conservative status; only successful empty evidence clears stale state.
- Durable database-only repair path on the admin journey endpoints (all-history reclassification from persisted events — the E1 repair vehicle).
- **Hall canary test** (real `sync_player(force_full=True)`, exact API payload): row 21704 → active/`sold`/Newcastle/`€ 33M`; owning-club row inactive; 2024+2025 Newcastle entries `first_team` dated 2024-07-01; loan entry preserved as 2023 history; journey owner cleared. All report acceptance criteria pass verbatim.
- Every legacy test that pinned the broken behavior updated with per-test justification (see commit; e.g. `test_open_ended_loan_overlaps_future` → `…stops_at_next_season_boundary`).

### Gates (independently verified by reviewer)
- ruff check + format: clean
- Full suite: 1,024 passed; failure/error sets **byte-identical** to the pre-existing main baseline (23F/12E/3S)
- Single alembic head `tre01`

### Deploy ordering
`tre01` DDL will be PRE-APPLIED to prod before merge (write-only table; no read-path 500 window either way, per migration docstring). After deploy: live Hall canary (force-full sync of 284492), then the 10 confirmed mislabels repaired via the durable repair path, then E1 sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)