### PR TITLE
feat(contact): scout-to-player contact rail behind CONTACT_RAIL_ENABLED (FC-B2)

### DIFF
--- a/academy-watch-backend/env.template
+++ b/academy-watch-backend/env.template
@@ -128,6 +128,13 @@ OPENROUTER_API_KEY=
 # Required if GOL_PROVIDER=openai
 OPENAI_API_KEY=
 
+# === SCOUT-TO-PLAYER CONTACT RAIL ===
+# Off by default; user-facing contact and interest-signal routes return 404.
+CONTACT_RAIL_ENABLED=false
+# Pending introduction lifetime and post-decline re-contact cooldown.
+CONTACT_REQUEST_EXPIRY_DAYS=14
+CONTACT_DECLINE_COOLDOWN_DAYS=30
+
 # === PRODUCTION NOTES ===
 # 1. In production, set these via your hosting platform's environment variables
 # 2. Never commit the actual .env file to version control

--- a/academy-watch-backend/migrations/versions/fc02_contact_rail.py
+++ b/academy-watch-backend/migrations/versions/fc02_contact_rail.py
@@ -1,0 +1,183 @@
+"""Scout-to-player contact requests, threads, audit events, and outcomes.
+
+Revision ID: fc02
+Revises: fc01
+
+This stacked migration intentionally chains from FC-B1's ``fc01``. PR #636
+(``gf01``, funding registry) is still independently ordered: if it lands first,
+re-point ``fc01`` onto ``gf01`` and retain ``fc02 -> fc01``; if this FC stack
+lands first, ``gf01`` must instead be re-pointed onto ``fc02``. Never merge an
+arrangement with two Alembic heads.
+
+All DDL is guarded because production has drifted out-of-band. Every new public
+table has RLS enabled in this same migration, with no permissive direct-client
+policies. Flask exposes only authenticated participant projections.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from migrations._migration_helpers import create_index_safe, index_exists, table_exists
+
+revision = "fc02"
+down_revision = "fc01"
+branch_labels = None
+depends_on = None
+
+
+NEW_TABLES = (
+    "contact_requests",
+    "contact_messages",
+    "contact_audit_events",
+    "contact_outcomes",
+)
+
+
+def upgrade():
+    if not table_exists("contact_requests"):
+        op.create_table(
+            "contact_requests",
+            sa.Column("id", sa.String(length=36), primary_key=True),
+            sa.Column("scout_user_id", sa.Integer(), sa.ForeignKey("user_accounts.id"), nullable=False),
+            sa.Column("player_api_id", sa.Integer(), nullable=False),
+            sa.Column("claim_id", sa.Integer(), sa.ForeignKey("player_profile_claims.id"), nullable=False),
+            sa.Column("message", sa.String(length=2000), nullable=False),
+            sa.Column("status", sa.String(length=20), nullable=False, server_default="pending"),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("responded_at", sa.DateTime(), nullable=True),
+            sa.Column("expires_at", sa.DateTime(), nullable=False),
+            sa.CheckConstraint(
+                "status IN ('pending','accepted','declined','withdrawn','expired')",
+                name="ck_contact_requests_status",
+            ),
+        )
+    create_index_safe(
+        "uq_contact_requests_active_scout_player",
+        "contact_requests",
+        ["scout_user_id", "player_api_id"],
+        unique=True,
+        postgresql_where=sa.text("status IN ('pending', 'accepted')"),
+        sqlite_where=sa.text("status IN ('pending', 'accepted')"),
+    )
+    create_index_safe(
+        "ix_contact_requests_scout_created",
+        "contact_requests",
+        ["scout_user_id", "created_at"],
+    )
+    create_index_safe(
+        "ix_contact_requests_claim_created",
+        "contact_requests",
+        ["claim_id", "created_at"],
+    )
+    create_index_safe(
+        "ix_contact_requests_player_created",
+        "contact_requests",
+        ["player_api_id", "created_at"],
+    )
+    create_index_safe(
+        "ix_contact_requests_status_expires",
+        "contact_requests",
+        ["status", "expires_at"],
+    )
+
+    if not table_exists("contact_messages"):
+        op.create_table(
+            "contact_messages",
+            sa.Column("id", sa.String(length=36), primary_key=True),
+            sa.Column(
+                "contact_request_id",
+                sa.String(length=36),
+                sa.ForeignKey("contact_requests.id"),
+                nullable=False,
+            ),
+            sa.Column("sender_user_id", sa.Integer(), sa.ForeignKey("user_accounts.id"), nullable=False),
+            sa.Column("body", sa.String(length=2000), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+        )
+    create_index_safe(
+        "ix_contact_messages_request_created",
+        "contact_messages",
+        ["contact_request_id", "created_at"],
+    )
+
+    if not table_exists("contact_audit_events"):
+        op.create_table(
+            "contact_audit_events",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "contact_request_id",
+                sa.String(length=36),
+                sa.ForeignKey("contact_requests.id"),
+                nullable=False,
+            ),
+            sa.Column("actor_user_id", sa.Integer(), sa.ForeignKey("user_accounts.id"), nullable=True),
+            sa.Column("event_type", sa.String(length=30), nullable=False),
+            sa.Column("metadata", sa.JSON(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.CheckConstraint(
+                "event_type IN "
+                "('created','accepted','declined','withdrawn','expired','message_sent','outcome_reported')",
+                name="ck_contact_audit_events_type",
+            ),
+        )
+    create_index_safe(
+        "ix_contact_audit_events_request_created",
+        "contact_audit_events",
+        ["contact_request_id", "created_at"],
+    )
+
+    if not table_exists("contact_outcomes"):
+        op.create_table(
+            "contact_outcomes",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "contact_request_id",
+                sa.String(length=36),
+                sa.ForeignKey("contact_requests.id"),
+                nullable=False,
+            ),
+            sa.Column("stage", sa.String(length=30), nullable=False),
+            sa.Column("reported_by_user_id", sa.Integer(), sa.ForeignKey("user_accounts.id"), nullable=False),
+            sa.Column("notes", sa.String(length=2000), nullable=True),
+            sa.Column("occurred_at", sa.DateTime(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.CheckConstraint(
+                "stage IN ('contacted','trial_scheduled','trial_completed','signed','no_fit')",
+                name="ck_contact_outcomes_stage",
+            ),
+        )
+    create_index_safe(
+        "ix_contact_outcomes_request_created",
+        "contact_outcomes",
+        ["contact_request_id", "created_at"],
+    )
+    create_index_safe(
+        "ix_contact_outcomes_request_occurred",
+        "contact_outcomes",
+        ["contact_request_id", "occurred_at"],
+    )
+
+    for table_name in NEW_TABLES:
+        # Idempotent and intentionally policy-free: direct/public roles see no
+        # rows. Participant access is enforced by the Flask contact blueprint.
+        op.execute(sa.text(f'ALTER TABLE "{table_name}" ENABLE ROW LEVEL SECURITY'))
+
+
+def downgrade():
+    indexes = (
+        ("ix_contact_outcomes_request_occurred", "contact_outcomes"),
+        ("ix_contact_outcomes_request_created", "contact_outcomes"),
+        ("ix_contact_audit_events_request_created", "contact_audit_events"),
+        ("ix_contact_messages_request_created", "contact_messages"),
+        ("ix_contact_requests_status_expires", "contact_requests"),
+        ("ix_contact_requests_player_created", "contact_requests"),
+        ("ix_contact_requests_claim_created", "contact_requests"),
+        ("ix_contact_requests_scout_created", "contact_requests"),
+        ("uq_contact_requests_active_scout_player", "contact_requests"),
+    )
+    for index_name, table_name in indexes:
+        if index_exists(index_name):
+            op.drop_index(index_name, table_name=table_name)
+
+    for table_name in reversed(NEW_TABLES):
+        if table_exists(table_name):
+            op.drop_table(table_name)

--- a/academy-watch-backend/src/main.py
+++ b/academy-watch-backend/src/main.py
@@ -16,6 +16,7 @@ from werkzeug.exceptions import HTTPException
 # Side-effect imports: register standalone tables in db.metadata so `flask db
 # migrate` autogenerate sees them (no spurious drop/create) and db.create_all()
 # includes them even before a route/service imports the model directly.
+import src.models.contact  # noqa: E402, F401
 import src.models.season_rollup  # noqa: E402, F401
 import src.models.transfer_event  # noqa: E402, F401
 import src.models.trust  # noqa: E402, F401
@@ -27,6 +28,7 @@ from src.routes.api import api_bp, require_api_key
 from src.routes.auth_routes import auth_bp
 from src.routes.cohort import cohort_bp
 from src.routes.community_takes import community_takes_bp
+from src.routes.contact import contact_bp
 from src.routes.curator import curator_bp
 from src.routes.events import events_bp
 from src.routes.feeder import feeder_bp
@@ -106,6 +108,7 @@ app.register_blueprint(scout_bp, url_prefix="/api")
 # routes take priority over any api_bp /players/<id>/* catch-alls.
 app.register_blueprint(showcase_bp, url_prefix="/api")
 app.register_blueprint(trust_bp, url_prefix="/api")
+app.register_blueprint(contact_bp, url_prefix="/api")
 app.register_blueprint(api_bp, url_prefix="/api")
 app.register_blueprint(auth_bp, url_prefix="/api")
 app.register_blueprint(journalist_bp, url_prefix="/api")

--- a/academy-watch-backend/src/models/contact.py
+++ b/academy-watch-backend/src/models/contact.py
@@ -1,0 +1,207 @@
+"""Scout-to-player contact rail models.
+
+Contact requests and messages use opaque UUID primary keys because their
+identifiers cross the API boundary. Audit events and outcomes are append-only
+records: the application exposes no update or delete path for either table.
+"""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import sqlalchemy as sa
+from src.models.league import db
+
+
+def _utcnow():
+    # Columns are ``timestamp without time zone`` throughout this repository;
+    # store a naive UTC value so SQLite and Postgres compare identically.
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+def _iso(value):
+    return value.isoformat() if value else None
+
+
+class ContactRequest(db.Model):
+    """A verified scout's introduction request to an adult player claimant."""
+
+    __tablename__ = "contact_requests"
+    __table_args__ = (
+        db.CheckConstraint(
+            "status IN ('pending','accepted','declined','withdrawn','expired')",
+            name="ck_contact_requests_status",
+        ),
+        db.Index(
+            "uq_contact_requests_active_scout_player",
+            "scout_user_id",
+            "player_api_id",
+            unique=True,
+            postgresql_where=sa.text("status IN ('pending', 'accepted')"),
+            sqlite_where=sa.text("status IN ('pending', 'accepted')"),
+        ),
+        db.Index("ix_contact_requests_scout_created", "scout_user_id", "created_at"),
+        db.Index("ix_contact_requests_claim_created", "claim_id", "created_at"),
+        db.Index("ix_contact_requests_player_created", "player_api_id", "created_at"),
+        db.Index("ix_contact_requests_status_expires", "status", "expires_at"),
+    )
+
+    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid4()))
+    scout_user_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"), nullable=False)
+    player_api_id = db.Column(db.Integer, nullable=False)
+    claim_id = db.Column(db.Integer, db.ForeignKey("player_profile_claims.id"), nullable=False)
+    message = db.Column(db.String(2000), nullable=False)
+    status = db.Column(db.String(20), nullable=False, default="pending", server_default="pending")
+    created_at = db.Column(db.DateTime, nullable=False, default=_utcnow)
+    responded_at = db.Column(db.DateTime)
+    expires_at = db.Column(db.DateTime, nullable=False)
+
+    scout = db.relationship("UserAccount", foreign_keys=[scout_user_id])
+    claim = db.relationship("PlayerProfileClaim", foreign_keys=[claim_id])
+    messages = db.relationship(
+        "ContactMessage",
+        back_populates="contact_request",
+        lazy="dynamic",
+        order_by="ContactMessage.created_at",
+    )
+    audit_events = db.relationship(
+        "ContactAuditEvent",
+        back_populates="contact_request",
+        lazy="dynamic",
+        order_by="ContactAuditEvent.created_at",
+    )
+    outcomes = db.relationship(
+        "ContactOutcome",
+        back_populates="contact_request",
+        lazy="dynamic",
+        order_by="ContactOutcome.created_at",
+    )
+
+    @property
+    def player_user(self):
+        return self.claim.user if self.claim is not None else None
+
+    def latest_outcome(self):
+        return (
+            self.outcomes.order_by(None)
+            .order_by(
+                ContactOutcome.occurred_at.desc(),
+                ContactOutcome.created_at.desc(),
+                ContactOutcome.id.desc(),
+            )
+            .first()
+        )
+
+    def to_dict(self):
+        latest = self.latest_outcome()
+        return {
+            "id": self.id,
+            "player_api_id": self.player_api_id,
+            "message": self.message,
+            "status": self.status,
+            "created_at": _iso(self.created_at),
+            "responded_at": _iso(self.responded_at),
+            "expires_at": _iso(self.expires_at),
+            "participants": {
+                "scout": {
+                    "display_name": self.scout.display_name if self.scout else None,
+                },
+                "player": {
+                    "display_name": self.player_user.display_name if self.player_user else None,
+                },
+            },
+            "latest_outcome": latest.to_dict() if latest else None,
+        }
+
+
+class ContactMessage(db.Model):
+    """One sanitized plain-text message in an accepted contact request."""
+
+    __tablename__ = "contact_messages"
+    __table_args__ = (db.Index("ix_contact_messages_request_created", "contact_request_id", "created_at"),)
+
+    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid4()))
+    contact_request_id = db.Column(db.String(36), db.ForeignKey("contact_requests.id"), nullable=False)
+    sender_user_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"), nullable=False)
+    body = db.Column(db.String(2000), nullable=False)
+    created_at = db.Column(db.DateTime, nullable=False, default=_utcnow)
+
+    contact_request = db.relationship("ContactRequest", back_populates="messages")
+    sender = db.relationship("UserAccount", foreign_keys=[sender_user_id])
+
+    def to_dict(self):
+        request_row = self.contact_request
+        sender_role = "scout" if request_row and self.sender_user_id == request_row.scout_user_id else "player"
+        return {
+            "id": self.id,
+            "contact_request_id": self.contact_request_id,
+            "sender_role": sender_role,
+            "sender_display_name": self.sender.display_name if self.sender else None,
+            "body": self.body,
+            "created_at": _iso(self.created_at),
+        }
+
+
+class ContactAuditEvent(db.Model):
+    """Append-only record of every state-changing contact-rail action."""
+
+    __tablename__ = "contact_audit_events"
+    __table_args__ = (
+        db.CheckConstraint(
+            "event_type IN ('created','accepted','declined','withdrawn','expired','message_sent','outcome_reported')",
+            name="ck_contact_audit_events_type",
+        ),
+        db.Index("ix_contact_audit_events_request_created", "contact_request_id", "created_at"),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    contact_request_id = db.Column(db.String(36), db.ForeignKey("contact_requests.id"), nullable=False)
+    actor_user_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"))
+    event_type = db.Column(db.String(30), nullable=False)
+    # ``metadata`` is reserved by SQLAlchemy's declarative API, so the Python
+    # attribute is named event_metadata while the physical column matches the contract.
+    event_metadata = db.Column("metadata", db.JSON, nullable=False, default=dict)
+    created_at = db.Column(db.DateTime, nullable=False, default=_utcnow)
+
+    contact_request = db.relationship("ContactRequest", back_populates="audit_events")
+    actor = db.relationship("UserAccount", foreign_keys=[actor_user_id])
+
+
+class ContactOutcome(db.Model):
+    """Append-only progression reported by either contact participant."""
+
+    __tablename__ = "contact_outcomes"
+    __table_args__ = (
+        db.CheckConstraint(
+            "stage IN ('contacted','trial_scheduled','trial_completed','signed','no_fit')",
+            name="ck_contact_outcomes_stage",
+        ),
+        db.Index("ix_contact_outcomes_request_created", "contact_request_id", "created_at"),
+        db.Index("ix_contact_outcomes_request_occurred", "contact_request_id", "occurred_at"),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    contact_request_id = db.Column(db.String(36), db.ForeignKey("contact_requests.id"), nullable=False)
+    stage = db.Column(db.String(30), nullable=False)
+    reported_by_user_id = db.Column(db.Integer, db.ForeignKey("user_accounts.id"), nullable=False)
+    notes = db.Column(db.String(2000))
+    occurred_at = db.Column(db.DateTime, nullable=False)
+    created_at = db.Column(db.DateTime, nullable=False, default=_utcnow)
+
+    contact_request = db.relationship("ContactRequest", back_populates="outcomes")
+    reporter = db.relationship("UserAccount", foreign_keys=[reported_by_user_id])
+
+    def to_dict(self):
+        return {
+            "stage": self.stage,
+            "notes": self.notes,
+            "occurred_at": _iso(self.occurred_at),
+            "created_at": _iso(self.created_at),
+        }
+
+
+__all__ = [
+    "ContactAuditEvent",
+    "ContactMessage",
+    "ContactOutcome",
+    "ContactRequest",
+]

--- a/academy-watch-backend/src/routes/contact.py
+++ b/academy-watch-backend/src/routes/contact.py
@@ -1,0 +1,554 @@
+"""Feature-gated scout-to-player contact requests, threads, and outcomes."""
+
+from __future__ import annotations
+
+import logging
+
+from flask import Blueprint, abort, g, jsonify, request
+from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
+from src.auth import _ensure_user_account, _safe_error_payload, require_user_auth
+from src.extensions import limiter
+from src.models.contact import ContactMessage, ContactOutcome, ContactRequest
+from src.models.league import UserAccount, db
+from src.models.showcase import PlayerProfileClaim
+from src.models.trust import ScoutVerification
+from src.services.contact import (
+    add_audit_event,
+    clean_plain_text,
+    contact_rail_enabled,
+    decline_cooldown_cutoff,
+    decline_cooldown_days,
+    expire_if_due,
+    parse_occurred_at,
+    request_expires_at,
+    require_contact_rail,
+    utcnow,
+)
+from src.services.trust import is_verified_scout
+
+logger = logging.getLogger(__name__)
+contact_bp = Blueprint("contact", __name__)
+
+ACTIVE_REQUEST_STATUSES = {"pending", "accepted"}
+OUTCOME_STAGES = {"contacted", "trial_scheduled", "trial_completed", "signed", "no_fit"}
+
+MAX_REQUEST_MESSAGE_LENGTH = 2000
+MAX_THREAD_MESSAGE_LENGTH = 2000
+MAX_OUTCOME_NOTES_LENGTH = 2000
+MAX_PAGE_SIZE = 200
+
+REQUEST_RATE_LIMIT = "10 per day"
+MESSAGE_RATE_LIMIT = "60 per hour"
+
+
+@contact_bp.before_app_request
+def _hide_contact_rail_paths_when_disabled():
+    """Hide even automatic OPTIONS and wrong-method probes while flag-off."""
+    path = request.path.rstrip("/")
+    is_contact_path = path.startswith("/api/contact/")
+    if is_contact_path and not contact_rail_enabled():
+        abort(404)
+
+
+def _user_rate_limit_key() -> str:
+    return getattr(g, "user_email", None) or request.remote_addr or "anon"
+
+
+def _current_user_account() -> UserAccount | None:
+    user = getattr(g, "user", None)
+    if user is not None:
+        return user
+    email = getattr(g, "user_email", None)
+    if not email:
+        return None
+    user = UserAccount.query.filter_by(email=email).first()
+    if user is None:
+        user = _ensure_user_account(email)
+        db.session.commit()
+    return user
+
+
+def _json_object() -> dict:
+    payload = request.get_json(silent=True)
+    if payload is None:
+        return {}
+    if not isinstance(payload, dict):
+        raise ValueError("JSON body must be an object")
+    return payload
+
+
+def _positive_player_id(value) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError("player_api_id must be a positive integer")
+    return value
+
+
+def _pagination() -> tuple[int, int]:
+    limit = request.args.get("limit", 50, type=int)
+    offset = request.args.get("offset", 0, type=int)
+    limit = min(MAX_PAGE_SIZE, max(1, limit if limit is not None else 50))
+    offset = max(0, offset if offset is not None else 0)
+    return limit, offset
+
+
+def _target_claim(player_api_id: int, *, for_update: bool = False) -> PlayerProfileClaim | None:
+    # FC-B1 permits multiple approved claimants. The newest approved self-claim
+    # is the deterministic introduction target and remains pinned by claim_id.
+    query = PlayerProfileClaim.query.filter_by(
+        player_api_id=player_api_id,
+        relationship_type="player",
+        status="approved",
+    )
+    query = query.order_by(PlayerProfileClaim.reviewed_at.desc(), PlayerProfileClaim.id.desc())
+    if for_update:
+        query = query.populate_existing().with_for_update()
+    return query.first()
+
+
+def _lock_verified_scout(user: UserAccount) -> ScoutVerification | None:
+    return (
+        ScoutVerification.query.filter_by(user_account_id=user.id, status="approved")
+        .order_by(ScoutVerification.submitted_at.desc(), ScoutVerification.id.desc())
+        .populate_existing()
+        .with_for_update()
+        .first()
+    )
+
+
+def _lock_claim_owner(contact_request: ContactRequest, user: UserAccount) -> PlayerProfileClaim | None:
+    return (
+        PlayerProfileClaim.query.filter_by(
+            id=contact_request.claim_id,
+            user_account_id=user.id,
+            relationship_type="player",
+            status="approved",
+        )
+        .populate_existing()
+        .with_for_update()
+        .first()
+    )
+
+
+def _is_claim_owner(contact_request: ContactRequest, user: UserAccount) -> bool:
+    claim = contact_request.claim
+    return bool(
+        claim is not None
+        and claim.user_account_id == user.id
+        and claim.status == "approved"
+        and claim.relationship_type == "player"
+    )
+
+
+def _is_participant(contact_request: ContactRequest, user: UserAccount) -> bool:
+    return contact_request.scout_user_id == user.id or _is_claim_owner(contact_request, user)
+
+
+def _expire_authorized_request(contact_request: ContactRequest) -> bool:
+    if not expire_if_due(contact_request):
+        return False
+    db.session.commit()
+    return True
+
+
+def _participant_request(request_id: str, user: UserAccount):
+    contact_request = db.session.get(ContactRequest, request_id)
+    if contact_request is None or not _is_participant(contact_request, user):
+        return None, (jsonify({"error": "contact request not found"}), 404)
+    if (
+        contact_request.status == "pending"
+        and contact_request.expires_at is not None
+        and contact_request.expires_at <= utcnow()
+    ):
+        contact_request = ContactRequest.query.filter_by(id=request_id).populate_existing().with_for_update().first()
+        _expire_authorized_request(contact_request)
+    return contact_request, None
+
+
+def _expire_visible_rows(query) -> None:
+    due = (
+        query.filter(ContactRequest.status == "pending", ContactRequest.expires_at <= utcnow())
+        .order_by(ContactRequest.id.asc())
+        .populate_existing()
+        .with_for_update()
+        .all()
+    )
+    changed = False
+    checked_at = utcnow()
+    for row in due:
+        changed = expire_if_due(row, now=checked_at) or changed
+    if changed:
+        db.session.commit()
+
+
+@contact_bp.route("/contact/requests", methods=["POST"])
+@require_contact_rail
+@require_user_auth
+@limiter.limit(REQUEST_RATE_LIMIT, key_func=_user_rate_limit_key)
+def create_contact_request():
+    """Create an introduction from a verified scout to an approved player claimant."""
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        if not is_verified_scout(user):
+            return jsonify({"error": "Scout verification is required", "code": "scout_not_verified"}), 403
+
+        payload = _json_object()
+        player_api_id = _positive_player_id(payload.get("player_api_id"))
+        message = clean_plain_text(
+            payload.get("message"),
+            "message",
+            max_len=MAX_REQUEST_MESSAGE_LENGTH,
+        )
+
+        claim = _target_claim(player_api_id)
+        if claim is None:
+            return jsonify({"error": "Player is not available for contact", "code": "player_not_claimable"}), 403
+
+        # An unread expired request must not keep the partial unique guard live.
+        matching = ContactRequest.query.filter_by(scout_user_id=user.id, player_api_id=player_api_id)
+        _expire_visible_rows(matching)
+
+        # Revalidate and lock both trust prerequisites through the insert
+        # commit so concurrent admin revocation cannot win after our checks.
+        if _lock_verified_scout(user) is None:
+            db.session.rollback()
+            return jsonify({"error": "Scout verification is required", "code": "scout_not_verified"}), 403
+        claim = _target_claim(player_api_id, for_update=True)
+        if claim is None:
+            db.session.rollback()
+            return jsonify({"error": "Player is not available for contact", "code": "player_not_claimable"}), 403
+
+        active = matching.filter(ContactRequest.status.in_(ACTIVE_REQUEST_STATUSES)).first()
+        if active is not None:
+            active_payload = active.to_dict()
+            db.session.rollback()
+            return jsonify(
+                {
+                    "error": "An active contact request already exists for this player",
+                    "code": "active_request_exists",
+                    "contact_request": active_payload,
+                }
+            ), 409
+
+        cooldown_cutoff = decline_cooldown_cutoff()
+        declined = (
+            matching.filter(
+                ContactRequest.status == "declined",
+                func.coalesce(ContactRequest.responded_at, ContactRequest.created_at) >= cooldown_cutoff,
+            )
+            .order_by(ContactRequest.responded_at.desc(), ContactRequest.created_at.desc())
+            .first()
+        )
+        if declined is not None:
+            db.session.rollback()
+            return jsonify(
+                {
+                    "error": "This player declined a recent request; please wait before contacting them again",
+                    "code": "decline_cooldown_active",
+                    "cooldown_days": decline_cooldown_days(),
+                }
+            ), 409
+
+        now = utcnow()
+        contact_request = ContactRequest(
+            scout_user_id=user.id,
+            player_api_id=player_api_id,
+            claim_id=claim.id,
+            message=message,
+            status="pending",
+            created_at=now,
+            expires_at=request_expires_at(now=now),
+        )
+        db.session.add(contact_request)
+        try:
+            db.session.flush()
+            add_audit_event(
+                contact_request,
+                "created",
+                actor_user_id=user.id,
+                metadata={"player_api_id": player_api_id, "claim_id": claim.id},
+                created_at=now,
+            )
+            db.session.commit()
+        except IntegrityError:
+            db.session.rollback()
+            active = (
+                ContactRequest.query.filter_by(scout_user_id=user.id, player_api_id=player_api_id)
+                .filter(ContactRequest.status.in_(ACTIVE_REQUEST_STATUSES))
+                .first()
+            )
+            if active is not None:
+                return jsonify(
+                    {
+                        "error": "An active contact request already exists for this player",
+                        "code": "active_request_exists",
+                        "contact_request": active.to_dict(),
+                    }
+                ), 409
+            raise
+        return jsonify({"contact_request": contact_request.to_dict()}), 201
+    except ValueError as exc:
+        db.session.rollback()
+        return jsonify({"error": str(exc)}), 400
+    except Exception as exc:
+        db.session.rollback()
+        logger.exception("Failed to create contact request")
+        return jsonify(_safe_error_payload(exc, "Failed to create contact request")), 500
+
+
+@contact_bp.route("/contact/requests", methods=["GET"])
+@require_contact_rail
+@require_user_auth
+def list_contact_requests():
+    """List the caller's sent requests or approved player-claim inbox."""
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        box = (request.args.get("box") or "sent").strip().lower()
+        if box == "sent":
+            query = ContactRequest.query.filter(ContactRequest.scout_user_id == user.id)
+        elif box == "inbox":
+            claim_ids = db.session.query(PlayerProfileClaim.id).filter_by(
+                user_account_id=user.id,
+                relationship_type="player",
+                status="approved",
+            )
+            query = ContactRequest.query.filter(ContactRequest.claim_id.in_(claim_ids))
+        else:
+            return jsonify({"error": "box must be sent or inbox"}), 400
+
+        _expire_visible_rows(query)
+        limit, offset = _pagination()
+        total = query.count()
+        rows = (
+            query.order_by(ContactRequest.created_at.desc(), ContactRequest.id.desc()).offset(offset).limit(limit).all()
+        )
+        return jsonify(
+            {
+                "requests": [row.to_dict() for row in rows],
+                "box": box,
+                "total": total,
+                "limit": limit,
+                "offset": offset,
+            }
+        )
+    except Exception as exc:
+        db.session.rollback()
+        logger.exception("Failed to list contact requests")
+        return jsonify(_safe_error_payload(exc, "Failed to list contact requests")), 500
+
+
+def _respond_to_request(request_id: str, action: str):
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        contact_request = ContactRequest.query.filter_by(id=request_id).populate_existing().with_for_update().first()
+        if contact_request is None:
+            return jsonify({"error": "contact request not found"}), 404
+        if _lock_claim_owner(contact_request, user) is None:
+            db.session.rollback()
+            return jsonify({"error": "Only the player claim owner can respond"}), 403
+        if _expire_authorized_request(contact_request):
+            return jsonify({"error": "contact request has expired", "code": "request_expired"}), 409
+        if contact_request.status != "pending":
+            db.session.rollback()
+            return jsonify({"error": f"cannot {action} a {contact_request.status} request"}), 409
+
+        now = utcnow()
+        contact_request.status = "accepted" if action == "accept" else "declined"
+        contact_request.responded_at = now
+        event_type = "accepted" if action == "accept" else "declined"
+        add_audit_event(contact_request, event_type, actor_user_id=user.id, created_at=now)
+        db.session.commit()
+        return jsonify({"contact_request": contact_request.to_dict()})
+    except Exception as exc:
+        db.session.rollback()
+        logger.exception("Failed to %s contact request %s", action, request_id)
+        return jsonify(_safe_error_payload(exc, f"Failed to {action} contact request")), 500
+
+
+@contact_bp.route("/contact/requests/<string:request_id>/accept", methods=["POST"])
+@require_contact_rail
+@require_user_auth
+def accept_contact_request(request_id: str):
+    return _respond_to_request(request_id, "accept")
+
+
+@contact_bp.route("/contact/requests/<string:request_id>/decline", methods=["POST"])
+@require_contact_rail
+@require_user_auth
+def decline_contact_request(request_id: str):
+    return _respond_to_request(request_id, "decline")
+
+
+@contact_bp.route("/contact/requests/<string:request_id>/withdraw", methods=["POST"])
+@require_contact_rail
+@require_user_auth
+def withdraw_contact_request(request_id: str):
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        contact_request = ContactRequest.query.filter_by(id=request_id).populate_existing().with_for_update().first()
+        if contact_request is None:
+            return jsonify({"error": "contact request not found"}), 404
+        if contact_request.scout_user_id != user.id:
+            return jsonify({"error": "Only the initiating scout can withdraw this request"}), 403
+        if _expire_authorized_request(contact_request):
+            return jsonify({"error": "contact request has expired", "code": "request_expired"}), 409
+        if contact_request.status != "pending":
+            return jsonify({"error": f"cannot withdraw a {contact_request.status} request"}), 409
+
+        now = utcnow()
+        contact_request.status = "withdrawn"
+        add_audit_event(contact_request, "withdrawn", actor_user_id=user.id, created_at=now)
+        db.session.commit()
+        return jsonify({"contact_request": contact_request.to_dict()})
+    except Exception as exc:
+        db.session.rollback()
+        logger.exception("Failed to withdraw contact request %s", request_id)
+        return jsonify(_safe_error_payload(exc, "Failed to withdraw contact request")), 500
+
+
+@contact_bp.route("/contact/requests/<string:request_id>/messages", methods=["GET"])
+@require_contact_rail
+@require_user_auth
+def list_contact_messages(request_id: str):
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        contact_request, error = _participant_request(request_id, user)
+        if error:
+            return error
+        if contact_request.status != "accepted":
+            return jsonify({"error": "messages are available only for accepted requests"}), 409
+
+        limit, offset = _pagination()
+        query = ContactMessage.query.filter_by(contact_request_id=contact_request.id)
+        total = query.count()
+        rows = (
+            query.order_by(ContactMessage.created_at.asc(), ContactMessage.id.asc()).offset(offset).limit(limit).all()
+        )
+        return jsonify(
+            {
+                "messages": [row.to_dict() for row in rows],
+                "contact_request": contact_request.to_dict(),
+                "total": total,
+                "limit": limit,
+                "offset": offset,
+            }
+        )
+    except Exception as exc:
+        db.session.rollback()
+        logger.exception("Failed to list messages for contact request %s", request_id)
+        return jsonify(_safe_error_payload(exc, "Failed to list contact messages")), 500
+
+
+@contact_bp.route("/contact/requests/<string:request_id>/messages", methods=["POST"])
+@require_contact_rail
+@require_user_auth
+@limiter.limit(MESSAGE_RATE_LIMIT, key_func=_user_rate_limit_key)
+def create_contact_message(request_id: str):
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        contact_request, error = _participant_request(request_id, user)
+        if error:
+            return error
+        if contact_request.status != "accepted":
+            return jsonify({"error": "messages can be sent only for accepted requests"}), 409
+        if contact_request.scout_user_id != user.id and _lock_claim_owner(contact_request, user) is None:
+            db.session.rollback()
+            return jsonify({"error": "contact request not found"}), 404
+
+        payload = _json_object()
+        body = clean_plain_text(payload.get("body"), "body", max_len=MAX_THREAD_MESSAGE_LENGTH)
+        now = utcnow()
+        message = ContactMessage(
+            contact_request_id=contact_request.id,
+            sender_user_id=user.id,
+            body=body,
+            created_at=now,
+        )
+        db.session.add(message)
+        db.session.flush()
+        add_audit_event(
+            contact_request,
+            "message_sent",
+            actor_user_id=user.id,
+            metadata={"message_id": message.id},
+            created_at=now,
+        )
+        db.session.commit()
+        return jsonify({"message": message.to_dict()}), 201
+    except ValueError as exc:
+        db.session.rollback()
+        return jsonify({"error": str(exc)}), 400
+    except Exception as exc:
+        db.session.rollback()
+        logger.exception("Failed to send message for contact request %s", request_id)
+        return jsonify(_safe_error_payload(exc, "Failed to send contact message")), 500
+
+
+@contact_bp.route("/contact/requests/<string:request_id>/outcome", methods=["POST"])
+@require_contact_rail
+@require_user_auth
+def report_contact_outcome(request_id: str):
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+        contact_request, error = _participant_request(request_id, user)
+        if error:
+            return error
+        if contact_request.scout_user_id != user.id and _lock_claim_owner(contact_request, user) is None:
+            db.session.rollback()
+            return jsonify({"error": "contact request not found"}), 404
+
+        payload = _json_object()
+        stage = clean_plain_text(payload.get("stage"), "stage", max_len=30).lower()
+        if stage not in OUTCOME_STAGES:
+            raise ValueError(f"stage must be one of {sorted(OUTCOME_STAGES)}")
+        notes = clean_plain_text(
+            payload.get("notes"),
+            "notes",
+            max_len=MAX_OUTCOME_NOTES_LENGTH,
+            required=False,
+        )
+        occurred_at = parse_occurred_at(payload.get("occurred_at"))
+        now = utcnow()
+        outcome = ContactOutcome(
+            contact_request_id=contact_request.id,
+            stage=stage,
+            reported_by_user_id=user.id,
+            notes=notes,
+            occurred_at=occurred_at,
+            created_at=now,
+        )
+        db.session.add(outcome)
+        db.session.flush()
+        add_audit_event(
+            contact_request,
+            "outcome_reported",
+            actor_user_id=user.id,
+            metadata={"outcome_id": outcome.id, "stage": stage},
+            created_at=now,
+        )
+        db.session.commit()
+        return jsonify({"outcome": outcome.to_dict(), "contact_request": contact_request.to_dict()}), 201
+    except ValueError as exc:
+        db.session.rollback()
+        return jsonify({"error": str(exc)}), 400
+    except Exception as exc:
+        db.session.rollback()
+        logger.exception("Failed to report outcome for contact request %s", request_id)
+        return jsonify(_safe_error_payload(exc, "Failed to report contact outcome")), 500
+
+
+__all__ = ["contact_bp"]

--- a/academy-watch-backend/src/routes/showcase.py
+++ b/academy-watch-backend/src/routes/showcase.py
@@ -20,11 +20,11 @@ Reuse decisions (see the build contract):
 
 import logging
 import re
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from urllib.parse import parse_qs, urlparse
 
-from flask import Blueprint, g, jsonify, request
-from sqlalchemy import func
+from flask import Blueprint, abort, g, jsonify, request
+from sqlalchemy import case, func
 from sqlalchemy.exc import IntegrityError
 from src.auth import (
     _ensure_user_account,
@@ -34,18 +34,28 @@ from src.auth import (
     require_user_auth,
 )
 from src.extensions import limiter
-from src.models.follow import PlayerShadow
+from src.models.follow import Follow, FollowList, PlayerShadow
 from src.models.journey import PlayerJourney
 from src.models.league import NewsletterPlayerYoutubeLink, PlayerLink, UserAccount, db
+from src.models.scout_watchlist import ScoutWatchlistEntry
 from src.models.showcase import PlayerProfileClaim, PlayerShowcaseProfile
 from src.models.tracked_player import TrackedPlayer
 from src.models.video import VideoMatch, VideoPlayerReport, VideoRosterEntry
+from src.services.contact import contact_rail_enabled, require_contact_rail, utcnow
 from src.utils.academy_window import age_from_birth_date
 from src.utils.sanitize import is_safe_https_url, sanitize_plain_text
 
 logger = logging.getLogger(__name__)
 
 showcase_bp = Blueprint("showcase", __name__)
+
+
+@showcase_bp.before_app_request
+def _hide_interest_signal_path_when_contact_rail_disabled():
+    """Hide OPTIONS and wrong-method probes as well as supported methods."""
+    if request.path.rstrip("/") == "/api/showcase/mine/interest-signals" and not contact_rail_enabled():
+        abort(404)
+
 
 RELATIONSHIP_TYPES = {"player", "agent", "guardian", "club_official"}
 CLAIM_STATUSES = {"pending", "approved", "rejected", "revoked"}
@@ -515,6 +525,122 @@ def my_claims():
     except Exception as e:
         logger.error("Error in my_claims: %s", e)
         return jsonify(_safe_error_payload(e, "Failed to load claims")), 500
+
+
+@showcase_bp.route("/showcase/mine/interest-signals", methods=["GET"])
+@require_contact_rail
+@require_user_auth
+def my_interest_signals():
+    """Aggregate, identity-free interest in the caller's claimed players.
+
+    Default follow lists mirror the legacy watchlist, so only active,
+    non-default direct player follows contribute to the separate follow count.
+    Existing digest snapshots contain performance stats rather than membership
+    history; ``added_this_week`` therefore counts accounts whose earliest
+    surviving membership began since Monday and is not presented as a net
+    change.
+    """
+    try:
+        user = _current_user_account()
+        if user is None:
+            return jsonify({"error": "auth context missing email"}), 401
+
+        player_ids = [
+            row[0]
+            for row in db.session.query(PlayerProfileClaim.player_api_id)
+            .filter_by(
+                user_account_id=user.id,
+                relationship_type="player",
+                status="approved",
+            )
+            .distinct()
+            .order_by(PlayerProfileClaim.player_api_id.asc())
+            .all()
+        ]
+        now = utcnow()
+        week_start = now.replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=now.weekday())
+        if not player_ids:
+            return jsonify(
+                {
+                    "week_start": week_start.replace(tzinfo=UTC).isoformat(),
+                    "interest_signals": [],
+                }
+            )
+
+        watchlist_rows = (
+            db.session.query(
+                ScoutWatchlistEntry.player_api_id,
+                func.count(func.distinct(ScoutWatchlistEntry.user_account_id)),
+                func.count(
+                    func.distinct(
+                        case(
+                            (ScoutWatchlistEntry.created_at >= week_start, ScoutWatchlistEntry.user_account_id),
+                            else_=None,
+                        )
+                    )
+                ),
+            )
+            .filter(ScoutWatchlistEntry.player_api_id.in_(player_ids))
+            .group_by(ScoutWatchlistEntry.player_api_id)
+            .all()
+        )
+        watchlists = {player_id: (total, added) for player_id, total, added in watchlist_rows}
+
+        followed_player_id = Follow.selector["player_api_id"].as_integer()
+        direct_followers = (
+            db.session.query(
+                followed_player_id.label("player_api_id"),
+                FollowList.user_account_id.label("user_account_id"),
+                func.min(Follow.created_at).label("first_followed_at"),
+            )
+            .join(FollowList, FollowList.id == Follow.list_id)
+            .filter(
+                Follow.kind == "player",
+                FollowList.is_active.is_(True),
+                FollowList.is_default.is_(False),
+                followed_player_id.in_(player_ids),
+            )
+            .group_by(followed_player_id, FollowList.user_account_id)
+            .subquery()
+        )
+        follow_rows = (
+            db.session.query(
+                direct_followers.c.player_api_id,
+                func.count(direct_followers.c.user_account_id),
+                func.count(
+                    case(
+                        (direct_followers.c.first_followed_at >= week_start, direct_followers.c.user_account_id),
+                        else_=None,
+                    )
+                ),
+            )
+            .group_by(direct_followers.c.player_api_id)
+            .all()
+        )
+        follows = {player_id: (total, added) for player_id, total, added in follow_rows}
+
+        return jsonify(
+            {
+                "week_start": week_start.replace(tzinfo=UTC).isoformat(),
+                "interest_signals": [
+                    {
+                        "player_api_id": player_id,
+                        "watchlists": {
+                            "total": watchlists.get(player_id, (0, 0))[0],
+                            "added_this_week": watchlists.get(player_id, (0, 0))[1],
+                        },
+                        "follows": {
+                            "total": follows.get(player_id, (0, 0))[0],
+                            "added_this_week": follows.get(player_id, (0, 0))[1],
+                        },
+                    }
+                    for player_id in player_ids
+                ],
+            }
+        )
+    except Exception as e:
+        logger.error("Error in my_interest_signals: %s", e)
+        return jsonify(_safe_error_payload(e, "Failed to load interest signals")), 500
 
 
 # ---------------------------------------------------------------------------

--- a/academy-watch-backend/src/services/contact.py
+++ b/academy-watch-backend/src/services/contact.py
@@ -1,0 +1,158 @@
+"""Shared policy helpers for the feature-gated contact rail."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from functools import wraps
+
+from flask import abort
+from src.models.contact import ContactAuditEvent, ContactRequest
+from src.models.league import db
+from src.utils.sanitize import sanitize_plain_text
+
+CONTACT_REQUEST_EXPIRY_ENV = "CONTACT_REQUEST_EXPIRY_DAYS"
+CONTACT_DECLINE_COOLDOWN_ENV = "CONTACT_DECLINE_COOLDOWN_DAYS"
+
+DEFAULT_REQUEST_EXPIRY_DAYS = 14
+DEFAULT_DECLINE_COOLDOWN_DAYS = 30
+MAX_POLICY_DAYS = 365
+
+
+def utcnow() -> datetime:
+    """Naive UTC matching the repository's timestamp-without-time-zone columns."""
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+def _env_days(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw.strip())
+    except (TypeError, ValueError):
+        return default
+    return min(MAX_POLICY_DAYS, max(1, value))
+
+
+def request_expiry_days() -> int:
+    return _env_days(CONTACT_REQUEST_EXPIRY_ENV, DEFAULT_REQUEST_EXPIRY_DAYS)
+
+
+def decline_cooldown_days() -> int:
+    return _env_days(CONTACT_DECLINE_COOLDOWN_ENV, DEFAULT_DECLINE_COOLDOWN_DAYS)
+
+
+def request_expires_at(*, now: datetime | None = None) -> datetime:
+    return (now or utcnow()) + timedelta(days=request_expiry_days())
+
+
+def decline_cooldown_cutoff(*, now: datetime | None = None) -> datetime:
+    return (now or utcnow()) - timedelta(days=decline_cooldown_days())
+
+
+def contact_rail_enabled() -> bool:
+    return os.getenv("CONTACT_RAIL_ENABLED", "false").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def require_contact_rail(view):
+    """Hide a user-facing route completely while the rollout flag is off."""
+
+    @wraps(view)
+    def wrapped(*args, **kwargs):
+        if not contact_rail_enabled():
+            abort(404)
+        return view(*args, **kwargs)
+
+    return wrapped
+
+
+def clean_plain_text(value, field: str, *, max_len: int, required: bool = True) -> str | None:
+    """Validate bounded, sanitized plain text without silently truncating it."""
+    if value is None:
+        if required:
+            raise ValueError(f"{field} is required")
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a string")
+    cleaned = sanitize_plain_text(value).strip()
+    if not cleaned:
+        if required:
+            raise ValueError(f"{field} is required")
+        return None
+    if len(cleaned) > max_len:
+        raise ValueError(f"{field} must be at most {max_len} characters")
+    return cleaned
+
+
+def parse_occurred_at(value) -> datetime:
+    """Parse an optional ISO-8601 timestamp and normalize it to naive UTC."""
+    if value is None:
+        return utcnow()
+    if not isinstance(value, str):
+        raise ValueError("occurred_at must be an ISO-8601 string")
+    raw = value.strip()
+    if not raw:
+        raise ValueError("occurred_at must be an ISO-8601 string")
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("occurred_at must be an ISO-8601 string") from exc
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone(UTC).replace(tzinfo=None)
+    return parsed
+
+
+def add_audit_event(
+    contact_request: ContactRequest,
+    event_type: str,
+    *,
+    actor_user_id: int | None,
+    metadata: dict | None = None,
+    created_at: datetime | None = None,
+) -> ContactAuditEvent:
+    """Append one audit event to the current transaction."""
+    event = ContactAuditEvent(
+        contact_request_id=contact_request.id,
+        actor_user_id=actor_user_id,
+        event_type=event_type,
+        event_metadata=dict(metadata or {}),
+        created_at=created_at or utcnow(),
+    )
+    db.session.add(event)
+    return event
+
+
+def expire_if_due(contact_request: ContactRequest, *, now: datetime | None = None) -> bool:
+    """Lazily expire one pending request and append its system audit event."""
+    checked_at = now or utcnow()
+    if (
+        contact_request.status != "pending"
+        or contact_request.expires_at is None
+        or contact_request.expires_at > checked_at
+    ):
+        return False
+    contact_request.status = "expired"
+    add_audit_event(
+        contact_request,
+        "expired",
+        actor_user_id=None,
+        metadata={"expired_at": checked_at.isoformat()},
+        created_at=checked_at,
+    )
+    return True
+
+
+__all__ = [
+    "add_audit_event",
+    "clean_plain_text",
+    "contact_rail_enabled",
+    "decline_cooldown_cutoff",
+    "decline_cooldown_days",
+    "expire_if_due",
+    "parse_occurred_at",
+    "request_expires_at",
+    "request_expiry_days",
+    "require_contact_rail",
+    "utcnow",
+]

--- a/academy-watch-backend/tests/test_contact.py
+++ b/academy-watch-backend/tests/test_contact.py
@@ -1,0 +1,659 @@
+"""FC-B2 contact-rail lifecycle, privacy, flag, and migration tests."""
+
+from datetime import timedelta
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+from flask import Flask
+from sqlalchemy.exc import IntegrityError
+from src.auth import _ensure_user_account, issue_user_token
+from src.extensions import limiter
+from src.models.contact import ContactAuditEvent, ContactMessage, ContactOutcome, ContactRequest
+from src.models.follow import Follow, FollowList
+from src.models.league import UserAccount, db
+from src.models.scout_watchlist import ScoutWatchlistEntry
+from src.models.showcase import PlayerProfileClaim
+from src.models.trust import ContentReport, ScoutVerification
+from src.services.contact import utcnow
+
+ADMIN_KEY = "contact-admin-test-key"
+
+
+@pytest.fixture
+def contact_app(monkeypatch):
+    monkeypatch.setenv("CONTACT_RAIL_ENABLED", "true")
+    monkeypatch.setenv("CONTACT_REQUEST_EXPIRY_DAYS", "14")
+    monkeypatch.setenv("CONTACT_DECLINE_COOLDOWN_DAYS", "30")
+    monkeypatch.setenv("ADMIN_API_KEY", ADMIN_KEY)
+    monkeypatch.setenv("ADMIN_IP_WHITELIST", "")
+
+    from src.routes.contact import contact_bp
+    from src.routes.showcase import showcase_bp
+    from src.routes.trust import trust_bp
+
+    app = Flask(__name__)
+    app.config.update(
+        TESTING=True,
+        SECRET_KEY="contact-fixture-secret",
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        RATELIMIT_ENABLED=True,
+    )
+    db.init_app(app)
+    limiter.init_app(app)
+    app.register_blueprint(showcase_bp, url_prefix="/api")
+    app.register_blueprint(contact_bp, url_prefix="/api")
+    app.register_blueprint(trust_bp, url_prefix="/api")
+
+    with app.app_context():
+        limiter.reset()
+        db.create_all()
+        yield app
+        limiter.reset()
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(contact_app):
+    return contact_app.test_client()
+
+
+def _headers(email: str):
+    user = UserAccount.query.filter_by(email=email).first()
+    if user is None:
+        user = _ensure_user_account(email)
+        db.session.commit()
+    return user, {"Authorization": f"Bearer {issue_user_token(email)['token']}"}
+
+
+def _admin_headers():
+    token = issue_user_token("contact-admin@example.com", role="admin")["token"]
+    return {"Authorization": f"Bearer {token}", "X-API-Key": ADMIN_KEY}
+
+
+def _verified_scout(email: str):
+    user, headers = _headers(email)
+    db.session.add(
+        ScoutVerification(
+            user_account_id=user.id,
+            full_name="Alex Scout",
+            organization="Fixture Recruitment",
+            role_title="Scout",
+            statement="I recruit adult academy players.",
+            evidence_urls=["https://example.com/scout"],
+            status="approved",
+            reviewed_at=utcnow(),
+        )
+    )
+    db.session.commit()
+    return user, headers
+
+
+def _claim(email: str, player_api_id: int, *, status="approved", relationship_type="player"):
+    user, headers = _headers(email)
+    claim = PlayerProfileClaim(
+        user_account_id=user.id,
+        player_api_id=player_api_id,
+        relationship_type=relationship_type,
+        status=status,
+        reviewed_at=utcnow() if status == "approved" else None,
+    )
+    db.session.add(claim)
+    db.session.commit()
+    return user, headers, claim
+
+
+def _create(client, headers, player_api_id: int, message="Hello from <b>recruitment</b>"):
+    return client.post(
+        "/api/contact/requests",
+        json={"player_api_id": player_api_id, "message": message},
+        headers=headers,
+    )
+
+
+def _seed_contact(client, *, suffix="base", player_api_id=5001):
+    scout, scout_headers = _verified_scout(f"scout-{suffix}@example.com")
+    player, player_headers, claim = _claim(f"player-{suffix}@example.com", player_api_id)
+    created = _create(client, scout_headers, player_api_id)
+    assert created.status_code == 201, created.get_json()
+    return scout, scout_headers, player, player_headers, claim, created.get_json()["contact_request"]
+
+
+class TestContactLifecycle:
+    def test_create_accept_messages_outcomes_and_every_audit(self, client):
+        scout, scout_headers, player, player_headers, claim, request_payload = _seed_contact(client)
+        request_id = request_payload["id"]
+        UUID(request_id)
+        assert request_payload["message"] == "Hello from recruitment"
+        assert request_payload["status"] == "pending"
+        assert request_payload["participants"]["scout"]["display_name"] == scout.display_name
+        assert request_payload["participants"]["player"]["display_name"] == player.display_name
+        stored_request = ContactRequest.query.one()
+        assert stored_request.claim_id == claim.id
+        assert stored_request.expires_at - stored_request.created_at == timedelta(days=14)
+
+        inbox = client.get("/api/contact/requests?box=inbox&limit=1&offset=0", headers=player_headers)
+        assert inbox.status_code == 200
+        assert inbox.get_json()["total"] == 1
+        assert inbox.get_json()["requests"][0]["id"] == request_id
+
+        accepted = client.post(f"/api/contact/requests/{request_id}/accept", headers=player_headers)
+        assert accepted.status_code == 200
+        assert accepted.get_json()["contact_request"]["status"] == "accepted"
+
+        scout_message = client.post(
+            f"/api/contact/requests/{request_id}/messages",
+            json={"body": "Can we arrange a <script>alert(1)</script> call?"},
+            headers=scout_headers,
+        )
+        assert scout_message.status_code == 201, scout_message.get_json()
+        scout_message_payload = scout_message.get_json()["message"]
+        UUID(scout_message_payload["id"])
+        assert "<" not in scout_message_payload["body"]
+        assert scout_message_payload["sender_role"] == "scout"
+
+        player_message = client.post(
+            f"/api/contact/requests/{request_id}/messages",
+            json={"body": "Yes, tomorrow works."},
+            headers=player_headers,
+        )
+        assert player_message.status_code == 201
+        assert player_message.get_json()["message"]["sender_role"] == "player"
+
+        thread = client.get(f"/api/contact/requests/{request_id}/messages", headers=player_headers)
+        assert thread.status_code == 200
+        assert thread.get_json()["total"] == 2
+        assert [row["sender_role"] for row in thread.get_json()["messages"]] == ["scout", "player"]
+        second_page = client.get(
+            f"/api/contact/requests/{request_id}/messages?limit=1&offset=1",
+            headers=player_headers,
+        )
+        assert second_page.status_code == 200
+        assert second_page.get_json()["total"] == 2
+        assert [row["sender_role"] for row in second_page.get_json()["messages"]] == ["player"]
+
+        contacted = client.post(
+            f"/api/contact/requests/{request_id}/outcome",
+            json={
+                "stage": "contacted",
+                "notes": "<b>Intro call</b> complete",
+                "occurred_at": "2026-07-16T09:30:00Z",
+            },
+            headers=player_headers,
+        )
+        assert contacted.status_code == 201, contacted.get_json()
+        assert contacted.get_json()["outcome"]["notes"] == "Intro call complete"
+
+        signed = client.post(
+            f"/api/contact/requests/{request_id}/outcome",
+            json={"stage": "signed", "notes": "Terms agreed"},
+            headers=scout_headers,
+        )
+        assert signed.status_code == 201
+        assert signed.get_json()["contact_request"]["latest_outcome"]["stage"] == "signed"
+
+        historical = client.post(
+            f"/api/contact/requests/{request_id}/outcome",
+            json={
+                "stage": "trial_scheduled",
+                "notes": "Backfilled historical milestone",
+                "occurred_at": "2026-01-10T12:00:00Z",
+            },
+            headers=player_headers,
+        )
+        assert historical.status_code == 201
+        assert historical.get_json()["contact_request"]["latest_outcome"]["stage"] == "signed"
+        assert ContactOutcome.query.count() == 3
+
+        events = ContactAuditEvent.query.order_by(ContactAuditEvent.id).all()
+        assert [event.event_type for event in events] == [
+            "created",
+            "accepted",
+            "message_sent",
+            "message_sent",
+            "outcome_reported",
+            "outcome_reported",
+            "outcome_reported",
+        ]
+        assert [event.actor_user_id for event in events] == [
+            scout.id,
+            player.id,
+            scout.id,
+            player.id,
+            player.id,
+            scout.id,
+            player.id,
+        ]
+
+    def test_decline_cooldown_then_rerequest_after_tunable_window(self, client, monkeypatch):
+        _, scout_headers, _, player_headers, _, request_payload = _seed_contact(
+            client, suffix="decline", player_api_id=5101
+        )
+        request_id = request_payload["id"]
+        declined = client.post(f"/api/contact/requests/{request_id}/decline", headers=player_headers)
+        assert declined.status_code == 200
+        assert declined.get_json()["contact_request"]["status"] == "declined"
+
+        cooldown = _create(client, scout_headers, 5101)
+        assert cooldown.status_code == 409
+        assert cooldown.get_json()["code"] == "decline_cooldown_active"
+
+        monkeypatch.setenv("CONTACT_DECLINE_COOLDOWN_DAYS", "1")
+        row = db.session.get(ContactRequest, request_id)
+        row.responded_at = utcnow() - timedelta(days=2)
+        db.session.commit()
+        retried = _create(client, scout_headers, 5101, message="Following up after the cooldown")
+        assert retried.status_code == 201, retried.get_json()
+        assert ContactRequest.query.count() == 2
+        assert [event.event_type for event in ContactAuditEvent.query.order_by(ContactAuditEvent.id)] == [
+            "created",
+            "declined",
+            "created",
+        ]
+
+    def test_withdraw_is_initiating_scout_only(self, client):
+        _, scout_headers, _, player_headers, _, request_payload = _seed_contact(
+            client, suffix="withdraw", player_api_id=5201
+        )
+        request_id = request_payload["id"]
+        forbidden = client.post(f"/api/contact/requests/{request_id}/withdraw", headers=player_headers)
+        assert forbidden.status_code == 403
+        withdrawn = client.post(f"/api/contact/requests/{request_id}/withdraw", headers=scout_headers)
+        assert withdrawn.status_code == 200
+        assert withdrawn.get_json()["contact_request"]["status"] == "withdrawn"
+        assert [event.event_type for event in ContactAuditEvent.query.order_by(ContactAuditEvent.id)] == [
+            "created",
+            "withdrawn",
+        ]
+
+    def test_lazy_expiry_is_once_only_and_unblocks_new_request(self, client):
+        _, scout_headers, _, player_headers, _, request_payload = _seed_contact(
+            client, suffix="expiry", player_api_id=5301
+        )
+        request_id = request_payload["id"]
+        row = db.session.get(ContactRequest, request_id)
+        row.expires_at = utcnow() - timedelta(seconds=1)
+        db.session.commit()
+
+        first_read = client.get("/api/contact/requests?box=sent", headers=scout_headers)
+        assert first_read.status_code == 200
+        assert first_read.get_json()["requests"][0]["status"] == "expired"
+        expiry_events = ContactAuditEvent.query.filter_by(event_type="expired").all()
+        assert len(expiry_events) == 1
+        assert expiry_events[0].actor_user_id is None
+
+        second_read = client.get("/api/contact/requests?box=inbox", headers=player_headers)
+        assert second_read.status_code == 200
+        assert len(ContactAuditEvent.query.filter_by(event_type="expired").all()) == 1
+
+        replacement = _create(client, scout_headers, 5301, message="A fresh request after expiry")
+        assert replacement.status_code == 201, replacement.get_json()
+        assert ContactRequest.query.filter_by(status="pending").count() == 1
+
+    def test_request_expiry_window_is_env_tunable(self, client, monkeypatch):
+        monkeypatch.setenv("CONTACT_REQUEST_EXPIRY_DAYS", "2")
+        _seed_contact(client, suffix="expiry-window", player_api_id=5351)
+        row = ContactRequest.query.one()
+        assert row.expires_at - row.created_at == timedelta(days=2)
+
+    def test_duplicate_pending_and_accepted_requests_are_blocked(self, client):
+        scout, scout_headers, _, player_headers, claim, request_payload = _seed_contact(
+            client, suffix="duplicate", player_api_id=5401
+        )
+        duplicate = _create(client, scout_headers, 5401)
+        assert duplicate.status_code == 409
+        assert duplicate.get_json()["code"] == "active_request_exists"
+        assert ContactRequest.query.count() == 1
+        assert ContactAuditEvent.query.filter_by(event_type="created").count() == 1
+
+        # The database partial unique index remains the final concurrency guard,
+        # independently of the route's friendly preflight check.
+        now = utcnow()
+        db.session.add(
+            ContactRequest(
+                scout_user_id=scout.id,
+                player_api_id=5401,
+                claim_id=claim.id,
+                message="Direct duplicate",
+                status="pending",
+                created_at=now,
+                expires_at=now + timedelta(days=14),
+            )
+        )
+        with pytest.raises(IntegrityError):
+            db.session.flush()
+        db.session.rollback()
+        assert ContactRequest.query.count() == 1
+
+        accepted = client.post(
+            f"/api/contact/requests/{request_payload['id']}/accept",
+            headers=player_headers,
+        )
+        assert accepted.status_code == 200
+        still_duplicate = _create(client, scout_headers, 5401)
+        assert still_duplicate.status_code == 409
+        assert ContactRequest.query.count() == 1
+
+
+class TestContactAuthorizationAndFlag:
+    def test_unverified_scout_and_unclaimed_player_have_clear_codes(self, client):
+        _, unverified_headers = _headers("unverified@example.com")
+        _claim("claimed-player@example.com", 5501)
+        unverified = _create(client, unverified_headers, 5501)
+        assert unverified.status_code == 403
+        assert unverified.get_json()["code"] == "scout_not_verified"
+
+        _, verified_headers = _verified_scout("verified-no-target@example.com")
+        unclaimed = _create(client, verified_headers, 999999)
+        assert unclaimed.status_code == 403
+        assert unclaimed.get_json()["code"] == "player_not_claimable"
+
+        _claim("agent-only@example.com", 5502, relationship_type="agent")
+        agent_claim = _create(client, verified_headers, 5502)
+        assert agent_claim.status_code == 403
+        assert agent_claim.get_json()["code"] == "player_not_claimable"
+
+    def test_thread_and_outcome_hide_request_from_non_participant(self, client):
+        _, scout_headers, _, player_headers, _, request_payload = _seed_contact(
+            client, suffix="private", player_api_id=5601
+        )
+        request_id = request_payload["id"]
+        _, stranger_headers = _headers("stranger@example.com")
+
+        assert client.get(f"/api/contact/requests/{request_id}/messages", headers=scout_headers).status_code == 409
+        assert (
+            client.post(
+                f"/api/contact/requests/{request_id}/messages",
+                json={"body": "Too soon"},
+                headers=player_headers,
+            ).status_code
+            == 409
+        )
+        assert client.post(f"/api/contact/requests/{request_id}/accept", headers=scout_headers).status_code == 403
+        assert client.post(f"/api/contact/requests/{request_id}/accept", headers=stranger_headers).status_code == 403
+        assert client.get(f"/api/contact/requests/{request_id}/messages", headers=stranger_headers).status_code == 404
+        assert (
+            client.post(
+                f"/api/contact/requests/{request_id}/messages",
+                json={"body": "Intrusion"},
+                headers=stranger_headers,
+            ).status_code
+            == 404
+        )
+        assert (
+            client.post(
+                f"/api/contact/requests/{request_id}/outcome",
+                json={"stage": "signed"},
+                headers=stranger_headers,
+            ).status_code
+            == 404
+        )
+
+        assert client.post(f"/api/contact/requests/{request_id}/accept", headers=player_headers).status_code == 200
+        assert client.get(f"/api/contact/requests/{request_id}/messages", headers=stranger_headers).status_code == 404
+
+    def test_revoked_claimant_loses_direct_request_access(self, client):
+        _, scout_headers, _, player_headers, claim, request_payload = _seed_contact(
+            client, suffix="revoked", player_api_id=5651
+        )
+        request_id = request_payload["id"]
+        claim.status = "revoked"
+        db.session.commit()
+
+        inbox = client.get("/api/contact/requests?box=inbox", headers=player_headers)
+        assert inbox.status_code == 200
+        assert inbox.get_json()["requests"] == []
+        assert client.post(f"/api/contact/requests/{request_id}/accept", headers=player_headers).status_code == 403
+        assert client.get(f"/api/contact/requests/{request_id}/messages", headers=player_headers).status_code == 404
+
+        # The initiating scout retains their own historical sent record.
+        sent = client.get("/api/contact/requests?box=sent", headers=scout_headers)
+        assert sent.status_code == 200
+        assert sent.get_json()["requests"][0]["id"] == request_id
+
+    def test_flag_off_hides_every_new_user_route_before_auth(self, client, monkeypatch):
+        monkeypatch.setenv("CONTACT_RAIL_ENABLED", "false")
+        hidden_routes = (
+            ("POST", "/api/contact/requests", {"player_api_id": 1, "message": "hidden"}),
+            ("GET", "/api/contact/requests?box=sent", None),
+            ("GET", "/api/contact/requests?box=inbox", None),
+            ("POST", "/api/contact/requests/opaque-id/accept", None),
+            ("POST", "/api/contact/requests/opaque-id/decline", None),
+            ("POST", "/api/contact/requests/opaque-id/withdraw", None),
+            ("GET", "/api/contact/requests/opaque-id/messages", None),
+            ("POST", "/api/contact/requests/opaque-id/messages", {"body": "hidden"}),
+            ("POST", "/api/contact/requests/opaque-id/outcome", {"stage": "contacted"}),
+            ("GET", "/api/showcase/mine/interest-signals", None),
+            ("OPTIONS", "/api/contact/requests", None),
+            ("DELETE", "/api/contact/requests", None),
+            ("OPTIONS", "/api/showcase/mine/interest-signals", None),
+        )
+        for method, path, payload in hidden_routes:
+            response = client.open(path, method=method, json=payload)
+            assert response.status_code == 404, (method, path, response.get_json())
+
+        monkeypatch.delenv("CONTACT_RAIL_ENABLED")
+        assert client.get("/api/showcase/mine/interest-signals").status_code == 404
+
+    @pytest.mark.parametrize("flag_state", ["true", "false"])
+    def test_participant_can_report_message_regardless_of_contact_flag(self, client, monkeypatch, flag_state):
+        _, scout_headers, _, player_headers, _, request_payload = _seed_contact(
+            client, suffix="report", player_api_id=5701
+        )
+        request_id = request_payload["id"]
+        assert client.post(f"/api/contact/requests/{request_id}/accept", headers=player_headers).status_code == 200
+        message = client.post(
+            f"/api/contact/requests/{request_id}/messages",
+            json={"body": "A reportable participant message"},
+            headers=scout_headers,
+        ).get_json()["message"]
+
+        monkeypatch.setenv("CONTACT_RAIL_ENABLED", flag_state)
+        report = client.post(
+            "/api/reports",
+            json={
+                "subject_type": "contact_message",
+                "subject_id": message["id"],
+                "reason_code": "participant_safety",
+                "details": "Please review this message.",
+            },
+            headers=player_headers,
+        )
+        assert report.status_code == 201, report.get_json()
+        assert report.get_json()["report"]["subject_id"] == message["id"]
+        assert ContentReport.query.filter_by(subject_type="contact_message").count() == 1
+
+        admin_queue = client.get("/api/admin/reports?status=open", headers=_admin_headers())
+        assert admin_queue.status_code == 200
+        assert admin_queue.get_json()["reports"][0]["subject_id"] == message["id"]
+
+
+class TestContactLimits:
+    def test_plain_text_fields_are_bounded_and_occurred_at_is_validated(self, client):
+        _, scout_headers = _verified_scout("bounded-scout@example.com")
+        _, player_headers, _ = _claim("bounded-player@example.com", 5901)
+
+        oversized_request = _create(client, scout_headers, 5901, message="x" * 2001)
+        assert oversized_request.status_code == 400
+        assert "at most 2000" in oversized_request.get_json()["error"]
+
+        created = _create(client, scout_headers, 5901, message="A bounded introduction")
+        assert created.status_code == 201
+        request_id = created.get_json()["contact_request"]["id"]
+        assert client.post(f"/api/contact/requests/{request_id}/accept", headers=player_headers).status_code == 200
+
+        oversized_message = client.post(
+            f"/api/contact/requests/{request_id}/messages",
+            json={"body": "x" * 2001},
+            headers=scout_headers,
+        )
+        assert oversized_message.status_code == 400
+        oversized_notes = client.post(
+            f"/api/contact/requests/{request_id}/outcome",
+            json={"stage": "contacted", "notes": "x" * 2001},
+            headers=player_headers,
+        )
+        assert oversized_notes.status_code == 400
+        invalid_occurred_at = client.post(
+            f"/api/contact/requests/{request_id}/outcome",
+            json={"stage": "contacted", "occurred_at": "not-a-date"},
+            headers=player_headers,
+        )
+        assert invalid_occurred_at.status_code == 400
+        assert ContactMessage.query.count() == 0
+        assert ContactOutcome.query.count() == 0
+
+    def test_request_limit_is_per_verified_scout(self, client):
+        _, scout_headers = _verified_scout("rate-scout@example.com")
+        for offset in range(11):
+            _claim(f"rate-player-{offset}@example.com", 6000 + offset)
+        for offset in range(10):
+            response = _create(client, scout_headers, 6000 + offset, message=f"Introduction {offset}")
+            assert response.status_code == 201, response.get_json()
+
+        limited = _create(client, scout_headers, 6010, message="Eleventh introduction")
+        assert limited.status_code == 429
+
+        _, independent_headers = _verified_scout("other-rate-scout@example.com")
+        independent = _create(client, independent_headers, 6010, message="Independent scout bucket")
+        assert independent.status_code == 201, independent.get_json()
+
+    def test_message_post_limit_is_per_participant(self, client):
+        _, scout_headers, _, player_headers, _, request_payload = _seed_contact(
+            client, suffix="message-rate", player_api_id=6101
+        )
+        request_id = request_payload["id"]
+        assert client.post(f"/api/contact/requests/{request_id}/accept", headers=player_headers).status_code == 200
+        for index in range(60):
+            sent = client.post(
+                f"/api/contact/requests/{request_id}/messages",
+                json={"body": f"Message {index}"},
+                headers=scout_headers,
+            )
+            assert sent.status_code == 201, (index, sent.get_json())
+        limited = client.post(
+            f"/api/contact/requests/{request_id}/messages",
+            json={"body": "Message 61"},
+            headers=scout_headers,
+        )
+        assert limited.status_code == 429
+
+        independent = client.post(
+            f"/api/contact/requests/{request_id}/messages",
+            json={"body": "Player response"},
+            headers=player_headers,
+        )
+        assert independent.status_code == 201
+        assert ContactMessage.query.count() == 61
+        assert ContactAuditEvent.query.filter_by(event_type="message_sent").count() == 61
+
+
+class TestInterestSignals:
+    def test_aggregates_are_correct_distinct_and_identity_free(self, client):
+        owner, owner_headers, _ = _claim("signal-owner@example.com", 7001)
+        _claim("signal-owner@example.com", 7002)
+        _claim("signal-owner@example.com", 7003, status="pending")
+        _claim("signal-owner@example.com", 7004, relationship_type="agent")
+
+        now = utcnow()
+        week_start = now.replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=now.weekday())
+        old = week_start - timedelta(days=2)
+        watcher_a, _ = _headers("watcher-a@example.com")
+        watcher_b, _ = _headers("watcher-b@example.com")
+        watcher_c, _ = _headers("watcher-c@example.com")
+        db.session.add_all(
+            [
+                ScoutWatchlistEntry(user_account_id=watcher_a.id, player_api_id=7001, created_at=old),
+                ScoutWatchlistEntry(user_account_id=watcher_b.id, player_api_id=7001, created_at=now),
+            ]
+        )
+
+        active_a = FollowList(user_account_id=watcher_a.id, name="Prospects A", is_active=True, is_default=False)
+        active_a_two = FollowList(user_account_id=watcher_a.id, name="Prospects A2", is_active=True, is_default=False)
+        active_b = FollowList(user_account_id=watcher_b.id, name="Prospects B", is_active=True, is_default=False)
+        active_c = FollowList(user_account_id=watcher_c.id, name="Prospects C", is_active=True, is_default=False)
+        default_mirror = FollowList(user_account_id=owner.id, name="My Watchlist", is_active=True, is_default=True)
+        inactive = FollowList(user_account_id=owner.id, name="Paused", is_active=False, is_default=False)
+        db.session.add_all([active_a, active_a_two, active_b, active_c, default_mirror, inactive])
+        db.session.flush()
+        db.session.add_all(
+            [
+                Follow(list_id=active_a.id, kind="player", selector={"player_api_id": 7001}, created_at=now),
+                Follow(list_id=active_a_two.id, kind="player", selector={"player_api_id": 7001}, created_at=old),
+                Follow(list_id=active_b.id, kind="player", selector={"player_api_id": 7001}, created_at=old),
+                Follow(list_id=active_c.id, kind="player", selector={"player_api_id": 7001}, created_at=now),
+                Follow(list_id=default_mirror.id, kind="player", selector={"player_api_id": 7001}, created_at=now),
+                Follow(list_id=inactive.id, kind="player", selector={"player_api_id": 7001}, created_at=now),
+                Follow(list_id=active_b.id, kind="geo", selector={"mode": "nationality", "value": "Japan"}),
+            ]
+        )
+        db.session.commit()
+
+        response = client.get("/api/showcase/mine/interest-signals", headers=owner_headers)
+        assert response.status_code == 200, response.get_json()
+        payload = response.get_json()
+        assert payload["week_start"].startswith(week_start.date().isoformat())
+        assert payload["interest_signals"] == [
+            {
+                "player_api_id": 7001,
+                "watchlists": {"total": 2, "added_this_week": 1},
+                "follows": {"total": 3, "added_this_week": 1},
+            },
+            {
+                "player_api_id": 7002,
+                "watchlists": {"total": 0, "added_this_week": 0},
+                "follows": {"total": 0, "added_this_week": 0},
+            },
+        ]
+
+        forbidden_keys = {
+            "user_id",
+            "user_account_id",
+            "email",
+            "display_name",
+            "list_id",
+            "list_name",
+            "follow_id",
+            "selector",
+            "note",
+            "last_snapshot",
+        }
+
+        def all_keys(value):
+            if isinstance(value, dict):
+                return set(value) | set().union(*(all_keys(item) for item in value.values()), set())
+            if isinstance(value, list):
+                return set().union(*(all_keys(item) for item in value), set())
+            return set()
+
+        assert not (all_keys(payload) & forbidden_keys)
+        assert "watcher-a@example.com" not in response.get_data(as_text=True)
+
+    def test_no_approved_player_claims_returns_empty(self, client):
+        _, headers = _headers("no-player-claims@example.com")
+        _claim("no-player-claims@example.com", 7101, relationship_type="agent")
+        response = client.get("/api/showcase/mine/interest-signals", headers=headers)
+        assert response.status_code == 200
+        assert response.get_json()["interest_signals"] == []
+
+
+def test_fc02_is_guarded_single_parent_and_enables_rls_for_all_tables():
+    migration = Path(__file__).resolve().parents[1] / "migrations" / "versions" / "fc02_contact_rail.py"
+    source = migration.read_text()
+    assert 'revision = "fc02"' in source
+    assert 'down_revision = "fc01"' in source
+    assert "PR #636" in source and "gf01" in source
+    assert "if not table_exists" in source
+    assert "create_index_safe" in source
+    assert "status IN ('pending', 'accepted')" in source
+    assert "for table_name in NEW_TABLES" in source
+    assert source.count("ENABLE ROW LEVEL SECURITY") == 1
+    for table_name in (
+        "contact_requests",
+        "contact_messages",
+        "contact_audit_events",
+        "contact_outcomes",
+    ):
+        assert f'"{table_name}"' in source


### PR DESCRIPTION
## Summary

FC-B2 of the **Full Circle** track — the scout↔player contact rail, **stacked on #645 (FC-B1)** and entirely behind `CONTACT_RAIL_ENABLED` (default **false** → every non-admin route 404s; feature is invisible in prod until the trust-floor items and ToS land).

- **Intro requests** — verified scouts (`is_verified_scout`, from #645) → players with an APPROVED `relationship_type='player'` claim (18+ guaranteed by #645's claim gate). One active request per scout↔player pair (partial unique index), per-user rate limits, 14-day expiry (lazy, audited), 30-day decline cooldown.
- **Thread** — participant-only messages, accepted requests only, sanitized + rate-limited.
- **Append-only audit** — `contact_audit_events` written on every action (create/accept/decline/withdraw/expire/message/outcome); no update/delete paths exist.
- **Outcomes** — append-only progression `contacted → trial_scheduled → trial_completed → signed | no_fit`; latest stage serialized.
- **Interest signals** — `GET /api/showcase/mine/interest-signals`: aggregate watchlist/follow counts + weekly adds for the caller's claimed player. Aggregate only; no scout identities.
- **Reporting** — no new endpoint; `/api/reports` (from #645) accepts `contact_message` subjects, proven by test.

## Migration

`fc02` chains `fc01`; guarded DDL, same-migration RLS on all four new tables, guarded downgrade; local Postgres replay upgrade→downgrade→upgrade verified (4/4 RLS). Docstring carries both orderings of the PR #636 (`gf01`) caveat.

## Verification

- 83 backend tests green (incl. exhaustive flag-off 404 coverage: every endpoint, unauth, OPTIONS, wrong-method, unset-default) — re-run independently by the reviewer
- `ruff check` + `ruff format --check` clean; migration single-head test green
- Live boot smoke, both states: flag OFF → contact + signals routes 404; flag ON → 401 unauthenticated; health 200 both
- Audit wiring independently traced: 5 route call sites + lazy-expiry path

Base is `feat/full-circle-rails` — re-target to `main` after #645 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
