### PR TITLE
fix(transfers): consumer-harness salvage — July-1 historical-club correction + fetch-failure hardening (R3)

### DIFF
--- a/academy-watch-backend/src/agents/weekly_newsletter_agent.py
+++ b/academy-watch-backend/src/agents/weekly_newsletter_agent.py
@@ -2303,30 +2303,45 @@ def _detect_recent_loan_returns(
         if not tp:
             continue
 
-        for event in resolution.events:
-            if event.kind != "loan_return":
-                continue
-            if not is_affiliate(
+        effective_events = [event for event in resolution.events if event.kind != "unknown"]
+        if not effective_events:
+            continue
+        qualifying_returns = [
+            event
+            for event in effective_events
+            if event.kind == "loan_return"
+            and is_affiliate(
                 event.in_club.api_id,
                 event.in_club.name,
                 parent_api_id,
                 parent_name,
-            ):
-                continue
-            t_date = event.transfer_date
-            if not (window_start <= t_date <= week_end):
-                continue
-            t_date_str = t_date.isoformat()
-            # Keep the most recent return per player
-            if pid not in seen or t_date_str > seen[pid]["return_date"]:
-                seen[pid] = {
-                    "player_api_id": pid,
-                    "player_name": tp.player_name,
-                    "returned_from_club_name": event.out_club.name,
-                    "returned_from_club_api_id": event.out_club.api_id,
-                    "return_date": t_date_str,
-                    "tp": tp,
-                }
+            )
+            and window_start <= event.transfer_date <= week_end
+        ]
+        if not qualifying_returns:
+            continue
+        event = qualifying_returns[-1]
+        current_club = resolution.current_club
+        # A later re-loan, sale, or release supersedes the headline. A later
+        # parent-internal move (for example senior side -> U21) does not.
+        if current_club is None:
+            continue
+        if not is_affiliate(
+            current_club.api_id,
+            current_club.name,
+            parent_api_id,
+            parent_name,
+        ):
+            continue
+        t_date = event.transfer_date
+        seen[pid] = {
+            "player_api_id": pid,
+            "player_name": tp.player_name,
+            "returned_from_club_name": event.out_club.name,
+            "returned_from_club_api_id": event.out_club.api_id,
+            "return_date": t_date.isoformat(),
+            "tp": tp,
+        }
 
     return list(seen.values())
 

--- a/academy-watch-backend/src/api_football_client.py
+++ b/academy-watch-backend/src/api_football_client.py
@@ -383,7 +383,7 @@ class APIFootballClient:
         # Cache team profiles for quick reuse (API payloads)
         self._team_profile_cache: dict[int, dict] = {}
         # Cache player payloads to avoid repeated API calls for profile details
-        self._player_profile_cache: dict[tuple[int, int | None], dict] = {}
+        self._player_profile_cache: dict[tuple[int, int | None, bool], dict] = {}
 
         # --- Performance optimization caches (added Oct 2025) ---
         # Transfer cache: {player_id: (data, timestamp)} - 24hr TTL
@@ -3551,20 +3551,47 @@ class APIFootballClient:
             logger.error(f"Error fetching current loans for team {team_id}: {e}")
             return []
 
-    def get_player_by_id(self, player_id: int, season: int | None = None) -> dict[str, Any]:
-        """Get player information by ID with smart fallbacks + local caching."""
+    def get_player_by_id(
+        self,
+        player_id: int,
+        season: int | None = None,
+        *,
+        allow_transfer_fallback: bool = True,
+    ) -> dict[str, Any]:
+        """Get player information by ID with smart fallbacks + local caching.
+
+        Callers that enforce their own transfer-fetch quota can disable the
+        final transfer-endpoint fallback without changing the normal profile
+        lookup contract.
+        """
         try:
             pid = int(player_id)
         except (TypeError, ValueError):
             pid = player_id
         target_season = season or self.current_season_start_year
-        cache_key = (pid, int(target_season) if target_season is not None else None)
+        cache_key = (
+            pid,
+            int(target_season) if target_season is not None else None,
+            bool(allow_transfer_fallback),
+        )
         if cache_key in self._player_profile_cache:
             return deepcopy(self._player_profile_cache[cache_key])
 
         def _store(payload: dict) -> dict:
             self._player_profile_cache[cache_key] = payload
             return deepcopy(payload)
+
+        def _minimal_profile() -> dict:
+            return {
+                "player": {
+                    "id": player_id,
+                    "name": f"Player {player_id}",
+                    "firstname": None,
+                    "lastname": None,
+                    "photo": None,
+                },
+                "statistics": [],
+            }
 
         try:
             resp = self._make_request("players", {"id": player_id, "season": target_season})
@@ -3591,45 +3618,44 @@ class APIFootballClient:
                 except Exception:
                     continue
 
-            try:
-                tr = self._make_request("transfers", {"player": player_id})
-                t_resp = tr.get("response", []) or []
-                if self.mode != "stub":
-                    _record_transfer_payload(t_resp, fallback_player_api_id=pid)
-                if t_resp:
-                    p = (t_resp[0] or {}).get("player", {})
-                    payload = {
-                        "player": {
-                            "id": player_id,
-                            "name": p.get("name") or "Unknown",
-                            "firstname": p.get("firstname"),
-                            "lastname": p.get("lastname"),
-                            "photo": (p.get("photo") if isinstance(p, dict) else None),
-                        },
-                        "statistics": [],
-                    }
-                    logger.info(f"ℹ️ Using transfers fallback name for player {player_id}: {payload['player']['name']}")
-                    return _store(payload)
-            except Exception:
-                pass
+            if allow_transfer_fallback:
+                try:
+                    tr = self._make_request("transfers", {"player": player_id})
+                    t_resp = tr.get("response", []) or []
+                    if self.mode != "stub":
+                        _record_transfer_payload(t_resp, fallback_player_api_id=pid)
+                    if t_resp:
+                        p = (t_resp[0] or {}).get("player", {})
+                        payload = {
+                            "player": {
+                                "id": player_id,
+                                "name": p.get("name") or "Unknown",
+                                "firstname": p.get("firstname"),
+                                "lastname": p.get("lastname"),
+                                "photo": (p.get("photo") if isinstance(p, dict) else None),
+                            },
+                            "statistics": [],
+                        }
+                        logger.info(
+                            "ℹ️ Using transfers fallback name for player %s: %s",
+                            player_id,
+                            payload["player"]["name"],
+                        )
+                        return _store(payload)
+                except Exception:
+                    pass
 
+            if not allow_transfer_fallback:
+                return _store(_minimal_profile())
             return _store(self._get_sample_player_data(player_id))
         except Exception as e:
             logger.error(f"Error fetching player {player_id}: {e}")
+            if not allow_transfer_fallback:
+                return _store(_minimal_profile())
             try:
                 return _store(self._get_sample_player_data(player_id))
             except Exception:
-                payload = {
-                    "player": {
-                        "id": player_id,
-                        "name": f"Player {player_id}",
-                        "firstname": None,
-                        "lastname": None,
-                        "photo": None,
-                    },
-                    "statistics": [],
-                }
-                return _store(payload)
+                return _store(_minimal_profile())
 
     def get_player_profile(self, player_id: int) -> dict[str, Any]:
         """Fetch a player profile using the players/profiles endpoint."""

--- a/academy-watch-backend/src/routes/api.py
+++ b/academy-watch-backend/src/routes/api.py
@@ -82,6 +82,7 @@ from src.models.league import (
 )
 from src.models.sponsor import Sponsor
 from src.models.tracked_player import TrackedPlayer
+from src.models.transfer_event import PlayerTransferEvent
 from src.services.email_service import email_service
 from src.services.transfer_resolver import resolve_transfer_state
 from src.utils.academy_classifier import (
@@ -93,6 +94,7 @@ from src.utils.academy_classifier import (
     is_same_club,
     latest_parent_permanent_departure,
     resolved_current_club_is_authoritative,
+    resolved_transfer_evidence_is_authoritative,
 )
 from src.utils.background_jobs import (
     STALE_JOB_TIMEOUT,
@@ -5247,6 +5249,11 @@ def admin_sync_all_player_fixtures():
         return jsonify(_safe_error_payload(e, "Failed to start batch fixture sync")), 500
 
 
+def _batch_now_utc() -> datetime:
+    """Clock seam for deterministic season-relative batch routing tests."""
+    return datetime.now(UTC)
+
+
 def _run_batch_fixture_sync(data: dict, job_id: str = None) -> dict:
     """
     Core logic for batch fixture sync.
@@ -5268,8 +5275,16 @@ def _run_batch_fixture_sync(data: dict, job_id: str = None) -> dict:
 
     from src.utils.academy_window import current_stats_season
 
-    now_utc = datetime.now(UTC)
-    season = data.get("season", current_stats_season())
+    now_utc = _batch_now_utc()
+    present_season = current_stats_season(now_utc)
+    season = int(data.get("season", present_season))
+    # The live client persists observed transfer evidence. A dry run therefore
+    # must never invoke it, even when a caller also requests a refresh.
+    refresh_transfers = data.get("refresh_transfers") is True and not dry_run
+    try:
+        transfer_refresh_limit = min(max(int(data.get("transfer_refresh_limit", 25)), 0), 100)
+    except (TypeError, ValueError):
+        transfer_refresh_limit = 25
 
     # ── 1. Gather all players grouped by current team API ID ──
     team_players = defaultdict(list)  # {team_api_id: [(player_api_id, player_name), ...]}
@@ -5280,17 +5295,6 @@ def _run_batch_fixture_sync(data: dict, job_id: str = None) -> dict:
         TrackedPlayer.status.in_(["on_loan", "first_team", "academy"]),
     ).all()
 
-    tracked_api_ids = set()
-    for tp in tracked:
-        if tp.status == "on_loan" and tp.current_club_api_id:
-            team_players[tp.current_club_api_id].append((tp.player_api_id, tp.player_name))
-            tracked_api_ids.add(tp.player_api_id)
-        elif tp.status in ("first_team", "academy") and tp.team_id:
-            parent_team = Team.query.get(tp.team_id)
-            if parent_team and parent_team.team_id:
-                team_players[parent_team.team_id].append((tp.player_api_id, tp.player_name))
-                tracked_api_ids.add(tp.player_api_id)
-
     # Create API client early — needed for team discovery below
     api_client = APIFootballClient()
 
@@ -5300,8 +5304,202 @@ def _run_batch_fixture_sync(data: dict, job_id: str = None) -> dict:
         TrackedPlayer.status.in_(["sold", "released", "left"]),
     ).all()
 
+    tracked_api_ids = set()
+    batch_player_ids = {tp.player_api_id for tp in [*tracked, *sold_released]}
+    durable_transfers_by_player = defaultdict(list)
+    if batch_player_ids:
+        durable_rows = (
+            PlayerTransferEvent.query.filter(PlayerTransferEvent.player_api_id.in_(batch_player_ids))
+            .order_by(
+                PlayerTransferEvent.player_api_id,
+                PlayerTransferEvent.transfer_date,
+                PlayerTransferEvent.id,
+            )
+            .all()
+        )
+        for row in durable_rows:
+            durable_transfers_by_player[row.player_api_id].append(row)
+
+    from src.models.journey import PlayerJourney, PlayerJourneyEntry
+    from src.models.season_rollup import LeagueSeasonConfig
+
+    season_entries_by_player = defaultdict(list)
+    if batch_player_ids:
+        calendar_rows = (
+            db.session.query(PlayerJourney.player_api_id, PlayerJourneyEntry)
+            .join(PlayerJourneyEntry, PlayerJourneyEntry.journey_id == PlayerJourney.id)
+            .filter(
+                PlayerJourney.player_api_id.in_(batch_player_ids),
+                PlayerJourneyEntry.season == season,
+                PlayerJourneyEntry.is_international.is_not(True),
+            )
+            .all()
+        )
+        for player_api_id, entry in calendar_rows:
+            season_entries_by_player[player_api_id].append(entry)
+
+    league_ids = {
+        entry.league_api_id
+        for entries in season_entries_by_player.values()
+        for entry in entries
+        if entry.league_api_id is not None
+    }
+    season_configs = {
+        row.league_api_id: row
+        for row in (
+            LeagueSeasonConfig.query.filter(LeagueSeasonConfig.league_api_id.in_(league_ids)).all()
+            if league_ids
+            else []
+        )
+    }
+
+    def _season_window(player_api_id, preferred_team_id=None):
+        entries = season_entries_by_player.get(player_api_id, [])
+        preferred = [entry for entry in entries if entry.club_api_id == preferred_team_id]
+        pool = preferred or entries
+        selected = max(
+            pool,
+            key=lambda entry: (
+                entry.sort_priority or 0,
+                entry.transfer_date or "",
+                entry.minutes or 0,
+                entry.appearances or 0,
+            ),
+            default=None,
+        )
+        config = season_configs.get(selected.league_api_id) if selected is not None else None
+        start_month = 7
+        if config is not None:
+            if isinstance(config.rollover_month, int) and 1 <= config.rollover_month <= 12:
+                start_month = config.rollover_month
+            elif (config.season_type or "").strip().casefold() == "calendar":
+                start_month = 1
+        season_end_exclusive = date(season + 1, start_month, 1)
+        routing_cutoff = min(now_utc.date(), season_end_exclusive - timedelta(days=1))
+        # Preserve the established Aug-1 fixture query for unconfigured split
+        # leagues; configured calendars use their actual rollover month.
+        fixture_start_month = start_month if config is not None else 8
+        fixture_start = date(season, fixture_start_month, 1).isoformat()
+        return start_month, routing_cutoff, fixture_start, routing_cutoff.isoformat()
+
     discovery_count = 0
     fee_count = 0
+    transfer_refresh_count = 0
+
+    def _history_starts_after_cutoff(resolution):
+        return bool(
+            resolution is not None
+            and resolution.normalized_events
+            and all(event.transfer_date > resolution.as_of for event in resolution.normalized_events)
+        )
+
+    def _resolved_team_block(resolution, *, allow_evidenced_initial_owner=False):
+        if resolution is None or resolution.loan_state == "indeterminate":
+            return None
+        effective_events = [event for event in resolution.events if event.kind != "unknown"]
+        has_routing_evidence = bool(effective_events) or (
+            allow_evidenced_initial_owner and _history_starts_after_cutoff(resolution)
+        )
+        resolved_club = resolution.current_club
+        resolved_id = resolved_club.api_id or resolved_club.organization_api_id if resolved_club else None
+        if not has_routing_evidence or not resolved_id or resolved_club is None or is_national_team(resolved_club.name):
+            return None
+        return {
+            "id": resolved_id,
+            "name": resolved_club.name or f"Team {resolved_id}",
+        }
+
+    def _routing_projection(transfer_events, initial_owner, player_api_id):
+        start_month, routing_cutoff, fixture_start, fixture_end = _season_window(player_api_id)
+        resolution = None
+        team_block = None
+        if transfer_events is not None:
+            resolution = resolve_transfer_state(
+                transfer_events,
+                as_of=routing_cutoff,
+                initial_owner=initial_owner,
+                season_start_month=start_month,
+            )
+            team_block = _resolved_team_block(
+                resolution,
+                allow_evidenced_initial_owner=True,
+            )
+            if team_block is not None:
+                preferred_window = _season_window(player_api_id, team_block["id"])
+                if preferred_window[0] != start_month:
+                    start_month, routing_cutoff, fixture_start, fixture_end = preferred_window
+                    resolution = resolve_transfer_state(
+                        transfer_events,
+                        as_of=routing_cutoff,
+                        initial_owner=initial_owner,
+                        season_start_month=start_month,
+                    )
+                    team_block = _resolved_team_block(
+                        resolution,
+                        allow_evidenced_initial_owner=True,
+                    )
+        return resolution, team_block, (fixture_start, fixture_end), routing_cutoff
+
+    def _queue_player(team_block, tp):
+        _, _, fixture_start, fixture_end = _season_window(
+            tp.player_api_id,
+            team_block["id"],
+        )
+        team_players[(team_block["id"], fixture_start, fixture_end)].append((tp.player_api_id, tp.player_name))
+
+    def _local_team_db_id(team_api_id):
+        if not team_api_id:
+            return None
+        row = Team.query.filter_by(team_id=team_api_id, is_active=True).order_by(Team.season.desc()).first()
+        return row.id if row else None
+
+    # Every active status uses the same requested-date projection for fixture
+    # routing. Current fields remain status-owned and are not mutated here.
+    for tp in tracked:
+        parent_team = db.session.get(Team, tp.team_id) if tp.team_id else None
+        parent_api_id = parent_team.team_id if parent_team else None
+        parent_club_name = parent_team.name if parent_team else None
+        transfer_events = durable_transfers_by_player.get(tp.player_api_id) or None
+        initial_owner = {"id": parent_api_id, "name": parent_club_name} if parent_api_id or parent_club_name else None
+        routing_resolution, routing_team, _, routing_as_of = _routing_projection(
+            transfer_events,
+            initial_owner,
+            tp.player_api_id,
+        )
+        fallback_team = None
+        if tp.status == "on_loan" and tp.current_club_api_id:
+            fallback_team = {
+                "id": tp.current_club_api_id,
+                "name": tp.current_club_name,
+            }
+        elif tp.status in ("first_team", "academy") and parent_api_id:
+            fallback_team = {"id": parent_api_id, "name": parent_club_name}
+
+        use_routing_projection = False
+        if routing_team is not None and routing_resolution is not None:
+            history_starts_after_cutoff = _history_starts_after_cutoff(routing_resolution)
+            has_post_window_move = any(
+                event.transfer_date > routing_as_of for event in routing_resolution.normalized_events
+            )
+            start_month = _season_window(tp.player_api_id, routing_team["id"])[0]
+            use_routing_projection = bool(
+                fallback_team is None
+                or history_starts_after_cutoff
+                or has_post_window_move
+                or resolved_current_club_is_authoritative(
+                    routing_resolution,
+                    fallback_team["id"],
+                    fallback_team["name"],
+                    latest_season=season,
+                    season_start_month=start_month,
+                )
+            )
+        if not use_routing_projection:
+            routing_team = fallback_team
+        if routing_team is not None:
+            _queue_player(routing_team, tp)
+            tracked_api_ids.add(tp.player_api_id)
+
     for tp in sold_released:
         if tp.player_api_id in tracked_api_ids:
             continue
@@ -5309,29 +5507,45 @@ def _run_batch_fixture_sync(data: dict, job_id: str = None) -> dict:
         parent_team = db.session.get(Team, tp.team_id) if tp.team_id else None
         parent_api_id = parent_team.team_id if parent_team else None
         parent_club_name = parent_team.name if parent_team else None
-        needs_fee = tp.status == "sold" and not tp.sale_fee and not dry_run
-        resolution = None
-        try:
-            transfers_resp = api_client.get_player_transfers(tp.player_api_id)
-            resolution = resolve_transfer_state(
-                flatten_transfers(transfers_resp),
+        initial_owner = {"id": parent_api_id, "name": parent_club_name} if parent_api_id or parent_club_name else None
+        transfer_events = durable_transfers_by_player.get(tp.player_api_id) or None
+        refreshed_this_player = False
+        if refresh_transfers and transfer_refresh_count < transfer_refresh_limit:
+            transfer_refresh_count += 1
+            refreshed_this_player = True
+            try:
+                transfers_resp = api_client.get_player_transfers(tp.player_api_id)
+                transfer_events = flatten_transfers(transfers_resp)
+            except Exception as exc:
+                logger.warning(
+                    "Batch sync explicit transfer refresh failed for player %s: %s; using durable evidence",
+                    tp.player_api_id,
+                    exc,
+                )
+
+        current_resolution = None
+        routing_resolution = None
+        routing_resolved_team = None
+        routing_as_of = _season_window(tp.player_api_id)[1]
+        if transfer_events is not None:
+            current_resolution = resolve_transfer_state(
+                transfer_events,
                 as_of=now_utc.date(),
-                initial_owner=({"id": parent_api_id, "name": parent_club_name} if parent_api_id else None),
+                initial_owner=initial_owner,
             )
-        except Exception as exc:
-            logger.debug(
-                "Batch sync transfer resolution failed for player %s: %s",
+            routing_resolution, routing_resolved_team, _, routing_as_of = _routing_projection(
+                transfer_events,
+                initial_owner,
                 tp.player_api_id,
-                exc,
             )
 
-        if needs_fee and resolution is not None and parent_api_id:
+        if not dry_run and current_resolution is not None and parent_api_id:
             parent_departure = latest_parent_permanent_departure(
-                resolution,
+                current_resolution,
                 parent_api_id,
                 parent_club_name,
             )
-            if parent_departure is not None and parent_departure.fee is not None:
+            if tp.status == "sold" and parent_departure is not None and tp.sale_fee != parent_departure.fee:
                 tp.sale_fee = parent_departure.fee
                 fee_count += 1
                 # Fee propagation is an independent repair.  Persist it before
@@ -5339,58 +5553,68 @@ def _run_batch_fixture_sync(data: dict, job_id: str = None) -> dict:
                 # silently roll back resolver-derived sale evidence.
                 db.session.commit()
 
-        resolved_team_block = None
-        if resolution is not None and resolution.loan_state != "indeterminate":
-            effective_events = [event for event in resolution.events if event.kind != "unknown"]
-            resolved_club = resolution.current_club
-            resolved_id = (
-                resolved_club.api_id or resolved_club.organization_api_id if resolved_club is not None else None
+        current_resolved_team = _resolved_team_block(current_resolution)
+        routing_uses_initial_owner = _history_starts_after_cutoff(routing_resolution)
+        has_post_window_move = bool(
+            current_resolution is not None
+            and any(
+                event.kind != "unknown" and event.transfer_date > routing_as_of for event in current_resolution.events
             )
-            if (
-                effective_events
-                and resolved_id
-                and resolved_club is not None
-                and not is_national_team(resolved_club.name)
-            ):
-                resolved_team_block = {
-                    "id": resolved_id,
-                    "name": resolved_club.name or f"Team {resolved_id}",
-                }
+        )
 
         # Reconcile a prior backfill with concrete chronological evidence
         # before the known-club fast path. Transfer failure remains distinct:
         # without a resolution, the stored club is preserved conservatively.
         if tp.current_club_api_id:
-            use_resolved_team = bool(
-                resolved_team_block is not None
-                and resolution is not None
+            use_current_resolved_team = bool(
+                current_resolved_team is not None
+                and current_resolution is not None
                 and resolved_current_club_is_authoritative(
-                    resolution,
+                    current_resolution,
                     tp.current_club_api_id,
                     tp.current_club_name,
-                    latest_season=season,
+                    latest_season=present_season,
                 )
             )
-            effective_team = (resolved_team_block if use_resolved_team else None) or {
+            current_team = (current_resolved_team if use_current_resolved_team else None) or {
                 "id": tp.current_club_api_id,
                 "name": tp.current_club_name,
             }
-            effective_team_id = effective_team["id"]
-            team_players[effective_team_id].append((tp.player_api_id, tp.player_name))
+            use_routing_resolved_team = bool(
+                routing_resolved_team is not None
+                and routing_resolution is not None
+                and (
+                    has_post_window_move
+                    or routing_uses_initial_owner
+                    or resolved_current_club_is_authoritative(
+                        routing_resolution,
+                        tp.current_club_api_id,
+                        tp.current_club_name,
+                        latest_season=season,
+                    )
+                )
+            )
+            routing_team = (routing_resolved_team if use_routing_resolved_team else None) or current_team
+            _queue_player(routing_team, tp)
             tracked_api_ids.add(tp.player_api_id)
             if not dry_run:
-                if use_resolved_team:
-                    tp.current_club_api_id = effective_team_id
-                    tp.current_club_name = effective_team["name"]
+                if use_current_resolved_team:
+                    tp.current_club_api_id = current_team["id"]
+                    tp.current_club_name = current_team["name"]
+                    tp.current_club_db_id = _local_team_db_id(current_team["id"])
                 db.session.commit()
-            if delay > 0:
+            if refreshed_this_player and delay > 0:
                 time.sleep(delay)
             continue
         # Discover team from API-Football /players endpoint
         try:
             best_team_block = None
             best_stat = None
-            player_data = api_client.get_player_by_id(tp.player_api_id, season)
+            player_data = api_client.get_player_by_id(
+                tp.player_api_id,
+                season,
+                allow_transfer_fallback=False,
+            )
             if player_data and player_data.get("statistics"):
                 # Find the best CLUB team (skip national teams + parent academy, prefer most appearances)
                 # For sold players, we want the club they were sold TO, not the parent
@@ -5417,26 +5641,44 @@ def _run_batch_fixture_sync(data: dict, job_id: str = None) -> dict:
             # must not replace newer stored/profile club evidence.
             profile_club_id = best_team_block.get("id") if best_team_block else None
             profile_club_name = best_team_block.get("name") if best_team_block else None
-            if (
-                resolved_team_block is not None
-                and resolution is not None
+            use_current_resolved_team = bool(
+                current_resolved_team is not None
+                and current_resolution is not None
                 and resolved_current_club_is_authoritative(
-                    resolution,
+                    current_resolution,
                     profile_club_id,
                     profile_club_name,
-                    latest_season=season,
+                    latest_season=present_season,
                 )
-            ):
-                best_team_block = resolved_team_block
+            )
+            current_team = (current_resolved_team if use_current_resolved_team else None) or best_team_block
+            use_routing_resolved_team = bool(
+                routing_resolved_team is not None
+                and routing_resolution is not None
+                and (
+                    has_post_window_move
+                    or routing_uses_initial_owner
+                    or resolved_current_club_is_authoritative(
+                        routing_resolution,
+                        profile_club_id,
+                        profile_club_name,
+                        latest_season=season,
+                    )
+                )
+            )
+            routing_team = (routing_resolved_team if use_routing_resolved_team else None) or best_team_block
 
-            if best_team_block:
-                team_api_id = best_team_block.get("id")
-                team_players[team_api_id].append((tp.player_api_id, tp.player_name))
+            if routing_team:
+                _queue_player(routing_team, tp)
                 tracked_api_ids.add(tp.player_api_id)
-                # Backfill team on TrackedPlayer
-                if not dry_run:
-                    tp.current_club_api_id = team_api_id
-                    tp.current_club_name = best_team_block.get("name")
+                # Present-day resolver state may always repair current fields;
+                # requested-season profile data may do so only for the current
+                # stats season, never during a historical backfill.
+                may_persist_current_team = use_current_resolved_team or season == present_season
+                if not dry_run and current_team and may_persist_current_team:
+                    tp.current_club_api_id = current_team.get("id")
+                    tp.current_club_name = current_team.get("name")
+                    tp.current_club_db_id = _local_team_db_id(current_team.get("id"))
                     # Also backfill position if missing
                     if not tp.position:
                         games = (best_stat or {}).get("games", {}) or {}
@@ -5447,11 +5689,28 @@ def _run_batch_fixture_sync(data: dict, job_id: str = None) -> dict:
             time.sleep(delay)  # Rate limit API calls
         except Exception as e:
             logger.warning(f"Failed to discover team for player {tp.player_api_id} ({tp.player_name}): {e}")
+            fallback_routing_team = routing_resolved_team or current_resolved_team
+            if fallback_routing_team:
+                _queue_player(fallback_routing_team, tp)
+                tracked_api_ids.add(tp.player_api_id)
+                discovery_count += 1
+                if not dry_run and current_resolved_team:
+                    tp.current_club_api_id = current_resolved_team["id"]
+                    tp.current_club_name = current_resolved_team["name"]
+                    tp.current_club_db_id = _local_team_db_id(current_resolved_team["id"])
+                    db.session.commit()
+            if refreshed_this_player and delay > 0:
+                time.sleep(delay)
 
     total_teams = len(team_players)
     total_players = sum(len(v) for v in team_players.values())
     logger.info(f"Batch sync: {total_players} players across {total_teams} teams, season={season}, dry_run={dry_run}")
-    logger.info(f"Team discovery: {discovery_count} sold/released players resolved, {fee_count} fees extracted")
+    logger.info(
+        "Team discovery: %s sold/released players resolved, %s fees repaired, %s explicit transfer refreshes",
+        discovery_count,
+        fee_count,
+        transfer_refresh_count,
+    )
 
     if job_id:
         _update_job(
@@ -5461,12 +5720,10 @@ def _run_batch_fixture_sync(data: dict, job_id: str = None) -> dict:
             current_player=f"Starting: {total_players} players across {total_teams} teams",
         )
 
-    season_start = f"{season}-08-01"
-    today = now_utc.strftime("%Y-%m-%d")
-
     summary = {
         "season": season,
         "dry_run": dry_run,
+        "transfer_refreshes": transfer_refresh_count,
         "total_teams": total_teams,
         "total_players": total_players,
         "total_fixtures_checked": 0,
@@ -5478,7 +5735,7 @@ def _run_batch_fixture_sync(data: dict, job_id: str = None) -> dict:
     players_processed = 0
 
     # ── 2. Process each team group ──
-    for team_api_id, players in team_players.items():
+    for (team_api_id, season_start, fixture_end), players in team_players.items():
         team_result = {
             "team_api_id": team_api_id,
             "players": len(players),
@@ -5489,7 +5746,17 @@ def _run_batch_fixture_sync(data: dict, job_id: str = None) -> dict:
         }
 
         try:
-            fixtures = api_client.get_fixtures_for_team_cached(team_api_id, season, season_start, today)
+            if season_start > fixture_end:
+                logger.info(
+                    "Batch sync: season %s has not started for team %s (%s > %s)",
+                    season,
+                    team_api_id,
+                    season_start,
+                    fixture_end,
+                )
+                fixtures = []
+            else:
+                fixtures = api_client.get_fixtures_for_team_cached(team_api_id, season, season_start, fixture_end)
 
             # Filter to finished games only
             finished = [
@@ -11669,37 +11936,71 @@ def _seed_single_team(team, max_age=30, sync_journeys=True, years=4, season=None
                 player_api_id=pid,
                 team_id=team_id,
             ).first()
-            if existing:
-                new_status, new_loan_id, new_loan_name = classify_tracked_player(
-                    current_club_api_id=journey.current_club_api_id if journey else None,
-                    current_club_name=journey.current_club_name if journey else None,
-                    current_level=journey.current_level if journey else None,
-                    parent_api_id=parent_api_id,
-                    parent_club_name=team.name,
-                    player_api_id=pid,
-                    api_client=_api,
-                    latest_season=_get_latest_season(
-                        journey.id, parent_api_id=parent_api_id, parent_club_name=team.name
-                    )
-                    if journey
-                    else None,
+            transfer_evidence = None
+            transfer_resolution = None
+            transfer_evidence_authoritative = False
+            try:
+                transfer_evidence = flatten_transfers(_api.get_player_transfers(pid))
+                transfer_resolution = resolve_transfer_state(
+                    transfer_evidence,
+                    as_of=datetime.now(UTC).date(),
+                    initial_owner={"id": parent_api_id, "name": team.name},
                 )
-                # Resolve the local Team FK so consumers that prefer
-                # current_club_db_id (radar comparison, journey badges,
-                # team-loans-out filters) don't have to do their own join.
-                new_db_id = None
-                if new_loan_id:
-                    target_team = Team.query.filter_by(team_id=new_loan_id).first()
-                    new_db_id = target_team.id if target_team else None
-                if (
-                    existing.status != new_status
-                    or existing.current_club_api_id != new_loan_id
-                    or existing.current_club_db_id != new_db_id
-                ):
-                    existing.status = new_status
-                    existing.current_club_api_id = new_loan_id
-                    existing.current_club_name = new_loan_name
-                    existing.current_club_db_id = new_db_id
+                transfer_evidence_authoritative = resolved_transfer_evidence_is_authoritative(
+                    transfer_evidence,
+                    transfer_resolution,
+                )
+            except Exception as transfer_err:
+                logger.warning(
+                    "seed: transfer fetch failed for player %d; preserving existing transfer state: %s",
+                    pid,
+                    transfer_err,
+                )
+            if existing:
+                if transfer_evidence_authoritative:
+                    new_status, new_loan_id, new_loan_name = classify_tracked_player(
+                        current_club_api_id=journey.current_club_api_id if journey else None,
+                        current_club_name=journey.current_club_name if journey else None,
+                        current_level=journey.current_level if journey else None,
+                        parent_api_id=parent_api_id,
+                        parent_club_name=team.name,
+                        transfers=transfer_evidence,
+                        transfer_resolution=transfer_resolution,
+                        latest_season=_get_latest_season(
+                            journey.id, parent_api_id=parent_api_id, parent_club_name=team.name
+                        )
+                        if journey
+                        else None,
+                    )
+                    # Resolve the local Team FK so consumers that prefer
+                    # current_club_db_id (radar comparison, journey badges,
+                    # team-loans-out filters) don't have to do their own join.
+                    new_db_id = None
+                    if new_loan_id:
+                        target_team = (
+                            Team.query.filter_by(team_id=new_loan_id, is_active=True)
+                            .order_by(Team.season.desc())
+                            .first()
+                        )
+                        new_db_id = target_team.id if target_team else None
+                    parent_departure = latest_parent_permanent_departure(
+                        transfer_resolution,
+                        parent_api_id,
+                        team.name,
+                    )
+                    new_sale_fee = parent_departure.fee if new_status == "sold" and parent_departure else None
+                    if (
+                        existing.status != new_status
+                        or existing.current_club_api_id != new_loan_id
+                        or existing.current_club_name != new_loan_name
+                        or existing.current_club_db_id != new_db_id
+                        or existing.sale_fee != new_sale_fee
+                    ):
+                        existing.status = new_status
+                        existing.current_club_api_id = new_loan_id
+                        existing.current_club_name = new_loan_name
+                        existing.current_club_db_id = new_db_id
+                        existing.sale_fee = new_sale_fee
                 skipped += 1
                 continue
 
@@ -11722,8 +12023,8 @@ def _seed_single_team(team, max_age=30, sync_journeys=True, years=4, season=None
                 current_level=journey.current_level if journey else None,
                 parent_api_id=parent_api_id,
                 parent_club_name=team.name,
-                player_api_id=pid,
-                api_client=_api,
+                transfers=transfer_evidence,
+                transfer_resolution=transfer_resolution,
                 latest_season=_get_latest_season(journey.id, parent_api_id=parent_api_id, parent_club_name=team.name)
                 if journey
                 else None,
@@ -11752,8 +12053,18 @@ def _seed_single_team(team, max_age=30, sync_journeys=True, years=4, season=None
             # rows have current_club_db_id populated from day one.
             current_club_db_id_val = None
             if current_club_api_id:
-                target_team_row = Team.query.filter_by(team_id=current_club_api_id).first()
+                target_team_row = (
+                    Team.query.filter_by(team_id=current_club_api_id, is_active=True)
+                    .order_by(Team.season.desc())
+                    .first()
+                )
                 current_club_db_id_val = target_team_row.id if target_team_row else None
+            parent_departure = latest_parent_permanent_departure(
+                transfer_resolution,
+                parent_api_id,
+                team.name,
+            )
+            sale_fee = parent_departure.fee if status == "sold" and parent_departure else None
 
             tp = TrackedPlayer(
                 player_api_id=pid,
@@ -11769,6 +12080,7 @@ def _seed_single_team(team, max_age=30, sync_journeys=True, years=4, season=None
                 current_club_api_id=current_club_api_id,
                 current_club_name=current_club_name,
                 current_club_db_id=current_club_db_id_val,
+                sale_fee=sale_fee,
                 data_source="api-football",
                 data_depth="full_stats",
                 journey_id=journey.id if journey else None,

--- a/academy-watch-backend/src/routes/teams.py
+++ b/academy-watch-backend/src/routes/teams.py
@@ -736,7 +736,7 @@ def get_academy_network(team_identifier):
                     journey.current_level,
                     team_api_id,
                     parent_name,
-                    transfers=[],  # read-only view, skip API calls
+                    transfers=None,  # read-only view: evidence was not fetched
                     latest_season=_get_latest_season(
                         journey.id, parent_api_id=team_api_id, parent_club_name=parent_name
                     ),

--- a/academy-watch-backend/src/services/gol_player_lookup.py
+++ b/academy-watch-backend/src/services/gol_player_lookup.py
@@ -12,7 +12,7 @@ The player cache is invalidated so GOL's DataFrames are refreshed on next access
 import logging
 import re
 import threading
-from datetime import date
+from datetime import UTC, date, datetime
 from difflib import SequenceMatcher
 from typing import Any
 
@@ -22,7 +22,13 @@ from src.models.journey import PlayerJourney
 from src.models.league import Team, db
 from src.models.tracked_player import TrackedPlayer
 from src.services.journey_sync import JourneySyncService
-from src.utils.academy_classifier import classify_tracked_player
+from src.services.transfer_resolver import resolve_transfer_state
+from src.utils.academy_classifier import (
+    classify_tracked_player,
+    flatten_transfers,
+    latest_parent_permanent_departure,
+    resolved_transfer_evidence_is_authoritative,
+)
 from src.utils.player_names import resolve_player_name
 
 logger = logging.getLogger(__name__)
@@ -200,12 +206,16 @@ class GolPlayerLookup:
 
             DataFrameCache.invalidate()
 
+            display_current_club = tracked.current_club_name
+            if not display_current_club and tracked.status in {"academy", "first_team"}:
+                display_current_club = (journey.current_club_name if journey else None) or parent_team.name
+
             return {
                 "found": True,
                 "player_name": tracked.player_name,
                 "team": tracked.team.name if tracked.team else parent_team.name,
                 "message": f"Added {tracked.player_name} to the database.\n"
-                f"Current club: {journey.current_club_name if journey else 'unknown'}.",
+                f"Current club: {display_current_club or 'unknown'}.",
                 "rate_limited": False,
             }
 
@@ -382,15 +392,53 @@ class GolPlayerLookup:
         current_club_name = journey.current_club_name if journey else None
         current_level = journey.current_level if journey else None
 
+        existing = TrackedPlayer.query.filter_by(
+            player_api_id=player_id,
+            team_id=team.id,
+        ).first()
+        transfer_evidence = None
+        transfer_resolution = None
+        transfer_evidence_authoritative = False
+        try:
+            transfer_evidence = flatten_transfers(self.api_client.get_player_transfers(player_id))
+            transfer_resolution = resolve_transfer_state(
+                transfer_evidence,
+                as_of=datetime.now(UTC).date(),
+                initial_owner={"id": team.team_id, "name": team.name},
+            )
+            transfer_evidence_authoritative = resolved_transfer_evidence_is_authoritative(
+                transfer_evidence,
+                transfer_resolution,
+            )
+        except Exception as exc:
+            logger.warning(
+                "GOL transfer fetch failed for player %s; preserving existing transfer state: %s",
+                player_id,
+                exc,
+            )
+
         status, current_club_api_id, current_club_name = classify_tracked_player(
             current_club_api_id=current_club_id,
             current_club_name=current_club_name,
             current_level=current_level,
             parent_api_id=team.team_id,
             parent_club_name=team.name,
-            player_api_id=player_id,
-            api_client=self.api_client,
+            transfers=transfer_evidence,
+            transfer_resolution=transfer_resolution,
         )
+        parent_departure = latest_parent_permanent_departure(
+            transfer_resolution,
+            team.team_id,
+            team.name,
+        )
+        sale_fee = parent_departure.fee if status == "sold" and parent_departure else None
+
+        current_club_db_id = None
+        if current_club_api_id:
+            current_team = (
+                Team.query.filter_by(team_id=current_club_api_id, is_active=True).order_by(Team.season.desc()).first()
+            )
+            current_club_db_id = current_team.id if current_team else None
 
         age = player.get("age")
         try:
@@ -406,11 +454,6 @@ class GolPlayerLookup:
                 position = games.get("position")
                 if position:
                     break
-
-        existing = TrackedPlayer.query.filter_by(
-            player_api_id=player_id,
-            team_id=team.id,
-        ).first()
 
         # Tracking-window gate for NEW rows: only academy players current or
         # within the past ACADEMY_WINDOW_YEARS seasons may be added. Existing
@@ -433,10 +476,13 @@ class GolPlayerLookup:
             existing.age = age if age is not None else existing.age
             if last_academy_season is not None:
                 existing.last_academy_season = last_academy_season
-            existing.status = status
             existing.current_level = current_level or existing.current_level
-            existing.current_club_api_id = current_club_api_id
-            existing.current_club_name = current_club_name
+            if transfer_evidence_authoritative:
+                existing.status = status
+                existing.current_club_api_id = current_club_api_id
+                existing.current_club_name = current_club_name
+                existing.current_club_db_id = current_club_db_id
+                existing.sale_fee = sale_fee
             existing.journey_id = journey.id if journey else existing.journey_id
             existing.data_source = "api-football"
             existing.data_depth = "full_stats"
@@ -457,6 +503,8 @@ class GolPlayerLookup:
             current_level=current_level,
             current_club_api_id=current_club_api_id,
             current_club_name=current_club_name,
+            current_club_db_id=current_club_db_id,
+            sale_fee=sale_fee,
             data_source="api-football",
             data_depth="full_stats",
             journey_id=journey.id if journey else None,

--- a/academy-watch-backend/src/services/journey_sync.py
+++ b/academy-watch-backend/src/services/journey_sync.py
@@ -111,6 +111,70 @@ def _club_ref_matches(ref: ClubRef | None, club_api_id: int | None, club_name: s
     return bool(base_name and ref.organization_key == f"name:{base_name}")
 
 
+def _stats_backed_club_ids(ref: ClubRef | None, entries: list) -> set[int]:
+    """Bind resolver identity to unambiguous statistics-backed club IDs.
+
+    Exact/provider affiliate IDs win. Name-only evidence is accepted only when
+    it identifies one stored club ID; two unrelated IDs with the same normalized
+    name remain ambiguous.
+    """
+    if ref is None:
+        return set()
+    candidates = {
+        (entry.club_api_id, entry.club_name)
+        for entry in entries
+        if entry.club_api_id is not None and _club_ref_matches(ref, entry.club_api_id, entry.club_name)
+    }
+    if not candidates:
+        return set()
+
+    direct_ids = {ref.api_id, ref.organization_api_id} - {None}
+    exact_ids = {club_id for club_id, _ in candidates if club_id in direct_ids}
+    if exact_ids:
+        return exact_ids
+
+    full_name = _metadata_name(ref.name)
+    full_name_ids = {
+        club_id for club_id, club_name in candidates if full_name and _metadata_name(club_name) == full_name
+    }
+    if len(full_name_ids) == 1:
+        return full_name_ids
+    if len(full_name_ids) > 1:
+        return set()
+
+    direct_senior_ids = {
+        resolve_senior_id(club_id, ref.name)
+        for club_id in direct_ids
+        if resolve_senior_id(club_id, ref.name) is not None
+    }
+    affiliate_ids = {
+        club_id for club_id, club_name in candidates if resolve_senior_id(club_id, club_name) in direct_senior_ids
+    }
+    if affiliate_ids:
+        return affiliate_ids
+
+    candidate_ids = {club_id for club_id, _ in candidates}
+    return candidate_ids if len(candidate_ids) == 1 else set()
+
+
+def _stats_backed_organization_ids(ref: ClubRef | None, entries: list) -> set[int]:
+    """Return all stats IDs for one uniquely anchored club organization."""
+    if ref is None:
+        return set()
+    candidates = {
+        entry.club_api_id
+        for entry in entries
+        if entry.club_api_id is not None and _club_ref_matches(ref, entry.club_api_id, entry.club_name)
+    }
+    if not candidates:
+        return set()
+    direct_ids = {ref.api_id, ref.organization_api_id} - {None}
+    if candidates & direct_ids:
+        return candidates
+    anchor_ids = _stats_backed_club_ids(ref, entries)
+    return candidates if len(anchor_ids) == 1 else set()
+
+
 def _raw_club_logo(event, direction: str) -> str:
     """Best-effort logo lookup without sacrificing the resolver's raw IDs."""
     raw = event.event.raw
@@ -1257,17 +1321,39 @@ class JourneySyncService:
         # Only topology-resolved permanent moves correct historical clubs. A
         # reverse-direction N/A return is excluded; a same-direction N/A
         # conversion is included by the same policy as every other consumer.
+        # Provider IDs enrich identity but are not mandatory: a name-only
+        # endpoint may bind to exactly one stats-backed journey club. Zero or
+        # multiple matches remain ambiguous and are left untouched.
+        evidence_entries = [entry for entry in entries if not entry.is_international]
+
+        def _evidence_id(ref: ClubRef) -> int | None:
+            direct_id = ref.api_id or ref.organization_api_id
+            matching_ids = _stats_backed_club_ids(ref, evidence_entries)
+            if direct_id in matching_ids:
+                return direct_id
+            if len(matching_ids) == 1:
+                return next(iter(matching_ids))
+            if not matching_ids and not any(
+                _club_ref_matches(ref, entry.club_api_id, entry.club_name) for entry in evidence_entries
+            ):
+                return direct_id
+            return None
+
         permanent_moves = []
         for event in resolution.events:
-            if event.kind != "permanent" or not event.in_club.api_id or not event.out_club.api_id:
+            if event.kind != "permanent":
+                continue
+            in_id = _evidence_id(event.in_club)
+            out_id = _evidence_id(event.out_club)
+            if in_id is None or out_id is None:
                 continue
             permanent_moves.append(
                 {
                     "date": event.transfer_date.isoformat(),
-                    "in_id": event.in_club.api_id,
+                    "in_id": in_id,
                     "in_name": event.in_club.name or "",
                     "in_logo": _raw_club_logo(event, "in"),
-                    "out_id": event.out_club.api_id,
+                    "out_id": out_id,
                     "out_name": event.out_club.name or "",
                     "out_logo": _raw_club_logo(event, "out"),
                 }
@@ -1284,7 +1370,7 @@ class JourneySyncService:
         # "Newcastle ⟸ Ashington AFC" alongside the genuine "Newcastle ⟸
         # Nottingham Forest". Correcting a season to that phantom source
         # manufactures a club the player never played for.
-        evidence_club_ids = {e.club_api_id for e in entries if not e.is_international}
+        evidence_club_ids = {e.club_api_id for e in evidence_entries}
 
         moves_by_in: dict[int, list] = {}
         for move in permanent_moves:
@@ -1453,19 +1539,16 @@ class JourneySyncService:
             transfer_resolution=transfer_resolution,
             as_of=as_of,
         )
-        permanent_transfer_dest_years = {}
+        domestic_entries = [entry for entry in entries if not entry.is_international]
+        permanent_transfer_destinations: list[tuple[set[int], int]] = []
         if resolution is not None:
             for event in resolution.events:
                 if event.kind != "permanent":
                     continue
                 year = event.transfer_date.year
-                for dest_id in {
-                    event.in_club.api_id,
-                    event.in_club.organization_api_id,
-                } - {None}:
-                    prior = permanent_transfer_dest_years.get(dest_id)
-                    if prior is None or year < prior:
-                        permanent_transfer_dest_years[dest_id] = year
+                destination_ids = _stats_backed_organization_ids(event.in_club, domestic_entries)
+                if destination_ids:
+                    permanent_transfer_destinations.append((destination_ids, year))
 
         # Parse birth year for age-at-entry validation
         birth_year = None
@@ -1538,13 +1621,18 @@ class JourneySyncService:
         # same-club first-team debut). Entries that PRECEDE the transfer stay
         # untouched — an academy product sold and bought back keeps academy
         # status for their formative years.
-        if permanent_transfer_dest_years:
+        if permanent_transfer_destinations:
             for entry in entries:
                 if entry.entry_type not in ("academy", "development") or entry.is_international:
                     continue
-                if entry.club_api_id not in permanent_transfer_dest_years:
+                matching_years = [
+                    year
+                    for destination_ids, year in permanent_transfer_destinations
+                    if entry.club_api_id in destination_ids
+                ]
+                if not matching_years:
                     continue
-                transfer_year = permanent_transfer_dest_years[entry.club_api_id]
+                transfer_year = min(matching_years)
                 # Teenage gate: a recorded transfer at <= 18 is an academy
                 # move (youth-to-youth), not a senior signing.
                 if transfer_year is not None and birth_year is not None and transfer_year - birth_year <= 18:
@@ -1790,6 +1878,10 @@ class JourneySyncService:
             season_start_day=resolution.season_start_day,
         ):
             destination_id = destination.api_id or destination.organization_api_id
+            if destination_id is None:
+                destination_ids = _stats_backed_club_ids(destination, domestic)
+                if len(destination_ids) == 1:
+                    destination_id = next(iter(destination_ids))
             journey.current_club_api_id = destination_id
             journey.current_club_name = destination.name
             if destination.name:

--- a/academy-watch-backend/src/utils/academy_classifier.py
+++ b/academy-watch-backend/src/utils/academy_classifier.py
@@ -667,6 +667,26 @@ def resolved_current_club_is_authoritative(
     )
 
 
+def resolved_transfer_evidence_is_authoritative(
+    transfers: list | None,
+    resolution: TransferResolution | None,
+) -> bool:
+    """Whether a successful fetch can safely replace known derived state.
+
+    A successful empty history is authoritative. A non-empty response is not
+    authoritative when normalization dropped evidence or topology left an
+    unknown event; consumers must preserve their existing transfer-derived
+    fields in that case.
+    """
+    if transfers is None or resolution is None:
+        return False
+    if not transfers:
+        return True
+    return len(resolution.normalized_events) == len(transfers) and not any(
+        event.kind == "unknown" for event in resolution.events
+    )
+
+
 def latest_parent_permanent_departure(
     resolution: TransferResolution | None,
     parent_api_id: int,

--- a/academy-watch-backend/tests/test_academy_provenance.py
+++ b/academy-watch-backend/tests/test_academy_provenance.py
@@ -507,6 +507,101 @@ class TestEntryTypingFinalForm:
         svc._apply_development_classification(entries, transfers=transfers, birth_date="1999-08-17")
         assert entries[1].entry_type == "integration"
 
+    def test_name_only_transfer_in_flags_matching_youth_entry(self):
+        svc = self._svc()
+        entries = [self._entry(club_api_id=7198, club_name="Manchester United U21", season=2024)]
+        transfers = [
+            {
+                "type": "€ 15M",
+                "date": "2022-07-05",
+                "teams": {
+                    "in": {"id": None, "name": "Manchester United"},
+                    "out": {"id": 209, "name": "Feyenoord"},
+                },
+            }
+        ]
+
+        svc._apply_development_classification(entries, transfers=transfers, birth_date=None)
+
+        assert entries[0].entry_type == "integration"
+
+    def test_name_only_transfer_in_does_not_flag_ambiguous_club_ids(self):
+        svc = self._svc()
+        entries = [
+            self._entry(club_api_id=7198, club_name="Manchester United U21", season=2024),
+            self._entry(club_api_id=9998, club_name="Manchester United U21", season=2024),
+        ]
+        transfers = [
+            {
+                "type": "€ 15M",
+                "date": "2022-07-05",
+                "teams": {
+                    "in": {"id": None, "name": "Manchester United"},
+                    "out": {"id": 209, "name": "Feyenoord"},
+                },
+            }
+        ]
+
+        svc._apply_development_classification(entries, transfers=transfers, birth_date=None)
+
+        assert [entry.entry_type for entry in entries] == ["academy", "academy"]
+
+    def test_direct_senior_transfer_flags_same_organization_youth_entry(self):
+        svc = self._svc()
+        entries = [
+            self._entry(
+                club_api_id=33,
+                club_name="Manchester United",
+                season=2022,
+                entry_type="first_team",
+                level="First Team",
+                appearances=30,
+            ),
+            self._entry(club_api_id=7198, club_name="Manchester United U21", season=2024),
+        ]
+        transfers = [
+            {
+                "type": "€ 15M",
+                "date": "2022-07-05",
+                "teams": {
+                    "in": {"id": 33, "name": "Manchester United"},
+                    "out": {"id": 209, "name": "Feyenoord"},
+                },
+            }
+        ]
+
+        svc._apply_development_classification(entries, transfers=transfers, birth_date=None)
+
+        assert entries[1].entry_type == "integration"
+
+    def test_name_only_senior_transfer_anchors_same_organization_youth_entry(self):
+        svc = self._svc()
+        entries = [
+            self._entry(
+                club_api_id=33,
+                club_name="Manchester United",
+                season=2022,
+                entry_type="first_team",
+                level="First Team",
+                appearances=30,
+            ),
+            self._entry(club_api_id=7198, club_name="Manchester United U21", season=2024),
+        ]
+        transfers = [
+            {
+                "type": "€ 15M",
+                "date": "2022-07-05",
+                "teams": {
+                    "in": {"id": None, "name": "Manchester United"},
+                    "out": {"id": 209, "name": "Feyenoord"},
+                },
+            }
+        ]
+
+        svc._apply_development_classification(entries, transfers=transfers, birth_date=None)
+
+        assert entries[1].entry_type == "integration"
+
     def test_teenage_transfer_into_academy_stays_academy(self):
         svc = self._svc()
         entries = [self._entry(club_api_id=7198, club_name="Manchester United U18", season=2020, level="U18")]

--- a/academy-watch-backend/tests/test_api_transfer_persistence.py
+++ b/academy-watch-backend/tests/test_api_transfer_persistence.py
@@ -54,6 +54,45 @@ def test_team_and_profile_transfer_paths_use_payload_adapter(monkeypatch):
     assert calls == [(blocks, {"fallback_player_api_id": 123})]
 
 
+def test_profile_lookup_can_disable_transfer_fallback(monkeypatch):
+    endpoints = []
+    client = APIFootballClient.__new__(APIFootballClient)
+    client.mode = "direct"
+    client.current_season_start_year = 2025
+    client._player_profile_cache = {}
+    client._get_sample_player_data = lambda player_id: {
+        "player": {"id": player_id, "name": "Sample"},
+        "statistics": [],
+    }
+
+    def request(endpoint, params):
+        endpoints.append(endpoint)
+        return {"response": []}
+
+    client._make_request = request
+
+    profile = client.get_player_by_id(123, season=2025, allow_transfer_fallback=False)
+
+    assert profile["player"]["name"] == "Player 123"
+    assert profile["statistics"] == []
+    assert endpoints == ["players", "players/seasons"]
+
+    endpoints.clear()
+    blocks = [_block()]
+
+    def request_with_transfers(endpoint, params):
+        endpoints.append(endpoint)
+        return {"response": blocks if endpoint == "transfers" else []}
+
+    monkeypatch.setattr(api_module, "_record_transfer_payload", lambda *args, **kwargs: None)
+    client._make_request = request_with_transfers
+
+    normal_profile = client.get_player_by_id(123, season=2025)
+
+    assert normal_profile["player"]["name"] == "Player"
+    assert endpoints == ["players", "players/seasons", "transfers"]
+
+
 def test_player_transfer_path_records_live_and_memory_cached_payloads(monkeypatch):
     calls = []
     monkeypatch.setattr(

--- a/academy-watch-backend/tests/test_gol_window_gate.py
+++ b/academy-watch-backend/tests/test_gol_window_gate.py
@@ -140,3 +140,283 @@ class TestGolWindowGate:
         assert tracked.id == existing.id
         assert tracked.is_active is False
         assert tracked.last_academy_season == old
+
+    def test_existing_transfer_state_survives_fetch_failure(self, app, lookup):
+        team = _seed_team()
+        destination = Team(
+            team_id=777,
+            name="Buying Club",
+            country="England",
+            season=2025,
+            league_id=team.league_id,
+            is_active=True,
+        )
+        db.session.add(destination)
+        db.session.flush()
+        recent = current_academy_season() - 1
+        journey = _journey(503, last_seasons={"100": recent})
+        journey.current_club_api_id = team.team_id
+        journey.current_club_name = team.name
+        existing = TrackedPlayer(
+            player_api_id=503,
+            player_name="Known Sale",
+            team_id=team.id,
+            status="sold",
+            current_club_api_id=777,
+            current_club_name="Buying Club",
+            current_club_db_id=destination.id,
+            sale_fee="€ 20M",
+            data_source="api-football",
+            is_active=True,
+        )
+        db.session.add(existing)
+        db.session.commit()
+
+        class _FailedTransfers:
+            def get_player_transfers(self, player_id):
+                raise RuntimeError("provider unavailable")
+
+        lookup.api_client = _FailedTransfers()
+        tracked = lookup._upsert_tracked_player(
+            player_id=503,
+            player_block=_player_block(birth_date="2005-01-01", age=21),
+            journey=journey,
+            team=team,
+        )
+
+        assert tracked.status == "sold"
+        assert (tracked.current_club_api_id, tracked.current_club_name) == (777, "Buying Club")
+        assert tracked.current_club_db_id == destination.id
+        assert tracked.sale_fee == "€ 20M"
+
+    def test_successful_sale_updates_club_fk_and_parent_fee(self, app, lookup):
+        team = _seed_team()
+        stale_destination = Team(
+            team_id=200,
+            name="Old Buying Club Row",
+            country="England",
+            season=2024,
+            league_id=team.league_id,
+            is_active=False,
+        )
+        destination = Team(
+            team_id=200,
+            name="Buying Club",
+            country="England",
+            season=2025,
+            league_id=team.league_id,
+            is_active=True,
+        )
+        db.session.add_all([stale_destination, destination])
+        recent = current_academy_season() - 1
+        journey = _journey(504, last_seasons={"100": recent})
+        journey.current_club_api_id = team.team_id
+        journey.current_club_name = team.name
+        existing = TrackedPlayer(
+            player_api_id=504,
+            player_name="Fresh Sale",
+            team_id=team.id,
+            status="first_team",
+            current_club_api_id=team.team_id,
+            current_club_name=team.name,
+            current_club_db_id=team.id,
+            data_source="api-football",
+            is_active=True,
+        )
+        db.session.add(existing)
+        db.session.commit()
+
+        class _SuccessfulTransfers:
+            def get_player_transfers(self, player_id):
+                return [
+                    {
+                        "player": {"id": player_id},
+                        "transfers": [
+                            {
+                                "date": "2025-07-01",
+                                "type": "€ 12M",
+                                "teams": {
+                                    "out": {"id": 100, "name": "Feyenoord"},
+                                    "in": {"id": 200, "name": "Buying Club"},
+                                },
+                            }
+                        ],
+                    }
+                ]
+
+        lookup.api_client = _SuccessfulTransfers()
+        tracked = lookup._upsert_tracked_player(
+            player_id=504,
+            player_block=_player_block(birth_date="2005-01-01", age=21),
+            journey=journey,
+            team=team,
+        )
+
+        assert tracked.status == "sold"
+        assert (tracked.current_club_api_id, tracked.current_club_name) == (200, "Buying Club")
+        assert tracked.current_club_db_id == destination.id
+        assert tracked.sale_fee == "€ 12M"
+
+    def test_successful_empty_history_clears_stale_sale_fee(self, app, lookup):
+        team = _seed_team()
+        recent = current_academy_season() - 1
+        journey = _journey(505, last_seasons={"100": recent})
+        journey.current_club_api_id = team.team_id
+        journey.current_club_name = team.name
+        existing = TrackedPlayer(
+            player_api_id=505,
+            player_name="Returned Player",
+            team_id=team.id,
+            status="sold",
+            current_club_api_id=777,
+            current_club_name="Old Buyer",
+            sale_fee="€ 20M",
+            data_source="api-football",
+            is_active=True,
+        )
+        db.session.add(existing)
+        db.session.commit()
+
+        class _EmptyTransfers:
+            def get_player_transfers(self, player_id):
+                return []
+
+        lookup.api_client = _EmptyTransfers()
+        tracked = lookup._upsert_tracked_player(
+            player_id=505,
+            player_block=_player_block(birth_date="2005-01-01", age=21),
+            journey=journey,
+            team=team,
+        )
+
+        assert tracked.status == "first_team"
+        assert (tracked.current_club_api_id, tracked.current_club_name) == (100, "Feyenoord")
+        assert tracked.current_club_db_id == team.id
+        assert tracked.sale_fee is None
+
+    def test_ambiguous_nonempty_history_preserves_existing_transfer_state(self, app, lookup):
+        team = _seed_team()
+        destination = Team(
+            team_id=777,
+            name="Known Buyer",
+            country="England",
+            season=2025,
+            league_id=team.league_id,
+            is_active=True,
+        )
+        db.session.add(destination)
+        db.session.flush()
+        recent = current_academy_season() - 1
+        journey = _journey(506, last_seasons={"100": recent})
+        journey.current_club_api_id = team.team_id
+        journey.current_club_name = team.name
+        existing = TrackedPlayer(
+            player_api_id=506,
+            player_name="Ambiguous Player",
+            team_id=team.id,
+            status="sold",
+            current_club_api_id=777,
+            current_club_name="Known Buyer",
+            current_club_db_id=destination.id,
+            sale_fee="€ 20M",
+            data_source="api-football",
+            is_active=True,
+        )
+        db.session.add(existing)
+        db.session.commit()
+
+        class _AmbiguousTransfers:
+            def get_player_transfers(self, player_id):
+                return [
+                    {
+                        "player": {"id": player_id},
+                        "transfers": [
+                            {
+                                "date": "2025-07-01",
+                                "type": "N/A",
+                                "teams": {
+                                    "out": {"id": 888, "name": "Unrelated"},
+                                    "in": {"id": 999, "name": "Other"},
+                                },
+                            }
+                        ],
+                    }
+                ]
+
+        lookup.api_client = _AmbiguousTransfers()
+        tracked = lookup._upsert_tracked_player(
+            player_id=506,
+            player_block=_player_block(birth_date="2005-01-01", age=21),
+            journey=journey,
+            team=team,
+        )
+
+        assert tracked.status == "sold"
+        assert (tracked.current_club_api_id, tracked.current_club_name) == (777, "Known Buyer")
+        assert tracked.current_club_db_id == destination.id
+        assert tracked.sale_fee == "€ 20M"
+
+
+def test_lookup_message_uses_persisted_tracked_club(app, lookup, monkeypatch):
+    team = _seed_team()
+    journey = _journey(507, last_seasons={"100": current_academy_season() - 1})
+    journey.current_club_name = "Stale Journey Club"
+    tracked = TrackedPlayer(
+        player_api_id=507,
+        player_name="Message Player",
+        team_id=team.id,
+        status="sold",
+        current_club_api_id=200,
+        current_club_name="Persisted Buyer",
+        data_source="api-football",
+        is_active=True,
+    )
+    db.session.add(tracked)
+    db.session.commit()
+    player_row = {"player": {"id": 507, "name": "Message Player"}, "statistics": []}
+
+    monkeypatch.setattr(lookup, "_find_existing", lambda name: None)
+    monkeypatch.setattr(lookup, "_is_rate_limited", lambda session_id: (False, ""))
+    monkeypatch.setattr(lookup.api_client, "search_player_profiles", lambda name: [player_row])
+    monkeypatch.setattr(lookup, "_pick_best_match", lambda rows, name, team_hint: player_row)
+    monkeypatch.setattr(lookup, "_sync_journey", lambda player_id: journey)
+    monkeypatch.setattr(lookup, "_resolve_parent_team", lambda row, team_hint: team)
+    monkeypatch.setattr(lookup, "_upsert_tracked_player", lambda **kwargs: tracked)
+
+    result = lookup.lookup("Message Player")
+
+    assert result["found"] is True
+    assert "Current club: Persisted Buyer." in result["message"]
+    assert "Stale Journey Club" not in result["message"]
+
+
+def test_lookup_message_uses_journey_club_for_parent_status(app, lookup, monkeypatch):
+    team = _seed_team()
+    journey = _journey(508, last_seasons={"100": current_academy_season() - 1})
+    journey.current_club_name = "Feyenoord U21"
+    tracked = TrackedPlayer(
+        player_api_id=508,
+        player_name="Academy Player",
+        team_id=team.id,
+        status="academy",
+        current_club_api_id=None,
+        current_club_name=None,
+        data_source="api-football",
+        is_active=True,
+    )
+    db.session.add(tracked)
+    db.session.commit()
+    player_row = {"player": {"id": 508, "name": "Academy Player"}, "statistics": []}
+
+    monkeypatch.setattr(lookup, "_find_existing", lambda name: None)
+    monkeypatch.setattr(lookup, "_is_rate_limited", lambda session_id: (False, ""))
+    monkeypatch.setattr(lookup.api_client, "search_player_profiles", lambda name: [player_row])
+    monkeypatch.setattr(lookup, "_pick_best_match", lambda rows, name, team_hint: player_row)
+    monkeypatch.setattr(lookup, "_sync_journey", lambda player_id: journey)
+    monkeypatch.setattr(lookup, "_resolve_parent_team", lambda row, team_hint: team)
+    monkeypatch.setattr(lookup, "_upsert_tracked_player", lambda **kwargs: tracked)
+
+    result = lookup.lookup("Academy Player")
+
+    assert result["found"] is True
+    assert "Current club: Feyenoord U21." in result["message"]

--- a/academy-watch-backend/tests/test_journey_resolver_audit.py
+++ b/academy-watch-backend/tests/test_journey_resolver_audit.py
@@ -238,6 +238,32 @@ def test_current_status_matches_name_only_clubs_from_resolver():
     assert journey.current_owner_name == "Owner"
 
 
+def test_name_only_current_projection_adopts_unique_stats_backed_id():
+    service = JourneySyncService(api_client=Mock())
+    journey = SimpleNamespace(
+        player_api_id=7011,
+        current_club_api_id=999,
+        current_club_name="Everton U21",
+        current_level="First Team",
+        current_status=None,
+        current_owner_api_id=None,
+        current_owner_name=None,
+    )
+    resolution = resolve_transfer_state(
+        [_transfer("2024-07-01", "Transfer", 1338, "Oxford United", None, "Everton U21")],
+        as_of="2026-07-16",
+    )
+
+    service.apply_resolved_current_state(
+        journey,
+        [_entry(season=2025, club_api_id=45, club_name="Everton U21", level="U21")],
+        resolution,
+    )
+
+    assert (journey.current_club_api_id, journey.current_club_name) == (45, "Everton U21")
+    assert journey.current_level == "U21"
+
+
 def test_resolved_release_clears_stale_current_club_status_owner_and_level():
     service = JourneySyncService(api_client=Mock())
     journey = SimpleNamespace(

--- a/academy-watch-backend/tests/test_journey_transfer_correction.py
+++ b/academy-watch-backend/tests/test_journey_transfer_correction.py
@@ -92,6 +92,62 @@ def test_single_hop_correction_still_applies():
     assert entries[0].club_name == "Old Club"
 
 
+def test_name_only_move_binds_to_unique_stats_backed_clubs():
+    transfers = [_transfer("2024-07-01", None, "New Club", None, "Old Club")]
+    misattributed = _Entry(2023, 50, "New Club")
+    old_club_evidence = _Entry(2022, 40, "Old Club")
+
+    _svc()._correct_club_ids_from_transfers(
+        [misattributed, old_club_evidence],
+        transfers,
+    )
+
+    assert (misattributed.club_api_id, misattributed.club_name) == (40, "Old Club")
+
+
+def test_raw_affiliate_id_binds_to_unique_stats_backed_organization_id():
+    transfers = [_transfer("2024-07-01", 7193, "Everton U21", 40, "Old Club")]
+    misattributed = _Entry(2023, 45, "Everton U21")
+    old_club_evidence = _Entry(2022, 40, "Old Club")
+
+    _svc()._correct_club_ids_from_transfers(
+        [misattributed, old_club_evidence],
+        transfers,
+    )
+
+    assert (misattributed.club_api_id, misattributed.club_name) == (40, "Old Club")
+
+
+def test_name_only_move_does_not_bind_ambiguous_stats_ids():
+    transfers = [_transfer("2024-07-01", None, "New Club", None, "Old Club")]
+    first = _Entry(2023, 50, "New Club")
+    second = _Entry(2023, 51, "New Club")
+    old_club_evidence = _Entry(2022, 40, "Old Club")
+
+    _svc()._correct_club_ids_from_transfers(
+        [first, second, old_club_evidence],
+        transfers,
+    )
+
+    assert (first.club_api_id, first.club_name) == (50, "New Club")
+    assert (second.club_api_id, second.club_name) == (51, "New Club")
+
+
+def test_name_only_senior_endpoint_prefers_exact_name_over_youth_affiliate():
+    transfers = [_transfer("2024-07-01", None, "Manchester United", 40, "Old Club")]
+    misattributed = _Entry(2023, 33, "Manchester United")
+    youth = _Entry(2023, 7198, "Manchester United U21")
+    old_club_evidence = _Entry(2022, 40, "Old Club")
+
+    _svc()._correct_club_ids_from_transfers(
+        [misattributed, youth, old_club_evidence],
+        transfers,
+    )
+
+    assert (misattributed.club_api_id, misattributed.club_name) == (40, "Old Club")
+    assert (youth.club_api_id, youth.club_name) == (7198, "Manchester United U21")
+
+
 def test_international_entries_are_never_rewritten():
     transfers = [_transfer("2025-07-11", 34, "Newcastle", 65, "Nottingham Forest")]
     natl = _Entry(2022, 34, "Sweden", is_international=True)

--- a/academy-watch-backend/tests/test_transfer_api_consumer.py
+++ b/academy-watch-backend/tests/test_transfer_api_consumer.py
@@ -1,11 +1,27 @@
 """Focused regressions for transfer consumers in API routes and classifier."""
 
+from datetime import UTC, datetime
+
+import pytest
 import src.routes.api as api_routes
+import src.routes.teams as team_routes
+from src.models.journey import PlayerJourney, PlayerJourneyEntry
 from src.models.league import Team, db
+from src.models.season_rollup import LeagueSeasonConfig
 from src.models.tracked_player import TrackedPlayer
-from src.routes.api import _academy_seed_transfer_fallback_eligible, _run_batch_fixture_sync
+from src.routes.api import _academy_seed_transfer_fallback_eligible, _run_batch_fixture_sync, _seed_single_team
+from src.services.transfer_events import record_transfer_events
 from src.services.transfer_resolver import resolve_transfer_state as real_resolve_transfer_state
 from src.utils.academy_classifier import classify_tracked_player
+
+
+@pytest.fixture(autouse=True)
+def _freeze_batch_clock(monkeypatch):
+    monkeypatch.setattr(
+        api_routes,
+        "_batch_now_utc",
+        lambda: datetime(2026, 7, 16, 0, 0, tzinfo=UTC),
+    )
 
 
 def _transfer(transfer_date, transfer_type, out_id, out_name, in_id, in_name):
@@ -42,23 +58,68 @@ class _BatchAPI:
         self.transfers = transfers
         self.profile = profile
         self.fixture_team_ids = []
+        self.fixture_requests = []
         self.transfer_calls = 0
+        self.profile_transfer_fallbacks = []
 
     def get_player_transfers(self, player_id):
         assert player_id == self.player_id
         self.transfer_calls += 1
         return _payload(player_id, self.transfers)
 
-    def get_player_by_id(self, player_id, season):
+    def get_player_by_id(self, player_id, season, *, allow_transfer_fallback=True):
         assert player_id == self.player_id
         assert season == 2025
+        self.profile_transfer_fallbacks.append(allow_transfer_fallback)
         if self.profile is None:
             raise AssertionError("known current club must not trigger profile discovery")
         return self.profile
 
     def get_fixtures_for_team_cached(self, team_id, season, start, end):
         self.fixture_team_ids.append(team_id)
+        self.fixture_requests.append((team_id, season, start, end))
         return []
+
+
+def _durable_batch_api(player_id, transfers, *, profile=None):
+    record_transfer_events(player_id, transfers, db.session)
+    db.session.commit()
+    return _BatchAPI(player_id, transfers, profile=profile)
+
+
+class _MultiBatchAPI:
+    def __init__(self):
+        self.transfer_calls = []
+        self.fixture_team_ids = []
+
+    def get_player_transfers(self, player_id):
+        self.transfer_calls.append(player_id)
+        return _payload(
+            player_id,
+            [_transfer("2025-07-01", "Transfer", 49, "Chelsea", 900 + player_id, "Resolved Club")],
+        )
+
+    def get_player_by_id(self, player_id, season, *, allow_transfer_fallback=True):
+        raise AssertionError("known current club must not trigger profile discovery")
+
+    def get_fixtures_for_team_cached(self, team_id, season, start, end):
+        self.fixture_team_ids.append(team_id)
+        return []
+
+
+def _known_sold_player(parent, player_id, club_id):
+    db.session.add(
+        TrackedPlayer(
+            player_api_id=player_id,
+            player_name=f"Known Player {player_id}",
+            team_id=parent.id,
+            status="sold",
+            current_club_api_id=club_id,
+            current_club_name=f"Known Club {club_id}",
+            data_source="journey-sync",
+            is_active=True,
+        )
+    )
 
 
 def test_batch_fee_uses_parent_departure_even_after_later_resale(app, monkeypatch):
@@ -73,14 +134,14 @@ def test_batch_fee_uses_parent_departure_even_after_later_resale(app, monkeypatc
             status="sold",
             current_club_api_id=66,
             current_club_name="Aston Villa",
-            sale_fee=None,
+            sale_fee="€ 50M",
             data_source="journey-sync",
             is_active=True,
         )
     )
     db.session.commit()
 
-    fake = _BatchAPI(
+    fake = _durable_batch_api(
         player_id,
         [
             _transfer("2024-07-01", "€ 33M", 49, "Chelsea", 34, "Newcastle"),
@@ -93,12 +154,358 @@ def test_batch_fee_uses_parent_departure_even_after_later_resale(app, monkeypatc
 
     tracked = TrackedPlayer.query.filter_by(player_api_id=player_id).one()
     assert tracked.sale_fee == "€ 33M"
+    assert (tracked.current_club_api_id, tracked.current_club_name) == (66, "Aston Villa")
+    assert fake.transfer_calls == 0
+    assert fake.fixture_team_ids == [34]
+    assert fake.fixture_requests == [(34, 2025, "2025-08-01", "2026-06-30")]
+
+
+def test_batch_known_rows_do_not_refresh_transfers_by_default(app, monkeypatch):
+    parent = _parent_team()
+    _known_sold_player(parent, 910001, 101)
+    _known_sold_player(parent, 910002, 102)
+    db.session.commit()
+    fake = _MultiBatchAPI()
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+
+    result = _run_batch_fixture_sync({"season": 2025, "delay": 0})
+
+    assert fake.transfer_calls == []
+    assert result["transfer_refreshes"] == 0
+
+
+def test_batch_explicit_transfer_refresh_obeys_run_cap(app, monkeypatch):
+    parent = _parent_team()
+    _known_sold_player(parent, 910003, 103)
+    _known_sold_player(parent, 910004, 104)
+    db.session.commit()
+    fake = _MultiBatchAPI()
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+
+    result = _run_batch_fixture_sync(
+        {
+            "season": 2025,
+            "delay": 0,
+            "refresh_transfers": True,
+            "transfer_refresh_limit": 1,
+        }
+    )
+
+    assert len(fake.transfer_calls) == 1
+    assert result["transfer_refreshes"] == 1
+
+
+def test_batch_explicit_refresh_failure_uses_durable_evidence(app, monkeypatch):
+    parent = _parent_team()
+    player_id = 910012
+    _known_sold_player(parent, player_id, 66)
+    db.session.commit()
+    fake = _durable_batch_api(
+        player_id,
+        [_transfer("2025-07-01", "Transfer", 49, "Chelsea", 34, "Newcastle")],
+    )
+
+    def _fail_refresh(requested_player_id):
+        assert requested_player_id == player_id
+        fake.transfer_calls += 1
+        raise RuntimeError("provider unavailable")
+
+    fake.get_player_transfers = _fail_refresh
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+
+    result = _run_batch_fixture_sync(
+        {
+            "season": 2025,
+            "delay": 0,
+            "refresh_transfers": True,
+            "transfer_refresh_limit": 1,
+        }
+    )
+
+    tracked = TrackedPlayer.query.filter_by(player_api_id=player_id).one()
     assert fake.transfer_calls == 1
-    assert fake.fixture_team_ids == [66]
+    assert result["transfer_refreshes"] == 1
+    assert (tracked.current_club_api_id, tracked.current_club_name) == (34, "Newcastle")
+    assert fake.fixture_team_ids == [34]
+
+
+def test_batch_dry_run_never_refreshes_persisted_transfer_evidence(app, monkeypatch):
+    parent = _parent_team()
+    _known_sold_player(parent, 910005, 105)
+    db.session.commit()
+    fake = _MultiBatchAPI()
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+
+    result = _run_batch_fixture_sync(
+        {
+            "season": 2025,
+            "delay": 0,
+            "dry_run": True,
+            "refresh_transfers": True,
+            "transfer_refresh_limit": 1,
+        }
+    )
+
+    assert fake.transfer_calls == []
+    assert result["transfer_refreshes"] == 0
+
+
+def test_batch_season_before_first_event_routes_to_initial_owner(app, monkeypatch):
+    parent = _parent_team()
+    player_id = 910006
+    _known_sold_player(parent, player_id, 66)
+    db.session.commit()
+    fake = _durable_batch_api(
+        player_id,
+        [_transfer("2025-07-01", "Transfer", 49, "Chelsea", 66, "Aston Villa")],
+    )
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+
+    _run_batch_fixture_sync({"season": 2023, "delay": 0})
+
+    tracked = TrackedPlayer.query.filter_by(player_api_id=player_id).one()
+    assert (tracked.current_club_api_id, tracked.current_club_name) == (66, "Aston Villa")
+    assert fake.fixture_requests == [(49, 2023, "2023-08-01", "2024-06-30")]
+
+
+def test_batch_current_loan_after_requested_season_routes_to_parent(app, monkeypatch):
+    parent = _parent_team()
+    player_id = 910007
+    db.session.add(
+        TrackedPlayer(
+            player_api_id=player_id,
+            player_name="Future Loanee",
+            team_id=parent.id,
+            status="on_loan",
+            current_club_api_id=44,
+            current_club_name="Burnley",
+            data_source="journey-sync",
+            is_active=True,
+        )
+    )
+    db.session.commit()
+    fake = _durable_batch_api(
+        player_id,
+        [_transfer("2026-07-10", "Loan", 49, "Chelsea", 44, "Burnley")],
+    )
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+
+    _run_batch_fixture_sync({"season": 2025, "delay": 0})
+
+    assert fake.fixture_team_ids == [49]
+
+
+def test_batch_present_active_loan_ignores_stale_durable_destination(app, monkeypatch):
+    parent = _parent_team()
+    player_id = 910013
+    db.session.add(
+        TrackedPlayer(
+            player_api_id=player_id,
+            player_name="Current Loanee",
+            team_id=parent.id,
+            status="on_loan",
+            current_club_api_id=44,
+            current_club_name="Burnley",
+            data_source="journey-sync",
+            is_active=True,
+        )
+    )
+    db.session.commit()
+    fake = _durable_batch_api(
+        player_id,
+        [_transfer("2023-07-01", "Transfer", 49, "Chelsea", 34, "Newcastle")],
+    )
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+
+    _run_batch_fixture_sync({"season": 2025, "delay": 0})
+
+    assert fake.fixture_team_ids == [44]
+
+
+def test_batch_future_season_does_not_query_an_inverted_fixture_window(app, monkeypatch):
+    parent = _parent_team()
+    player_id = 910014
+    db.session.add(
+        TrackedPlayer(
+            player_api_id=player_id,
+            player_name="Future Season Player",
+            team_id=parent.id,
+            status="first_team",
+            current_club_api_id=parent.team_id,
+            current_club_name=parent.name,
+            data_source="journey-sync",
+            is_active=True,
+        )
+    )
+    db.session.commit()
+    fake = _BatchAPI(player_id, [])
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+
+    result = _run_batch_fixture_sync({"season": 2026, "delay": 0})
+
+    assert result["total_players"] == 1
+    assert fake.fixture_requests == []
+
+
+def test_batch_calendar_year_entry_controls_routing_and_fixture_window(app, monkeypatch):
+    parent = _parent_team()
+    player_id = 910010
+    journey = PlayerJourney(
+        player_api_id=player_id,
+        player_name="Calendar Loanee",
+        current_club_api_id=2530,
+        current_club_name="MLS Borrower",
+    )
+    db.session.add(journey)
+    db.session.flush()
+    db.session.add_all(
+        [
+            PlayerJourneyEntry(
+                journey_id=journey.id,
+                player_api_id=player_id,
+                season=2024,
+                club_api_id=2530,
+                club_name="MLS Borrower",
+                league_api_id=253,
+                league_name="Major League Soccer",
+                level="First Team",
+                entry_type="loan",
+                is_international=False,
+                appearances=20,
+                minutes=1800,
+            ),
+            LeagueSeasonConfig(
+                league_api_id=253,
+                season_type="calendar",
+                rollover_month=1,
+            ),
+            TrackedPlayer(
+                player_api_id=player_id,
+                player_name="Calendar Loanee",
+                team_id=parent.id,
+                status="on_loan",
+                current_club_api_id=2530,
+                current_club_name="MLS Borrower",
+                journey_id=journey.id,
+                data_source="journey-sync",
+                is_active=True,
+            ),
+        ]
+    )
+    db.session.commit()
+    fake = _durable_batch_api(
+        player_id,
+        [_transfer("2024-08-01", "Loan", 49, "Chelsea", 2530, "MLS Borrower")],
+    )
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+
+    _run_batch_fixture_sync({"season": 2024, "delay": 0})
+
+    assert fake.fixture_requests == [(2530, 2024, "2024-01-01", "2024-12-31")]
+
+
+def test_batch_calendar_fallback_uses_final_stored_club_entry(app, monkeypatch):
+    parent = _parent_team()
+    player_id = 910011
+    journey = PlayerJourney(
+        player_api_id=player_id,
+        player_name="Calendar Fallback",
+        current_club_api_id=2530,
+        current_club_name="MLS Borrower",
+    )
+    db.session.add(journey)
+    db.session.flush()
+    db.session.add_all(
+        [
+            PlayerJourneyEntry(
+                journey_id=journey.id,
+                player_api_id=player_id,
+                season=2024,
+                club_api_id=49,
+                club_name="Chelsea",
+                league_api_id=39,
+                league_name="Premier League",
+                level="First Team",
+                entry_type="first_team",
+                is_international=False,
+                appearances=30,
+                minutes=2700,
+            ),
+            PlayerJourneyEntry(
+                journey_id=journey.id,
+                player_api_id=player_id,
+                season=2024,
+                club_api_id=2530,
+                club_name="MLS Borrower",
+                league_api_id=253,
+                league_name="Major League Soccer",
+                level="First Team",
+                entry_type="loan",
+                is_international=False,
+                appearances=5,
+                minutes=300,
+                transfer_date="2024-08-01",
+            ),
+            LeagueSeasonConfig(
+                league_api_id=253,
+                season_type="calendar",
+                rollover_month=1,
+            ),
+            TrackedPlayer(
+                player_api_id=player_id,
+                player_name="Calendar Fallback",
+                team_id=parent.id,
+                status="on_loan",
+                current_club_api_id=2530,
+                current_club_name="MLS Borrower",
+                journey_id=journey.id,
+                data_source="journey-sync",
+                is_active=True,
+            ),
+        ]
+    )
+    db.session.commit()
+    fake = _BatchAPI(player_id, [])
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+
+    _run_batch_fixture_sync({"season": 2024, "delay": 0})
+
+    assert fake.fixture_requests == [(2530, 2024, "2024-01-01", "2024-12-31")]
+
+
+@pytest.mark.parametrize("status", ["first_team", "academy"])
+def test_batch_current_parent_status_routes_historical_loan_to_borrower(app, monkeypatch, status):
+    parent = _parent_team()
+    player_id = 910008 if status == "first_team" else 910009
+    db.session.add(
+        TrackedPlayer(
+            player_api_id=player_id,
+            player_name=f"Historical {status}",
+            team_id=parent.id,
+            status=status,
+            current_club_api_id=49,
+            current_club_name="Chelsea",
+            data_source="journey-sync",
+            is_active=True,
+        )
+    )
+    db.session.commit()
+    fake = _durable_batch_api(
+        player_id,
+        [
+            _transfer("2024-02-01", "Loan", 49, "Chelsea", 34, "Newcastle"),
+            _transfer("2024-12-31", "Back from Loan", 34, "Newcastle", 49, "Chelsea"),
+        ],
+    )
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+
+    _run_batch_fixture_sync({"season": 2023, "delay": 0})
+
+    assert fake.fixture_team_ids == [34]
 
 
 def test_batch_current_club_ignores_later_ambiguous_na(app, monkeypatch):
-    """Parent context resolves the first N/A while unrelated N/A stays inert."""
+    """A topology-resolved parent departure survives a later unrelated N/A."""
     parent = _parent_team()
     player_id = 900002
     db.session.add(
@@ -115,7 +522,7 @@ def test_batch_current_club_ignores_later_ambiguous_na(app, monkeypatch):
     )
     db.session.commit()
 
-    fake = _BatchAPI(
+    fake = _durable_batch_api(
         player_id,
         [
             _transfer("2024-07-01", "N/A", 49, "Chelsea", 34, "Newcastle"),
@@ -129,13 +536,221 @@ def test_batch_current_club_ignores_later_ambiguous_na(app, monkeypatch):
 
     tracked = TrackedPlayer.query.filter_by(player_api_id=player_id).one()
     assert (tracked.current_club_api_id, tracked.current_club_name) == (34, "Newcastle")
-    assert fake.transfer_calls == 1
+    assert fake.transfer_calls == 0
+    assert fake.profile_transfer_fallbacks == [False]
     assert fake.fixture_team_ids == [34]
+
+
+def test_batch_newer_profile_club_survives_later_ambiguous_na(app, monkeypatch):
+    """Ambiguous topology cannot replace newer requested-season statistics."""
+    parent = _parent_team()
+    player_id = 900002
+    db.session.add(
+        TrackedPlayer(
+            player_api_id=player_id,
+            player_name="Topology Player",
+            team_id=parent.id,
+            status="sold",
+            current_club_api_id=None,
+            current_club_name=None,
+            data_source="journey-sync",
+            is_active=True,
+        )
+    )
+    db.session.commit()
+
+    fake = _durable_batch_api(
+        player_id,
+        [
+            _transfer("2024-07-01", "N/A", 49, "Chelsea", 34, "Newcastle"),
+            _transfer("2025-07-01", "N/A", 777, "Unrelated", 888, "Current Club"),
+        ],
+        profile={
+            "statistics": [
+                {
+                    "team": {"id": 888, "name": "Current Club"},
+                    "games": {"appearences": 20, "position": "Midfielder"},
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+
+    _run_batch_fixture_sync({"season": 2025, "delay": 0})
+
+    tracked = TrackedPlayer.query.filter_by(player_api_id=player_id).one()
+    assert (tracked.current_club_api_id, tracked.current_club_name) == (888, "Current Club")
+    assert fake.transfer_calls == 0
+    assert fake.profile_transfer_fallbacks == [False]
+    assert fake.fixture_team_ids == [888]
+
+
+def test_batch_historical_run_does_not_rewind_present_club(app, monkeypatch):
+    parent = _parent_team()
+    player_id = 900013
+    db.session.add(
+        TrackedPlayer(
+            player_api_id=player_id,
+            player_name="Historical Backfill",
+            team_id=parent.id,
+            status="sold",
+            current_club_api_id=66,
+            current_club_name="Aston Villa",
+            data_source="journey-sync",
+            is_active=True,
+        )
+    )
+    db.session.commit()
+    fake = _durable_batch_api(
+        player_id,
+        [_transfer("2023-07-01", "Transfer", 49, "Chelsea", 34, "Newcastle")],
+    )
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+
+    _run_batch_fixture_sync({"season": 2023, "delay": 0})
+
+    tracked = TrackedPlayer.query.filter_by(player_api_id=player_id).one()
+    assert (tracked.current_club_api_id, tracked.current_club_name) == (66, "Aston Villa")
+    assert fake.fixture_team_ids == [34]
+
+
+def test_batch_unknown_history_preserves_stored_route_and_current(app, monkeypatch):
+    parent = _parent_team()
+    player_id = 900014
+    db.session.add(
+        TrackedPlayer(
+            player_api_id=player_id,
+            player_name="Ambiguous History",
+            team_id=parent.id,
+            status="sold",
+            current_club_api_id=66,
+            current_club_name="Aston Villa",
+            data_source="journey-sync",
+            is_active=True,
+        )
+    )
+    db.session.commit()
+    fake = _durable_batch_api(
+        player_id,
+        [_transfer("2023-07-01", "N/A", 777, "Unrelated", 888, "Other")],
+    )
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+
+    _run_batch_fixture_sync({"season": 2023, "delay": 0})
+
+    tracked = TrackedPlayer.query.filter_by(player_api_id=player_id).one()
+    assert (tracked.current_club_api_id, tracked.current_club_name) == (66, "Aston Villa")
+    assert fake.fixture_team_ids == [66]
+
+
+@pytest.mark.parametrize("status", ["released", "left"])
+def test_batch_does_not_write_sale_fee_for_non_sold_status(app, monkeypatch, status):
+    parent = _parent_team()
+    player_id = 900015 if status == "released" else 900016
+    db.session.add(
+        TrackedPlayer(
+            player_api_id=player_id,
+            player_name=f"Non-sale {status}",
+            team_id=parent.id,
+            status=status,
+            current_club_api_id=34,
+            current_club_name="Newcastle",
+            sale_fee=None,
+            data_source="journey-sync",
+            is_active=True,
+        )
+    )
+    db.session.commit()
+    fake = _durable_batch_api(
+        player_id,
+        [_transfer("2024-07-01", "€ 12M", 49, "Chelsea", 34, "Newcastle")],
+    )
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+
+    _run_batch_fixture_sync({"season": 2025, "delay": 0})
+
+    assert TrackedPlayer.query.filter_by(player_api_id=player_id).one().sale_fee is None
+
+
+def test_batch_clears_stale_fee_when_parent_sale_has_no_fee(app, monkeypatch):
+    parent = _parent_team()
+    player_id = 900019
+    db.session.add(
+        TrackedPlayer(
+            player_api_id=player_id,
+            player_name="Undisclosed Sale",
+            team_id=parent.id,
+            status="sold",
+            current_club_api_id=34,
+            current_club_name="Newcastle",
+            sale_fee="€ 50M",
+            data_source="journey-sync",
+            is_active=True,
+        )
+    )
+    db.session.commit()
+    fake = _durable_batch_api(
+        player_id,
+        [_transfer("2024-07-01", "N/A", 49, "Chelsea", 34, "Newcastle")],
+    )
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+
+    _run_batch_fixture_sync({"season": 2025, "delay": 0})
+
+    assert TrackedPlayer.query.filter_by(player_api_id=player_id).one().sale_fee is None
+
+
+def test_batch_refresh_delay_applies_after_profile_failure(app, monkeypatch):
+    parent = _parent_team()
+    for player_id in (900020, 900021):
+        db.session.add(
+            TrackedPlayer(
+                player_api_id=player_id,
+                player_name=f"Profile Failure {player_id}",
+                team_id=parent.id,
+                status="sold",
+                current_club_api_id=None,
+                data_source="journey-sync",
+                is_active=True,
+            )
+        )
+    db.session.commit()
+    fake = _MultiBatchAPI()
+    delays = []
+    monkeypatch.setattr("src.api_football_client.APIFootballClient", lambda: fake)
+    monkeypatch.setattr("time.sleep", delays.append)
+
+    _run_batch_fixture_sync(
+        {
+            "season": 2025,
+            "delay": 0.25,
+            "refresh_transfers": True,
+            "transfer_refresh_limit": 2,
+        }
+    )
+
+    assert len(fake.transfer_calls) == 2
+    assert delays == [0.25, 0.25]
 
 
 def test_batch_reconciles_stale_stored_club_before_early_continue(app, monkeypatch):
     """Fresh resolver state must replace a contradictory prior backfill."""
     parent = _parent_team()
+    stale_destination = Team(
+        team_id=34,
+        name="Old Newcastle Row",
+        country="England",
+        season=2024,
+        is_active=False,
+    )
+    destination = Team(
+        team_id=34,
+        name="Newcastle",
+        country="England",
+        season=2025,
+        is_active=True,
+    )
+    db.session.add_all([stale_destination, destination])
     player_id = 900004
     db.session.add(
         TrackedPlayer(
@@ -145,6 +760,7 @@ def test_batch_reconciles_stale_stored_club_before_early_continue(app, monkeypat
             status="sold",
             current_club_api_id=66,
             current_club_name="Aston Villa",
+            current_club_db_id=parent.id,
             sale_fee="Undisclosed",
             data_source="journey-sync",
             is_active=True,
@@ -152,7 +768,7 @@ def test_batch_reconciles_stale_stored_club_before_early_continue(app, monkeypat
     )
     db.session.commit()
 
-    fake = _BatchAPI(
+    fake = _durable_batch_api(
         player_id,
         [_transfer("2025-07-01", "Transfer", 49, "Chelsea", 34, "Newcastle")],
     )
@@ -162,7 +778,8 @@ def test_batch_reconciles_stale_stored_club_before_early_continue(app, monkeypat
 
     tracked = TrackedPlayer.query.filter_by(player_api_id=player_id).one()
     assert (tracked.current_club_api_id, tracked.current_club_name) == (34, "Newcastle")
-    assert fake.transfer_calls == 1
+    assert tracked.current_club_db_id == destination.id
+    assert fake.transfer_calls == 0
     assert fake.fixture_team_ids == [34]
 
 
@@ -184,7 +801,7 @@ def test_batch_indeterminate_historical_loan_preserves_newer_stored_club(app, mo
     )
     db.session.commit()
 
-    fake = _BatchAPI(
+    fake = _durable_batch_api(
         player_id,
         [_transfer("2023-07-01", "Loan", 49, "Chelsea", 34, "Newcastle")],
     )
@@ -215,7 +832,7 @@ def test_batch_old_permanent_move_preserves_newer_unrelated_stored_club(app, mon
     )
     db.session.commit()
 
-    fake = _BatchAPI(
+    fake = _durable_batch_api(
         player_id,
         [_transfer("2023-07-01", "Transfer", 49, "Chelsea", 34, "Newcastle")],
     )
@@ -247,7 +864,7 @@ def test_batch_indeterminate_historical_loan_preserves_newer_profile_club(app, m
     )
     db.session.commit()
 
-    fake = _BatchAPI(
+    fake = _durable_batch_api(
         player_id,
         [_transfer("2023-07-01", "Loan", 49, "Chelsea", 34, "Newcastle")],
         profile={
@@ -285,7 +902,7 @@ def test_batch_commits_resolver_fee_before_profile_failure(app, monkeypatch):
     )
     db.session.commit()
 
-    fake = _BatchAPI(
+    fake = _durable_batch_api(
         player_id,
         [_transfer("2024-07-01", "€ 12M", 49, "Chelsea", 34, "Newcastle")],
     )
@@ -297,6 +914,309 @@ def test_batch_commits_resolver_fee_before_profile_failure(app, monkeypatch):
     db.session.expire_all()
     tracked = TrackedPlayer.query.filter_by(player_api_id=player_id).one()
     assert tracked.sale_fee == "€ 12M"
+    assert (tracked.current_club_api_id, tracked.current_club_name) == (34, "Newcastle")
+    assert fake.fixture_team_ids == [34]
+
+
+def test_academy_network_marks_unfetched_transfers_as_unknown(app, client, monkeypatch):
+    parent = _parent_team()
+    journey = PlayerJourney(
+        player_api_id=900011,
+        player_name="Unfetched Loan",
+        academy_club_ids=[parent.team_id],
+        current_club_api_id=300,
+        current_club_name="Hull City",
+        current_level="Senior",
+    )
+    db.session.add(journey)
+    db.session.commit()
+    observed_transfers = []
+
+    class _JourneyQuery:
+        def filter(self, *args):
+            return self
+
+        def all(self):
+            return [journey]
+
+    def _capture_classifier(*args, **kwargs):
+        observed_transfers.append(kwargs.get("transfers"))
+        return "on_loan", 300, "Hull City"
+
+    monkeypatch.setattr(team_routes, "classify_tracked_player", _capture_classifier)
+    monkeypatch.setattr(PlayerJourney, "query", _JourneyQuery())
+
+    response = client.get(f"/api/teams/{parent.team_id}/academy-network")
+
+    assert response.status_code == 200
+    assert observed_transfers == [None]
+    assert response.get_json()["all_players"][0]["status"] == "on_loan"
+
+
+def test_seed_existing_transfer_state_survives_fetch_failure(app, monkeypatch):
+    parent = _parent_team()
+    destination = Team(
+        team_id=777,
+        name="Buying Club",
+        country="England",
+        season=2025,
+        is_active=True,
+    )
+    db.session.add(destination)
+    db.session.flush()
+    journey = PlayerJourney(
+        player_api_id=900012,
+        player_name="Known Seed Sale",
+        academy_club_ids=[parent.team_id],
+        current_club_api_id=parent.team_id,
+        current_club_name=parent.name,
+        current_level="First Team",
+        seasons_synced=[2025],
+    )
+    db.session.add(journey)
+    db.session.flush()
+    existing = TrackedPlayer(
+        player_api_id=journey.player_api_id,
+        player_name=journey.player_name,
+        team_id=parent.id,
+        status="sold",
+        current_club_api_id=777,
+        current_club_name="Buying Club",
+        current_club_db_id=destination.id,
+        sale_fee="€ 20M",
+        data_source="journey-sync",
+        is_active=True,
+    )
+    db.session.add(existing)
+    db.session.commit()
+
+    class _JourneyQuery:
+        def filter(self, *args):
+            return self
+
+        def all(self):
+            return [journey]
+
+    class _FailedTransferAPI:
+        current_season_start_year = 2025
+
+        def get_team_players(self, team_id, season):
+            return []
+
+        def get_player_transfers(self, player_id):
+            raise RuntimeError("provider unavailable")
+
+    monkeypatch.setattr(PlayerJourney, "query", _JourneyQuery())
+    monkeypatch.setattr(api_routes, "APIFootballClient", _FailedTransferAPI)
+
+    _seed_single_team(parent, sync_journeys=False, years=1, season=2025)
+
+    db.session.expire_all()
+    persisted = TrackedPlayer.query.filter_by(player_api_id=journey.player_api_id).one()
+    assert persisted.status == "sold"
+    assert (persisted.current_club_api_id, persisted.current_club_name) == (777, "Buying Club")
+    assert persisted.current_club_db_id == destination.id
+    assert persisted.sale_fee == "€ 20M"
+
+
+def test_seed_successful_sale_updates_name_club_fk_and_parent_fee(app, monkeypatch):
+    parent = _parent_team()
+    stale_destination = Team(
+        team_id=34,
+        name="Old Newcastle Row",
+        country="England",
+        season=2024,
+        is_active=False,
+    )
+    destination = Team(
+        team_id=34,
+        name="Newcastle",
+        country="England",
+        season=2025,
+        is_active=True,
+    )
+    db.session.add_all([stale_destination, destination])
+    journey = PlayerJourney(
+        player_api_id=900017,
+        player_name="Seed Sale",
+        academy_club_ids=[parent.team_id],
+        current_club_api_id=parent.team_id,
+        current_club_name=parent.name,
+        current_level="First Team",
+        seasons_synced=[2025],
+    )
+    db.session.add(journey)
+    db.session.flush()
+    existing = TrackedPlayer(
+        player_api_id=journey.player_api_id,
+        player_name=journey.player_name,
+        team_id=parent.id,
+        status="sold",
+        current_club_api_id=34,
+        current_club_name="Stale Buyer Name",
+        current_club_db_id=destination.id,
+        sale_fee="€ 50M",
+        data_source="journey-sync",
+        is_active=True,
+    )
+    db.session.add(existing)
+    db.session.commit()
+
+    class _JourneyQuery:
+        def filter(self, *args):
+            return self
+
+        def all(self):
+            return [journey]
+
+    class _SuccessfulTransferAPI:
+        current_season_start_year = 2025
+
+        def get_team_players(self, team_id, season):
+            return []
+
+        def get_player_transfers(self, player_id):
+            return _payload(
+                player_id,
+                [_transfer("2025-07-01", "€ 12M", 49, "Chelsea", 34, "Newcastle")],
+            )
+
+    monkeypatch.setattr(PlayerJourney, "query", _JourneyQuery())
+    monkeypatch.setattr(api_routes, "APIFootballClient", _SuccessfulTransferAPI)
+
+    _seed_single_team(parent, sync_journeys=False, years=1, season=2025)
+
+    db.session.expire_all()
+    persisted = TrackedPlayer.query.filter_by(player_api_id=journey.player_api_id).one()
+    assert persisted.status == "sold"
+    assert (persisted.current_club_api_id, persisted.current_club_name) == (34, "Newcastle")
+    assert persisted.current_club_db_id == destination.id
+    assert persisted.sale_fee == "€ 12M"
+
+
+def test_seed_successful_empty_history_clears_stale_sale_state(app, monkeypatch):
+    parent = _parent_team()
+    journey = PlayerJourney(
+        player_api_id=900018,
+        player_name="Seed Return",
+        academy_club_ids=[parent.team_id],
+        current_club_api_id=parent.team_id,
+        current_club_name=parent.name,
+        current_level="First Team",
+        seasons_synced=[2025],
+    )
+    db.session.add(journey)
+    db.session.flush()
+    existing = TrackedPlayer(
+        player_api_id=journey.player_api_id,
+        player_name=journey.player_name,
+        team_id=parent.id,
+        status="sold",
+        current_club_api_id=777,
+        current_club_name="Old Buyer",
+        sale_fee="€ 20M",
+        data_source="journey-sync",
+        is_active=True,
+    )
+    db.session.add(existing)
+    db.session.commit()
+
+    class _JourneyQuery:
+        def filter(self, *args):
+            return self
+
+        def all(self):
+            return [journey]
+
+    class _EmptyTransferAPI:
+        current_season_start_year = 2025
+
+        def get_team_players(self, team_id, season):
+            return []
+
+        def get_player_transfers(self, player_id):
+            return []
+
+    monkeypatch.setattr(PlayerJourney, "query", _JourneyQuery())
+    monkeypatch.setattr(api_routes, "APIFootballClient", _EmptyTransferAPI)
+
+    _seed_single_team(parent, sync_journeys=False, years=1, season=2025)
+
+    db.session.expire_all()
+    persisted = TrackedPlayer.query.filter_by(player_api_id=journey.player_api_id).one()
+    assert persisted.status == "first_team"
+    assert (persisted.current_club_api_id, persisted.current_club_name) == (49, "Chelsea")
+    assert persisted.current_club_db_id == parent.id
+    assert persisted.sale_fee is None
+
+
+def test_seed_ambiguous_nonempty_history_preserves_existing_transfer_state(app, monkeypatch):
+    parent = _parent_team()
+    destination = Team(
+        team_id=777,
+        name="Known Buyer",
+        country="England",
+        season=2025,
+        is_active=True,
+    )
+    db.session.add(destination)
+    db.session.flush()
+    journey = PlayerJourney(
+        player_api_id=900022,
+        player_name="Ambiguous Seed",
+        academy_club_ids=[parent.team_id],
+        current_club_api_id=parent.team_id,
+        current_club_name=parent.name,
+        current_level="First Team",
+        seasons_synced=[2025],
+    )
+    db.session.add(journey)
+    db.session.flush()
+    existing = TrackedPlayer(
+        player_api_id=journey.player_api_id,
+        player_name=journey.player_name,
+        team_id=parent.id,
+        status="sold",
+        current_club_api_id=777,
+        current_club_name="Known Buyer",
+        current_club_db_id=destination.id,
+        sale_fee="€ 20M",
+        data_source="journey-sync",
+        is_active=True,
+    )
+    db.session.add(existing)
+    db.session.commit()
+
+    class _JourneyQuery:
+        def filter(self, *args):
+            return self
+
+        def all(self):
+            return [journey]
+
+    class _AmbiguousTransferAPI:
+        current_season_start_year = 2025
+
+        def get_team_players(self, team_id, season):
+            return []
+
+        def get_player_transfers(self, player_id):
+            return _payload(
+                player_id,
+                [_transfer("2025-07-01", "N/A", 888, "Unrelated", 999, "Other")],
+            )
+
+    monkeypatch.setattr(PlayerJourney, "query", _JourneyQuery())
+    monkeypatch.setattr(api_routes, "APIFootballClient", _AmbiguousTransferAPI)
+
+    _seed_single_team(parent, sync_journeys=False, years=1, season=2025)
+
+    db.session.expire_all()
+    persisted = TrackedPlayer.query.filter_by(player_api_id=journey.player_api_id).one()
+    assert persisted.status == "sold"
+    assert (persisted.current_club_api_id, persisted.current_club_name) == (777, "Known Buyer")
+    assert persisted.current_club_db_id == destination.id
+    assert persisted.sale_fee == "€ 20M"
 
 
 class _SeedTransferAPI:

--- a/academy-watch-backend/tests/test_weekly_newsletter_transfer_returns.py
+++ b/academy-watch-backend/tests/test_weekly_newsletter_transfer_returns.py
@@ -172,6 +172,71 @@ def test_latest_resolved_parent_return_wins_and_other_destinations_are_excluded(
     assert returns[0]["return_date"] == "2024-01-10"
 
 
+def test_same_week_reloan_suppresses_earlier_return(app, monkeypatch):
+    parent = _seed_parent(49, "Chelsea")
+    player = _seed_player(parent, 1007, "Returned Then Re-loaned")
+    events = [
+        _transfer("2024-01-01", "Loan", 49, "Chelsea", 300, "Hull City"),
+        _transfer("2024-01-08", "Back from loan", 300, "Hull City", 49, "Chelsea"),
+        _transfer("2024-01-10", "Loan", 49, "Chelsea", 301, "Crystal Palace"),
+    ]
+
+    returns = _detect(
+        monkeypatch,
+        parent,
+        {player.player_api_id: events},
+        date(2024, 1, 8),
+        date(2024, 1, 14),
+    )
+
+    assert returns == []
+
+
+def test_parent_internal_move_does_not_suppress_return(app, monkeypatch):
+    parent = _seed_parent(49, "Chelsea")
+    player = _seed_player(parent, 1008, "Returned To U21")
+    events = [
+        _transfer("2024-01-01", "Loan", 49, "Chelsea", 300, "Hull City"),
+        _transfer("2024-01-08", "Back from loan", 300, "Hull City", 49, "Chelsea"),
+        _transfer("2024-01-10", "Transfer", 49, "Chelsea", 9949, "Chelsea U21"),
+    ]
+
+    returns = _detect(
+        monkeypatch,
+        parent,
+        {player.player_api_id: events},
+        date(2024, 1, 8),
+        date(2024, 1, 14),
+    )
+
+    assert len(returns) == 1
+    assert returns[0]["player_api_id"] == player.player_api_id
+    assert returns[0]["returned_from_club_name"] == "Hull City"
+    assert returns[0]["return_date"] == "2024-01-08"
+
+
+def test_parent_internal_loan_does_not_suppress_return(app, monkeypatch):
+    parent = _seed_parent(49, "Chelsea")
+    player = _seed_player(parent, 1009, "Returned Then Internal Loan")
+    events = [
+        _transfer("2024-01-01", "Loan", 49, "Chelsea", 300, "Hull City"),
+        _transfer("2024-01-08", "Back from loan", 300, "Hull City", 49, "Chelsea"),
+        _transfer("2024-01-10", "Loan", 49, "Chelsea", 9949, "Chelsea U21"),
+    ]
+
+    returns = _detect(
+        monkeypatch,
+        parent,
+        {player.player_api_id: events},
+        date(2024, 1, 8),
+        date(2024, 1, 14),
+    )
+
+    assert len(returns) == 1
+    assert returns[0]["player_api_id"] == player.player_api_id
+    assert returns[0]["returned_from_club_name"] == "Hull City"
+
+
 def test_batch_failure_omission_is_not_resolved_as_empty_history(app, monkeypatch, caplog):
     parent = _seed_parent(49, "Chelsea")
     covered = _seed_player(parent, 1005, "Covered Return")


### PR DESCRIPTION
## Salvage of the parallel session's resolver delta (audited)

Follow-up to #642. A parallel session independently produced a 2,106-line delta on the resolver work; after it stood down, this PR lands the **audited** net-new portion (hunk-by-hunk review; dispositions in the audit report). Base: `f043c27` (shipped resolver).

### Kept (net-new, confirmed)
- **July-1 historical-club correction** (confirmed real): syncing a past season for a player who has since moved again routed fixtures to the *present-day* club. Now projects through end-exclusive July-1 boundaries (regression: Chelsea→Newcastle 2024, Newcastle→Villa 2026, sync season 2025 → routes to Newcastle).
- **Fetch-failure hardening in outer consumers**: the shipped resolver already distinguished failure from empty, but `_seed_single_team` and GOL wrote classifier output unconditionally after failed fetches, and a `teams.py` read path fabricated "successful empty" evidence without fetching. All now preserve known state on failure; only authoritative evidence writes.
- **8-case consumer test harness** (+ net-new cases; 255 targeted tests green) — independently caught both bugs above.
- Batch controls: durable-evidence-first transfer loading, explicit capped refresh, deterministic clock seam, cache keys split by fallback policy (no hidden `/transfers` calls bypassing quota policy).

### Reverted from the foreign delta (with reasons)
- Global name-only destination matching in `admin_explain_academy` — could label unrelated same-name clubs as transfer destinations, untested.
- A raw-provider-ID contract violation in journey current-projection that would have changed live-verified Mills behavior.
- Duplicate/semantic-drift test pins; the shipped ambiguous-N/A test restored.

### Refuted claim
The parallel session's "2 baseline failures removed" — those tests fail on shipped main for an unrelated pre-existing app-context issue; its delta does not fix them.

### Gates (audited run + independently re-verified by reviewer)
- ruff check + format clean
- 255 targeted transfer/journey/consumer tests pass
- Full suite: 1,067 passed; failure/error sets byte-identical to `f043c27` baseline (∅ added / ∅ removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)