### PR TITLE
feat(trust): scout verification, content reports, 18+ claim gate (FC-B1)

### DIFF
--- a/academy-watch-backend/migrations/versions/fc01_trust_prerequisites.py
+++ b/academy-watch-backend/migrations/versions/fc01_trust_prerequisites.py
@@ -1,0 +1,132 @@
+"""Marketplace trust prerequisites for scout verification and content reports.
+
+Revision ID: fc01
+Revises: tre01
+
+IMPORTANT: ``tre01`` was the sole head on this branch when this migration was
+authored. PR #636 (``gf01``, funding registry) is open and may merge first. If
+``gf01`` or another head lands first, re-point ``down_revision`` before merge.
+Never allow a migration fork.
+
+All DDL is guarded because production has drifted out-of-band. Both new public
+tables have RLS enabled in this same migration. No permissive policies are
+created: Flask exposes only authenticated, narrowly serialized views.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from migrations._migration_helpers import create_index_safe, index_exists, table_exists
+
+revision = "fc01"
+down_revision = "tre01"
+branch_labels = None
+depends_on = None
+
+
+NEW_TABLES = (
+    "scout_verifications",
+    "content_reports",
+)
+
+
+def upgrade():
+    if not table_exists("scout_verifications"):
+        op.create_table(
+            "scout_verifications",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("user_account_id", sa.Integer(), sa.ForeignKey("user_accounts.id"), nullable=False),
+            sa.Column("full_name", sa.String(length=200), nullable=False),
+            sa.Column("organization", sa.String(length=200), nullable=False),
+            sa.Column("role_title", sa.String(length=120), nullable=False),
+            sa.Column("statement", sa.String(length=2000), nullable=False),
+            sa.Column("evidence_urls", sa.JSON(), nullable=False),
+            sa.Column("status", sa.String(length=20), nullable=False, server_default="pending"),
+            sa.Column("submitted_at", sa.DateTime(), nullable=False),
+            sa.Column("reviewed_at", sa.DateTime(), nullable=True),
+            sa.Column("reviewed_by", sa.String(length=200), nullable=True),
+            sa.Column("review_notes", sa.String(length=2000), nullable=True),
+            sa.Column("revocation_reason", sa.String(length=1000), nullable=True),
+            sa.CheckConstraint(
+                "status IN ('pending','approved','rejected','revoked')",
+                name="ck_scout_verifications_status",
+            ),
+        )
+    create_index_safe(
+        "uq_scout_verifications_active_user",
+        "scout_verifications",
+        ["user_account_id"],
+        unique=True,
+        postgresql_where=sa.text("status IN ('pending', 'approved')"),
+        sqlite_where=sa.text("status IN ('pending', 'approved')"),
+    )
+    create_index_safe(
+        "ix_scout_verifications_user_submitted",
+        "scout_verifications",
+        ["user_account_id", "submitted_at"],
+    )
+    create_index_safe(
+        "ix_scout_verifications_status_submitted",
+        "scout_verifications",
+        ["status", "submitted_at"],
+    )
+
+    if not table_exists("content_reports"):
+        op.create_table(
+            "content_reports",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("reporter_user_id", sa.Integer(), sa.ForeignKey("user_accounts.id"), nullable=False),
+            sa.Column("subject_type", sa.String(length=40), nullable=False),
+            sa.Column("subject_id", sa.String(length=200), nullable=False),
+            sa.Column("reason_code", sa.String(length=80), nullable=False),
+            sa.Column("details", sa.String(length=2000), nullable=True),
+            sa.Column("status", sa.String(length=20), nullable=False, server_default="open"),
+            sa.Column("resolution_notes", sa.String(length=2000), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("resolved_at", sa.DateTime(), nullable=True),
+            sa.CheckConstraint(
+                "subject_type IN ('player_profile','showcase_content','club_program','contact_message','other')",
+                name="ck_content_reports_subject_type",
+            ),
+            sa.CheckConstraint(
+                "status IN ('open','reviewing','resolved','dismissed')",
+                name="ck_content_reports_status",
+            ),
+        )
+    create_index_safe(
+        "ix_content_reports_reporter_created",
+        "content_reports",
+        ["reporter_user_id", "created_at"],
+    )
+    create_index_safe(
+        "ix_content_reports_status_created",
+        "content_reports",
+        ["status", "created_at"],
+    )
+    create_index_safe(
+        "ix_content_reports_subject",
+        "content_reports",
+        ["subject_type", "subject_id"],
+    )
+
+    for table_name in NEW_TABLES:
+        # Idempotent and intentionally policy-free: direct/public roles see no
+        # rows. Flask publishes only explicitly serialized fields.
+        op.execute(sa.text(f'ALTER TABLE "{table_name}" ENABLE ROW LEVEL SECURITY'))
+
+
+def downgrade():
+    indexes = (
+        ("ix_content_reports_subject", "content_reports"),
+        ("ix_content_reports_status_created", "content_reports"),
+        ("ix_content_reports_reporter_created", "content_reports"),
+        ("ix_scout_verifications_status_submitted", "scout_verifications"),
+        ("ix_scout_verifications_user_submitted", "scout_verifications"),
+        ("uq_scout_verifications_active_user", "scout_verifications"),
+    )
+    for index_name, table_name in indexes:
+        if index_exists(index_name):
+            op.drop_index(index_name, table_name=table_name)
+
+    for table_name in reversed(NEW_TABLES):
+        if table_exists(table_name):
+            op.drop_table(table_name)

--- a/academy-watch-backend/src/auth.py
+++ b/academy-watch-backend/src/auth.py
@@ -19,6 +19,9 @@ from uuid import uuid4
 from flask import Blueprint, current_app, g, jsonify, make_response, request
 from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 
+# Register trust tables before test/local ``db.create_all()`` calls that reach
+# UserAccount serializers outside the production app factory.
+import src.models.trust  # noqa: F401
 from src.models.league import UserAccount, db
 from src.utils.sanitize import sanitize_plain_text
 

--- a/academy-watch-backend/src/main.py
+++ b/academy-watch-backend/src/main.py
@@ -18,6 +18,7 @@ from werkzeug.exceptions import HTTPException
 # includes them even before a route/service imports the model directly.
 import src.models.season_rollup  # noqa: E402, F401
 import src.models.transfer_event  # noqa: E402, F401
+import src.models.trust  # noqa: E402, F401
 from src.extensions import limiter
 from src.models.league import League, Newsletter, Team, UserSubscription, db
 from src.models.tracked_player import TrackedPlayer
@@ -40,6 +41,7 @@ from src.routes.scout import scout_bp
 from src.routes.season_rollup import season_rollup_bp
 from src.routes.showcase import showcase_bp
 from src.routes.teams import teams_bp
+from src.routes.trust import trust_bp
 from src.routes.video import video_bp
 
 dotenv.load_dotenv(dotenv.find_dotenv())
@@ -103,6 +105,7 @@ app.register_blueprint(scout_bp, url_prefix="/api")
 # Registered BEFORE api_bp (mirroring players_bp) so /players/<id>/showcase*
 # routes take priority over any api_bp /players/<id>/* catch-alls.
 app.register_blueprint(showcase_bp, url_prefix="/api")
+app.register_blueprint(trust_bp, url_prefix="/api")
 app.register_blueprint(api_bp, url_prefix="/api")
 app.register_blueprint(auth_bp, url_prefix="/api")
 app.register_blueprint(journalist_bp, url_prefix="/api")

--- a/academy-watch-backend/src/models/league.py
+++ b/academy-watch-backend/src/models/league.py
@@ -562,6 +562,13 @@ class UserAccount(db.Model):
         """Return True if this placeholder account has been claimed by the writer."""
         return self.managed_by_user_id is not None and self.claimed_at is not None
 
+    @property
+    def is_verified_scout(self) -> bool:
+        """Derived from an approved scout verification; never persisted."""
+        from src.services.trust import is_verified_scout
+
+        return is_verified_scout(self)
+
     def to_dict(self):
         return {
             "id": self.id,
@@ -583,6 +590,7 @@ class UserAccount(db.Model):
             "email_delivery_preference": self.email_delivery_preference or "individual",
             "is_editor": self.is_editor,
             "is_curator": self.is_curator,
+            "is_verified_scout": self.is_verified_scout,
             "is_placeholder": self.is_placeholder(),
             "is_claimed": self.is_claimed(),
             "managed_by_user_id": self.managed_by_user_id,

--- a/academy-watch-backend/src/models/trust.py
+++ b/academy-watch-backend/src/models/trust.py
@@ -1,0 +1,157 @@
+"""Marketplace trust prerequisites: scout verification and content reports.
+
+These rows deliberately establish identity and moderation state without
+persisting a scout role on ``UserAccount``.  Scout status is derived from an
+approved verification row at serialization time by the auth layer.
+"""
+
+from datetime import UTC, datetime
+
+import sqlalchemy as sa
+from src.models.league import db
+
+
+def _iso(value):
+    return value.isoformat() if value else None
+
+
+class ScoutVerification(db.Model):
+    """Admin-reviewed evidence that a user is a legitimate football scout."""
+
+    __tablename__ = "scout_verifications"
+    __table_args__ = (
+        db.CheckConstraint(
+            "status IN ('pending','approved','rejected','revoked')",
+            name="ck_scout_verifications_status",
+        ),
+        db.Index(
+            "uq_scout_verifications_active_user",
+            "user_account_id",
+            unique=True,
+            postgresql_where=sa.text("status IN ('pending', 'approved')"),
+            sqlite_where=sa.text("status IN ('pending', 'approved')"),
+        ),
+        db.Index(
+            "ix_scout_verifications_user_submitted",
+            "user_account_id",
+            "submitted_at",
+        ),
+        db.Index(
+            "ix_scout_verifications_status_submitted",
+            "status",
+            "submitted_at",
+        ),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_account_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"), nullable=False)
+    full_name = db.Column(db.String(200), nullable=False)
+    organization = db.Column(db.String(200), nullable=False)
+    role_title = db.Column(db.String(120), nullable=False)
+    statement = db.Column(db.String(2000), nullable=False)
+    evidence_urls = db.Column(db.JSON, nullable=False, default=list)
+    status = db.Column(db.String(20), nullable=False, default="pending", server_default="pending")
+    submitted_at = db.Column(db.DateTime, nullable=False, default=lambda: datetime.now(UTC))
+    reviewed_at = db.Column(db.DateTime)
+    reviewed_by = db.Column(db.String(200))
+    review_notes = db.Column(db.String(2000))
+    revocation_reason = db.Column(db.String(1000))
+
+    user = db.relationship(
+        "UserAccount",
+        foreign_keys=[user_account_id],
+        backref=db.backref("scout_verifications", lazy="dynamic"),
+    )
+
+    def to_dict(self, *, admin=False):
+        """Serialize the applicant-facing view, optionally with admin identity."""
+        payload = {
+            "id": self.id,
+            "full_name": self.full_name,
+            "organization": self.organization,
+            "role_title": self.role_title,
+            "statement": self.statement,
+            "evidence_urls": list(self.evidence_urls or []),
+            "status": self.status,
+            "submitted_at": _iso(self.submitted_at),
+            "reviewed_at": _iso(self.reviewed_at),
+            "review_notes": self.review_notes,
+            "revocation_reason": self.revocation_reason,
+        }
+        if admin:
+            payload.update(
+                {
+                    "user_account_id": self.user_account_id,
+                    "user_email": self.user.email if self.user else None,
+                    "reviewed_by": self.reviewed_by,
+                }
+            )
+        return payload
+
+    def admin_dict(self):
+        return self.to_dict(admin=True)
+
+
+class ContentReport(db.Model):
+    """A user-submitted moderation report spanning several subject types."""
+
+    __tablename__ = "content_reports"
+    __table_args__ = (
+        db.CheckConstraint(
+            "subject_type IN ('player_profile','showcase_content','club_program','contact_message','other')",
+            name="ck_content_reports_subject_type",
+        ),
+        db.CheckConstraint(
+            "status IN ('open','reviewing','resolved','dismissed')",
+            name="ck_content_reports_status",
+        ),
+        db.Index(
+            "ix_content_reports_reporter_created",
+            "reporter_user_id",
+            "created_at",
+        ),
+        db.Index("ix_content_reports_status_created", "status", "created_at"),
+        db.Index("ix_content_reports_subject", "subject_type", "subject_id"),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    reporter_user_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"), nullable=False)
+    subject_type = db.Column(db.String(40), nullable=False)
+    subject_id = db.Column(db.String(200), nullable=False)
+    reason_code = db.Column(db.String(80), nullable=False)
+    details = db.Column(db.String(2000))
+    status = db.Column(db.String(20), nullable=False, default="open", server_default="open")
+    resolution_notes = db.Column(db.String(2000))
+    created_at = db.Column(db.DateTime, nullable=False, default=lambda: datetime.now(UTC))
+    resolved_at = db.Column(db.DateTime)
+
+    reporter = db.relationship(
+        "UserAccount",
+        foreign_keys=[reporter_user_id],
+        backref=db.backref("content_reports", lazy="dynamic"),
+    )
+
+    def to_dict(self, *, admin=False):
+        """Serialize the reporter-facing view, optionally with reporter identity."""
+        payload = {
+            "id": self.id,
+            "subject_type": self.subject_type,
+            "subject_id": self.subject_id,
+            "reason_code": self.reason_code,
+            "details": self.details,
+            "status": self.status,
+            "resolution_notes": self.resolution_notes,
+            "created_at": _iso(self.created_at),
+            "resolved_at": _iso(self.resolved_at),
+        }
+        if admin:
+            payload.update(
+                {
+                    "reporter_user_id": self.reporter_user_id,
+                    "reporter_email": self.reporter.email if self.reporter else None,
+                }
+            )
+        return payload
+
+    def admin_dict(self):
+        return self.to_dict(admin=True)

--- a/academy-watch-backend/src/routes/auth_routes.py
+++ b/academy-watch-backend/src/routes/auth_routes.py
@@ -37,6 +37,7 @@ from src.models.league import (
     db,
 )
 from src.services.email_service import email_service
+from src.services.trust import is_verified_scout
 
 logger = logging.getLogger(__name__)
 
@@ -210,6 +211,7 @@ def verify_login_code():
             {
                 "message": "Logged in",
                 "role": role,
+                "is_verified_scout": is_verified_scout(user),
                 "display_name": user.display_name if user else None,
                 "display_name_confirmed": bool(user.display_name_confirmed) if user else False,
                 **out,
@@ -249,6 +251,7 @@ def auth_me():
                 "display_name_confirmed": bool(user.display_name_confirmed) if user else False,
                 "is_journalist": bool(user.is_journalist) if user else False,
                 "is_curator": bool(user.is_curator) if user else False,
+                "is_verified_scout": is_verified_scout(user),
             }
         )
     except Exception as e:

--- a/academy-watch-backend/src/routes/showcase.py
+++ b/academy-watch-backend/src/routes/showcase.py
@@ -34,10 +34,13 @@ from src.auth import (
     require_user_auth,
 )
 from src.extensions import limiter
+from src.models.follow import PlayerShadow
+from src.models.journey import PlayerJourney
 from src.models.league import NewsletterPlayerYoutubeLink, PlayerLink, UserAccount, db
 from src.models.showcase import PlayerProfileClaim, PlayerShowcaseProfile
 from src.models.tracked_player import TrackedPlayer
 from src.models.video import VideoMatch, VideoPlayerReport, VideoRosterEntry
+from src.utils.academy_window import age_from_birth_date
 from src.utils.sanitize import is_safe_https_url, sanitize_plain_text
 
 logger = logging.getLogger(__name__)
@@ -267,6 +270,58 @@ def _resolve_player_name(player_api_id: int):
     return tracked.player_name if tracked and tracked.player_name else None
 
 
+def _resolve_player_age_from_dob(player_api_id: int) -> int | None:
+    """Resolve a current age from persisted DOB sources only.
+
+    ``TrackedPlayer.age`` is deliberately excluded: it is a stale snapshot and
+    the adults-only self-claim policy requires a known birth date. Malformed
+    values fall through so a valid journey or shadow profile can still prove
+    eligibility.
+    """
+    candidates = [
+        row[0]
+        for row in db.session.query(TrackedPlayer.birth_date)
+        .filter(
+            TrackedPlayer.player_api_id == player_api_id,
+            TrackedPlayer.birth_date.isnot(None),
+        )
+        .order_by(TrackedPlayer.id.asc())
+        .all()
+    ]
+    journey = PlayerJourney.query.filter_by(player_api_id=player_api_id).first()
+    if journey is not None:
+        candidates.append(journey.birth_date)
+    shadow = PlayerShadow.query.filter_by(player_api_id=player_api_id, is_active=True).first()
+    if shadow is not None:
+        candidates.append(shadow.birth_date)
+
+    for birth_date in candidates:
+        age = age_from_birth_date(birth_date)
+        if age is not None:
+            return age
+    return None
+
+
+def _adult_player_claim_error(player_api_id: int):
+    """Return the D1 policy error response for an ineligible self-claim."""
+    age = _resolve_player_age_from_dob(player_api_id)
+    if age is None:
+        return jsonify(
+            {
+                "error": "A known birth date is required for a player to claim their own profile",
+                "code": "dob_unknown",
+            }
+        ), 422
+    if age < 18:
+        return jsonify(
+            {
+                "error": "Players must be at least 18 to claim their own profile",
+                "code": "minor_claim_blocked",
+            }
+        ), 422
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Flywheel X — Film Room → verified footage evidence
 # ---------------------------------------------------------------------------
@@ -389,20 +444,27 @@ def submit_profile_claim(player_api_id: int):
 
         existing = PlayerProfileClaim.query.filter_by(player_api_id=player_api_id, user_account_id=user.id).first()
         if existing:
-            if existing.status in ("rejected", "revoked"):
-                # Recovery path: a rejected/revoked claim may be resubmitted —
-                # reset it to pending for a fresh admin review.
-                existing.relationship_type = relationship_type
-                existing.message = message
-                existing.status = "pending"
-                existing.reviewed_by = None
-                existing.reviewed_at = None
-                existing.created_at = datetime.now(UTC)
-                db.session.commit()
-                return jsonify({"claim": existing.to_dict()}), 201
-            return jsonify(
-                {"error": "You have already submitted a claim for this player", "claim": existing.to_dict()}
-            ), 409
+            if existing.status not in ("rejected", "revoked"):
+                return jsonify(
+                    {"error": "You have already submitted a claim for this player", "claim": existing.to_dict()}
+                ), 409
+
+        if relationship_type == "player":
+            policy_error = _adult_player_claim_error(player_api_id)
+            if policy_error is not None:
+                return policy_error
+
+        if existing:
+            # Recovery path: a rejected/revoked claim may be resubmitted —
+            # reset it to pending for a fresh admin review.
+            existing.relationship_type = relationship_type
+            existing.message = message
+            existing.status = "pending"
+            existing.reviewed_by = None
+            existing.reviewed_at = None
+            existing.created_at = datetime.now(UTC)
+            db.session.commit()
+            return jsonify({"claim": existing.to_dict()}), 201
 
         claim = PlayerProfileClaim(
             player_api_id=player_api_id,
@@ -662,6 +724,11 @@ def admin_review_claim(claim_id: int):
         allowed_from, target = transitions[action]
         if claim.status not in allowed_from:
             return jsonify({"error": f"cannot {action} a {claim.status} claim"}), 409
+
+        if action == "approve" and claim.relationship_type == "player":
+            policy_error = _adult_player_claim_error(claim.player_api_id)
+            if policy_error is not None:
+                return policy_error
 
         claim.status = target
         claim.reviewed_by = getattr(g, "user_email", None)

--- a/academy-watch-backend/src/routes/trust.py
+++ b/academy-watch-backend/src/routes/trust.py
@@ -1,0 +1,434 @@
+"""Trust prerequisites for scout verification and user content reports."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from flask import Blueprint, g, jsonify, request
+from sqlalchemy.exc import IntegrityError
+from src.auth import _ensure_user_account, _safe_error_payload, require_api_key, require_user_auth
+from src.extensions import limiter
+from src.models.league import UserAccount, db
+from src.models.trust import ContentReport, ScoutVerification
+from src.utils.sanitize import is_safe_https_url, sanitize_comment_body, sanitize_plain_text
+
+logger = logging.getLogger(__name__)
+trust_bp = Blueprint("trust", __name__)
+
+VERIFICATION_STATUSES = {"pending", "approved", "rejected", "revoked"}
+ACTIVE_VERIFICATION_STATUSES = {"pending", "approved"}
+REPORT_SUBJECT_TYPES = {
+    "player_profile",
+    "showcase_content",
+    "club_program",
+    "contact_message",
+    "other",
+}
+REPORT_STATUSES = {"open", "reviewing", "resolved", "dismissed"}
+REPORT_RESOLUTION_STATUSES = {"resolved", "dismissed"}
+
+MAX_FULL_NAME_LENGTH = 200
+MAX_ORGANIZATION_LENGTH = 200
+MAX_ROLE_TITLE_LENGTH = 120
+MAX_STATEMENT_LENGTH = 2000
+MAX_REVIEW_NOTES_LENGTH = 2000
+MAX_REVOCATION_REASON_LENGTH = 1000
+MAX_EVIDENCE_URL_LENGTH = 500
+MAX_EVIDENCE_URLS = 10
+
+MAX_SUBJECT_ID_LENGTH = 200
+MAX_REASON_CODE_LENGTH = 80
+MAX_REPORT_DETAILS_LENGTH = 2000
+MAX_RESOLUTION_NOTES_LENGTH = 2000
+MAX_ADMIN_PAGE_SIZE = 200
+
+VERIFICATION_RATE_LIMIT = "3 per hour"
+REPORT_RATE_LIMIT_PER_MINUTE = "10 per minute"
+REPORT_RATE_LIMIT_PER_HOUR = "30 per hour"
+
+
+def _clean_text(value, field: str, *, max_len: int, required: bool = True) -> str | None:
+    """Validate and bleach-clean a short plain-text value."""
+    if value is None:
+        if required:
+            raise ValueError(f"{field} is required")
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a string")
+    cleaned = sanitize_plain_text(value).strip()
+    if not cleaned:
+        if required:
+            raise ValueError(f"{field} is required")
+        return None
+    if len(cleaned) > max_len:
+        raise ValueError(f"{field} must be at most {max_len} characters")
+    return cleaned
+
+
+def _clean_body(value, field: str, *, max_len: int, required: bool = True) -> str | None:
+    """Validate and bleach-clean a bounded free-text value."""
+    if value is None:
+        if required:
+            raise ValueError(f"{field} is required")
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a string")
+    cleaned = sanitize_comment_body(value).strip()
+    if not cleaned:
+        if required:
+            raise ValueError(f"{field} is required")
+        return None
+    if len(cleaned) > max_len:
+        raise ValueError(f"{field} must be at most {max_len} characters")
+    return cleaned
+
+
+def _enum(value, field: str, allowed: set[str]) -> str:
+    cleaned = _clean_text(value, field, max_len=80)
+    normalized = cleaned.lower()
+    if normalized not in allowed:
+        raise ValueError(f"{field} must be one of {sorted(allowed)}")
+    return normalized
+
+
+def _evidence_urls(value) -> list[str]:
+    if not isinstance(value, list) or not value:
+        raise ValueError("evidence_urls must be a non-empty list")
+    if len(value) > MAX_EVIDENCE_URLS:
+        raise ValueError(f"evidence_urls must contain at most {MAX_EVIDENCE_URLS} URLs")
+
+    urls: list[str] = []
+    for item in value:
+        cleaned = _clean_text(item, "evidence_urls item", max_len=MAX_EVIDENCE_URL_LENGTH)
+        if not is_safe_https_url(cleaned):
+            raise ValueError("evidence_urls entries must be absolute https URLs")
+        if cleaned not in urls:
+            urls.append(cleaned)
+    return urls
+
+
+def _user_rate_limit_key() -> str:
+    # The ingress proxy makes request.remote_addr a shared bucket in production;
+    # authenticated trust actions must be limited per account instead.
+    return getattr(g, "user_email", None) or request.remote_addr or "anon"
+
+
+def _current_user_account() -> UserAccount | None:
+    user = getattr(g, "user", None)
+    if user is not None:
+        return user
+    email = getattr(g, "user_email", None)
+    if not email:
+        return None
+    user = UserAccount.query.filter_by(email=email).first()
+    if user is None:
+        user = _ensure_user_account(email)
+        db.session.commit()
+    return user
+
+
+def _active_verification(user_id: int) -> ScoutVerification | None:
+    return (
+        ScoutVerification.query.filter(
+            ScoutVerification.user_account_id == user_id,
+            ScoutVerification.status.in_(ACTIVE_VERIFICATION_STATUSES),
+        )
+        .order_by(ScoutVerification.submitted_at.desc(), ScoutVerification.id.desc())
+        .first()
+    )
+
+
+def _admin_actor() -> str:
+    return (getattr(g, "user_email", None) or "admin")[:200]
+
+
+def _pagination() -> tuple[int, int]:
+    limit = request.args.get("limit", 50, type=int)
+    offset = request.args.get("offset", 0, type=int)
+    limit = min(MAX_ADMIN_PAGE_SIZE, max(1, limit if limit is not None else 50))
+    offset = max(0, offset if offset is not None else 0)
+    return limit, offset
+
+
+def _json_object() -> dict:
+    payload = request.get_json(silent=True)
+    if payload is None:
+        return {}
+    if not isinstance(payload, dict):
+        raise ValueError("JSON body must be an object")
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Scout verification
+# ---------------------------------------------------------------------------
+
+
+@trust_bp.route("/scout/verification", methods=["POST"])
+@require_user_auth
+@limiter.limit(VERIFICATION_RATE_LIMIT, key_func=_user_rate_limit_key)
+def submit_scout_verification():
+    """Submit a scout verification application for admin review."""
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+
+        active = _active_verification(user.id)
+        if active is not None:
+            return jsonify(
+                {"error": "an active scout verification already exists", "verification": active.to_dict()}
+            ), 409
+
+        payload = _json_object()
+        verification = ScoutVerification(
+            user_account_id=user.id,
+            full_name=_clean_text(payload.get("full_name"), "full_name", max_len=MAX_FULL_NAME_LENGTH),
+            organization=_clean_text(payload.get("organization"), "organization", max_len=MAX_ORGANIZATION_LENGTH),
+            role_title=_clean_text(payload.get("role_title"), "role_title", max_len=MAX_ROLE_TITLE_LENGTH),
+            statement=_clean_body(payload.get("statement"), "statement", max_len=MAX_STATEMENT_LENGTH),
+            evidence_urls=_evidence_urls(payload.get("evidence_urls")),
+            status="pending",
+        )
+        db.session.add(verification)
+        try:
+            db.session.commit()
+        except IntegrityError:
+            # The partial unique index is authoritative if simultaneous requests
+            # both pass the application-level active-row check.
+            db.session.rollback()
+            active = _active_verification(user.id)
+            if active is not None:
+                return jsonify(
+                    {"error": "an active scout verification already exists", "verification": active.to_dict()}
+                ), 409
+            raise
+        return jsonify({"verification": verification.to_dict()}), 201
+    except ValueError as exc:
+        db.session.rollback()
+        return jsonify({"error": str(exc)}), 400
+    except Exception as exc:
+        db.session.rollback()
+        logger.exception("Failed to submit scout verification")
+        return jsonify(_safe_error_payload(exc, "Failed to submit scout verification")), 500
+
+
+@trust_bp.route("/scout/verification", methods=["GET"])
+@require_user_auth
+def get_scout_verification():
+    """Return the caller's latest scout verification, including inactive history."""
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        verification = (
+            ScoutVerification.query.filter_by(user_account_id=user.id)
+            .order_by(ScoutVerification.submitted_at.desc(), ScoutVerification.id.desc())
+            .first()
+        )
+        return jsonify({"verification": verification.to_dict() if verification else None})
+    except Exception as exc:
+        logger.exception("Failed to load scout verification")
+        return jsonify(_safe_error_payload(exc, "Failed to load scout verification")), 500
+
+
+@trust_bp.route("/admin/scout-verifications", methods=["GET"])
+@require_api_key
+def admin_list_scout_verifications():
+    """List verification applications, defaulting to the pending queue."""
+    try:
+        status = (request.args.get("status") or "pending").strip().lower()
+        query = ScoutVerification.query
+        if status != "all":
+            if status not in VERIFICATION_STATUSES:
+                return jsonify({"error": f"status must be one of {sorted(VERIFICATION_STATUSES)} or all"}), 400
+            query = query.filter(ScoutVerification.status == status)
+
+        limit, offset = _pagination()
+        total = query.count()
+        rows = (
+            query.order_by(ScoutVerification.submitted_at.asc(), ScoutVerification.id.asc())
+            .offset(offset)
+            .limit(limit)
+            .all()
+        )
+        return jsonify(
+            {
+                "verifications": [row.admin_dict() for row in rows],
+                "total": total,
+                "limit": limit,
+                "offset": offset,
+            }
+        )
+    except Exception as exc:
+        logger.exception("Failed to list scout verifications")
+        return jsonify(_safe_error_payload(exc, "Failed to list scout verifications")), 500
+
+
+def _review_scout_verification(verification_id: int, action: str):
+    try:
+        verification = db.session.get(ScoutVerification, verification_id)
+        if verification is None:
+            return jsonify({"error": "scout verification not found"}), 404
+
+        payload = _json_object()
+        now = datetime.now(UTC)
+        if action == "approve":
+            if verification.status != "pending":
+                return jsonify({"error": f"cannot approve a {verification.status} verification"}), 409
+            verification.status = "approved"
+            verification.review_notes = _clean_body(
+                payload.get("review_notes", payload.get("notes", payload.get("reason"))),
+                "review_notes",
+                max_len=MAX_REVIEW_NOTES_LENGTH,
+            )
+        elif action == "reject":
+            if verification.status != "pending":
+                return jsonify({"error": f"cannot reject a {verification.status} verification"}), 409
+            verification.status = "rejected"
+            verification.review_notes = _clean_body(
+                payload.get("review_notes", payload.get("notes", payload.get("reason"))),
+                "review_notes",
+                max_len=MAX_REVIEW_NOTES_LENGTH,
+            )
+        elif action == "revoke":
+            if verification.status != "approved":
+                return jsonify({"error": f"cannot revoke a {verification.status} verification"}), 409
+            verification.status = "revoked"
+            verification.revocation_reason = _clean_body(
+                payload.get("revocation_reason", payload.get("reason")),
+                "revocation_reason",
+                max_len=MAX_REVOCATION_REASON_LENGTH,
+            )
+        else:  # pragma: no cover - routes below pass constants only
+            raise ValueError("unsupported verification action")
+
+        verification.reviewed_by = _admin_actor()
+        verification.reviewed_at = now
+        db.session.commit()
+        return jsonify({"verification": verification.admin_dict()})
+    except ValueError as exc:
+        db.session.rollback()
+        return jsonify({"error": str(exc)}), 400
+    except Exception as exc:
+        db.session.rollback()
+        logger.exception("Failed to %s scout verification %s", action, verification_id)
+        return jsonify(_safe_error_payload(exc, f"Failed to {action} scout verification")), 500
+
+
+@trust_bp.route("/admin/scout-verifications/<int:verification_id>/approve", methods=["POST"])
+@require_api_key
+def admin_approve_scout_verification(verification_id: int):
+    return _review_scout_verification(verification_id, "approve")
+
+
+@trust_bp.route("/admin/scout-verifications/<int:verification_id>/reject", methods=["POST"])
+@require_api_key
+def admin_reject_scout_verification(verification_id: int):
+    return _review_scout_verification(verification_id, "reject")
+
+
+@trust_bp.route("/admin/scout-verifications/<int:verification_id>/revoke", methods=["POST"])
+@require_api_key
+def admin_revoke_scout_verification(verification_id: int):
+    return _review_scout_verification(verification_id, "revoke")
+
+
+# ---------------------------------------------------------------------------
+# Content reports
+# ---------------------------------------------------------------------------
+
+
+@trust_bp.route("/reports", methods=["POST"])
+@require_user_auth
+@limiter.limit(REPORT_RATE_LIMIT_PER_MINUTE, key_func=_user_rate_limit_key)
+@limiter.limit(REPORT_RATE_LIMIT_PER_HOUR, key_func=_user_rate_limit_key)
+def submit_content_report():
+    """Submit a bounded, sanitized report for admin moderation."""
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        payload = _json_object()
+        report = ContentReport(
+            reporter_user_id=user.id,
+            subject_type=_enum(payload.get("subject_type"), "subject_type", REPORT_SUBJECT_TYPES),
+            subject_id=_clean_text(payload.get("subject_id"), "subject_id", max_len=MAX_SUBJECT_ID_LENGTH),
+            reason_code=_clean_text(payload.get("reason_code"), "reason_code", max_len=MAX_REASON_CODE_LENGTH).lower(),
+            details=_clean_body(payload.get("details"), "details", max_len=MAX_REPORT_DETAILS_LENGTH, required=False),
+            status="open",
+        )
+        db.session.add(report)
+        db.session.commit()
+        return jsonify({"report": report.to_dict()}), 201
+    except ValueError as exc:
+        db.session.rollback()
+        return jsonify({"error": str(exc)}), 400
+    except Exception as exc:
+        db.session.rollback()
+        logger.exception("Failed to submit content report")
+        return jsonify(_safe_error_payload(exc, "Failed to submit content report")), 500
+
+
+@trust_bp.route("/admin/reports", methods=["GET"])
+@require_api_key
+def admin_list_content_reports():
+    """List content reports, defaulting to the open moderation queue."""
+    try:
+        status = (request.args.get("status") or "open").strip().lower()
+        query = ContentReport.query
+        if status != "all":
+            if status not in REPORT_STATUSES:
+                return jsonify({"error": f"status must be one of {sorted(REPORT_STATUSES)} or all"}), 400
+            query = query.filter(ContentReport.status == status)
+
+        limit, offset = _pagination()
+        total = query.count()
+        rows = query.order_by(ContentReport.created_at.asc(), ContentReport.id.asc()).offset(offset).limit(limit).all()
+        return jsonify(
+            {
+                "reports": [row.admin_dict() for row in rows],
+                "total": total,
+                "limit": limit,
+                "offset": offset,
+            }
+        )
+    except Exception as exc:
+        logger.exception("Failed to list content reports")
+        return jsonify(_safe_error_payload(exc, "Failed to list content reports")), 500
+
+
+@trust_bp.route("/admin/reports/<int:report_id>/resolve", methods=["POST"])
+@require_api_key
+def admin_resolve_content_report(report_id: int):
+    """Resolve or dismiss a content report with a bounded admin note."""
+    try:
+        report = db.session.get(ContentReport, report_id)
+        if report is None:
+            return jsonify({"error": "content report not found"}), 404
+        if report.status in REPORT_RESOLUTION_STATUSES:
+            return jsonify({"error": f"content report is already {report.status}"}), 409
+
+        payload = _json_object()
+        status = _enum(payload.get("status"), "status", REPORT_RESOLUTION_STATUSES)
+        resolution_notes = _clean_body(
+            payload.get("resolution_notes"),
+            "resolution_notes",
+            max_len=MAX_RESOLUTION_NOTES_LENGTH,
+        )
+        report.status = status
+        report.resolution_notes = resolution_notes
+        report.resolved_at = datetime.now(UTC)
+        db.session.commit()
+        return jsonify({"report": report.admin_dict()})
+    except ValueError as exc:
+        db.session.rollback()
+        return jsonify({"error": str(exc)}), 400
+    except Exception as exc:
+        db.session.rollback()
+        logger.exception("Failed to resolve content report %s", report_id)
+        return jsonify(_safe_error_payload(exc, "Failed to resolve content report")), 500
+
+
+__all__ = ["trust_bp"]

--- a/academy-watch-backend/src/services/trust.py
+++ b/academy-watch-backend/src/services/trust.py
@@ -1,0 +1,33 @@
+"""Derived trust state backed by current moderation records."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.models.league import db
+from src.models.trust import ScoutVerification
+
+if TYPE_CHECKING:
+    from src.models.league import UserAccount
+
+
+def is_verified_scout(user: UserAccount | None) -> bool:
+    """Return whether ``user`` currently has an approved verification.
+
+    The value is intentionally queried from the authoritative review row and
+    is never persisted as a role flag on ``user_accounts``.
+    """
+    if user is None or user.id is None:
+        return False
+    return (
+        db.session.query(ScoutVerification.id)
+        .filter(
+            ScoutVerification.user_account_id == user.id,
+            ScoutVerification.status == "approved",
+        )
+        .first()
+        is not None
+    )
+
+
+__all__ = ["is_verified_scout"]

--- a/academy-watch-backend/tests/conftest.py
+++ b/academy-watch-backend/tests/conftest.py
@@ -9,13 +9,14 @@ if str(ROOT) not in sys.path:
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
-from types import SimpleNamespace
-
 import pytest
 import sqlalchemy as sa
 from flask import Flask
 
-if "bleach" not in sys.modules:
+try:
+    import bleach  # noqa: F401
+except ModuleNotFoundError:
+    from types import SimpleNamespace
 
     def _clean(value, *args, **kwargs):
         return value
@@ -26,7 +27,10 @@ if "bleach" not in sys.modules:
     sys.modules["bleach"] = SimpleNamespace(clean=_clean, linkify=_linkify)
 
 
-if "flask_limiter" not in sys.modules:
+try:
+    import flask_limiter  # noqa: F401
+except ModuleNotFoundError:
+    from types import SimpleNamespace
 
     class _Limiter:
         def __init__(self, *args, **kwargs):
@@ -42,9 +46,6 @@ if "flask_limiter" not in sys.modules:
             return None
 
     sys.modules["flask_limiter"] = SimpleNamespace(Limiter=_Limiter)
-
-
-if "flask_limiter.util" not in sys.modules:
 
     def _get_remote_address(*args, **kwargs):
         return "127.0.0.1"

--- a/academy-watch-backend/tests/test_auth_endpoints.py
+++ b/academy-watch-backend/tests/test_auth_endpoints.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
+from src.extensions import limiter
 from src.models.league import EmailToken, UserAccount, db
 
 
@@ -26,6 +27,7 @@ def auth_bp_app():
     )
 
     db.init_app(app)
+    limiter.init_app(app)
     app.register_blueprint(auth_bp, url_prefix="/api")
 
     with app.app_context():
@@ -120,6 +122,7 @@ class TestVerifyLoginCode:
             assert "token" in data
             assert "expires_in" in data
             assert data["message"] == "Logged in"
+            assert data["is_verified_scout"] is False
 
     def test_verify_code_invalid_code_returns_400(self, auth_bp_app, auth_bp_client, mock_email_service):
         """Should return 400 for invalid code."""
@@ -163,6 +166,7 @@ class TestAuthMe:
             assert data["email"] == "me@example.com"
             assert data["display_name"] == "TestUser"
             assert data["role"] == "user"
+            assert data["is_verified_scout"] is False
 
     def test_auth_me_without_token_returns_401(self, auth_bp_client):
         """Should return 401 without auth token."""

--- a/academy-watch-backend/tests/test_showcase.py
+++ b/academy-watch-backend/tests/test_showcase.py
@@ -11,6 +11,9 @@ from datetime import date
 import pytest
 from flask import Flask
 from src.auth import _ensure_user_account, issue_user_token
+from src.extensions import limiter
+from src.models.follow import PlayerShadow
+from src.models.journey import PlayerJourney
 from src.models.league import League, PlayerLink, Team, db
 from src.models.showcase import PlayerProfileClaim, PlayerShowcaseProfile
 from src.models.tracked_player import TrackedPlayer
@@ -39,11 +42,20 @@ def app(monkeypatch):
     )
 
     db.init_app(flask_app)
+    limiter.init_app(flask_app)
     flask_app.register_blueprint(showcase_bp, url_prefix="/api")
     flask_app.register_blueprint(api_bp, url_prefix="/api")
 
     with flask_app.app_context():
         db.create_all()
+        db.session.add(
+            PlayerJourney(
+                player_api_id=5001,
+                player_name="Kobbie Mainoo",
+                birth_date="2000-01-01",
+            )
+        )
+        db.session.commit()
         yield flask_app
         db.session.remove()
         db.drop_all()
@@ -73,6 +85,25 @@ def _make_user(email):
     user = _ensure_user_account(email)
     db.session.commit()
     return user
+
+
+def _birth_date_years_ago(years: int) -> date:
+    today = date.today()
+    try:
+        return today.replace(year=today.year - years)
+    except ValueError:  # February 29 against a non-leap birth year.
+        return today.replace(year=today.year - years, month=2, day=28)
+
+
+def _journey(player_api_id: int, birth_date):
+    journey = PlayerJourney(
+        player_api_id=player_api_id,
+        player_name=f"Player {player_api_id}",
+        birth_date=birth_date.isoformat() if isinstance(birth_date, date) else birth_date,
+    )
+    db.session.add(journey)
+    db.session.flush()
+    return journey
 
 
 def _seed_team(team_id=33, name="Manchester United"):
@@ -280,6 +311,168 @@ class TestAdminClaimReview:
         # A plain user Bearer token (no admin role / X-API-Key) is rejected.
         resp = client.post(f"/api/admin/showcase/claims/{claim_id}/review", json={"action": "approve"}, headers=headers)
         assert resp.status_code in (401, 403)
+
+
+class TestAdultPlayerClaimGate:
+    def test_under_18_player_submission_is_blocked(self, app, client):
+        with app.app_context():
+            team = _seed_team()
+            _tracked(
+                team,
+                player_api_id=6101,
+                name="Minor Player",
+                birth_date=_birth_date_years_ago(17).isoformat(),
+            )
+            db.session.commit()
+
+        response = client.post(
+            "/api/players/6101/claim",
+            json={"relationship_type": "player"},
+            headers=_user_headers("minor-player@example.com"),
+        )
+
+        assert response.status_code == 422
+        assert response.get_json()["code"] == "minor_claim_blocked"
+        with app.app_context():
+            assert PlayerProfileClaim.query.filter_by(player_api_id=6101).count() == 0
+
+    def test_unknown_dob_player_submission_is_blocked(self, app, client):
+        response = client.post(
+            "/api/players/6102/claim",
+            json={"relationship_type": "player"},
+            headers=_user_headers("unknown-dob@example.com"),
+        )
+
+        assert response.status_code == 422
+        assert response.get_json()["code"] == "dob_unknown"
+        with app.app_context():
+            assert PlayerProfileClaim.query.filter_by(player_api_id=6102).count() == 0
+
+    def test_exactly_18_journey_dob_passes(self, app, client):
+        with app.app_context():
+            _journey(6103, _birth_date_years_ago(18))
+            db.session.commit()
+
+        response = client.post(
+            "/api/players/6103/claim",
+            json={"relationship_type": "player"},
+            headers=_user_headers("adult-today@example.com"),
+        )
+
+        assert response.status_code == 201
+
+    def test_shadow_profile_dob_passes(self, app, client):
+        with app.app_context():
+            db.session.add(
+                PlayerShadow(
+                    player_api_id=6104,
+                    player_name="Shadow Adult",
+                    birth_date=_birth_date_years_ago(20),
+                    is_active=True,
+                )
+            )
+            db.session.commit()
+
+        response = client.post(
+            "/api/players/6104/claim",
+            json={"relationship_type": "player"},
+            headers=_user_headers("shadow-adult@example.com"),
+        )
+
+        assert response.status_code == 201
+
+    def test_malformed_tracked_dob_falls_through_to_journey(self, app, client):
+        with app.app_context():
+            team = _seed_team()
+            _tracked(team, player_api_id=6105, name="Fallback Adult", birth_date="not-a-date")
+            _journey(6105, _birth_date_years_ago(19))
+            db.session.commit()
+
+        response = client.post(
+            "/api/players/6105/claim",
+            json={"relationship_type": "player"},
+            headers=_user_headers("fallback-adult@example.com"),
+        )
+
+        assert response.status_code == 201
+
+    @pytest.mark.parametrize("relationship_type", ["agent", "guardian", "club_official"])
+    def test_non_player_relationships_do_not_require_dob(self, client, relationship_type):
+        player_api_id = {"agent": 6110, "guardian": 6111, "club_official": 6112}[relationship_type]
+        response = client.post(
+            f"/api/players/{player_api_id}/claim",
+            json={"relationship_type": relationship_type},
+            headers=_user_headers(f"{relationship_type}@example.com"),
+        )
+        assert response.status_code == 201
+
+        claim_id = response.get_json()["claim"]["id"]
+        approval = client.post(
+            f"/api/admin/showcase/claims/{claim_id}/review",
+            json={"action": "approve"},
+            headers=_admin_headers(),
+        )
+        assert approval.status_code == 200
+
+    def test_admin_approval_rechecks_and_blocks_newly_minor_player(self, app, client):
+        with app.app_context():
+            team = _seed_team()
+            tracked = _tracked(
+                team,
+                player_api_id=6120,
+                name="Changed DOB",
+                birth_date=_birth_date_years_ago(20).isoformat(),
+            )
+            db.session.commit()
+            tracked_id = tracked.id
+
+        submitted = client.post(
+            "/api/players/6120/claim",
+            json={"relationship_type": "player"},
+            headers=_user_headers("changed-dob@example.com"),
+        )
+        claim_id = submitted.get_json()["claim"]["id"]
+        with app.app_context():
+            db.session.get(TrackedPlayer, tracked_id).birth_date = _birth_date_years_ago(17).isoformat()
+            db.session.commit()
+
+        approval = client.post(
+            f"/api/admin/showcase/claims/{claim_id}/review",
+            json={"action": "approve"},
+            headers=_admin_headers(),
+        )
+
+        assert approval.status_code == 422
+        assert approval.get_json()["code"] == "minor_claim_blocked"
+        with app.app_context():
+            assert db.session.get(PlayerProfileClaim, claim_id).status == "pending"
+
+    def test_admin_approval_rechecks_and_blocks_missing_dob(self, app, client):
+        with app.app_context():
+            journey = _journey(6121, _birth_date_years_ago(20))
+            db.session.commit()
+            journey_id = journey.id
+
+        submitted = client.post(
+            "/api/players/6121/claim",
+            json={"relationship_type": "player"},
+            headers=_user_headers("removed-dob@example.com"),
+        )
+        claim_id = submitted.get_json()["claim"]["id"]
+        with app.app_context():
+            db.session.get(PlayerJourney, journey_id).birth_date = None
+            db.session.commit()
+
+        approval = client.post(
+            f"/api/admin/showcase/claims/{claim_id}/review",
+            json={"action": "approve"},
+            headers=_admin_headers(),
+        )
+
+        assert approval.status_code == 422
+        assert approval.get_json()["code"] == "dob_unknown"
+        with app.app_context():
+            assert db.session.get(PlayerProfileClaim, claim_id).status == "pending"
 
 
 # --------------------------------------------------------------------------- #

--- a/academy-watch-backend/tests/test_trust.py
+++ b/academy-watch-backend/tests/test_trust.py
@@ -1,0 +1,354 @@
+"""Scout verification and content-report trust prerequisite tests."""
+
+from pathlib import Path
+
+import pytest
+from flask import Flask
+from src.auth import _ensure_user_account, issue_user_token
+from src.extensions import limiter
+from src.models.league import UserAccount, db
+from src.models.trust import ContentReport, ScoutVerification
+from src.routes.auth_routes import auth_bp
+from src.routes.trust import trust_bp
+
+ADMIN_KEY = "trust-admin-test-key"
+
+
+@pytest.fixture
+def trust_app(monkeypatch):
+    monkeypatch.setenv("ADMIN_API_KEY", ADMIN_KEY)
+    monkeypatch.setenv("ADMIN_IP_WHITELIST", "")
+
+    app = Flask(__name__)
+    app.config.update(
+        TESTING=True,
+        SECRET_KEY="trust-fixture-secret",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        RATELIMIT_ENABLED=True,
+    )
+    db.init_app(app)
+    limiter.init_app(app)
+    app.register_blueprint(trust_bp, url_prefix="/api")
+    app.register_blueprint(auth_bp, url_prefix="/api")
+
+    with app.app_context():
+        limiter.reset()
+        db.create_all()
+        yield app
+        limiter.reset()
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(trust_app):
+    return trust_app.test_client()
+
+
+def _user_headers(email="scout-fixture@example.com"):
+    user = UserAccount.query.filter_by(email=email).first()
+    if user is None:
+        user = _ensure_user_account(email)
+        db.session.commit()
+    token = issue_user_token(email)["token"]
+    return user, {"Authorization": f"Bearer {token}"}
+
+
+def _admin_headers():
+    token = issue_user_token("trust-admin@example.com", role="admin")["token"]
+    return {"Authorization": f"Bearer {token}", "X-API-Key": ADMIN_KEY}
+
+
+def _verification_payload(**overrides):
+    payload = {
+        "full_name": "Alex Scout",
+        "organization": "Fixture Scouting Network",
+        "role_title": "First-team scout",
+        "statement": "I scout academy players for our recruitment team.",
+        "evidence_urls": ["https://example.com/scouting-profile"],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _report_payload(index=1, **overrides):
+    payload = {
+        "subject_type": "player_profile",
+        "subject_id": str(5000 + index),
+        "reason_code": "misleading_information",
+        "details": f"Fixture report details {index}",
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestScoutVerificationLifecycle:
+    def test_apply_duplicate_approve_derive_and_revoke(self, client):
+        user, headers = _user_headers()
+
+        created = client.post("/api/scout/verification", json=_verification_payload(), headers=headers)
+        assert created.status_code == 201, created.get_json()
+        verification = created.get_json()["verification"]
+        assert verification["status"] == "pending"
+        assert verification["evidence_urls"] == ["https://example.com/scouting-profile"]
+
+        duplicate = client.post("/api/scout/verification", json=_verification_payload(), headers=headers)
+        assert duplicate.status_code == 409
+        assert ScoutVerification.query.count() == 1
+
+        queue = client.get("/api/admin/scout-verifications?status=pending", headers=_admin_headers())
+        assert queue.status_code == 200
+        assert queue.get_json()["total"] == 1
+        assert queue.get_json()["verifications"][0]["user_email"] == user.email
+
+        approved = client.post(
+            f"/api/admin/scout-verifications/{verification['id']}/approve",
+            json={"review_notes": "<b>Evidence confirmed</b>"},
+            headers=_admin_headers(),
+        )
+        assert approved.status_code == 200, approved.get_json()
+        approved_body = approved.get_json()["verification"]
+        assert approved_body["status"] == "approved"
+        assert approved_body["review_notes"] == "Evidence confirmed"
+        assert approved_body["reviewed_by"] == "trust-admin@example.com"
+
+        own_status = client.get("/api/scout/verification", headers=headers)
+        assert own_status.status_code == 200
+        assert own_status.get_json()["verification"]["status"] == "approved"
+
+        me = client.get("/api/auth/me", headers=headers)
+        assert me.status_code == 200
+        assert me.get_json()["is_verified_scout"] is True
+        assert user.to_dict()["is_verified_scout"] is True
+
+        revoked = client.post(
+            f"/api/admin/scout-verifications/{verification['id']}/revoke",
+            json={"revocation_reason": "Organization withdrew the credential"},
+            headers=_admin_headers(),
+        )
+        assert revoked.status_code == 200, revoked.get_json()
+        assert revoked.get_json()["verification"]["status"] == "revoked"
+        assert revoked.get_json()["verification"]["revocation_reason"] == "Organization withdrew the credential"
+
+        me_after_revoke = client.get("/api/auth/me", headers=headers)
+        assert me_after_revoke.status_code == 200
+        assert me_after_revoke.get_json()["is_verified_scout"] is False
+        assert user.to_dict()["is_verified_scout"] is False
+
+    def test_rejected_resubmissions_are_limited_to_three_per_hour(self, client):
+        _, headers = _user_headers("resubmit-scout@example.com")
+        admin = _admin_headers()
+
+        for attempt in range(3):
+            submitted = client.post(
+                "/api/scout/verification",
+                json=_verification_payload(statement=f"Application attempt {attempt}"),
+                headers=headers,
+            )
+            assert submitted.status_code == 201, submitted.get_json()
+            verification_id = submitted.get_json()["verification"]["id"]
+            rejected = client.post(
+                f"/api/admin/scout-verifications/{verification_id}/reject",
+                json={"review_notes": f"Insufficient evidence attempt {attempt}"},
+                headers=admin,
+            )
+            assert rejected.status_code == 200, rejected.get_json()
+
+        limited = client.post("/api/scout/verification", json=_verification_payload(), headers=headers)
+        assert limited.status_code == 429
+        assert ScoutVerification.query.count() == 3
+
+    def test_verification_validation_and_admin_auth(self, client):
+        assert client.post("/api/scout/verification", json=_verification_payload()).status_code == 401
+
+        _, headers = _user_headers("validation-scout@example.com")
+        insecure_url = client.post(
+            "/api/scout/verification",
+            json=_verification_payload(evidence_urls=["http://example.com/not-secure"]),
+            headers=headers,
+        )
+        assert insecure_url.status_code == 400
+
+        empty_evidence = client.post(
+            "/api/scout/verification",
+            json=_verification_payload(evidence_urls=[]),
+            headers=headers,
+        )
+        assert empty_evidence.status_code == 400
+
+        too_long = client.post(
+            "/api/scout/verification",
+            json=_verification_payload(full_name="x" * 201),
+            headers=headers,
+        )
+        assert too_long.status_code == 400
+
+        _, object_headers = _user_headers("object-validation-scout@example.com")
+        non_object = client.post("/api/scout/verification", json=["not", "an", "object"], headers=object_headers)
+        assert non_object.status_code == 400
+
+        plain_user = client.get("/api/admin/scout-verifications", headers=headers)
+        assert plain_user.status_code in (401, 403)
+        invalid_filter = client.get("/api/admin/scout-verifications?status=unknown", headers=_admin_headers())
+        assert invalid_filter.status_code == 400
+
+    def test_review_notes_required_and_transitions_are_strict(self, client):
+        _, headers = _user_headers("review-scout@example.com")
+        created = client.post("/api/scout/verification", json=_verification_payload(), headers=headers)
+        verification_id = created.get_json()["verification"]["id"]
+        admin = _admin_headers()
+
+        missing_notes = client.post(f"/api/admin/scout-verifications/{verification_id}/approve", json={}, headers=admin)
+        assert missing_notes.status_code == 400
+        non_object = client.post(
+            f"/api/admin/scout-verifications/{verification_id}/approve", json=["not-an-object"], headers=admin
+        )
+        assert non_object.status_code == 400
+
+        rejected = client.post(
+            f"/api/admin/scout-verifications/{verification_id}/reject",
+            json={"reason": "Identity could not be confirmed"},
+            headers=admin,
+        )
+        assert rejected.status_code == 200
+        invalid_approve = client.post(
+            f"/api/admin/scout-verifications/{verification_id}/approve",
+            json={"review_notes": "Late approval"},
+            headers=admin,
+        )
+        assert invalid_approve.status_code == 409
+        assert client.post("/api/admin/scout-verifications/999999/revoke", json={}, headers=admin).status_code == 404
+
+
+class TestContentReports:
+    def test_report_submit_list_resolve_and_sanitize(self, client):
+        user, headers = _user_headers("reporter@example.com")
+        created = client.post(
+            "/api/reports",
+            json=_report_payload(
+                reason_code="MISLEADING_INFORMATION",
+                details="<script>alert(1)</script><b>Wrong club history</b>",
+            ),
+            headers=headers,
+        )
+        assert created.status_code == 201, created.get_json()
+        report = created.get_json()["report"]
+        assert report["status"] == "open"
+        assert report["reason_code"] == "misleading_information"
+        assert "<script>" not in report["details"]
+        assert "<b>" not in report["details"]
+        assert "Wrong club history" in report["details"]
+
+        listed = client.get("/api/admin/reports?status=open", headers=_admin_headers())
+        assert listed.status_code == 200
+        listed_body = listed.get_json()
+        assert listed_body["total"] == 1
+        assert listed_body["reports"][0]["reporter_user_id"] == user.id
+        assert listed_body["reports"][0]["reporter_email"] == user.email
+
+        resolved = client.post(
+            f"/api/admin/reports/{report['id']}/resolve",
+            json={"status": "resolved", "resolution_notes": "<i>Profile corrected</i>"},
+            headers=_admin_headers(),
+        )
+        assert resolved.status_code == 200, resolved.get_json()
+        resolved_report = resolved.get_json()["report"]
+        assert resolved_report["status"] == "resolved"
+        assert resolved_report["resolution_notes"] == "Profile corrected"
+        assert resolved_report["resolved_at"] is not None
+
+        resolved_queue = client.get("/api/admin/reports?status=resolved", headers=_admin_headers())
+        assert resolved_queue.status_code == 200
+        assert [row["id"] for row in resolved_queue.get_json()["reports"]] == [report["id"]]
+        repeated = client.post(
+            f"/api/admin/reports/{report['id']}/resolve",
+            json={"status": "dismissed", "resolution_notes": "Second decision"},
+            headers=_admin_headers(),
+        )
+        assert repeated.status_code == 409
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            _report_payload(subject_type="article"),
+            _report_payload(subject_id=123),
+            _report_payload(reason_code="x" * 81),
+            _report_payload(details="x" * 2001),
+            _report_payload(details={"not": "text"}),
+        ],
+    )
+    def test_report_validation(self, client, payload):
+        _, headers = _user_headers("report-validation@example.com")
+        response = client.post("/api/reports", json=payload, headers=headers)
+        assert response.status_code == 400
+
+    def test_report_and_admin_endpoints_require_auth(self, client):
+        assert client.post("/api/reports", json=_report_payload()).status_code == 401
+        _, user_headers = _user_headers("plain-report-user@example.com")
+        assert client.get("/api/admin/reports", headers=user_headers).status_code in (401, 403)
+
+        non_object = client.post("/api/reports", json=["not-an-object"], headers=user_headers)
+        assert non_object.status_code == 400
+
+    def test_resolution_validation_and_filters(self, client):
+        _, headers = _user_headers("resolution-validation@example.com")
+        report_id = client.post("/api/reports", json=_report_payload(), headers=headers).get_json()["report"]["id"]
+        admin = _admin_headers()
+
+        invalid_filter = client.get("/api/admin/reports?status=pending", headers=admin)
+        assert invalid_filter.status_code == 400
+        invalid_status = client.post(
+            f"/api/admin/reports/{report_id}/resolve",
+            json={"status": "reviewing", "resolution_notes": "Not terminal"},
+            headers=admin,
+        )
+        assert invalid_status.status_code == 400
+        missing_notes = client.post(
+            f"/api/admin/reports/{report_id}/resolve",
+            json={"status": "dismissed"},
+            headers=admin,
+        )
+        assert missing_notes.status_code == 400
+        non_object = client.post(f"/api/admin/reports/{report_id}/resolve", json=["not-an-object"], headers=admin)
+        assert non_object.status_code == 400
+        dismissed = client.post(
+            f"/api/admin/reports/{report_id}/resolve",
+            json={"status": "dismissed", "resolution_notes": "Report was not substantiated"},
+            headers=admin,
+        )
+        assert dismissed.status_code == 200
+        assert dismissed.get_json()["report"]["status"] == "dismissed"
+        assert (
+            client.post(
+                "/api/admin/reports/999999/resolve",
+                json={"status": "dismissed", "resolution_notes": "Not found"},
+                headers=admin,
+            ).status_code
+            == 404
+        )
+
+    def test_report_rate_limit_is_per_authenticated_user(self, client):
+        _, headers = _user_headers("rate-limited-reporter@example.com")
+        for index in range(10):
+            response = client.post("/api/reports", json=_report_payload(index=index), headers=headers)
+            assert response.status_code == 201, response.get_json()
+
+        limited = client.post("/api/reports", json=_report_payload(index=99), headers=headers)
+        assert limited.status_code == 429
+
+        _, other_headers = _user_headers("independent-reporter@example.com")
+        independent = client.post("/api/reports", json=_report_payload(index=100), headers=other_headers)
+        assert independent.status_code == 201
+        assert ContentReport.query.count() == 11
+
+
+def test_fc01_is_guarded_single_parent_and_enables_rls_for_both_tables():
+    migration = Path(__file__).resolve().parents[1] / "migrations" / "versions" / "fc01_trust_prerequisites.py"
+    source = migration.read_text()
+    assert 'down_revision = "tre01"' in source
+    assert '"scout_verifications"' in source
+    assert '"content_reports"' in source
+    assert "for table_name in NEW_TABLES" in source
+    assert "ENABLE ROW LEVEL SECURITY" in source
+    assert "if not table_exists" in source


### PR DESCRIPTION
## Summary

FC-B1 of the **Full Circle** track (scout↔player marketplace loop): the trust prerequisites that must exist before any contact rail.

- **Scout verification** — apply → admin review (approve/reject/revoke); one active application per user (partial unique index); https-only evidence URLs; per-user rate limits; auth payloads expose derived `is_verified_scout` (computed, never a persisted role).
- **Content reports** — authenticated, rate-limited report/flag backend (subject types include the future `contact_message`) + admin queue/resolve. Also an App Store UGC prerequisite for the iOS surfaces.
- **Adults-only claim gate** (roadmap D1) — player self-claims require a known DOB ≥ 18, enforced at submission AND re-checked at admin approval (`minor_claim_blocked` / `dob_unknown`, HTTP 422). DOB resolves from TrackedPlayer/journey/shadow birth dates only; the stale `TrackedPlayer.age` snapshot is deliberately excluded. Non-player relationships unaffected.

## Migration

`fc01` (chains `tre01`, the sole head at branch time). Guarded DDL via `_migration_helpers`, same-migration RLS on both new tables (policy-free default-deny), guarded downgrade; replayed upgrade→downgrade→upgrade on local Postgres.

⚠️ **Ordering caveat:** PR #636 (`gf01`, funding registry) is open. Whichever merges second must re-point its `down_revision` — the fc01 docstring carries the warning.

## Verification

- 78 backend tests green (verification lifecycle, reports lifecycle, 18+ gate incl. approval re-check), migration single-head test green — re-run independently by the reviewer
- `ruff check` + `ruff format --check` clean
- Live boot smoke from the branch: `/api/health` 200; all new endpoints 401 unauthenticated
- Existing approved player-relationship claims audit: 1 row, 0 would fail the new gate

FC-B2 (contact rail: intro requests, thread, audit, outcomes, interest signals, `CONTACT_RAIL_ENABLED` flag) follows as a stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
